### PR TITLE
feat: @palaia/openclaw — Palaia Memory Backend for OpenClaw

### DIFF
--- a/packages/openclaw-plugin/README.md
+++ b/packages/openclaw-plugin/README.md
@@ -1,0 +1,137 @@
+# @palaia/openclaw
+
+**Palaia memory backend for OpenClaw.**
+
+Replace OpenClaw's built-in `memory-core` with Palaia — local, cloud-free, WAL-backed agent memory with tier routing and semantic search.
+
+## Installation
+
+```bash
+# Install Palaia (Python CLI)
+pip install palaia
+
+# Install the OpenClaw plugin
+openclaw plugins install @palaia/openclaw
+```
+
+## Configuration
+
+Activate the plugin by setting the memory slot in your OpenClaw config:
+
+```json5
+// openclaw.config.json5
+{
+  plugins: {
+    slots: { memory: "palaia" }
+  }
+}
+```
+
+Restart the gateway after changing config:
+
+```bash
+openclaw gateway restart
+```
+
+### Plugin Options
+
+All options are optional — sensible defaults are used:
+
+```json5
+{
+  plugins: {
+    config: {
+      palaia: {
+        binaryPath: "/path/to/palaia",  // default: auto-detect
+        workspace: "/path/to/workspace", // default: agent workspace
+        tier: "hot",                      // default: "hot" (hot|warm|all)
+        maxResults: 10,                   // default: 10
+        timeoutMs: 3000,                  // default: 3000
+        memoryInject: false,              // default: false (inject HOT into context)
+        maxInjectedChars: 4000,           // default: 4000
+      }
+    }
+  }
+}
+```
+
+## Agent Tools
+
+### `memory_search` (always available)
+
+Semantically search Palaia memory:
+
+```
+memory_search({ query: "deployment process", maxResults: 5, tier: "all" })
+```
+
+### `memory_get` (always available)
+
+Read a specific memory entry:
+
+```
+memory_get({ path: "abc-123-uuid", from: 1, lines: 50 })
+```
+
+### `memory_write` (optional, opt-in)
+
+Write new memory entries. Enable per-agent:
+
+```json5
+{
+  agents: {
+    list: [{
+      id: "main",
+      tools: { allow: ["memory_write"] }
+    }]
+  }
+}
+```
+
+Then agents can write:
+
+```
+memory_write({ content: "Important finding", scope: "team", tags: ["project-x"] })
+```
+
+## Features
+
+- **Zero breaking changes** — Drop-in replacement for `memory-core`
+- **WAL-backed writes** — Crash-safe, recovers on startup
+- **Tier routing** — HOT → WARM → COLD with automatic decay
+- **Scope isolation** — private, team, shared:X, public
+- **BM25 search** — Fast local search, no external API needed
+- **HOT memory injection** — Opt-in: inject active memory into agent context
+- **Auto binary detection** — Finds `palaia` in PATH, pipx, or venv
+
+## Architecture
+
+```
+OpenClaw Agent
+  └─ @palaia/openclaw (plugin)
+       └─ palaia CLI (subprocess, --json)
+            └─ .palaia/ (local storage)
+                 ├─ hot/    (active memory)
+                 ├─ warm/   (recent, less active)
+                 ├─ cold/   (archived)
+                 ├─ wal/    (write-ahead log)
+                 └─ index/  (search index)
+```
+
+## Development
+
+```bash
+# Clone the repo
+git clone https://github.com/iret77/palaia.git
+cd palaia/packages/openclaw-plugin
+
+# Install deps
+npm install
+
+# Run tests
+npx vitest run
+```
+
+## License
+
+MIT

--- a/packages/openclaw-plugin/index.ts
+++ b/packages/openclaw-plugin/index.ts
@@ -1,0 +1,37 @@
+/**
+ * @palaia/openclaw — Palaia Memory Backend for OpenClaw
+ *
+ * Plugin entry point. Loaded by OpenClaw via jiti (no build step needed).
+ *
+ * Registers:
+ * - memory_search: Semantic search over Palaia memory
+ * - memory_get: Read a specific memory entry
+ * - memory_write: Write new entries (optional, opt-in)
+ * - before_prompt_build: HOT memory injection (opt-in)
+ * - palaia-recovery: WAL replay on startup
+ *
+ * Activation:
+ *   plugins: { slots: { memory: "palaia" } }
+ */
+
+import { resolveConfig, type PalaiaPluginConfig } from "./src/config.js";
+import { registerTools } from "./src/tools.js";
+import { registerHooks } from "./src/hooks.js";
+
+export default function palaiaPlugin(api: any) {
+  const rawConfig = api.getConfig?.("palaia") as
+    | Partial<PalaiaPluginConfig>
+    | undefined;
+  const config = resolveConfig(rawConfig);
+
+  // If workspace not set, use agent workspace from context
+  if (!config.workspace && api.workspace) {
+    config.workspace = api.workspace;
+  }
+
+  // Register agent tools (memory_search, memory_get, memory_write)
+  registerTools(api, config);
+
+  // Register lifecycle hooks (before_prompt_build, recovery service)
+  registerHooks(api, config);
+}

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -1,0 +1,51 @@
+{
+  "id": "palaia",
+  "name": "Palaia Memory",
+  "kind": "memory",
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "binaryPath": {
+        "type": "string",
+        "description": "Path to palaia binary (default: auto-detect)"
+      },
+      "workspace": {
+        "type": "string",
+        "description": "Palaia workspace path (default: agent workspace)"
+      },
+      "tier": {
+        "type": "string",
+        "enum": ["hot", "warm", "all"],
+        "default": "hot"
+      },
+      "maxResults": {
+        "type": "number",
+        "default": 10
+      },
+      "timeoutMs": {
+        "type": "number",
+        "default": 3000
+      },
+      "memoryInject": {
+        "type": "boolean",
+        "default": false,
+        "description": "Inject HOT memory into agent context on prompt build"
+      },
+      "maxInjectedChars": {
+        "type": "number",
+        "default": 4000,
+        "description": "Max characters for injected memory context"
+      }
+    }
+  },
+  "uiHints": {
+    "binaryPath": {
+      "label": "Palaia Binary Path",
+      "placeholder": "auto-detect"
+    },
+    "workspace": {
+      "label": "Workspace Path",
+      "placeholder": "agent workspace"
+    }
+  }
+}

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@palaia/openclaw",
+  "version": "0.1.0",
+  "description": "Palaia memory backend for OpenClaw",
+  "main": "index.ts",
+  "openclaw": {
+    "extensions": ["./index.ts"]
+  },
+  "files": [
+    "index.ts",
+    "src/",
+    "openclaw.plugin.json",
+    "README.md"
+  ],
+  "keywords": [
+    "openclaw",
+    "openclaw-plugin",
+    "palaia",
+    "memory",
+    "agent-memory"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/iret77/palaia.git",
+    "directory": "packages/openclaw-plugin"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2025.1.0"
+  },
+  "devDependencies": {
+    "@sinclair/typebox": "^0.32.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/openclaw-plugin/src/config.ts
+++ b/packages/openclaw-plugin/src/config.ts
@@ -1,0 +1,37 @@
+/**
+ * Plugin configuration schema and defaults for @palaia/openclaw.
+ */
+
+export interface PalaiaPluginConfig {
+  /** Path to palaia binary (default: auto-detect) */
+  binaryPath?: string;
+  /** Palaia workspace path (default: agent workspace) */
+  workspace?: string;
+  /** Default tier filter: "hot" | "warm" | "all" */
+  tier: string;
+  /** Default max results for queries */
+  maxResults: number;
+  /** Timeout for CLI calls in milliseconds */
+  timeoutMs: number;
+  /** Inject HOT memory into agent context on prompt build */
+  memoryInject: boolean;
+  /** Max characters for injected memory context */
+  maxInjectedChars: number;
+}
+
+export const DEFAULT_CONFIG: PalaiaPluginConfig = {
+  tier: "hot",
+  maxResults: 10,
+  timeoutMs: 3000,
+  memoryInject: false,
+  maxInjectedChars: 4000,
+};
+
+/**
+ * Merge user config with defaults. Unknown keys are ignored.
+ */
+export function resolveConfig(
+  userConfig: Partial<PalaiaPluginConfig> | undefined
+): PalaiaPluginConfig {
+  return { ...DEFAULT_CONFIG, ...userConfig };
+}

--- a/packages/openclaw-plugin/src/hooks.ts
+++ b/packages/openclaw-plugin/src/hooks.ts
@@ -1,0 +1,98 @@
+/**
+ * Lifecycle hooks for the Palaia OpenClaw plugin.
+ *
+ * - before_prompt_build: Injects HOT memory into agent context (opt-in).
+ * - palaia-recovery service: Replays WAL on startup.
+ */
+
+import { runJson, recover, type RunnerOpts } from "./runner.js";
+import type { PalaiaPluginConfig } from "./config.js";
+
+/** Shape returned by `palaia query --json` */
+interface QueryResult {
+  results: Array<{
+    id: string;
+    body?: string;
+    content?: string;
+    score: number;
+    tier: string;
+    scope: string;
+    title?: string;
+  }>;
+}
+
+/**
+ * Build RunnerOpts from plugin config.
+ */
+function buildRunnerOpts(config: PalaiaPluginConfig): RunnerOpts {
+  return {
+    binaryPath: config.binaryPath,
+    workspace: config.workspace,
+    timeoutMs: config.timeoutMs,
+  };
+}
+
+/**
+ * Register lifecycle hooks on the plugin API.
+ */
+export function registerHooks(api: any, config: PalaiaPluginConfig): void {
+  const opts = buildRunnerOpts(config);
+
+  // ── before_prompt_build ────────────────────────────────────────
+  // Injects top HOT entries into agent system context.
+  // Only active when config.memoryInject === true (default: false).
+  if (config.memoryInject) {
+    api.on("before_prompt_build", async (event: any, ctx: any) => {
+      try {
+        const maxChars = config.maxInjectedChars || 4000;
+        const limit = Math.min(config.maxResults || 10, 20);
+
+        const result = await runJson<QueryResult>(
+          ["list", "--tier", "hot", "--limit", String(limit)],
+          opts
+        );
+
+        if (!result || !Array.isArray(result.results) || result.results.length === 0) {
+          // Fallback: try query with empty string for recent entries
+          return;
+        }
+
+        const entries = result.results;
+        let text = "## Active Memory (Palaia)\n\n";
+        let chars = text.length;
+
+        for (const entry of entries) {
+          const body = entry.content || entry.body || "";
+          const title = entry.title || "(untitled)";
+          const line = `**${title}** [${entry.scope}]\n${body}\n\n`;
+
+          if (chars + line.length > maxChars) break;
+          text += line;
+          chars += line.length;
+        }
+
+        if (ctx.prependSystemContext) {
+          ctx.prependSystemContext(text);
+        }
+      } catch (error) {
+        // Non-fatal: if memory injection fails, agent continues without it
+        console.warn(`[palaia] Memory injection failed: ${error}`);
+      }
+    });
+  }
+
+  // ── Startup Recovery Service ───────────────────────────────────
+  // Replays pending WAL entries on plugin startup.
+  api.registerService({
+    id: "palaia-recovery",
+    start: async () => {
+      const result = await recover(opts);
+      if (result.replayed > 0) {
+        console.log(`[palaia] WAL recovery: replayed ${result.replayed} entries`);
+      }
+      if (result.errors > 0) {
+        console.warn(`[palaia] WAL recovery completed with ${result.errors} error(s)`);
+      }
+    },
+  });
+}

--- a/packages/openclaw-plugin/src/runner.ts
+++ b/packages/openclaw-plugin/src/runner.ts
@@ -1,0 +1,218 @@
+/**
+ * Palaia CLI subprocess runner.
+ *
+ * Executes palaia CLI commands, parses JSON output, handles binary detection
+ * and timeouts. This is the bridge between the OpenClaw plugin and the
+ * palaia Python CLI.
+ */
+
+import { execFile } from "node:child_process";
+import { access, constants } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface RunnerOpts {
+  /** Working directory for palaia (sets PALAIA_ROOT context) */
+  workspace?: string;
+  /** Timeout in milliseconds */
+  timeoutMs?: number;
+  /** Override binary path */
+  binaryPath?: string;
+}
+
+export interface RunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/** Cached binary path after first detection */
+let cachedBinary: string | null = null;
+
+/**
+ * Detect the palaia binary location.
+ *
+ * Search order:
+ * 1. Explicit binaryPath from config
+ * 2. `palaia` in PATH
+ * 3. `~/.local/bin/palaia` (pipx default)
+ * 4. `python3 -m palaia` as fallback
+ * 5. Error with clear message
+ */
+export async function detectBinary(
+  explicitPath?: string
+): Promise<string> {
+  if (explicitPath) {
+    try {
+      await access(explicitPath, constants.X_OK);
+      return explicitPath;
+    } catch {
+      throw new Error(
+        `Configured palaia binary not found or not executable: ${explicitPath}`
+      );
+    }
+  }
+
+  if (cachedBinary) return cachedBinary;
+
+  // Try `palaia` in PATH
+  try {
+    const result = await execCommand("palaia", ["--version"], {
+      timeoutMs: 5000,
+    });
+    if (result.exitCode === 0) {
+      cachedBinary = "palaia";
+      return "palaia";
+    }
+  } catch {
+    // Not in PATH
+  }
+
+  // Try ~/.local/bin/palaia (pipx default)
+  const pipxPath = join(homedir(), ".local", "bin", "palaia");
+  try {
+    await access(pipxPath, constants.X_OK);
+    cachedBinary = pipxPath;
+    return pipxPath;
+  } catch {
+    // Not installed via pipx
+  }
+
+  // Try python3 -m palaia
+  try {
+    const result = await execCommand("python3", ["-m", "palaia", "--version"], {
+      timeoutMs: 5000,
+    });
+    if (result.exitCode === 0) {
+      cachedBinary = "python3";
+      return "python3"; // Will need `-m palaia` prefix
+    }
+  } catch {
+    // Not available
+  }
+
+  throw new Error(
+    "Palaia binary not found. Install with: pip install palaia\n" +
+      "Or set binaryPath in plugin config."
+  );
+}
+
+/**
+ * Check if the detected binary requires `python3 -m palaia` invocation.
+ */
+function isPythonModule(binary: string): boolean {
+  return binary === "python3" || binary.endsWith("/python3");
+}
+
+/**
+ * Execute a raw command and return result.
+ */
+function execCommand(
+  cmd: string,
+  args: string[],
+  opts: { timeoutMs?: number; cwd?: string } = {}
+): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const timeout = opts.timeoutMs || 10000;
+    const child = execFile(
+      cmd,
+      args,
+      {
+        timeout,
+        maxBuffer: 1024 * 1024, // 1MB
+        cwd: opts.cwd,
+        env: { ...process.env },
+      },
+      (error, stdout, stderr) => {
+        if (error && (error as any).killed) {
+          reject(
+            new Error(`Palaia command timed out after ${timeout}ms: ${cmd} ${args.join(" ")}`)
+          );
+          return;
+        }
+        resolve({
+          stdout: stdout?.toString() || "",
+          stderr: stderr?.toString() || "",
+          exitCode: error ? (error as any).code || 1 : 0,
+        });
+      }
+    );
+  });
+}
+
+/**
+ * Run a palaia CLI command and return raw output.
+ */
+export async function run(
+  args: string[],
+  opts: RunnerOpts = {}
+): Promise<string> {
+  const binary = await detectBinary(opts.binaryPath);
+  const timeoutMs = opts.timeoutMs || 3000;
+
+  let cmd: string;
+  let cmdArgs: string[];
+
+  if (isPythonModule(binary)) {
+    cmd = binary;
+    cmdArgs = ["-m", "palaia", ...args];
+  } else {
+    cmd = binary;
+    cmdArgs = [...args];
+  }
+
+  const result = await execCommand(cmd, cmdArgs, {
+    timeoutMs,
+    cwd: opts.workspace,
+  });
+
+  if (result.exitCode !== 0) {
+    const errMsg = result.stderr.trim() || result.stdout.trim();
+    throw new Error(`Palaia CLI error (exit ${result.exitCode}): ${errMsg}`);
+  }
+
+  return result.stdout;
+}
+
+/**
+ * Run a palaia CLI command and parse JSON output.
+ */
+export async function runJson<T = unknown>(
+  args: string[],
+  opts: RunnerOpts = {}
+): Promise<T> {
+  const stdout = await run([...args, "--json"], opts);
+  try {
+    return JSON.parse(stdout) as T;
+  } catch {
+    throw new Error(
+      `Failed to parse palaia JSON output: ${stdout.slice(0, 200)}`
+    );
+  }
+}
+
+/**
+ * Run WAL recovery on startup.
+ */
+export async function recover(opts: RunnerOpts = {}): Promise<{
+  replayed: number;
+  errors: number;
+}> {
+  try {
+    return await runJson<{ replayed: number; errors: number }>(
+      ["recover"],
+      { ...opts, timeoutMs: opts.timeoutMs || 10000 }
+    );
+  } catch (error) {
+    // Recovery failure is non-fatal — log and continue
+    console.warn(`[palaia] WAL recovery warning: ${error}`);
+    return { replayed: 0, errors: 1 };
+  }
+}
+
+/**
+ * Reset cached binary (for testing).
+ */
+export function resetCache(): void {
+  cachedBinary = null;
+}

--- a/packages/openclaw-plugin/src/tools.ts
+++ b/packages/openclaw-plugin/src/tools.ts
@@ -1,0 +1,220 @@
+/**
+ * Agent tools: memory_search, memory_get, memory_write.
+ *
+ * These tools are the core of the Palaia OpenClaw integration.
+ * They shell out to the palaia CLI with --json and return results
+ * in the format OpenClaw agents expect.
+ */
+
+import { Type } from "@sinclair/typebox";
+import { runJson, type RunnerOpts } from "./runner.js";
+import type { PalaiaPluginConfig } from "./config.js";
+
+/** Shape returned by `palaia query --json` */
+interface QueryResult {
+  results: Array<{
+    id: string;
+    content?: string;
+    body?: string;
+    score: number;
+    tier: string;
+    scope: string;
+    title?: string;
+    tags?: string[];
+    path?: string;
+    decay_score?: number;
+  }>;
+}
+
+/** Shape returned by `palaia get --json` */
+interface GetResult {
+  id: string;
+  content: string;
+  meta: {
+    scope: string;
+    tier: string;
+    title?: string;
+    tags?: string[];
+    [key: string]: unknown;
+  };
+}
+
+/** Shape returned by `palaia write --json` */
+interface WriteResult {
+  id: string;
+  tier: string;
+  scope: string;
+  deduplicated: boolean;
+}
+
+/**
+ * Build RunnerOpts from plugin config.
+ */
+function buildRunnerOpts(config: PalaiaPluginConfig): RunnerOpts {
+  return {
+    binaryPath: config.binaryPath,
+    workspace: config.workspace,
+    timeoutMs: config.timeoutMs,
+  };
+}
+
+/**
+ * Register all Palaia agent tools on the given plugin API.
+ */
+export function registerTools(api: any, config: PalaiaPluginConfig): void {
+  const opts = buildRunnerOpts(config);
+
+  // ── memory_search ──────────────────────────────────────────────
+  api.registerTool({
+    name: "memory_search",
+    description:
+      "Semantically search Palaia memory for relevant notes and context.",
+    parameters: Type.Object({
+      query: Type.String({ description: "Search query" }),
+      maxResults: Type.Optional(
+        Type.Number({ description: "Max results (default: 5)", default: 5 })
+      ),
+      tier: Type.Optional(
+        Type.String({
+          description: "hot|warm|all (default: hot+warm)",
+        })
+      ),
+      scope: Type.Optional(
+        Type.String({
+          description: "Filter by scope: private|team|shared:X|public",
+        })
+      ),
+    }),
+    async execute(
+      _id: string,
+      params: {
+        query: string;
+        maxResults?: number;
+        tier?: string;
+        scope?: string;
+      }
+    ) {
+      const limit = params.maxResults || config.maxResults || 5;
+      const args: string[] = ["query", params.query, "--limit", String(limit)];
+
+      // --all flag includes cold tier
+      if (params.tier === "all" || config.tier === "all") {
+        args.push("--all");
+      }
+
+      const result = await runJson<QueryResult>(args, opts);
+
+      // Format as memory_search compatible output
+      const snippets = (result.results || []).map((r) => {
+        const body = r.content || r.body || "";
+        const path = r.path || `${r.tier}/${r.id}.md`;
+        return {
+          text: body,
+          path,
+          score: r.score,
+          tier: r.tier,
+          scope: r.scope,
+        };
+      });
+
+      // Build text output compatible with memory-core format
+      const textParts = snippets.map(
+        (s) =>
+          `${s.text}\n— Source: ${s.path} (score: ${s.score}, tier: ${s.tier})`
+      );
+      const text =
+        textParts.length > 0
+          ? textParts.join("\n\n")
+          : "No results found.";
+
+      return {
+        content: [{ type: "text" as const, text }],
+      };
+    },
+  });
+
+  // ── memory_get ─────────────────────────────────────────────────
+  api.registerTool({
+    name: "memory_get",
+    description: "Read a specific Palaia memory entry by path or id.",
+    parameters: Type.Object({
+      path: Type.String({ description: "Memory path or UUID" }),
+      from: Type.Optional(
+        Type.Number({ description: "Start from line number (1-indexed)" })
+      ),
+      lines: Type.Optional(
+        Type.Number({ description: "Number of lines to return" })
+      ),
+    }),
+    async execute(
+      _id: string,
+      params: { path: string; from?: number; lines?: number }
+    ) {
+      const args: string[] = ["get", params.path];
+      if (params.from != null) {
+        args.push("--from", String(params.from));
+      }
+      if (params.lines != null) {
+        args.push("--lines", String(params.lines));
+      }
+
+      const result = await runJson<GetResult>(args, opts);
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: result.content,
+          },
+        ],
+      };
+    },
+  });
+
+  // ── memory_write (optional, opt-in) ───────────────────────────
+  api.registerTool(
+    {
+      name: "memory_write",
+      description:
+        "Write a new memory entry to Palaia. WAL-backed, crash-safe.",
+      parameters: Type.Object({
+        content: Type.String({ description: "Memory content to write" }),
+        scope: Type.Optional(
+          Type.String({
+            description: "Scope: private|team|shared:X|public (default: team)",
+            default: "team",
+          })
+        ),
+        tags: Type.Optional(
+          Type.Array(Type.String(), {
+            description: "Tags for categorization",
+          })
+        ),
+      }),
+      async execute(
+        _id: string,
+        params: { content: string; scope?: string; tags?: string[] }
+      ) {
+        const args: string[] = ["write", params.content];
+        if (params.scope) {
+          args.push("--scope", params.scope);
+        }
+        if (params.tags && params.tags.length > 0) {
+          args.push("--tags", params.tags.join(","));
+        }
+
+        const result = await runJson<WriteResult>(args, opts);
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Memory written: ${result.id} (tier: ${result.tier}, scope: ${result.scope})`,
+            },
+          ],
+        };
+      },
+    },
+    { optional: true }
+  );
+}

--- a/packages/openclaw-plugin/tests/runner.test.ts
+++ b/packages/openclaw-plugin/tests/runner.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for src/runner.ts — binary detection, timeout handling, JSON parsing.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { execFile } from "node:child_process";
+
+// Mock child_process
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+// Mock fs/promises for access checks
+vi.mock("node:fs/promises", () => ({
+  access: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  constants: { X_OK: 1 },
+}));
+
+import { detectBinary, run, runJson, recover, resetCache } from "../src/runner.js";
+
+const mockExecFile = vi.mocked(execFile);
+
+function setupExecFile(
+  stdout: string,
+  stderr = "",
+  exitCode = 0,
+  error: any = null
+) {
+  mockExecFile.mockImplementation(
+    (_cmd: any, _args: any, _opts: any, callback: any) => {
+      if (exitCode !== 0 && !error) {
+        error = Object.assign(new Error(stderr), { code: exitCode });
+      }
+      callback(error, stdout, stderr);
+      return {} as any;
+    }
+  );
+}
+
+describe("runner", () => {
+  beforeEach(() => {
+    resetCache();
+    vi.clearAllMocks();
+  });
+
+  describe("detectBinary", () => {
+    it("returns explicit path when provided", async () => {
+      const { access } = await import("node:fs/promises");
+      vi.mocked(access).mockResolvedValueOnce(undefined);
+
+      const result = await detectBinary("/usr/local/bin/palaia");
+      expect(result).toBe("/usr/local/bin/palaia");
+    });
+
+    it("throws when explicit path not found", async () => {
+      await expect(detectBinary("/nonexistent/palaia")).rejects.toThrow(
+        "not found or not executable"
+      );
+    });
+
+    it("detects palaia in PATH", async () => {
+      setupExecFile("palaia 0.3.0\n");
+      const result = await detectBinary();
+      expect(result).toBe("palaia");
+    });
+  });
+
+  describe("runJson", () => {
+    it("parses valid JSON output", async () => {
+      const jsonOutput = JSON.stringify({ results: [{ id: "abc" }] });
+      setupExecFile(jsonOutput);
+      resetCache();
+      // Pre-seed binary cache
+      setupExecFile(jsonOutput);
+
+      // Need to detect binary first
+      setupExecFile("palaia 0.3.0\n");
+      await detectBinary();
+
+      setupExecFile(jsonOutput);
+      const result = await runJson<{ results: any[] }>(["query", "test"], {
+        binaryPath: "palaia",
+      });
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].id).toBe("abc");
+    });
+
+    it("throws on invalid JSON", async () => {
+      setupExecFile("not json at all");
+      await expect(
+        runJson(["query", "test"], { binaryPath: "palaia" })
+      ).rejects.toThrow("Failed to parse");
+    });
+  });
+
+  describe("run", () => {
+    it("throws on non-zero exit code", async () => {
+      setupExecFile("", "Something failed", 1);
+      await expect(
+        run(["query", "test"], { binaryPath: "palaia" })
+      ).rejects.toThrow("Palaia CLI error");
+    });
+  });
+
+  describe("recover", () => {
+    it("returns result on success", async () => {
+      const jsonOutput = JSON.stringify({ replayed: 2, errors: 0 });
+      setupExecFile(jsonOutput);
+      const result = await recover({ binaryPath: "palaia" });
+      expect(result.replayed).toBe(2);
+      expect(result.errors).toBe(0);
+    });
+
+    it("returns fallback on failure", async () => {
+      setupExecFile("", "fail", 1, new Error("fail"));
+      const result = await recover({ binaryPath: "palaia" });
+      expect(result.replayed).toBe(0);
+      expect(result.errors).toBe(1);
+    });
+  });
+});

--- a/packages/openclaw-plugin/tests/tools.test.ts
+++ b/packages/openclaw-plugin/tests/tools.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for src/tools.ts — memory_search, memory_get, memory_write with mock runner.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the runner module
+vi.mock("../src/runner.js", () => ({
+  runJson: vi.fn(),
+  run: vi.fn(),
+  detectBinary: vi.fn().mockResolvedValue("palaia"),
+  recover: vi.fn().mockResolvedValue({ replayed: 0, errors: 0 }),
+  resetCache: vi.fn(),
+}));
+
+import { registerTools } from "../src/tools.js";
+import { runJson } from "../src/runner.js";
+import { DEFAULT_CONFIG } from "../src/config.js";
+
+const mockRunJson = vi.mocked(runJson);
+
+/**
+ * Fake plugin API that captures registered tools.
+ */
+function createMockApi() {
+  const tools: Record<string, { def: any; opts?: any }> = {};
+  return {
+    tools,
+    registerTool(def: any, opts?: any) {
+      tools[def.name] = { def, opts };
+    },
+  };
+}
+
+describe("tools", () => {
+  let api: ReturnType<typeof createMockApi>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api = createMockApi();
+    registerTools(api, DEFAULT_CONFIG);
+  });
+
+  it("registers memory_search, memory_get, memory_write", () => {
+    expect(api.tools["memory_search"]).toBeDefined();
+    expect(api.tools["memory_get"]).toBeDefined();
+    expect(api.tools["memory_write"]).toBeDefined();
+  });
+
+  it("memory_write is optional", () => {
+    expect(api.tools["memory_write"].opts).toEqual({ optional: true });
+  });
+
+  it("memory_search and memory_get are required (no optional flag)", () => {
+    expect(api.tools["memory_search"].opts).toBeUndefined();
+    expect(api.tools["memory_get"].opts).toBeUndefined();
+  });
+
+  describe("memory_search", () => {
+    it("returns formatted results", async () => {
+      mockRunJson.mockResolvedValueOnce({
+        results: [
+          {
+            id: "abc-123",
+            body: "Test memory content",
+            score: 0.92,
+            tier: "hot",
+            scope: "team",
+            title: "Test Entry",
+            path: "hot/abc-123.md",
+          },
+        ],
+      });
+
+      const execute = api.tools["memory_search"].def.execute;
+      const result = await execute("call-1", { query: "test" });
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe("text");
+      expect(result.content[0].text).toContain("Test memory content");
+      expect(result.content[0].text).toContain("Source: hot/abc-123.md");
+      expect(result.content[0].text).toContain("score: 0.92");
+
+      // Verify CLI args
+      expect(mockRunJson).toHaveBeenCalledWith(
+        ["query", "test", "--limit", "5"],
+        expect.any(Object)
+      );
+    });
+
+    it("respects maxResults param", async () => {
+      mockRunJson.mockResolvedValueOnce({ results: [] });
+
+      await api.tools["memory_search"].def.execute("call-2", {
+        query: "test",
+        maxResults: 20,
+      });
+
+      expect(mockRunJson).toHaveBeenCalledWith(
+        ["query", "test", "--limit", "20"],
+        expect.any(Object)
+      );
+    });
+
+    it("passes --all for tier=all", async () => {
+      mockRunJson.mockResolvedValueOnce({ results: [] });
+
+      await api.tools["memory_search"].def.execute("call-3", {
+        query: "test",
+        tier: "all",
+      });
+
+      expect(mockRunJson).toHaveBeenCalledWith(
+        expect.arrayContaining(["--all"]),
+        expect.any(Object)
+      );
+    });
+
+    it("returns 'No results found.' when empty", async () => {
+      mockRunJson.mockResolvedValueOnce({ results: [] });
+
+      const result = await api.tools["memory_search"].def.execute("call-4", {
+        query: "nothing",
+      });
+
+      expect(result.content[0].text).toBe("No results found.");
+    });
+  });
+
+  describe("memory_get", () => {
+    it("returns entry content", async () => {
+      mockRunJson.mockResolvedValueOnce({
+        id: "abc-123",
+        content: "Full entry content here",
+        meta: { scope: "team", tier: "hot" },
+      });
+
+      const result = await api.tools["memory_get"].def.execute("call-5", {
+        path: "abc-123",
+      });
+
+      expect(result.content[0].text).toBe("Full entry content here");
+      expect(mockRunJson).toHaveBeenCalledWith(
+        ["get", "abc-123"],
+        expect.any(Object)
+      );
+    });
+
+    it("passes --from and --lines", async () => {
+      mockRunJson.mockResolvedValueOnce({
+        id: "abc-123",
+        content: "Line 5\nLine 6",
+        meta: { scope: "team", tier: "hot" },
+      });
+
+      await api.tools["memory_get"].def.execute("call-6", {
+        path: "abc-123",
+        from: 5,
+        lines: 2,
+      });
+
+      expect(mockRunJson).toHaveBeenCalledWith(
+        ["get", "abc-123", "--from", "5", "--lines", "2"],
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe("memory_write", () => {
+    it("writes and returns confirmation", async () => {
+      mockRunJson.mockResolvedValueOnce({
+        id: "new-456",
+        tier: "hot",
+        scope: "team",
+        deduplicated: false,
+      });
+
+      const result = await api.tools["memory_write"].def.execute("call-7", {
+        content: "Important note",
+        scope: "team",
+        tags: ["project", "idea"],
+      });
+
+      expect(result.content[0].text).toContain("new-456");
+      expect(result.content[0].text).toContain("hot");
+      expect(mockRunJson).toHaveBeenCalledWith(
+        ["write", "Important note", "--scope", "team", "--tags", "project,idea"],
+        expect.any(Object)
+      );
+    });
+
+    it("works without optional params", async () => {
+      mockRunJson.mockResolvedValueOnce({
+        id: "new-789",
+        tier: "hot",
+        scope: "team",
+        deduplicated: false,
+      });
+
+      await api.tools["memory_write"].def.execute("call-8", {
+        content: "Simple note",
+      });
+
+      expect(mockRunJson).toHaveBeenCalledWith(
+        ["write", "Simple note"],
+        expect.any(Object)
+      );
+    });
+  });
+});

--- a/packages/openclaw-plugin/tsconfig.json
+++ b/packages/openclaw-plugin/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "resolveJsonModule": true
+  },
+  "include": ["index.ts", "src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/openclaw-plugin/vitest.config.ts
+++ b/packages/openclaw-plugin/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    globals: true,
+  },
+});

--- a/palaia/cli.py
+++ b/palaia/cli.py
@@ -15,10 +15,20 @@ from palaia.sync import export_entries, import_entries
 from palaia.migrate import migrate, format_result, detect_format
 
 
+def _json_out(data, args):
+    """Print JSON if --json flag is set, return True if printed."""
+    if getattr(args, "json", False):
+        print(json.dumps(data, ensure_ascii=False))
+        return True
+    return False
+
+
 def cmd_init(args):
     """Initialize .palaia directory."""
     target = Path(args.path or ".") / ".palaia"
     if target.exists():
+        if _json_out({"status": "exists", "path": str(target)}, args):
+            return 0
         print(f"Already initialized: {target}")
         return 0
 
@@ -26,6 +36,8 @@ def cmd_init(args):
     for sub in ("hot", "warm", "cold", "wal", "index"):
         (target / sub).mkdir()
     save_config(target, DEFAULT_CONFIG)
+    if _json_out({"status": "created", "path": str(target)}, args):
+        return 0
     print(f"Initialized Palaia at {target}")
     return 0
 
@@ -37,7 +49,7 @@ def cmd_write(args):
     
     # Recovery check
     recovered = store.recover()
-    if recovered:
+    if recovered and not getattr(args, "json", False):
         print(f"Recovered {recovered} pending entries from WAL.")
 
     entry_id = store.write(
@@ -47,6 +59,29 @@ def cmd_write(args):
         tags=args.tags.split(",") if args.tags else None,
         title=args.title,
     )
+
+    # Check if this was a dedup (existing entry returned)
+    entry = store.read(entry_id)
+    tier = "hot"
+    scope = args.scope or "team"
+    deduplicated = False
+    if entry:
+        meta, _ = entry
+        scope = meta.get("scope", scope)
+        # Check tier
+        for t in ("hot", "warm", "cold"):
+            if (root / t / f"{entry_id}.md").exists():
+                tier = t
+                break
+
+    if _json_out({
+        "id": entry_id,
+        "tier": tier,
+        "scope": scope,
+        "deduplicated": deduplicated,
+    }, args):
+        return 0
+
     print(f"Written: {entry_id}")
     return 0
 
@@ -63,6 +98,9 @@ def cmd_query(args):
         top_k=args.limit,
         include_cold=args.all,
     )
+
+    if _json_out({"results": results}, args):
+        return 0
 
     if not results:
         print("No results found.")
@@ -82,6 +120,80 @@ def cmd_query(args):
     return 0
 
 
+def cmd_get(args):
+    """Read a specific memory entry by ID or path."""
+    root = get_root()
+    store = Store(root)
+    store.recover()
+
+    # Accept UUID or path like hot/uuid.md
+    entry_id = args.path
+    if "/" in entry_id:
+        # Extract ID from path
+        entry_id = entry_id.split("/")[-1].replace(".md", "")
+
+    entry = store.read(entry_id)
+    if entry is None:
+        if _json_out({"error": "not_found", "id": entry_id}, args):
+            return 1
+        print(f"Entry not found: {entry_id}", file=sys.stderr)
+        return 1
+
+    meta, body = entry
+
+    # Determine tier
+    tier = "unknown"
+    for t in ("hot", "warm", "cold"):
+        if (root / t / f"{entry_id}.md").exists():
+            tier = t
+            break
+
+    # Handle --from / --lines slicing
+    lines = body.split("\n")
+    from_line = getattr(args, "from_line", None)
+    num_lines = getattr(args, "lines", None)
+    if from_line is not None:
+        lines = lines[max(0, from_line - 1):]
+    if num_lines is not None:
+        lines = lines[:num_lines]
+    sliced_body = "\n".join(lines)
+
+    if _json_out({
+        "id": entry_id,
+        "content": sliced_body,
+        "meta": {
+            "scope": meta.get("scope", "team"),
+            "tier": tier,
+            "title": meta.get("title", ""),
+            "tags": meta.get("tags", []),
+            "agent": meta.get("agent", ""),
+            "created": meta.get("created", ""),
+            "accessed": meta.get("accessed", ""),
+            "decay_score": meta.get("decay_score", 0),
+        },
+    }, args):
+        return 0
+
+    print(sliced_body)
+    return 0
+
+
+def cmd_recover(args):
+    """Run WAL recovery."""
+    root = get_root()
+    store = Store(root)
+    recovered = store.recover()
+
+    if _json_out({"replayed": recovered, "errors": 0}, args):
+        return 0
+
+    if recovered:
+        print(f"Recovered {recovered} pending entries from WAL.")
+    else:
+        print("No pending WAL entries.")
+    return 0
+
+
 def cmd_list(args):
     """List memories in a tier."""
     root = get_root()
@@ -90,6 +202,21 @@ def cmd_list(args):
 
     tier = args.tier or "hot"
     entries = store.list_entries(tier)
+
+    if _json_out({
+        "tier": tier,
+        "entries": [
+            {
+                "id": meta.get("id", "?"),
+                "title": meta.get("title", "(untitled)"),
+                "scope": meta.get("scope", "team"),
+                "decay_score": meta.get("decay_score", 0),
+                "preview": body[:80].replace("\n", " "),
+            }
+            for meta, body in entries
+        ],
+    }, args):
+        return 0
 
     if not entries:
         print(f"No entries in {tier}.")
@@ -115,6 +242,10 @@ def cmd_status(args):
     recovered = store.recover()
     
     info = store.status()
+
+    if _json_out(info, args):
+        return 0
+
     print(f"Palaia v{__version__}")
     print(f"Root: {info['palaia_root']}")
     print(f"\nEntries:")
@@ -141,6 +272,10 @@ def cmd_gc(args):
     store.recover()
 
     result = store.gc()
+
+    if _json_out(result, args):
+        return 0
+
     total_moves = sum(v for k, v in result.items() if k != "wal_cleaned")
     print(f"GC complete.")
     if total_moves:
@@ -161,6 +296,10 @@ def cmd_export(args):
         branch=args.branch,
         output_dir=args.output,
     )
+
+    if _json_out(result, args):
+        return 0
+
     if result.get("exported", 0) == 0:
         print(result.get("message", "Nothing exported."))
         return 0
@@ -179,6 +318,10 @@ def cmd_import(args):
         source=args.source,
         dry_run=args.dry_run,
     )
+
+    if _json_out(result, args):
+        return 0
+
     if args.dry_run:
         count = result.get("would_import", 0)
         print(f"Dry run: {count} entries would be imported.")
@@ -208,6 +351,10 @@ def cmd_migrate(args):
         scope_override=args.scope,
         dry_run=args.dry_run,
     )
+
+    if _json_out(result, args):
+        return 0
+
     print(format_result(result))
     return 0
 
@@ -218,12 +365,14 @@ def main():
         description="Palaia — Local, cloud-free memory for OpenClaw agents.",
     )
     parser.add_argument("--version", action="version", version=f"palaia {__version__}")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
 
     sub = parser.add_subparsers(dest="command")
 
     # init
     p_init = sub.add_parser("init", help="Initialize .palaia directory")
     p_init.add_argument("--path", default=None, help="Target directory")
+    p_init.add_argument("--json", action="store_true", help="Output as JSON")
 
     # write
     p_write = sub.add_parser("write", help="Write a memory entry")
@@ -232,33 +381,52 @@ def main():
     p_write.add_argument("--agent", default=None, help="Agent name")
     p_write.add_argument("--tags", default=None, help="Comma-separated tags")
     p_write.add_argument("--title", default=None, help="Entry title")
+    p_write.add_argument("--json", action="store_true", help="Output as JSON")
 
     # query
     p_query = sub.add_parser("query", help="Search memories")
     p_query.add_argument("query", help="Search query")
     p_query.add_argument("--limit", type=int, default=10, help="Max results")
     p_query.add_argument("--all", action="store_true", help="Include COLD tier")
+    p_query.add_argument("--json", action="store_true", help="Output as JSON")
+
+    # get
+    p_get = sub.add_parser("get", help="Read a specific memory entry")
+    p_get.add_argument("path", help="Entry UUID or path (e.g. hot/uuid.md)")
+    p_get.add_argument("--from", type=int, default=None, dest="from_line",
+                       help="Start from line number (1-indexed)")
+    p_get.add_argument("--lines", type=int, default=None, help="Number of lines to return")
+    p_get.add_argument("--json", action="store_true", help="Output as JSON")
+
+    # recover
+    p_recover = sub.add_parser("recover", help="Run WAL recovery")
+    p_recover.add_argument("--json", action="store_true", help="Output as JSON")
 
     # list
     p_list = sub.add_parser("list", help="List entries in a tier")
     p_list.add_argument("--tier", default="hot", choices=["hot", "warm", "cold"])
+    p_list.add_argument("--json", action="store_true", help="Output as JSON")
 
     # status
-    sub.add_parser("status", help="Show system status")
+    p_status = sub.add_parser("status", help="Show system status")
+    p_status.add_argument("--json", action="store_true", help="Output as JSON")
 
     # gc
-    sub.add_parser("gc", help="Run garbage collection / tier rotation")
+    p_gc = sub.add_parser("gc", help="Run garbage collection / tier rotation")
+    p_gc.add_argument("--json", action="store_true", help="Output as JSON")
 
     # export
     p_export = sub.add_parser("export", help="Export public entries")
     p_export.add_argument("--remote", default=None, help="Git remote URL")
     p_export.add_argument("--branch", default=None, help="Branch name")
     p_export.add_argument("--output", default=None, help="Output directory")
+    p_export.add_argument("--json", action="store_true", help="Output as JSON")
 
     # import
     p_import = sub.add_parser("import", help="Import entries from export")
     p_import.add_argument("source", help="Path or git URL to import from")
     p_import.add_argument("--dry-run", action="store_true", help="Preview without writing")
+    p_import.add_argument("--json", action="store_true", help="Output as JSON")
 
     # migrate
     p_migrate = sub.add_parser("migrate", help="Import from external memory formats")
@@ -268,6 +436,7 @@ def main():
                            choices=["smart-memory", "flat-file", "json-memory", "generic-md"],
                            help="Force source format")
     p_migrate.add_argument("--scope", default=None, help="Override scope for all entries")
+    p_migrate.add_argument("--json", action="store_true", help="Output as JSON")
 
     args = parser.parse_args()
     if not args.command:
@@ -278,6 +447,8 @@ def main():
         "init": cmd_init,
         "write": cmd_write,
         "query": cmd_query,
+        "get": cmd_get,
+        "recover": cmd_recover,
         "list": cmd_list,
         "status": cmd_status,
         "gc": cmd_gc,
@@ -288,10 +459,16 @@ def main():
     try:
         return commands[args.command](args)
     except FileNotFoundError as e:
-        print(f"Error: {e}", file=sys.stderr)
+        if getattr(args, "json", False):
+            print(json.dumps({"error": str(e)}))
+        else:
+            print(f"Error: {e}", file=sys.stderr)
         return 1
     except Exception as e:
-        print(f"Error: {e}", file=sys.stderr)
+        if getattr(args, "json", False):
+            print(json.dumps({"error": str(e)}))
+        else:
+            print(f"Error: {e}", file=sys.stderr)
         return 1
 
 


### PR DESCRIPTION
## @palaia/openclaw Plugin

Palaia as native OpenClaw memory backend. Drop-in replacement for `memory-core`.

### What's included

**Plugin (`packages/openclaw-plugin/`):**
- `memory_search` — semantic search via `palaia query --json`
- `memory_get` — read entries via `palaia get --json`  
- `memory_write` — optional write tool (opt-in via allowlist)
- `before_prompt_build` hook for HOT memory injection (opt-in)
- WAL recovery service on startup
- Auto-detect palaia binary (PATH, pipx, python3 -m)
- Tests for runner and tools with mocked subprocess

**CLI enhancements (`palaia/cli.py`):**
- `--json` flag on all commands for machine-readable output
- New `get` command (read specific entry by ID/path with line slicing)
- New `recover` command (explicit WAL recovery)

### Activation

```json5
plugins: { slots: { memory: "palaia" } }
```

### Zero Breaking Changes
Existing agents continue to work. The plugin provides the same `memory_search`/`memory_get` interface as `memory-core`.