### PR TITLE
feat: Multi-provider embeddings, detect command, audit fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,126 +1,132 @@
-# Palaia 🧠
+# 🧠 Palaia
 
 [![CI](https://github.com/iret77/palaia/actions/workflows/ci.yml/badge.svg)](https://github.com/iret77/palaia/actions/workflows/ci.yml)
-[![PyPI](https://img.shields.io/pypi/v/palaia)](https://pypi.org/project/palaia/)
-[![Python](https://img.shields.io/pypi/pyversions/palaia)](https://pypi.org/project/palaia/)
+[![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> *From Greek: "the old, the enduring"*
+**Memory for AI agents that actually sticks.**
 
-**Local, cloud-free memory for OpenClaw agents.**  
-No API key. No cloud. No lock-in.
+Palaia gives your agent a persistent, local notebook. Write something today, find it next week. No cloud, no API keys, no setup beyond `pip install`.
 
----
+## Why Palaia?
 
-## What is Palaia?
+AI agents forget everything between sessions. Palaia fixes that:
 
-Palaia is a persistent memory system for AI agents built on OpenClaw.  
-It solves the fundamental problem of agents losing context between sessions — without sending your data anywhere.
+- **Write once, remember forever** — Notes survive restarts, crashes, and updates
+- **Find by meaning, not just keywords** — Semantic search understands what you meant (optional, works with ollama, sentence-transformers, or OpenAI)
+- **Smart organization** — Palaia remembers what's important right now and quietly moves old, unused notes to the archive so they don't slow things down. They're still there when you need them.
+- **Crash-safe** — Every write goes through a write-ahead log. If your machine dies mid-write, nothing is lost.
+- **Private by default** — Everything stays on your machine. You choose what to share.
 
-### Core Principles
-
-- **Local first** — runs fully offline
-- **Zero hard dependencies** — Python stdlib is enough for the base layer
-- **Crash-safe** — Write-Ahead Log (WAL) before every write
-- **Multi-agent** — Scope tags control what each agent can see
-- **No context bloat** — Query-on-demand, not everything-in-prompt
-
----
-
-## Features
-
-### MVP
-- ✅ WAL protocol — crash recovery built-in
-- ✅ HOT/WARM/COLD tiering — automatic memory temperature management
-- ✅ Auto-deduplication — hash-based, no duplicate entries
-- ✅ Memory decay scoring — older, unused memories fade automatically
-- ✅ BM25 search — fast keyword search, zero install
-
-### Extended
-- 🔧 Scope tags — `private` / `team` / `shared:project` / `public`
-- 🔧 Tiered semantic search — ollama → API → BM25 fallback
-- 🔧 Git-based cross-team sync — share only what you choose
-
----
-
-## Semantic Search (Tiered)
-
-Palaia automatically uses the best available search:
-
-| Tier | Requires | Quality |
-|------|----------|---------|
-| BM25/TF-IDF | Nothing (default) | Good |
-| Local embeddings | `ollama` + `nomic-embed-text` | Great |
-| API embeddings | OpenAI / Voyage AI key | Best |
-
-No configuration needed — Palaia detects what's available.
-
----
-
-## Cross-Team Knowledge Transfer via Git
-
-Share knowledge between agent teams without a central server:
-
-```bash
-# Publish your public memories
-palaia export --remote git@github.com:org/knowledge-base.git
-
-# Import from another team
-palaia import git@github.com:org/knowledge-base.git
-```
-
-Only memories tagged `scope: public` are ever exported.  
-`scope: team` memories never leave your workspace.
-
----
-
-## Scope Tags
-
-Every memory entry carries a scope:
-
-```yaml
----
-scope: private      # only the writing agent
-scope: team         # all agents in this workspace
-scope: shared:proj  # agents with access to project "proj"
-scope: public       # exportable via git
----
-```
-
-**Sharing is always explicit — never implicit.**
-
----
-
-## Architecture
-
-```
-.palaia/
-  hot/        active memories (< 7 days or high score)
-  warm/       occasional access (7–30 days)
-  cold/       archive (> 30 days, still searchable)
-  wal/        write-ahead log (crash recovery)
-  index/      search index (BM25 + optional embeddings)
-```
-
----
-
-## Installation
+## Quick Start
 
 ```bash
 pip install palaia
+palaia init
+palaia write "The deploy server is at 10.0.1.5" --tags "infra,servers"
+palaia query "where is the server"
 ```
 
-## Status
+## How It Works
 
-**v0.1.0** — Core features complete. See [CHANGELOG](CHANGELOG.md) for details.  
-Architecture Decision Records: [`docs/adr/`](docs/adr/)
+Palaia organizes memories into three tiers, like a desk:
 
----
+- 🔥 **Hot** — Things you use all the time. Right in front of you.
+- 🌤 **Warm** — Things you used recently. In the drawer.
+- ❄️ **Cold** — Old stuff. In the filing cabinet. Still searchable.
+
+Memories automatically move between tiers based on how often you access them. No manual cleanup needed — just run `palaia gc` occasionally (or let your agent do it).
+
+## Search Options
+
+**Keyword search** works out of the box — zero setup, zero dependencies.
+
+For smarter search that understands meaning (finding "due date" when you stored "deadline"):
+
+```bash
+# See what's available on your machine
+palaia detect
+
+# Option A: Local AI server (recommended)
+ollama pull nomic-embed-text
+palaia config set embedding_provider ollama
+
+# Option B: Pure Python (no server needed)
+pip install "palaia[sentence-transformers]"
+palaia config set embedding_provider sentence-transformers
+
+# Option C: Cloud (needs API key)
+export OPENAI_API_KEY="sk-..."
+palaia config set embedding_provider openai
+```
+
+When semantic search is active, Palaia combines keyword matching with meaning-based search for the best results.
+
+## Sharing Between Agents
+
+Control who sees what with scope tags:
+
+```bash
+palaia write "my secret" --scope private       # Only this agent
+palaia write "team info" --scope team           # All agents in workspace
+palaia write "public docs" --scope public       # Can be exported
+palaia export --remote git@github.com:team/shared-memory.git
+```
+
+## OpenClaw Integration
+
+Palaia is a drop-in replacement for OpenClaw's built-in memory:
+
+```bash
+npm install @palaia/openclaw
+```
+
+Add `"@palaia/openclaw"` to your plugins list and you're done.
+
+## CLI Reference
+
+| Command | Description |
+|---------|-------------|
+| `palaia init` | Set up a new memory store |
+| `palaia write "text"` | Save a memory |
+| `palaia query "search"` | Find memories |
+| `palaia get <id>` | Read a specific memory |
+| `palaia list` | List memories in a tier |
+| `palaia status` | Check system health |
+| `palaia gc` | Clean up and rotate tiers |
+| `palaia detect` | Show available embedding providers |
+| `palaia config set <k> <v>` | Change a setting |
+| `palaia export` | Export public memories |
+| `palaia import <path>` | Import shared memories |
+| `palaia migrate <path>` | Import from other memory formats |
+| `palaia recover` | Replay any interrupted writes |
+
+## Migrating from smart-memory
+
+```bash
+palaia migrate . --dry-run   # Preview first
+palaia migrate .             # Import everything
+```
+
+## Configuration
+
+Settings live in `.palaia/config.json`. Change them with `palaia config set`:
+
+```bash
+palaia config set embedding_provider sentence-transformers
+palaia config set hot_threshold_days 14
+palaia config list
+```
+
+## Development
+
+```bash
+git clone https://github.com/iret77/palaia.git
+cd palaia
+pip install -e ".[dev]"
+pytest
+```
 
 ## License
 
-MIT — free to use, modify, and build on.
-
----
-
-*Built for the [OpenClaw](https://github.com/openclaw/openclaw) ecosystem.*
+MIT — do what you want with it.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,112 +1,246 @@
-# Palaia — Agent Memory Skill
+---
+name: palaia
+description: >
+  Persistent memory for OpenClaw agents. Local, crash-safe, no API key needed.
+  Agents remember things across sessions. You control what's shared between agents.
+  Drop-in replacement for OpenClaw's built-in memory via @palaia/openclaw plugin.
+metadata:
+  openclaw:
+    emoji: 🧠
+    requires: { bins: ["python3"] }
+---
 
-> Local, cloud-free persistent memory for OpenClaw agents.
+# Palaia — Memory That Sticks
 
-## Quick Start
+## What Palaia Does (plain English)
+
+Palaia gives your agent a notebook that survives restarts. When your agent learns something — a preference, a project detail, a lesson — it writes it down. Next session, it's still there. Think of it as a filing cabinet: important stuff up front, old stuff in the back, nothing gets lost.
+
+## Quick Install
 
 ```bash
-# Initialize (once per workspace)
+pip install palaia
 palaia init
+palaia status
+```
 
+That's it. You now have a working memory system with keyword search. No API keys, no servers, no cloud.
+
+## Setting Up Semantic Search
+
+Keyword search works out of the box. But if you want your agent to find things by *meaning* (not just matching words), you'll want semantic search. Run this to see what's available on your machine:
+
+```bash
+palaia detect
+```
+
+This shows which embedding providers are installed, which are running, and what Palaia recommends.
+
+### The Options — What's Right for You?
+
+#### Option 1: No Setup (Keyword Search)
+
+This is what you get by default. Palaia uses BM25 — a smart keyword matching algorithm. It's fast, needs zero setup, and works well when your queries use similar words to what's stored.
+
+**When it's enough:** Most setups. If your agent writes "project deadline is Friday" and later asks "when is the deadline?", keyword search finds it.
+
+**What's missing:** It won't find "project due date" if you stored "project deadline". That's where semantic search helps.
+
+#### Option 2: ollama (Recommended for most)
+
+Ollama is a local AI server that runs on your machine. It understands meaning, not just words. Your data never leaves your computer.
+
+**Pros:** Private, fast after first load, no API costs, good quality  
+**Cons:** Uses ~1GB RAM while running, needs initial setup  
+
+```bash
+# Install ollama (if not already)
+curl -fsSL https://ollama.com/install.sh | sh
+
+# Pull the embedding model
+ollama pull nomic-embed-text
+
+# Tell Palaia to use it
+palaia config set embedding_provider ollama
+palaia status
+```
+
+**Choose this when:** You want smart search without sending data to the cloud.
+
+#### Option 3: sentence-transformers (Best quality, pure Python)
+
+A Python library that runs AI models directly. No separate server needed. Best quality embeddings for local use.
+
+**Pros:** Best local quality, no server to manage, works offline  
+**Cons:** Slower first load (~30s), uses more RAM (~500MB), needs pip install  
+
+```bash
+pip install "palaia[sentence-transformers]"
+palaia config set embedding_provider sentence-transformers
+palaia status
+```
+
+**Choose this when:** You want the best local search quality and don't mind the RAM usage.
+
+#### Option 4: fastembed (Lightweight option)
+
+A lighter alternative to sentence-transformers. Smaller models, faster startup, less RAM.
+
+**Pros:** Lightweight, fast startup, works offline  
+**Cons:** Slightly lower quality than sentence-transformers  
+
+```bash
+pip install "palaia[fastembed]"
+palaia config set embedding_provider fastembed
+palaia status
+```
+
+**Choose this when:** You're on a machine with limited RAM or want faster startup.
+
+#### Option 5: OpenAI or Voyage (Cloud-based)
+
+Use OpenAI's or Voyage's embedding APIs. Best quality, but requires an API key and sends data to the cloud.
+
+**Pros:** Highest quality, no local compute needed  
+**Cons:** Costs money (small amounts), data leaves your machine, needs internet  
+
+```bash
+export OPENAI_API_KEY="sk-..."
+palaia config set embedding_provider openai
+palaia status
+```
+
+**Choose this when:** You already use OpenAI and don't mind cloud processing.
+
+### Guided Setup Flow (Agent Instructions)
+
+When setting up Palaia for a user, follow these steps:
+
+1. **Run detection:** `palaia detect` — parse the output
+2. **Present results** to the user in plain language: "You have ollama running with nomic-embed-text available. I can set that up for semantic search, or keyword search works fine too."
+3. **Ask the user** which option they prefer. Don't assume.
+4. **Install + configure** based on their choice:
+   - If they chose a provider: install it, run `palaia config set embedding_provider <name>`
+   - If they're fine with keyword search: do nothing, it's the default
+5. **Confirm** with `palaia status` — show them the output
+
+## Connecting to OpenClaw (the important bit)
+
+Palaia integrates with OpenClaw through its plugin system:
+
+```bash
+# In your OpenClaw workspace
+npm install @palaia/openclaw
+```
+
+Then add to your OpenClaw config:
+```json
+{
+  "plugins": ["@palaia/openclaw"]
+}
+```
+
+The plugin automatically routes memory operations through Palaia instead of OpenClaw's built-in memory.
+
+## Core Commands
+
+```bash
 # Write a memory
-palaia write "The API endpoint changed to /v2/data" --scope team --tags "api,migration"
+palaia write "Christian prefers dark mode in all apps" --tags "preferences,ui"
 
 # Search memories
-palaia query "API endpoint"
+palaia query "what does Christian prefer"
 
-# List active memories
-palaia list
+# List what's in active memory
+palaia list --tier hot
 
-# System status
+# Check system status
 palaia status
 
-# Garbage collect (tier rotation)
+# Run garbage collection (moves old stuff to archive)
 palaia gc
+
+# Export public memories for sharing
+palaia export --output ./shared-memories
+
+# Import memories from another agent
+palaia import ./shared-memories
+
+# Detect available embedding providers
+palaia detect
+
+# Configure settings
+palaia config set embedding_provider ollama
+palaia config get embedding_provider
+palaia config list
 ```
 
-## Agent Usage Patterns
+## Migrating from smart-memory
 
-### Writing Memories
-
-Use `palaia write` after learning something worth remembering:
+If you're already using OpenClaw's smart-memory system, Palaia can import everything:
 
 ```bash
-# Simple write (default scope: team)
-palaia write "Christian prefers short responses, no sycophancy"
+# Preview what would be imported (safe, no changes)
+palaia migrate . --dry-run
 
-# With metadata
-palaia write "Clawsy uses WebSocket on port 3456" \
-  --scope shared:clawsy \
-  --agent cyberclaw \
-  --tags "clawsy,config" \
-  --title "Clawsy WebSocket Port"
+# Actually import
+palaia migrate .
 
-# Private memory (only this agent can read)
-palaia write "My SSH key is stored at ~/.ssh/id_ed25519" --scope private --agent elliot
+# Verify
+palaia status
+palaia list --tier hot
 ```
 
-### Querying Memories
+Palaia auto-detects the smart-memory format and maps layers to tiers:
+- Active context → HOT (frequently accessed)
+- Project files → WARM (referenced occasionally)
+- Daily logs → COLD (archived but searchable)
+
+## Sharing Memory Between Agents
+
+Palaia uses scope tags to control who sees what:
+
+- **`team`** (default) — All agents in the same workspace can read it
+- **`private`** — Only the agent that wrote it can read it
+- **`public`** — Can be exported and shared with other workspaces
+- **`shared:<project>`** — Only agents working on that project can read it
 
 ```bash
-# Basic search (searches HOT + WARM tiers)
-palaia query "websocket port"
+# Write a private note
+palaia write "My API key is stored in ~/.secrets" --scope private
 
-# Include archived (COLD) memories
-palaia query "old deployment config" --all
+# Write a team-visible note
+palaia write "The deploy server is at 10.0.1.5" --scope team
 
-# Limit results
-palaia query "API" --limit 5
+# Share across workspaces
+palaia write "Project uses Python 3.11" --scope public
+palaia export --remote git@github.com:team/shared-memory.git
 ```
 
-### Scope Rules
+## Configuration Reference
 
-| Scope | Visible to | Exportable |
-|-------|-----------|------------|
-| `private` | Only the writing agent | No |
-| `team` | All agents in workspace | No |
-| `shared:<name>` | Agents in that project | No |
-| `public` | All agents | Yes (via git) |
+Configuration lives in `.palaia/config.json`:
 
-**Default scope is `team`** — visible to all agents, not exported.
-
-### Memory Lifecycle
-
-Memories automatically move between tiers based on access patterns:
-
-- **🔥 HOT** — Active, recently accessed (< 7 days or high score)
-- **🌤 WARM** — Occasionally used (7-30 days)
-- **❄️ COLD** — Archived (> 30 days, still searchable with `--all`)
-
-Run `palaia gc` periodically to trigger tier rotation.
-
-## When to Use Palaia
-
-**Write when:**
-- Learning a new fact about the user or project
-- Discovering a configuration detail
-- Making an important decision (with rationale)
-- Completing a task (for audit trail)
-
-**Query when:**
-- Starting a new session (recall context)
-- Before making decisions (check past learnings)
-- When a topic comes up that might have history
-
-## Installation
-
-```bash
-cd /path/to/palaia
-pip install -e .
+```json
+{
+  "version": 1,
+  "decay_lambda": 0.1,
+  "hot_threshold_days": 7,
+  "warm_threshold_days": 30,
+  "hot_max_entries": 50,
+  "default_scope": "team",
+  "embedding_provider": "auto",
+  "embedding_model": ""
+}
 ```
 
-Requires Python 3.10+. No external dependencies for core functionality.
+| Key | Default | Description |
+|-----|---------|-------------|
+| `embedding_provider` | `auto` | `auto`, `ollama`, `sentence-transformers`, `fastembed`, `openai`, `none` |
+| `embedding_model` | `""` | Override the default model for your provider (empty = provider's default) |
+| `decay_lambda` | `0.1` | How fast memories fade (higher = faster decay) |
+| `hot_threshold_days` | `7` | Days before a memory moves from active to warm |
+| `warm_threshold_days` | `30` | Days before a memory moves from warm to archive |
+| `default_scope` | `team` | Default scope for new memories |
 
-## Search Tiers
-
-Palaia auto-detects the best available search:
-
-1. **BM25** (always) — keyword search, zero install
-2. **Ollama** (if available) — local embeddings via nomic-embed-text
-3. **API** (if key set) — OpenAI/Voyage embeddings
-
-No configuration needed — quality improves automatically.
+Use `palaia config set <key> <value>` to change any setting.

--- a/palaia/cli.py
+++ b/palaia/cli.py
@@ -8,7 +8,7 @@ import sys
 from pathlib import Path
 
 from palaia import __version__
-from palaia.config import DEFAULT_CONFIG, find_palaia_root, get_root, save_config
+from palaia.config import DEFAULT_CONFIG, find_palaia_root, get_root, load_config, save_config
 from palaia.store import Store
 from palaia.search import SearchEngine
 from palaia.sync import export_entries, import_entries
@@ -258,10 +258,170 @@ def cmd_status(args):
     if recovered:
         print(f"  Recovered: {recovered} entries")
 
-    from palaia.search import detect_search_tier
-    tier = detect_search_tier()
-    tier_names = {1: "BM25 (Python)", 2: "Ollama Embeddings", 3: "API Embeddings"}
-    print(f"\nSearch: {tier_names[tier]}")
+    # Embedding status
+    from palaia.embeddings import auto_detect_provider, get_provider_display_info, BM25Provider
+    provider = auto_detect_provider(store.config)
+    provider_display = get_provider_display_info(provider)
+    has_embed = not isinstance(provider, BM25Provider)
+
+    print(f"\nEmbedding: {provider_display} {'✓' if has_embed else '(fallback)'}")
+    print(f"  → BM25 keyword search: active")
+    if has_embed:
+        print(f"  → Semantic search: active ({provider.name})")
+    else:
+        print(f"  → Semantic search: not configured")
+
+    # Check API providers
+    from palaia.embeddings import _check_openai_key, _check_voyage_key
+    if _check_openai_key() or _check_voyage_key():
+        print(f"  → API search: configured")
+    else:
+        print(f"  → API search: not configured")
+
+    return 0
+
+
+def cmd_detect(args):
+    """Detect available embedding providers."""
+    import platform
+    from palaia.embeddings import detect_providers
+
+    sys_info = f"{platform.system()} {platform.machine()}"
+    py_ver = platform.python_version()
+
+    providers = detect_providers()
+
+    if _json_out({
+        "system": sys_info,
+        "python": py_ver,
+        "providers": providers,
+    }, args):
+        return 0
+
+    print("Palaia Environment Detection")
+    print("=" * 29)
+    print(f"System: {sys_info}")
+    print(f"Python: {py_ver}")
+    print()
+    print("Embedding providers found:")
+
+    available = []
+    for p in providers:
+        name = p["name"]
+        if name == "ollama":
+            if p["server_running"]:
+                has_nomic = p.get("has_nomic", False)
+                model_status = f"nomic-embed-text: {'available ✓' if has_nomic else 'not pulled (ollama pull nomic-embed-text)'}"
+                mark = "✓" if p["available"] else "△"
+                print(f"  {mark} ollama        — server running at localhost:11434")
+                print(f"                    {model_status}")
+                if p["available"]:
+                    available.append("ollama")
+            else:
+                print(f"  ✗ ollama        — server not running ({p.get('install_hint', 'start with: ollama serve')})")
+        elif name == "sentence-transformers":
+            if p["available"]:
+                print(f"  ✓ sentence-transformers {p['version']} — installed")
+                available.append("sentence-transformers")
+            else:
+                print(f"  ✗ sentence-transformers — not installed ({p['install_hint']})")
+        elif name == "fastembed":
+            if p["available"]:
+                print(f"  ✓ fastembed {p['version']} — installed")
+                available.append("fastembed")
+            else:
+                print(f"  ✗ fastembed     — not installed ({p['install_hint']})")
+        elif name == "openai":
+            if p["available"]:
+                print(f"  ✓ OpenAI API    — key found")
+                available.append("openai")
+            else:
+                print(f"  ✗ OpenAI API    — no key found")
+        elif name == "voyage":
+            if p["available"]:
+                print(f"  ✓ Voyage API    — key found")
+                available.append("voyage")
+            else:
+                print(f"  ✗ Voyage API    — no key found")
+
+    print()
+    print("BM25 keyword search: always available ✓")
+
+    if available:
+        rec = available[0]
+        rec_desc = {
+            "ollama": "ollama (server running, nomic-embed-text available)",
+            "sentence-transformers": "sentence-transformers (installed, best local quality)",
+            "fastembed": "fastembed (installed, lightweight)",
+            "openai": "OpenAI API (cloud-based)",
+        }
+        print(f"\nRecommendation: {rec_desc.get(rec, rec)}")
+        if len(available) > 1:
+            alt = available[1]
+            print(f"Alternatively:  {rec_desc.get(alt, alt)}")
+    else:
+        print("\nNo embedding providers found. Using keyword search (BM25).")
+        print("Install one for semantic search: pip install 'palaia[sentence-transformers]'")
+
+    # Show current config
+    try:
+        root = get_root()
+        config = load_config(root)
+        provider_cfg = config.get("embedding_provider", "auto")
+        print(f"\nCurrent config: embedding_provider = {provider_cfg}")
+    except FileNotFoundError:
+        print(f"\nCurrent config: not initialized (run 'palaia init' first)")
+
+    return 0
+
+
+def cmd_config(args):
+    """Get or set configuration values."""
+    if args.action == "get":
+        root = get_root()
+        config = load_config(root)
+        key = args.key
+        if key in config:
+            if _json_out({"key": key, "value": config[key]}, args):
+                return 0
+            print(f"{key} = {config[key]}")
+        else:
+            if _json_out({"error": f"Unknown key: {key}"}, args):
+                return 1
+            print(f"Unknown config key: {key}", file=sys.stderr)
+            return 1
+    elif args.action == "set":
+        root = get_root()
+        config = load_config(root)
+        key = args.key
+        value = args.value
+
+        # Type coercion based on default config
+        if key in DEFAULT_CONFIG:
+            default_val = DEFAULT_CONFIG[key]
+            if isinstance(default_val, int):
+                try:
+                    value = int(value)
+                except ValueError:
+                    pass
+            elif isinstance(default_val, float):
+                try:
+                    value = float(value)
+                except ValueError:
+                    pass
+
+        config[key] = value
+        save_config(root, config)
+        if _json_out({"key": key, "value": value}, args):
+            return 0
+        print(f"{key} = {value}")
+    elif args.action == "list":
+        root = get_root()
+        config = load_config(root)
+        if _json_out(config, args):
+            return 0
+        for k, v in sorted(config.items()):
+            print(f"{k} = {v}")
     return 0
 
 
@@ -428,6 +588,23 @@ def main():
     p_import.add_argument("--dry-run", action="store_true", help="Preview without writing")
     p_import.add_argument("--json", action="store_true", help="Output as JSON")
 
+    # detect
+    p_detect = sub.add_parser("detect", help="Detect available embedding providers")
+    p_detect.add_argument("--json", action="store_true", help="Output as JSON")
+
+    # config
+    p_config = sub.add_parser("config", help="Get or set configuration")
+    config_sub = p_config.add_subparsers(dest="action")
+    p_config_get = config_sub.add_parser("get", help="Get a config value")
+    p_config_get.add_argument("key", help="Config key")
+    p_config_get.add_argument("--json", action="store_true", help="Output as JSON")
+    p_config_set = config_sub.add_parser("set", help="Set a config value")
+    p_config_set.add_argument("key", help="Config key")
+    p_config_set.add_argument("value", help="Config value")
+    p_config_set.add_argument("--json", action="store_true", help="Output as JSON")
+    p_config_list = config_sub.add_parser("list", help="List all config values")
+    p_config_list.add_argument("--json", action="store_true", help="Output as JSON")
+
     # migrate
     p_migrate = sub.add_parser("migrate", help="Import from external memory formats")
     p_migrate.add_argument("source", help="Source path (directory or file)")
@@ -455,6 +632,8 @@ def main():
         "export": cmd_export,
         "import": cmd_import,
         "migrate": cmd_migrate,
+        "detect": cmd_detect,
+        "config": cmd_config,
     }
     try:
         return commands[args.command](args)

--- a/palaia/config.py
+++ b/palaia/config.py
@@ -17,6 +17,8 @@ DEFAULT_CONFIG = {
     "default_scope": "team",
     "wal_retention_days": 7,
     "lock_timeout_seconds": 5,
+    "embedding_provider": "auto",
+    "embedding_model": "",
 }
 
 

--- a/palaia/embeddings.py
+++ b/palaia/embeddings.py
@@ -1,0 +1,447 @@
+"""Multi-provider embedding support for semantic search.
+
+Providers are detected automatically in this order:
+1. ollama (local server with nomic-embed-text)
+2. sentence-transformers (pure Python)
+3. fastembed (lightweight)
+4. OpenAI API (cloud, needs key)
+5. BM25 (always available, keyword-based fallback)
+"""
+
+from __future__ import annotations
+
+import importlib.metadata as _importlib_metadata
+import importlib.util
+import math
+import os
+import re
+import warnings
+from collections import Counter
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class EmbeddingProvider(Protocol):
+    """Protocol for embedding providers."""
+
+    name: str
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        """Embed a batch of texts. Returns list of vectors."""
+        ...
+
+    def embed_query(self, text: str) -> list[float]:
+        """Embed a single query text. Returns a vector."""
+        ...
+
+
+class OllamaProvider:
+    """Embedding via local ollama server."""
+
+    name = "ollama"
+    default_model = "nomic-embed-text"
+
+    def __init__(self, model: str | None = None, base_url: str = "http://localhost:11434"):
+        self.model = model or self.default_model
+        self.base_url = base_url
+        self._client = None
+
+    def _get_client(self):
+        if self._client is None:
+            try:
+                import ollama as ollama_lib
+                self._client = ollama_lib.Client(host=self.base_url)
+            except ImportError:
+                # Fall back to raw HTTP
+                self._client = "http"
+        return self._client
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        client = self._get_client()
+        if client == "http":
+            return [self._embed_http(t) for t in texts]
+        results = []
+        for text in texts:
+            resp = client.embed(model=self.model, input=text)
+            # ollama returns {"embeddings": [[...]]}
+            if isinstance(resp, dict) and "embeddings" in resp:
+                results.append(resp["embeddings"][0])
+            else:
+                results.append(resp.embeddings[0] if hasattr(resp, 'embeddings') else [])
+        return results
+
+    def embed_query(self, text: str) -> list[float]:
+        return self.embed([text])[0]
+
+    def _embed_http(self, text: str) -> list[float]:
+        import json
+        import urllib.request
+        data = json.dumps({"model": self.model, "input": text}).encode()
+        req = urllib.request.Request(
+            f"{self.base_url}/api/embed",
+            data=data,
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            result = json.loads(resp.read())
+        return result.get("embeddings", [[]])[0]
+
+
+class SentenceTransformersProvider:
+    """Embedding via sentence-transformers library."""
+
+    name = "sentence-transformers"
+    default_model = "all-MiniLM-L6-v2"
+
+    def __init__(self, model: str | None = None):
+        self.model_name = model or self.default_model
+        self._model = None
+
+    def _get_model(self):
+        if self._model is None:
+            from sentence_transformers import SentenceTransformer
+            self._model = SentenceTransformer(self.model_name)
+        return self._model
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        model = self._get_model()
+        embeddings = model.encode(texts, convert_to_numpy=True)
+        return [e.tolist() for e in embeddings]
+
+    def embed_query(self, text: str) -> list[float]:
+        return self.embed([text])[0]
+
+
+class FastEmbedProvider:
+    """Embedding via fastembed library."""
+
+    name = "fastembed"
+    default_model = "BAAI/bge-small-en-v1.5"
+
+    def __init__(self, model: str | None = None):
+        self.model_name = model or self.default_model
+        self._model = None
+
+    def _get_model(self):
+        if self._model is None:
+            from fastembed import TextEmbedding
+            self._model = TextEmbedding(model_name=self.model_name)
+        return self._model
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        model = self._get_model()
+        embeddings = list(model.embed(texts))
+        return [e.tolist() if hasattr(e, 'tolist') else list(e) for e in embeddings]
+
+    def embed_query(self, text: str) -> list[float]:
+        return self.embed([text])[0]
+
+
+class OpenAIProvider:
+    """Embedding via OpenAI API."""
+
+    name = "openai"
+    default_model = "text-embedding-3-small"
+
+    def __init__(self, model: str | None = None, api_key: str | None = None):
+        self.model_name = model or self.default_model
+        self.api_key = api_key or os.environ.get("OPENAI_API_KEY", "")
+        self._client = None
+
+    def _get_client(self):
+        if self._client is None:
+            try:
+                from openai import OpenAI
+                self._client = OpenAI(api_key=self.api_key)
+            except ImportError:
+                self._client = "http"
+        return self._client
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        client = self._get_client()
+        if client == "http":
+            return self._embed_http(texts)
+        resp = client.embeddings.create(model=self.model_name, input=texts)
+        return [d.embedding for d in resp.data]
+
+    def embed_query(self, text: str) -> list[float]:
+        return self.embed([text])[0]
+
+    def _embed_http(self, texts: list[str]) -> list[list[float]]:
+        import json
+        import urllib.request
+        data = json.dumps({"model": self.model_name, "input": texts}).encode()
+        req = urllib.request.Request(
+            "https://api.openai.com/v1/embeddings",
+            data=data,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.api_key}",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            result = json.loads(resp.read())
+        return [d["embedding"] for d in result["data"]]
+
+
+class BM25Provider:
+    """Keyword-based search provider. Always available, no vectors."""
+
+    name = "bm25"
+
+    def __init__(self, k1: float = 1.5, b: float = 0.75):
+        self.k1 = k1
+        self.b = b
+        self.corpus: list[tuple[str, list[str]]] = []
+        self.doc_freqs: Counter = Counter()
+        self.doc_lens: list[int] = []
+        self.avg_dl: float = 0.0
+        self.n_docs: int = 0
+
+    def index(self, documents: list[tuple[str, str]]) -> None:
+        """Index a list of (doc_id, text) tuples."""
+        self.corpus = []
+        self.doc_freqs = Counter()
+        self.doc_lens = []
+
+        for doc_id, text in documents:
+            tokens = _tokenize(text)
+            self.corpus.append((doc_id, tokens))
+            self.doc_lens.append(len(tokens))
+            seen = set(tokens)
+            for t in seen:
+                self.doc_freqs[t] += 1
+
+        self.n_docs = len(self.corpus)
+        self.avg_dl = sum(self.doc_lens) / self.n_docs if self.n_docs else 1.0
+
+    def search(self, query: str, top_k: int = 10) -> list[tuple[str, float]]:
+        """Search the index. Returns list of (doc_id, score) sorted desc."""
+        query_tokens = _tokenize(query)
+        if not query_tokens or not self.corpus:
+            return []
+
+        scores = []
+        for idx, (doc_id, doc_tokens) in enumerate(self.corpus):
+            score = 0.0
+            dl = self.doc_lens[idx]
+            tf_map = Counter(doc_tokens)
+
+            for qt in query_tokens:
+                if qt not in tf_map:
+                    continue
+                tf = tf_map[qt]
+                df = self.doc_freqs.get(qt, 0)
+                idf = math.log((self.n_docs - df + 0.5) / (df + 0.5) + 1.0)
+                tf_norm = (tf * (self.k1 + 1)) / (
+                    tf + self.k1 * (1 - self.b + self.b * dl / self.avg_dl)
+                )
+                score += idf * tf_norm
+
+            if score > 0:
+                scores.append((doc_id, score))
+
+        scores.sort(key=lambda x: x[1], reverse=True)
+        return scores[:top_k]
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        """Not applicable for BM25. Raises NotImplementedError."""
+        raise NotImplementedError("BM25 does not produce embedding vectors")
+
+    def embed_query(self, text: str) -> list[float]:
+        """Not applicable for BM25. Raises NotImplementedError."""
+        raise NotImplementedError("BM25 does not produce embedding vectors")
+
+
+def _tokenize(text: str) -> list[str]:
+    """Simple whitespace + punctuation tokenizer."""
+    text = text.lower()
+    return re.findall(r"\b\w+\b", text)
+
+
+def cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Compute cosine similarity between two vectors."""
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(x * x for x in b))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def _check_ollama_available(base_url: str = "http://localhost:11434") -> tuple[bool, str | None, list[str]]:
+    """Check if ollama server is running and which models are available.
+    
+    Returns: (server_running, version_or_none, list_of_models)
+    """
+    import json
+    import urllib.request
+    try:
+        req = urllib.request.Request(f"{base_url}/api/tags", method="GET")
+        with urllib.request.urlopen(req, timeout=3) as resp:
+            data = json.loads(resp.read())
+        models = [m.get("name", "").split(":")[0] for m in data.get("models", [])]
+        return True, None, models
+    except Exception:
+        return False, None, []
+
+
+def _check_openai_key() -> str | None:
+    """Check for OpenAI API key in env or openclaw auth."""
+    key = os.environ.get("OPENAI_API_KEY")
+    if key:
+        return key
+    # Check openclaw auth profiles
+    auth_dir = os.path.expanduser("~/.openclaw")
+    for candidate in ["auth.json", "config.json"]:
+        path = os.path.join(auth_dir, candidate)
+        if os.path.exists(path):
+            try:
+                import json
+                with open(path) as f:
+                    data = json.load(f)
+                # Look for openai key in various formats
+                if isinstance(data, dict):
+                    if "openai_api_key" in data:
+                        return data["openai_api_key"]
+                    for profile in data.values():
+                        if isinstance(profile, dict) and "openai_api_key" in profile:
+                            return profile["openai_api_key"]
+            except (OSError, ValueError):
+                pass
+    return None
+
+
+def _check_voyage_key() -> str | None:
+    """Check for Voyage API key in env."""
+    return os.environ.get("VOYAGE_API_KEY")
+
+
+def detect_providers() -> list[dict]:
+    """Detect all available embedding providers.
+    
+    Returns list of dicts with keys: name, available, version, models, install_hint
+    """
+    providers = []
+
+    # 1. ollama
+    server_running, version, models = _check_ollama_available()
+    has_nomic = "nomic-embed-text" in models if models else False
+    providers.append({
+        "name": "ollama",
+        "available": server_running and has_nomic,
+        "server_running": server_running,
+        "models": models,
+        "has_nomic": has_nomic,
+        "version": version,
+        "install_hint": None if server_running else "curl -fsSL https://ollama.com/install.sh | sh && ollama pull nomic-embed-text",
+    })
+
+    # 2. sentence-transformers
+    st_spec = importlib.util.find_spec("sentence_transformers")
+    st_version = None
+    if st_spec:
+        try:
+            # already imported as _importlib_metadata
+            st_version = _importlib_metadata.version("sentence-transformers")
+        except Exception:
+            st_version = "installed"
+    providers.append({
+        "name": "sentence-transformers",
+        "available": st_spec is not None,
+        "version": st_version,
+        "install_hint": 'pip install "palaia[sentence-transformers]"' if not st_spec else None,
+    })
+
+    # 3. fastembed
+    fe_spec = importlib.util.find_spec("fastembed")
+    fe_version = None
+    if fe_spec:
+        try:
+            # already imported as _importlib_metadata
+            fe_version = _importlib_metadata.version("fastembed")
+        except Exception:
+            fe_version = "installed"
+    providers.append({
+        "name": "fastembed",
+        "available": fe_spec is not None,
+        "version": fe_version,
+        "install_hint": 'pip install "palaia[fastembed]"' if not fe_spec else None,
+    })
+
+    # 4. OpenAI
+    openai_key = _check_openai_key()
+    providers.append({
+        "name": "openai",
+        "available": openai_key is not None,
+        "version": None,
+        "install_hint": None if openai_key else "Set OPENAI_API_KEY environment variable",
+    })
+
+    # 5. Voyage
+    voyage_key = _check_voyage_key()
+    providers.append({
+        "name": "voyage",
+        "available": voyage_key is not None,
+        "version": None,
+        "install_hint": None if voyage_key else "Set VOYAGE_API_KEY environment variable",
+    })
+
+    return providers
+
+
+def auto_detect_provider(config: dict | None = None) -> EmbeddingProvider | BM25Provider:
+    """Auto-detect the best available embedding provider.
+    
+    Order: ollama → sentence-transformers → fastembed → openai → bm25
+    
+    Args:
+        config: Optional config dict with embedding_provider and embedding_model keys.
+    
+    Returns:
+        An embedding provider instance.
+    """
+    config = config or {}
+    provider_name = config.get("embedding_provider", "auto")
+    model = config.get("embedding_model", "") or None
+
+    if provider_name == "none":
+        return BM25Provider()
+
+    if provider_name != "auto":
+        # Explicit provider requested
+        return _create_provider(provider_name, model)
+
+    # Auto-detect
+    providers = detect_providers()
+    for p in providers:
+        if p["available"] and p["name"] != "voyage":  # voyage is not a provider we implement
+            return _create_provider(p["name"], model)
+
+    # Fallback
+    return BM25Provider()
+
+
+def _create_provider(name: str, model: str | None = None) -> EmbeddingProvider | BM25Provider:
+    """Create a provider by name."""
+    if name == "ollama":
+        return OllamaProvider(model=model)
+    elif name == "sentence-transformers":
+        return SentenceTransformersProvider(model=model)
+    elif name == "fastembed":
+        return FastEmbedProvider(model=model)
+    elif name == "openai":
+        return OpenAIProvider(model=model)
+    elif name == "bm25" or name == "none":
+        return BM25Provider()
+    else:
+        raise ValueError(f"Unknown embedding provider: {name}")
+
+
+def get_provider_display_info(provider: EmbeddingProvider | BM25Provider) -> str:
+    """Get a human-readable display string for a provider."""
+    if isinstance(provider, BM25Provider):
+        return "BM25 (keyword search)"
+    name = getattr(provider, 'name', 'unknown')
+    model = getattr(provider, 'model_name', None) or getattr(provider, 'model', None) or 'default'
+    return f"{name} ({model})"

--- a/palaia/entry.py
+++ b/palaia/entry.py
@@ -24,6 +24,7 @@ def _parse_yaml_simple(text: str) -> dict:
             continue
         if ":" not in line:
             continue
+        # Only split on the FIRST colon to preserve colons in values (URLs, timestamps, etc.)
         key, _, value = line.partition(":")
         key = key.strip()
         value = value.strip()

--- a/palaia/lock.py
+++ b/palaia/lock.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 import fcntl
 import json
 import os
+import sys
 import time
+import warnings
 from pathlib import Path
+
+STALE_LOCK_SECONDS = 60
 
 
 class LockError(Exception):
@@ -21,9 +25,43 @@ class PalaiaLock:
         self.timeout = timeout
         self._fd = None
 
+    def _check_stale(self) -> bool:
+        """Check if existing lock is stale (>60s old). If stale, remove it and warn."""
+        if not self.lock_path.exists():
+            return False
+        try:
+            with open(self.lock_path, "r") as f:
+                data = json.load(f)
+            lock_ts = data.get("ts", 0)
+            lock_pid = data.get("pid", 0)
+            age = time.time() - lock_ts
+            if age > STALE_LOCK_SECONDS:
+                warnings.warn(
+                    f"Stale lock detected (age: {age:.0f}s, pid: {lock_pid}). "
+                    f"Overriding stale lock.",
+                    stacklevel=3,
+                )
+                try:
+                    self.lock_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+                return True
+        except (json.JSONDecodeError, OSError, ValueError):
+            # Corrupt lock file — treat as stale
+            try:
+                self.lock_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            return True
+        return False
+
     def acquire(self) -> None:
         deadline = time.monotonic() + self.timeout
         self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        
+        # Check for stale lock before first attempt
+        self._check_stale()
+        
         self._fd = open(self.lock_path, "w")
         while True:
             try:
@@ -34,6 +72,18 @@ class PalaiaLock:
                 return
             except (IOError, OSError):
                 if time.monotonic() >= deadline:
+                    # One more stale check before giving up
+                    if self._check_stale():
+                        # Retry once after removing stale lock
+                        try:
+                            self._fd.close()
+                            self._fd = open(self.lock_path, "w")
+                            fcntl.flock(self._fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                            self._fd.write(json.dumps({"pid": os.getpid(), "ts": time.time()}))
+                            self._fd.flush()
+                            return
+                        except (IOError, OSError):
+                            pass
                     self._fd.close()
                     self._fd = None
                     raise LockError(

--- a/palaia/search.py
+++ b/palaia/search.py
@@ -1,4 +1,4 @@
-"""BM25 search with tiered embedding support (ADR-001)."""
+"""Hybrid search: BM25 + semantic embeddings (ADR-001)."""
 
 from __future__ import annotations
 
@@ -7,10 +7,16 @@ import re
 from collections import Counter
 from pathlib import Path
 
+from palaia.embeddings import (
+    BM25Provider,
+    auto_detect_provider,
+    cosine_similarity,
+    get_provider_display_info,
+)
+
 
 def tokenize(text: str) -> list[str]:
     """Simple whitespace + punctuation tokenizer."""
-
     text = text.lower()
     tokens = re.findall(r"\b\w+\b", text)
     return tokens
@@ -80,59 +86,118 @@ def detect_search_tier() -> int:
     
     Returns:
         1: BM25 only
-        2: ollama available
-        3: API key available
+        2: Local embeddings (ollama, sentence-transformers, fastembed)
+        3: API embeddings (OpenAI)
     """
-    import shutil
-    import subprocess
-    import os
-
-    # Check Tier 3: API key
-    if os.environ.get("OPENAI_API_KEY") or os.environ.get("VOYAGE_API_KEY"):
-        return 3
-
-    # Check Tier 2: ollama
-    if shutil.which("ollama"):
-        try:
-            result = subprocess.run(
-                ["ollama", "list"], capture_output=True, text=True, timeout=5
-            )
-            if "nomic-embed-text" in result.stdout:
+    from palaia.embeddings import detect_providers
+    
+    providers = detect_providers()
+    for p in providers:
+        if p["available"]:
+            if p["name"] == "openai":
+                return 3
+            elif p["name"] in ("ollama", "sentence-transformers", "fastembed"):
                 return 2
-        except (subprocess.TimeoutExpired, FileNotFoundError):
-            pass
-
     return 1
 
 
 class SearchEngine:
-    """Unified search across tiers."""
+    """Unified hybrid search: BM25 + semantic embeddings."""
 
-    def __init__(self, store):
+    def __init__(self, store, config: dict | None = None):
         self.store = store
         self.bm25 = BM25()
-        self.tier = detect_search_tier()
+        self.config = config or store.config
+        self._provider = None
 
-    def build_index(self, include_cold: bool = False) -> None:
-        """Build search index from store entries."""
+    @property
+    def provider(self):
+        if self._provider is None:
+            self._provider = auto_detect_provider(self.config)
+        return self._provider
+
+    @property
+    def has_embeddings(self) -> bool:
+        return not isinstance(self.provider, BM25Provider)
+
+    def build_index(self, include_cold: bool = False) -> list[tuple[str, str, dict]]:
+        """Build search index from store entries. Returns (doc_id, full_text, meta) list."""
         entries = self.store.all_entries(include_cold=include_cold)
         docs = []
+        docs_with_meta = []
         for meta, body, tier in entries:
             doc_id = meta.get("id", "unknown")
-            # Index both title and body
             title = meta.get("title", "")
             tags = " ".join(meta.get("tags", []))
             full_text = f"{title} {tags} {body}"
             docs.append((doc_id, full_text))
+            docs_with_meta.append((doc_id, full_text, meta))
         self.bm25.index(docs)
+        return docs_with_meta
 
     def search(self, query: str, top_k: int = 10, include_cold: bool = False) -> list[dict]:
-        """Search memories. Returns list of result dicts."""
-        self.build_index(include_cold=include_cold)
-        results = self.bm25.search(query, top_k=top_k)
+        """Search memories using hybrid ranking (BM25 + embeddings when available)."""
+        docs_with_meta = self.build_index(include_cold=include_cold)
 
+        # BM25 scores
+        bm25_results = self.bm25.search(query, top_k=top_k * 2)  # get more candidates for hybrid
+        bm25_scores = {doc_id: score for doc_id, score in bm25_results}
+
+        # Normalize BM25 scores to [0, 1]
+        max_bm25 = max(bm25_scores.values()) if bm25_scores else 1.0
+        bm25_norm = {k: v / max_bm25 for k, v in bm25_scores.items()} if max_bm25 > 0 else {}
+
+        # Embedding scores (if available)
+        embed_norm = {}
+        if self.has_embeddings and docs_with_meta:
+            try:
+                query_vec = self.provider.embed_query(query)
+                # Only embed BM25 candidates + a few extra for recall
+                candidate_ids = set(bm25_scores.keys())
+                texts_to_embed = []
+                ids_to_embed = []
+                for doc_id, full_text, meta in docs_with_meta:
+                    # Check cache first
+                    cached = self.store.embedding_cache.get_cached(doc_id)
+                    if cached:
+                        sim = cosine_similarity(query_vec, cached)
+                        embed_norm[doc_id] = sim
+                    elif doc_id in candidate_ids or len(texts_to_embed) < top_k:
+                        texts_to_embed.append(full_text)
+                        ids_to_embed.append(doc_id)
+
+                if texts_to_embed:
+                    vectors = self.provider.embed(texts_to_embed)
+                    model_name = getattr(self.provider, 'model_name', None) or getattr(self.provider, 'model', 'unknown')
+                    for doc_id, vec in zip(ids_to_embed, vectors):
+                        self.store.embedding_cache.set_cached(doc_id, vec, model=model_name)
+                        sim = cosine_similarity(query_vec, vec)
+                        embed_norm[doc_id] = sim
+            except Exception as e:
+                # If embedding fails, fall back to BM25 only
+                import warnings
+                warnings.warn(f"Embedding search failed, using BM25 only: {e}")
+                embed_norm = {}
+
+        # Combine scores: hybrid ranking
+        all_ids = set(bm25_norm.keys()) | set(embed_norm.keys())
+        combined = {}
+        for doc_id in all_ids:
+            bm25_s = bm25_norm.get(doc_id, 0.0)
+            embed_s = embed_norm.get(doc_id, 0.0)
+            if embed_norm:
+                # Weighted combination: 40% BM25 + 60% embedding
+                combined[doc_id] = 0.4 * bm25_s + 0.6 * embed_s
+            else:
+                combined[doc_id] = bm25_s
+
+        # Sort by combined score
+        ranked = sorted(combined.items(), key=lambda x: x[1], reverse=True)[:top_k]
+
+        # Build output
         output = []
-        for doc_id, score in results:
+        search_method = "hybrid" if embed_norm else "BM25"
+        for doc_id, score in ranked:
             entry = self.store.read(doc_id)
             if entry:
                 meta, body = entry
@@ -154,3 +219,15 @@ class SearchEngine:
             if (self.store.root / tier / f"{entry_id}.md").exists():
                 return tier
         return "unknown"
+
+    def search_info(self) -> dict:
+        """Get info about current search configuration."""
+        provider = self.provider
+        provider_display = get_provider_display_info(provider)
+        has_embed = self.has_embeddings
+        return {
+            "provider": provider_display,
+            "has_embeddings": has_embed,
+            "bm25_active": True,
+            "semantic_active": has_embed,
+        }

--- a/palaia/store.py
+++ b/palaia/store.py
@@ -47,6 +47,8 @@ class Store:
         title: str | None = None,
     ) -> str:
         """Write a new memory entry. Returns the entry ID."""
+        if not body or not body.strip():
+            raise ValueError("Cannot write empty content. Provide a non-empty text body.")
         scope = normalize_scope(scope, self.config["default_scope"])
         
         # Dedup check
@@ -185,11 +187,19 @@ class Store:
                     new_text = serialize_entry(meta, body)
 
                     if new_tier != tier:
-                        new_path = self.root / new_tier / p.name
-                        new_path.parent.mkdir(parents=True, exist_ok=True)
-                        with open(new_path, "w") as f:
-                            f.write(new_text)
+                        new_target = f"{new_tier}/{p.name}"
+                        old_target = f"{tier}/{p.name}"
+                        # WAL: log the move with payload for crash recovery
+                        wal_entry = WALEntry(
+                            operation="write",
+                            target=new_target,
+                            payload_hash=meta.get("content_hash", ""),
+                            payload=new_text,
+                        )
+                        self.wal.log(wal_entry)
+                        self.write_raw(new_target, new_text)
                         p.unlink()
+                        self.wal.commit(wal_entry)
                         key = f"{tier}_to_{new_tier}"
                         moves[key] = moves.get(key, 0) + 1
                     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,10 @@ palaia = "palaia.cli:main"
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "ruff>=0.3.0"]
+ollama = ["ollama>=0.4.0"]
+fastembed = ["fastembed>=0.3.0"]
+sentence-transformers = ["sentence-transformers>=3.0.0"]
+embeddings = ["ollama>=0.4.0", "fastembed>=0.3.0", "sentence-transformers>=3.0.0"]
 
 [tool.setuptools.packages.find]
 include = ["palaia*"]

--- a/tests/test_audit_fixes.py
+++ b/tests/test_audit_fixes.py
@@ -1,0 +1,149 @@
+"""Tests for audit fix items."""
+
+import json
+import time
+import warnings
+
+import pytest
+from pathlib import Path
+
+from palaia.config import DEFAULT_CONFIG, save_config
+from palaia.store import Store
+from palaia.entry import _parse_yaml_simple, parse_entry, create_entry
+from palaia.lock import PalaiaLock, STALE_LOCK_SECONDS
+
+
+@pytest.fixture
+def palaia_root(tmp_path):
+    root = tmp_path / ".palaia"
+    root.mkdir()
+    for sub in ("hot", "warm", "cold", "wal", "index"):
+        (root / sub).mkdir()
+    save_config(root, DEFAULT_CONFIG)
+    return root
+
+
+# --- Audit Fix 1: Empty content raises ValueError ---
+
+def test_write_empty_string_raises(palaia_root):
+    store = Store(palaia_root)
+    with pytest.raises(ValueError, match="empty content"):
+        store.write("")
+
+
+def test_write_whitespace_only_raises(palaia_root):
+    store = Store(palaia_root)
+    with pytest.raises(ValueError, match="empty content"):
+        store.write("   \n\t  ")
+
+
+def test_write_normal_content_works(palaia_root):
+    store = Store(palaia_root)
+    entry_id = store.write("Valid content here")
+    assert entry_id is not None
+
+
+# --- Audit Fix 3: YAML parsing with colons ---
+
+def test_yaml_parse_url_value():
+    yaml_text = "url: https://example.com:8080/path"
+    result = _parse_yaml_simple(yaml_text)
+    assert result["url"] == "https://example.com:8080/path"
+
+
+def test_yaml_parse_title_with_colon():
+    yaml_text = "title: Foo: Bar: Baz"
+    result = _parse_yaml_simple(yaml_text)
+    assert result["title"] == "Foo: Bar: Baz"
+
+
+def test_yaml_parse_iso_timestamp():
+    yaml_text = "created: 2026-03-11T10:24:00+00:00"
+    result = _parse_yaml_simple(yaml_text)
+    assert result["created"] == "2026-03-11T10:24:00+00:00"
+
+
+def test_yaml_parse_multiple_colons():
+    yaml_text = """id: abc-123
+title: Fix: YAML: Parser
+created: 2026-03-11T10:24:00+00:00"""
+    result = _parse_yaml_simple(yaml_text)
+    assert result["id"] == "abc-123"
+    assert result["title"] == "Fix: YAML: Parser"
+    assert "2026-03-11T10" in result["created"]
+
+
+# --- Audit Fix 2: GC uses WAL ---
+
+def test_gc_uses_wal(palaia_root):
+    """Verify that GC tier moves are WAL-logged."""
+    store = Store(palaia_root)
+    
+    # Write an entry
+    entry_id = store.write("Test GC WAL", scope="team")
+    
+    # Manually age the entry to force tier move
+    entry_path = palaia_root / "hot" / f"{entry_id}.md"
+    text = entry_path.read_text()
+    
+    # Replace timestamps to make it 60 days old
+    old_date = "2025-01-01T00:00:00+00:00"
+    text = text.replace(
+        text.split("created: ")[1].split("\n")[0],
+        old_date
+    ).replace(
+        text.split("accessed: ")[1].split("\n")[0],
+        old_date
+    )
+    entry_path.write_text(text)
+    
+    # Run GC
+    result = store.gc()
+    
+    # Should have moved from hot to cold/warm
+    total_moves = sum(v for k, v in result.items() if k.startswith("hot_to"))
+    # Check that WAL has committed entries for the move
+    wal_files = list((palaia_root / "wal").glob("*.json"))
+    committed = 0
+    for wf in wal_files:
+        data = json.loads(wf.read_text())
+        if data.get("status") == "committed" and data.get("operation") == "write":
+            committed += 1
+    
+    if total_moves > 0:
+        assert committed >= total_moves, "GC tier moves should be WAL-logged"
+
+
+# --- Audit Fix 4: Lock stale detection ---
+
+def test_stale_lock_detection(palaia_root):
+    """Lock older than 60s should be detected as stale."""
+    lock = PalaiaLock(palaia_root, timeout=1.0)
+    
+    # Create a fake stale lock
+    lock_path = palaia_root / ".lock"
+    stale_ts = time.time() - (STALE_LOCK_SECONDS + 10)
+    lock_path.write_text(json.dumps({"pid": 99999, "ts": stale_ts}))
+    
+    # Should be able to acquire despite stale lock
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        lock.acquire()
+        lock.release()
+    
+    # Should have warned about stale lock
+    stale_warnings = [x for x in w if "Stale lock" in str(x.message)]
+    assert len(stale_warnings) > 0
+
+
+def test_fresh_lock_not_stale(palaia_root):
+    """Lock that's fresh should not be flagged as stale."""
+    lock = PalaiaLock(palaia_root, timeout=2.0)
+    
+    # Create a fresh lock (but don't actually flock it)
+    lock_path = palaia_root / ".lock"
+    lock_path.write_text(json.dumps({"pid": 99999, "ts": time.time()}))
+    
+    # The _check_stale should not remove a fresh lock
+    is_stale = lock._check_stale()
+    assert is_stale is False

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -1,0 +1,92 @@
+"""Tests for palaia detect CLI command output format."""
+
+import pytest
+from unittest.mock import patch
+from io import StringIO
+import sys
+
+
+def test_detect_output_format():
+    """Test that palaia detect outputs the expected format."""
+    from palaia.cli import cmd_detect
+    
+    args = type("Args", (), {"json": False})()
+    
+    # Capture stdout
+    captured = StringIO()
+    old_stdout = sys.stdout
+    sys.stdout = captured
+    
+    try:
+        with patch("palaia.embeddings._check_ollama_available", return_value=(False, None, [])):
+            with patch("palaia.embeddings.importlib.util.find_spec", return_value=None):
+                with patch("palaia.embeddings._check_openai_key", return_value=None):
+                    with patch("palaia.embeddings._check_voyage_key", return_value=None):
+                        cmd_detect(args)
+    finally:
+        sys.stdout = old_stdout
+    
+    output = captured.getvalue()
+    
+    # Check required sections
+    assert "Palaia Environment Detection" in output
+    assert "=====" in output
+    assert "System:" in output
+    assert "Python:" in output
+    assert "Embedding providers found:" in output
+    assert "BM25 keyword search: always available ✓" in output
+
+
+def test_detect_json_output():
+    """Test JSON output mode."""
+    from palaia.cli import cmd_detect
+    import json
+    
+    args = type("Args", (), {"json": True})()
+    
+    captured = StringIO()
+    old_stdout = sys.stdout
+    sys.stdout = captured
+    
+    try:
+        with patch("palaia.embeddings._check_ollama_available", return_value=(False, None, [])):
+            with patch("palaia.embeddings.importlib.util.find_spec", return_value=None):
+                with patch("palaia.embeddings._check_openai_key", return_value=None):
+                    with patch("palaia.embeddings._check_voyage_key", return_value=None):
+                        cmd_detect(args)
+    finally:
+        sys.stdout = old_stdout
+    
+    output = captured.getvalue()
+    data = json.loads(output)
+    
+    assert "system" in data
+    assert "python" in data
+    assert "providers" in data
+    assert isinstance(data["providers"], list)
+    assert len(data["providers"]) == 5  # ollama, st, fastembed, openai, voyage
+
+
+def test_detect_with_ollama_available():
+    """Test detect when ollama is running."""
+    from palaia.cli import cmd_detect
+    
+    args = type("Args", (), {"json": False})()
+    
+    captured = StringIO()
+    old_stdout = sys.stdout
+    sys.stdout = captured
+    
+    try:
+        with patch("palaia.embeddings._check_ollama_available", return_value=(True, None, ["nomic-embed-text", "llama3"])):
+            with patch("palaia.embeddings.importlib.util.find_spec", return_value=None):
+                with patch("palaia.embeddings._check_openai_key", return_value=None):
+                    with patch("palaia.embeddings._check_voyage_key", return_value=None):
+                        cmd_detect(args)
+    finally:
+        sys.stdout = old_stdout
+    
+    output = captured.getvalue()
+    assert "✓ ollama" in output
+    assert "nomic-embed-text: available ✓" in output
+    assert "Recommendation: ollama" in output

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,0 +1,288 @@
+"""Tests for embedding providers and auto-detection."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from palaia.embeddings import (
+    OllamaProvider,
+    SentenceTransformersProvider,
+    FastEmbedProvider,
+    OpenAIProvider,
+    BM25Provider,
+    auto_detect_provider,
+    detect_providers,
+    cosine_similarity,
+    _check_ollama_available,
+    _create_provider,
+)
+
+
+# --- Cosine Similarity ---
+
+def test_cosine_similarity_identical():
+    v = [1.0, 0.0, 0.0]
+    assert cosine_similarity(v, v) == pytest.approx(1.0)
+
+
+def test_cosine_similarity_orthogonal():
+    a = [1.0, 0.0]
+    b = [0.0, 1.0]
+    assert cosine_similarity(a, b) == pytest.approx(0.0)
+
+
+def test_cosine_similarity_zero_vector():
+    a = [0.0, 0.0]
+    b = [1.0, 1.0]
+    assert cosine_similarity(a, b) == 0.0
+
+
+# --- BM25Provider ---
+
+def test_bm25_provider_search():
+    bm25 = BM25Provider()
+    bm25.index([
+        ("doc1", "the cat sat on the mat"),
+        ("doc2", "the dog played in the yard"),
+        ("doc3", "cats and dogs are friends"),
+    ])
+    results = bm25.search("cat mat", top_k=2)
+    assert len(results) > 0
+    assert results[0][0] == "doc1"
+
+
+def test_bm25_provider_embed_raises():
+    bm25 = BM25Provider()
+    with pytest.raises(NotImplementedError):
+        bm25.embed(["hello"])
+    with pytest.raises(NotImplementedError):
+        bm25.embed_query("hello")
+
+
+# --- OllamaProvider (mocked) ---
+
+def test_ollama_provider_embed_mocked():
+    provider = OllamaProvider(model="nomic-embed-text")
+    mock_client = MagicMock()
+    mock_client.embed.return_value = {"embeddings": [[0.1, 0.2, 0.3]]}
+    provider._client = mock_client
+
+    result = provider.embed(["hello world"])
+    assert len(result) == 1
+    assert result[0] == [0.1, 0.2, 0.3]
+    mock_client.embed.assert_called_once()
+
+
+def test_ollama_provider_embed_query_mocked():
+    provider = OllamaProvider()
+    mock_client = MagicMock()
+    mock_client.embed.return_value = {"embeddings": [[0.5, 0.6]]}
+    provider._client = mock_client
+
+    result = provider.embed_query("test")
+    assert result == [0.5, 0.6]
+
+
+# --- SentenceTransformersProvider (mocked) ---
+
+def test_sentence_transformers_provider_mocked():
+    provider = SentenceTransformersProvider(model="all-MiniLM-L6-v2")
+    # Use a mock that returns list-like objects (simulating numpy arrays with .tolist())
+    mock_arr = MagicMock()
+    mock_arr.__iter__ = lambda self: iter([MagicMock(tolist=lambda: [0.1, 0.2]), MagicMock(tolist=lambda: [0.3, 0.4])])
+    
+    class FakeArray:
+        def __init__(self, data):
+            self._data = data
+        def __iter__(self):
+            return iter(self._data)
+        def tolist(self):
+            return self._data
+    
+    class FakeResult:
+        def __init__(self, rows):
+            self._rows = [FakeArray(r) for r in rows]
+        def __iter__(self):
+            return iter(self._rows)
+    
+    mock_model = MagicMock()
+    mock_model.encode.return_value = FakeResult([[0.1, 0.2], [0.3, 0.4]])
+    provider._model = mock_model
+
+    result = provider.embed(["hello", "world"])
+    assert len(result) == 2
+    assert result[0] == pytest.approx([0.1, 0.2])
+    mock_model.encode.assert_called_once()
+
+
+def test_sentence_transformers_query_mocked():
+    provider = SentenceTransformersProvider()
+    
+    class FakeArray:
+        def __init__(self, data):
+            self._data = data
+        def tolist(self):
+            return self._data
+    
+    class FakeResult:
+        def __init__(self, rows):
+            self._rows = [FakeArray(r) for r in rows]
+        def __iter__(self):
+            return iter(self._rows)
+    
+    mock_model = MagicMock()
+    mock_model.encode.return_value = FakeResult([[0.7, 0.8]])
+    provider._model = mock_model
+
+    result = provider.embed_query("test")
+    assert result == pytest.approx([0.7, 0.8])
+
+
+# --- FastEmbedProvider (mocked) ---
+
+def test_fastembed_provider_mocked():
+    provider = FastEmbedProvider(model="BAAI/bge-small-en-v1.5")
+    
+    class FakeArray:
+        def __init__(self, data):
+            self._data = data
+        def tolist(self):
+            return self._data
+        def __iter__(self):
+            return iter(self._data)
+    
+    mock_model = MagicMock()
+    mock_model.embed.return_value = [FakeArray([0.1, 0.2]), FakeArray([0.3, 0.4])]
+    provider._model = mock_model
+
+    result = provider.embed(["hello", "world"])
+    assert len(result) == 2
+    assert result[0] == pytest.approx([0.1, 0.2])
+
+
+# --- OpenAIProvider (mocked) ---
+
+def test_openai_provider_mocked():
+    provider = OpenAIProvider(model="text-embedding-3-small", api_key="test-key")
+    mock_client = MagicMock()
+    mock_data = MagicMock()
+    mock_data.embedding = [0.1, 0.2, 0.3]
+    mock_resp = MagicMock()
+    mock_resp.data = [mock_data]
+    mock_client.embeddings.create.return_value = mock_resp
+    provider._client = mock_client
+
+    result = provider.embed(["hello"])
+    assert result == [[0.1, 0.2, 0.3]]
+
+
+# --- Auto-Detect ---
+
+def test_auto_detect_none_config():
+    result = auto_detect_provider({"embedding_provider": "none"})
+    assert isinstance(result, BM25Provider)
+
+
+def test_auto_detect_explicit_bm25():
+    result = auto_detect_provider({"embedding_provider": "bm25"})
+    assert isinstance(result, BM25Provider)
+
+
+def test_auto_detect_explicit_ollama():
+    result = _create_provider("ollama", "nomic-embed-text")
+    assert isinstance(result, OllamaProvider)
+    assert result.model == "nomic-embed-text"
+
+
+def test_auto_detect_explicit_sentence_transformers():
+    result = _create_provider("sentence-transformers")
+    assert isinstance(result, SentenceTransformersProvider)
+
+
+def test_auto_detect_explicit_fastembed():
+    result = _create_provider("fastembed")
+    assert isinstance(result, FastEmbedProvider)
+
+
+def test_auto_detect_explicit_openai():
+    result = _create_provider("openai")
+    assert isinstance(result, OpenAIProvider)
+
+
+def test_auto_detect_unknown_provider():
+    with pytest.raises(ValueError, match="Unknown embedding provider"):
+        _create_provider("unknown_provider")
+
+
+@patch("palaia.embeddings.detect_providers")
+def test_auto_detect_prefers_ollama(mock_detect):
+    mock_detect.return_value = [
+        {"name": "ollama", "available": True},
+        {"name": "sentence-transformers", "available": True},
+        {"name": "fastembed", "available": False},
+        {"name": "openai", "available": True},
+        {"name": "voyage", "available": False},
+    ]
+    result = auto_detect_provider({"embedding_provider": "auto"})
+    assert isinstance(result, OllamaProvider)
+
+
+@patch("palaia.embeddings.detect_providers")
+def test_auto_detect_falls_to_st_when_no_ollama(mock_detect):
+    mock_detect.return_value = [
+        {"name": "ollama", "available": False},
+        {"name": "sentence-transformers", "available": True},
+        {"name": "fastembed", "available": False},
+        {"name": "openai", "available": False},
+        {"name": "voyage", "available": False},
+    ]
+    result = auto_detect_provider({"embedding_provider": "auto"})
+    assert isinstance(result, SentenceTransformersProvider)
+
+
+@patch("palaia.embeddings.detect_providers")
+def test_auto_detect_falls_to_bm25_when_nothing(mock_detect):
+    mock_detect.return_value = [
+        {"name": "ollama", "available": False},
+        {"name": "sentence-transformers", "available": False},
+        {"name": "fastembed", "available": False},
+        {"name": "openai", "available": False},
+        {"name": "voyage", "available": False},
+    ]
+    result = auto_detect_provider({"embedding_provider": "auto"})
+    assert isinstance(result, BM25Provider)
+
+
+@patch("palaia.embeddings.detect_providers")
+def test_auto_detect_fastembed_over_openai(mock_detect):
+    mock_detect.return_value = [
+        {"name": "ollama", "available": False},
+        {"name": "sentence-transformers", "available": False},
+        {"name": "fastembed", "available": True},
+        {"name": "openai", "available": True},
+        {"name": "voyage", "available": False},
+    ]
+    result = auto_detect_provider({"embedding_provider": "auto"})
+    assert isinstance(result, FastEmbedProvider)
+
+
+# --- detect_providers ---
+
+@patch("palaia.embeddings._check_ollama_available", return_value=(True, None, ["nomic-embed-text", "llama3"]))
+@patch("palaia.embeddings.importlib.util.find_spec", return_value=None)
+@patch("palaia.embeddings._check_openai_key", return_value=None)
+@patch("palaia.embeddings._check_voyage_key", return_value=None)
+def test_detect_providers_ollama_only(mock_voyage, mock_openai, mock_spec, mock_ollama):
+    providers = detect_providers()
+    ollama_p = next(p for p in providers if p["name"] == "ollama")
+    assert ollama_p["available"] is True
+    assert ollama_p["has_nomic"] is True
+
+
+@patch("palaia.embeddings._check_ollama_available", return_value=(False, None, []))
+@patch("palaia.embeddings.importlib.util.find_spec", return_value=None)
+@patch("palaia.embeddings._check_openai_key", return_value=None)
+@patch("palaia.embeddings._check_voyage_key", return_value=None)
+def test_detect_providers_nothing_available(mock_voyage, mock_openai, mock_spec, mock_ollama):
+    providers = detect_providers()
+    for p in providers:
+        assert p["available"] is False


### PR DESCRIPTION
## Summary

Complete embeddings sprint: audit fixes, `palaia detect`, multi-provider embedding support, hybrid search, SKILL.md + README rewrite.

### TEIL 1: Audit Fixes
- `palaia write ""` → ValueError with clear message
- GC tier moves now WAL-backed for crash safety
- YAML parsing: values with colons (URLs, timestamps) correctly handled
- Stale lock detection: locks older than 60s overridden with warning

### TEIL 2: `palaia detect` Command
New CLI command that analyzes the host environment:
- Checks ollama (HTTP probe for running server + model list)
- Checks sentence-transformers, fastembed (importlib.util.find_spec)
- Checks OpenAI/Voyage API keys (env vars + openclaw auth)
- Shows recommendations and current config
- Supports `--json` output

### TEIL 3: Multi-Provider Embedding Support
- `palaia/embeddings.py`: OllamaProvider, SentenceTransformersProvider, FastEmbedProvider, OpenAIProvider, BM25Provider
- Auto-detect order: ollama → sentence-transformers → fastembed → openai → bm25
- `palaia config set embedding_provider <name>` works
- Hybrid search in `search.py`: 40% BM25 + 60% embedding similarity
- Embedding cache integration for performance
- pyproject.toml extras: `ollama`, `fastembed`, `sentence-transformers`, `embeddings`
- `palaia status` shows embedding provider and search capabilities

### TEIL 4: Documentation
- **SKILL.md**: Complete rewrite for OpenClaw agents. Plain English, guided setup flow, all options explained with pros/cons.
- **README.md**: Rewrite for non-nerds. Badges, clear value prop, ~130 lines.

### Tests
- 104 tests total (was 67), all passing
- Unit tests for all EmbeddingProvider implementations (mocked)
- Auto-detect tests with all provider combinations
- `palaia detect` output format tests
- Audit fix tests (empty write, WAL GC, YAML colons, stale lock)
