### PR TITLE
feat: Configurable Embedding Fallback Chain

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -26,103 +26,145 @@ palaia status
 
 That's it. You now have a working memory system with keyword search. No API keys, no servers, no cloud.
 
-## Setting Up Semantic Search
+## Setting Up Your Embedding Chain
 
-Keyword search works out of the box. But if you want your agent to find things by *meaning* (not just matching words), you'll want semantic search. Run this to see what's available on your machine:
+Keyword search works out of the box. But if you want your agent to find things by *meaning* (not just matching words), you'll want semantic search.
+
+An **embedding chain** is a priority list — Palaia tries the first provider. If it doesn't work (server down, rate limit, missing API key), it automatically moves to the next one. BM25 keyword search is always the last resort, so search never breaks.
+
+### Quick Detection
 
 ```bash
 palaia detect
 ```
 
-This shows which embedding providers are installed, which are running, and what Palaia recommends.
+This shows what's available on your machine and recommends a chain. The output includes a ready-to-paste command.
 
-### The Options — What's Right for You?
-
-#### Option 1: No Setup (Keyword Search)
-
-This is what you get by default. Palaia uses BM25 — a smart keyword matching algorithm. It's fast, needs zero setup, and works well when your queries use similar words to what's stored.
-
-**When it's enough:** Most setups. If your agent writes "project deadline is Friday" and later asks "when is the deadline?", keyword search finds it.
-
-**What's missing:** It won't find "project due date" if you stored "project deadline". That's where semantic search helps.
-
-#### Option 2: ollama (Recommended for most)
-
-Ollama is a local AI server that runs on your machine. It understands meaning, not just words. Your data never leaves your computer.
-
-**Pros:** Private, fast after first load, no API costs, good quality  
-**Cons:** Uses ~1GB RAM while running, needs initial setup  
+### Setting Your Chain
 
 ```bash
-# Install ollama (if not already)
-curl -fsSL https://ollama.com/install.sh | sh
+# Best setup: cloud + local fallback + keyword backup
+palaia config set-chain openai sentence-transformers bm25
 
-# Pull the embedding model
+# Local only, no cloud
+palaia config set-chain sentence-transformers bm25
+
+# Just keyword search (always works, zero setup)
+palaia config set-chain bm25
+```
+
+Check what's active:
+
+```bash
+palaia status
+```
+
+Output looks like:
+```
+Embedding chain: openai → sentence-transformers → bm25
+  1. openai (text-embedding-3-large) ✓ API key found
+  2. sentence-transformers (all-MiniLM-L6-v2) ✓ installed
+  3. bm25 ✓ always available
+Active: openai (primary)
+```
+
+If the primary provider fails, you'll see:
+```
+Active: sentence-transformers (fallback — openai: 429 Too Many Requests)
+```
+
+### The Providers
+
+| Provider | Type | Pros | Cons |
+|----------|------|------|------|
+| **openai** | Cloud | Best quality, no local compute | Costs money, needs internet + API key |
+| **sentence-transformers** | Local | Best local quality, works offline | ~500MB RAM, ~30s first load |
+| **ollama** | Local | Private, good quality, no API costs | ~1GB RAM, needs server running |
+| **fastembed** | Local | Lightweight, fast startup | Slightly lower quality |
+| **bm25** | Built-in | Zero setup, always works | Keyword matching only (no meaning) |
+
+### Installing Providers
+
+```bash
+# sentence-transformers
+pip install "palaia[sentence-transformers]"
+
+# fastembed
+pip install "palaia[fastembed]"
+
+# ollama
+curl -fsSL https://ollama.com/install.sh | sh
 ollama pull nomic-embed-text
 
-# Tell Palaia to use it
-palaia config set embedding_provider ollama
-palaia status
-```
-
-**Choose this when:** You want smart search without sending data to the cloud.
-
-#### Option 3: sentence-transformers (Best quality, pure Python)
-
-A Python library that runs AI models directly. No separate server needed. Best quality embeddings for local use.
-
-**Pros:** Best local quality, no server to manage, works offline  
-**Cons:** Slower first load (~30s), uses more RAM (~500MB), needs pip install  
-
-```bash
-pip install "palaia[sentence-transformers]"
-palaia config set embedding_provider sentence-transformers
-palaia status
-```
-
-**Choose this when:** You want the best local search quality and don't mind the RAM usage.
-
-#### Option 4: fastembed (Lightweight option)
-
-A lighter alternative to sentence-transformers. Smaller models, faster startup, less RAM.
-
-**Pros:** Lightweight, fast startup, works offline  
-**Cons:** Slightly lower quality than sentence-transformers  
-
-```bash
-pip install "palaia[fastembed]"
-palaia config set embedding_provider fastembed
-palaia status
-```
-
-**Choose this when:** You're on a machine with limited RAM or want faster startup.
-
-#### Option 5: OpenAI or Voyage (Cloud-based)
-
-Use OpenAI's or Voyage's embedding APIs. Best quality, but requires an API key and sends data to the cloud.
-
-**Pros:** Highest quality, no local compute needed  
-**Cons:** Costs money (small amounts), data leaves your machine, needs internet  
-
-```bash
+# OpenAI (just set the key)
 export OPENAI_API_KEY="sk-..."
-palaia config set embedding_provider openai
-palaia status
 ```
 
-**Choose this when:** You already use OpenAI and don't mind cloud processing.
+### Model Overrides
+
+Each provider has a sensible default model. Override per provider if needed:
+
+```json
+{
+  "embedding_chain": ["openai", "sentence-transformers", "bm25"],
+  "embedding_model": {
+    "openai": "text-embedding-3-large",
+    "sentence-transformers": "all-MiniLM-L6-v2"
+  }
+}
+```
+
+### Backward Compatibility
+
+The old `embedding_provider` setting still works:
+
+```bash
+# These still work exactly as before
+palaia config set embedding_provider sentence-transformers
+palaia config set embedding_provider auto
+```
+
+If both `embedding_chain` and `embedding_provider` are set, `embedding_chain` takes priority.
 
 ### Guided Setup Flow (Agent Instructions)
 
 When setting up Palaia for a user, follow these steps:
 
 1. **Run detection:** `palaia detect` — parse the output
-2. **Present results** to the user in plain language: "You have ollama running with nomic-embed-text available. I can set that up for semantic search, or keyword search works fine too."
-3. **Ask the user** which option they prefer. Don't assume.
-4. **Install + configure** based on their choice:
-   - If they chose a provider: install it, run `palaia config set embedding_provider <name>`
-   - If they're fine with keyword search: do nothing, it's the default
-5. **Confirm** with `palaia status` — show them the output
+2. **Explain** what's available in plain language
+3. **Recommend** a chain based on what's detected (see decision tree below)
+4. **Let the user decide** — recommend, don't force
+5. **Apply** with `palaia config set-chain ...`
+6. **Confirm** with `palaia status`
+
+#### Agent Decision Tree (recommend, don't decide)
+
+```
+If OpenAI key + local provider installed (sentence-transformers/ollama/fastembed):
+  → Recommend: openai → <local> → bm25
+  → Say: "Best quality with local fallback. If OpenAI is unreachable,
+          <local> takes over automatically."
+
+If only local provider (no OpenAI key):
+  → Recommend: <local> → bm25
+  → Say: "Fully local, no cloud dependency."
+
+If only ollama:
+  → Recommend: ollama → bm25
+  → Say: "Runs on your local ollama server."
+
+If only OpenAI key (no local provider):
+  → Recommend: openai → bm25
+  → Say: "Cloud-based. I'd suggest also installing sentence-transformers
+          for offline fallback: pip install 'palaia[sentence-transformers]'"
+
+If nothing available:
+  → Recommend: bm25
+  → Say: "Keyword search works right away. For smarter search:
+          pip install 'palaia[sentence-transformers]'"
+```
+
+The user always makes the final call. Explain trade-offs in context of their system.
 
 ## Connecting to OpenClaw (the important bit)
 
@@ -229,15 +271,19 @@ Configuration lives in `.palaia/config.json`:
   "warm_threshold_days": 30,
   "hot_max_entries": 50,
   "default_scope": "team",
-  "embedding_provider": "auto",
-  "embedding_model": ""
+  "embedding_chain": ["openai", "sentence-transformers", "bm25"],
+  "embedding_model": {
+    "openai": "text-embedding-3-large",
+    "sentence-transformers": "all-MiniLM-L6-v2"
+  }
 }
 ```
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `embedding_provider` | `auto` | `auto`, `ollama`, `sentence-transformers`, `fastembed`, `openai`, `none` |
-| `embedding_model` | `""` | Override the default model for your provider (empty = provider's default) |
+| `embedding_chain` | (auto-detected) | Ordered list of providers to try. BM25 is always last resort. |
+| `embedding_model` | `{}` | Per-provider model overrides (dict) or single model string (legacy) |
+| `embedding_provider` | `"auto"` | Legacy: `auto`, `ollama`, `sentence-transformers`, `fastembed`, `openai`, `none`. Use `embedding_chain` instead. |
 | `decay_lambda` | `0.1` | How fast memories fade (higher = faster decay) |
 | `hot_threshold_days` | `7` | Days before a memory moves from active to warm |
 | `warm_threshold_days` | `30` | Days before a memory moves from warm to archive |

--- a/palaia/cli.py
+++ b/palaia/cli.py
@@ -258,25 +258,30 @@ def cmd_status(args):
     if recovered:
         print(f"  Recovered: {recovered} entries")
 
-    # Embedding status
-    from palaia.embeddings import auto_detect_provider, get_provider_display_info, BM25Provider
-    provider = auto_detect_provider(store.config)
-    provider_display = get_provider_display_info(provider)
-    has_embed = not isinstance(provider, BM25Provider)
+    # Embedding chain status
+    from palaia.embeddings import build_embedding_chain, BM25Provider
 
-    print(f"\nEmbedding: {provider_display} {'✓' if has_embed else '(fallback)'}")
-    print(f"  → BM25 keyword search: active")
-    if has_embed:
-        print(f"  → Semantic search: active ({provider.name})")
-    else:
-        print(f"  → Semantic search: not configured")
+    chain = build_embedding_chain(store.config)
+    statuses = chain.provider_status()
 
-    # Check API providers
-    from palaia.embeddings import _check_openai_key, _check_voyage_key
-    if _check_openai_key() or _check_voyage_key():
-        print(f"  → API search: configured")
+    chain_display = " → ".join(s["name"] for s in statuses)
+    print(f"\nEmbedding chain: {chain_display}")
+    for i, s in enumerate(statuses, 1):
+        model_str = f" ({s['model']})" if s.get("model") else ""
+        mark = "✓" if s["available"] else "✗"
+        print(f"  {i}. {s['name']}{model_str} {mark} {s['status']}")
+
+    # Determine active provider
+    has_embed = any(s["available"] and s["name"] != "bm25" for s in statuses)
+    if chain.fallback_reason:
+        active = chain.active_provider_name or "bm25"
+        print(f"Active: {active} (fallback — {chain.fallback_reason})")
+    elif has_embed:
+        # First available non-bm25
+        active = next((s["name"] for s in statuses if s["available"] and s["name"] != "bm25"), "bm25")
+        print(f"Active: {active} (primary)")
     else:
-        print(f"  → API search: not configured")
+        print(f"Active: bm25 (keyword search)")
 
     return 0
 
@@ -363,20 +368,85 @@ def cmd_detect(args):
         print("\nNo embedding providers found. Using keyword search (BM25).")
         print("Install one for semantic search: pip install 'palaia[sentence-transformers]'")
 
+    # Recommended chain
+    has_openai = "openai" in available
+    has_local = any(p in available for p in ("sentence-transformers", "fastembed", "ollama"))
+    local_name = next((p for p in ("sentence-transformers", "fastembed", "ollama") if p in available), None)
+
+    print()
+    if has_openai and has_local:
+        chain_parts = ["openai", local_name, "bm25"]
+        chain_str = " → ".join(chain_parts)
+        print(f"Recommended chain: {chain_str}")
+        print(f"  (Best quality cloud + best local fallback + always-on keyword backup)")
+    elif has_local:
+        chain_parts = [local_name, "bm25"]
+        chain_str = " → ".join(chain_parts)
+        print(f"Recommended chain: {chain_str}")
+        print(f"  (Local provider, no cloud dependency)")
+    elif has_openai:
+        chain_parts = ["openai", "bm25"]
+        chain_str = " → ".join(chain_parts)
+        print(f"Recommended chain: {chain_str}")
+        print(f"  (Cloud-based. Install sentence-transformers for offline fallback)")
+    else:
+        chain_parts = ["bm25"]
+        chain_str = "bm25"
+        print(f"Recommended chain: {chain_str}")
+        print(f"  (Keyword search. pip install 'palaia[sentence-transformers]' for better results)")
+
+    cmd_str = " ".join(chain_parts)
+    print(f"\nSet with: palaia config set-chain {cmd_str}")
+
     # Show current config
     try:
         root = get_root()
         config = load_config(root)
+        chain_cfg = config.get("embedding_chain")
         provider_cfg = config.get("embedding_provider", "auto")
-        print(f"\nCurrent config: embedding_provider = {provider_cfg}")
+        if chain_cfg:
+            print(f"\nCurrent config: embedding_chain = {' → '.join(chain_cfg)}")
+        else:
+            print(f"\nCurrent config: embedding_provider = {provider_cfg}")
     except FileNotFoundError:
         print(f"\nCurrent config: not initialized (run 'palaia init' first)")
 
     return 0
 
 
+def cmd_config_set_chain(args):
+    """Set the embedding fallback chain."""
+    root = get_root()
+    config = load_config(root)
+
+    chain = args.providers
+    valid_providers = {"openai", "sentence-transformers", "fastembed", "ollama", "bm25"}
+    for p in chain:
+        if p not in valid_providers:
+            if _json_out({"error": f"Unknown provider: {p}. Valid: {', '.join(sorted(valid_providers))}"}, args):
+                return 1
+            print(f"Unknown provider: {p}", file=sys.stderr)
+            print(f"Valid providers: {', '.join(sorted(valid_providers))}", file=sys.stderr)
+            return 1
+
+    # Ensure bm25 at the end if not present
+    if "bm25" not in chain:
+        chain = chain + ["bm25"]
+
+    config["embedding_chain"] = chain
+    save_config(root, config)
+
+    chain_str = " → ".join(chain)
+    if _json_out({"embedding_chain": chain}, args):
+        return 0
+    print(f"Embedding chain: {chain_str}")
+    return 0
+
+
 def cmd_config(args):
     """Get or set configuration values."""
+    if args.action == "set-chain":
+        return cmd_config_set_chain(args)
     if args.action == "get":
         root = get_root()
         config = load_config(root)
@@ -604,6 +674,9 @@ def main():
     p_config_set.add_argument("--json", action="store_true", help="Output as JSON")
     p_config_list = config_sub.add_parser("list", help="List all config values")
     p_config_list.add_argument("--json", action="store_true", help="Output as JSON")
+    p_config_set_chain = config_sub.add_parser("set-chain", help="Set the embedding fallback chain")
+    p_config_set_chain.add_argument("providers", nargs="+", help="Provider names in priority order")
+    p_config_set_chain.add_argument("--json", action="store_true", help="Output as JSON")
 
     # migrate
     p_migrate = sub.add_parser("migrate", help="Import from external memory formats")

--- a/palaia/embeddings.py
+++ b/palaia/embeddings.py
@@ -6,6 +6,11 @@ Providers are detected automatically in this order:
 3. fastembed (lightweight)
 4. OpenAI API (cloud, needs key)
 5. BM25 (always available, keyword-based fallback)
+
+Embedding Chain:
+  A configurable fallback chain lets you define a priority list of providers.
+  Palaia tries the first provider; if it fails (rate-limit, timeout, import error),
+  it moves to the next. BM25 is always the last resort.
 """
 
 from __future__ import annotations
@@ -390,6 +395,195 @@ def detect_providers() -> list[dict]:
     return providers
 
 
+class EmbeddingChain:
+    """Tries providers in order. Falls back on error."""
+
+    def __init__(self, chain: list[str], models: dict[str, str] | None = None):
+        self.chain_names = chain
+        self.providers: list[EmbeddingProvider] = []
+        self.models = models or {}
+        self._last_error: str | None = None
+        self._active_provider: str | None = None
+        self._fallback_reason: str | None = None
+        for name in chain:
+            if name == "bm25":
+                continue  # BM25 is always the implicit last resort
+            try:
+                provider = _create_provider(name, self.models.get(name))
+                self.providers.append(provider)
+            except (ImportError, ValueError):
+                continue  # skip unavailable
+
+    @property
+    def name(self) -> str:
+        """Display name for the chain."""
+        return " → ".join(self.chain_names)
+
+    @property
+    def active_provider_name(self) -> str | None:
+        """Name of the currently active (last successful) provider."""
+        return self._active_provider
+
+    @property
+    def fallback_reason(self) -> str | None:
+        """Reason why we fell back from the primary provider."""
+        return self._fallback_reason
+
+    def embed_query(self, text: str) -> tuple[list[float], str]:
+        """Returns (vector, provider_name). Tries each provider in order."""
+        self._fallback_reason = None
+        primary_name = self.providers[0].name if self.providers else None
+        for provider in self.providers:
+            try:
+                vector = provider.embed_query(text)
+                self._active_provider = provider.name
+                if provider.name != primary_name:
+                    self._fallback_reason = self._last_error
+                return vector, provider.name
+            except Exception as e:
+                self._last_error = f"{provider.name}: {e}"
+                warnings.warn(f"{provider.name} failed: {e}, trying next...")
+                continue
+        # All failed → BM25 (return empty vector)
+        self._active_provider = "bm25"
+        if primary_name:
+            self._fallback_reason = self._last_error
+        return [], "bm25"
+
+    def embed(self, texts: list[str]) -> tuple[list[list[float]], str]:
+        """Batch embed. Returns (vectors, provider_name)."""
+        self._fallback_reason = None
+        primary_name = self.providers[0].name if self.providers else None
+        for provider in self.providers:
+            try:
+                vectors = provider.embed(texts)
+                self._active_provider = provider.name
+                if provider.name != primary_name:
+                    self._fallback_reason = self._last_error
+                return vectors, provider.name
+            except Exception as e:
+                self._last_error = f"{provider.name}: {e}"
+                warnings.warn(f"{provider.name} failed: {e}, trying next...")
+                continue
+        self._active_provider = "bm25"
+        if primary_name:
+            self._fallback_reason = self._last_error
+        return [], "bm25"
+
+    def provider_status(self) -> list[dict]:
+        """Get status info for each provider in the chain."""
+        detected = {p["name"]: p for p in detect_providers()}
+        statuses = []
+        for name in self.chain_names:
+            if name == "bm25":
+                statuses.append({
+                    "name": "bm25",
+                    "model": None,
+                    "available": True,
+                    "status": "always available",
+                })
+                continue
+            info = detected.get(name, {})
+            model = self.models.get(name)
+            # Get default model from provider class
+            if not model:
+                defaults = {
+                    "openai": OpenAIProvider.default_model,
+                    "sentence-transformers": SentenceTransformersProvider.default_model,
+                    "fastembed": FastEmbedProvider.default_model,
+                    "ollama": OllamaProvider.default_model,
+                }
+                model = defaults.get(name)
+            available = info.get("available", False)
+            if name == "openai":
+                status = "API key found" if available else "no key found"
+            elif name == "ollama":
+                if info.get("server_running"):
+                    status = "server running" if available else "model not pulled"
+                else:
+                    status = "server not running"
+            else:
+                status = "installed" if available else "not installed"
+            statuses.append({
+                "name": name,
+                "model": model,
+                "available": available,
+                "status": status,
+            })
+        return statuses
+
+
+def _resolve_embedding_models(config: dict) -> dict[str, str]:
+    """Extract per-provider model overrides from config.
+    
+    Supports both:
+      - embedding_model: "text-embedding-3-large"  (old format, applies to active provider)
+      - embedding_model: {"openai": "text-embedding-3-large", ...}  (new format)
+    """
+    raw = config.get("embedding_model", "")
+    if isinstance(raw, dict):
+        return raw
+    # Old format: single string → no per-provider mapping
+    return {}
+
+
+def _resolve_single_model(config: dict) -> str | None:
+    """Get single model string for backward compat."""
+    raw = config.get("embedding_model", "")
+    if isinstance(raw, str) and raw:
+        return raw
+    return None
+
+
+def build_embedding_chain(config: dict) -> EmbeddingChain:
+    """Build an EmbeddingChain from config.
+    
+    Supports:
+      - embedding_chain: ["openai", "sentence-transformers", "bm25"]
+      - embedding_provider: "auto" (legacy, auto-detect)
+      - embedding_provider: "sentence-transformers" (legacy, single provider)
+    
+    embedding_chain takes precedence over embedding_provider.
+    """
+    models = _resolve_embedding_models(config)
+    single_model = _resolve_single_model(config)
+
+    # New format: explicit chain
+    chain = config.get("embedding_chain")
+    if chain and isinstance(chain, list):
+        # Ensure bm25 is always at the end
+        if "bm25" not in chain:
+            chain = chain + ["bm25"]
+        return EmbeddingChain(chain, models)
+
+    # Legacy format: embedding_provider
+    provider_name = config.get("embedding_provider", "auto")
+
+    if provider_name == "none":
+        return EmbeddingChain(["bm25"], models)
+
+    if provider_name != "auto":
+        # Single explicit provider + bm25 fallback
+        chain_list = [provider_name, "bm25"]
+        # If single_model is set, map it to this provider
+        if single_model and provider_name not in models:
+            models[provider_name] = single_model
+        return EmbeddingChain(chain_list, models)
+
+    # Auto-detect: build chain from available providers
+    detected = detect_providers()
+    chain_list = []
+    for p in detected:
+        if p["available"] and p["name"] != "voyage":
+            chain_list.append(p["name"])
+    chain_list.append("bm25")
+    if single_model:
+        # Apply single model to first provider if no per-provider config
+        if chain_list and chain_list[0] not in models:
+            models[chain_list[0]] = single_model
+    return EmbeddingChain(chain_list, models)
+
+
 def auto_detect_provider(config: dict | None = None) -> EmbeddingProvider | BM25Provider:
     """Auto-detect the best available embedding provider.
     
@@ -400,10 +594,15 @@ def auto_detect_provider(config: dict | None = None) -> EmbeddingProvider | BM25
     
     Returns:
         An embedding provider instance.
+    
+    Note: For new code, prefer build_embedding_chain() which supports fallback chains.
     """
     config = config or {}
     provider_name = config.get("embedding_provider", "auto")
     model = config.get("embedding_model", "") or None
+    # Handle dict-style embedding_model for backward compat
+    if isinstance(model, dict):
+        model = None
 
     if provider_name == "none":
         return BM25Provider()

--- a/tests/test_chain_cli.py
+++ b/tests/test_chain_cli.py
@@ -1,0 +1,106 @@
+"""Tests for the config set-chain CLI command and chain integration."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from palaia.config import load_config, save_config
+
+
+@pytest.fixture
+def palaia_dir(tmp_path):
+    """Create a minimal .palaia directory."""
+    pd = tmp_path / ".palaia"
+    pd.mkdir()
+    for sub in ("hot", "warm", "cold", "wal", "index"):
+        (pd / sub).mkdir()
+    save_config(pd, {
+        "version": 1,
+        "embedding_provider": "auto",
+        "embedding_model": "",
+    })
+    return pd
+
+
+def _run_palaia(args, cwd):
+    """Run palaia CLI as subprocess."""
+    result = subprocess.run(
+        [sys.executable, "-m", "palaia.cli"] + args,
+        capture_output=True, text=True, cwd=str(cwd),
+    )
+    return result
+
+
+def test_set_chain_writes_config(palaia_dir):
+    """palaia config set-chain writes embedding_chain to config.json."""
+    result = _run_palaia(
+        ["config", "set-chain", "openai", "sentence-transformers", "bm25"],
+        cwd=palaia_dir.parent,
+    )
+    assert result.returncode == 0
+    assert "openai → sentence-transformers → bm25" in result.stdout
+
+    config = load_config(palaia_dir)
+    assert config["embedding_chain"] == ["openai", "sentence-transformers", "bm25"]
+
+
+def test_set_chain_auto_appends_bm25(palaia_dir):
+    """If bm25 not specified, it gets appended."""
+    result = _run_palaia(
+        ["config", "set-chain", "sentence-transformers"],
+        cwd=palaia_dir.parent,
+    )
+    assert result.returncode == 0
+
+    config = load_config(palaia_dir)
+    assert config["embedding_chain"] == ["sentence-transformers", "bm25"]
+
+
+def test_set_chain_invalid_provider(palaia_dir):
+    """Unknown provider name → error."""
+    result = _run_palaia(
+        ["config", "set-chain", "magic-provider"],
+        cwd=palaia_dir.parent,
+    )
+    assert result.returncode == 1
+    assert "Unknown provider" in result.stderr
+
+
+def test_set_chain_json_output(palaia_dir):
+    """--json flag returns JSON."""
+    result = _run_palaia(
+        ["config", "set-chain", "--json", "openai", "bm25"],
+        cwd=palaia_dir.parent,
+    )
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert data["embedding_chain"] == ["openai", "bm25"]
+
+
+def test_backward_compat_embedding_provider(palaia_dir):
+    """Legacy embedding_provider still works when no embedding_chain."""
+    save_config(palaia_dir, {
+        "version": 1,
+        "embedding_provider": "sentence-transformers",
+        "embedding_model": "",
+    })
+    from palaia.embeddings import build_embedding_chain
+    config = load_config(palaia_dir)
+    chain = build_embedding_chain(config)
+    assert chain.chain_names == ["sentence-transformers", "bm25"]
+
+
+def test_embedding_chain_overrides_provider(palaia_dir):
+    """When both are set, embedding_chain wins."""
+    save_config(palaia_dir, {
+        "version": 1,
+        "embedding_provider": "ollama",
+        "embedding_chain": ["openai", "bm25"],
+    })
+    from palaia.embeddings import build_embedding_chain
+    config = load_config(palaia_dir)
+    chain = build_embedding_chain(config)
+    assert chain.chain_names == ["openai", "bm25"]

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -9,7 +9,9 @@ from palaia.embeddings import (
     FastEmbedProvider,
     OpenAIProvider,
     BM25Provider,
+    EmbeddingChain,
     auto_detect_provider,
+    build_embedding_chain,
     detect_providers,
     cosine_similarity,
     _check_ollama_available,
@@ -286,3 +288,177 @@ def test_detect_providers_nothing_available(mock_voyage, mock_openai, mock_spec,
     providers = detect_providers()
     for p in providers:
         assert p["available"] is False
+
+
+# --- EmbeddingChain ---
+
+class _MockProvider:
+    """Mock provider for chain tests."""
+    def __init__(self, name, fail=False, fail_msg="mock error"):
+        self.name = name
+        self._fail = fail
+        self._fail_msg = fail_msg
+
+    def embed_query(self, text):
+        if self._fail:
+            raise RuntimeError(self._fail_msg)
+        return [0.1, 0.2, 0.3]
+
+    def embed(self, texts):
+        if self._fail:
+            raise RuntimeError(self._fail_msg)
+        return [[0.1, 0.2, 0.3]] * len(texts)
+
+
+def test_chain_first_provider_succeeds():
+    """First provider works → use it."""
+    chain = EmbeddingChain(["openai", "sentence-transformers", "bm25"])
+    p1 = _MockProvider("openai")
+    p2 = _MockProvider("sentence-transformers")
+    chain.providers = [p1, p2]
+
+    vec, name = chain.embed_query("hello")
+    assert name == "openai"
+    assert vec == [0.1, 0.2, 0.3]
+    assert chain.fallback_reason is None
+
+
+def test_chain_first_fails_second_succeeds():
+    """First provider fails → second is used."""
+    chain = EmbeddingChain(["openai", "sentence-transformers", "bm25"])
+    p1 = _MockProvider("openai", fail=True, fail_msg="429 Too Many Requests")
+    p2 = _MockProvider("sentence-transformers")
+    chain.providers = [p1, p2]
+
+    vec, name = chain.embed_query("hello")
+    assert name == "sentence-transformers"
+    assert vec == [0.1, 0.2, 0.3]
+    assert chain.fallback_reason is not None
+    assert "429" in chain.fallback_reason
+
+
+def test_chain_all_fail_bm25_fallback():
+    """All providers fail → BM25 fallback (empty vector)."""
+    chain = EmbeddingChain(["openai", "sentence-transformers", "bm25"])
+    p1 = _MockProvider("openai", fail=True)
+    p2 = _MockProvider("sentence-transformers", fail=True)
+    chain.providers = [p1, p2]
+
+    vec, name = chain.embed_query("hello")
+    assert name == "bm25"
+    assert vec == []
+    assert chain.fallback_reason is not None
+
+
+def test_chain_batch_embed_fallback():
+    """Batch embed also falls back correctly."""
+    chain = EmbeddingChain(["openai", "sentence-transformers", "bm25"])
+    p1 = _MockProvider("openai", fail=True)
+    p2 = _MockProvider("sentence-transformers")
+    chain.providers = [p1, p2]
+
+    vecs, name = chain.embed(["hello", "world"])
+    assert name == "sentence-transformers"
+    assert len(vecs) == 2
+
+
+def test_chain_batch_all_fail():
+    """Batch embed — all fail → BM25."""
+    chain = EmbeddingChain(["openai", "bm25"])
+    p1 = _MockProvider("openai", fail=True)
+    chain.providers = [p1]
+
+    vecs, name = chain.embed(["hello"])
+    assert name == "bm25"
+    assert vecs == []
+
+
+# --- build_embedding_chain ---
+
+def test_build_chain_from_explicit_config():
+    """embedding_chain in config → EmbeddingChain with those providers."""
+    config = {
+        "embedding_chain": ["openai", "sentence-transformers", "bm25"],
+        "embedding_model": {"openai": "text-embedding-3-large"},
+    }
+    chain = build_embedding_chain(config)
+    assert chain.chain_names == ["openai", "sentence-transformers", "bm25"]
+    assert chain.models.get("openai") == "text-embedding-3-large"
+
+
+def test_build_chain_adds_bm25():
+    """If bm25 not in chain, it gets appended."""
+    config = {"embedding_chain": ["openai"]}
+    chain = build_embedding_chain(config)
+    assert chain.chain_names == ["openai", "bm25"]
+
+
+def test_build_chain_legacy_single_provider():
+    """Legacy embedding_provider: "sentence-transformers" → chain of one + bm25."""
+    config = {"embedding_provider": "sentence-transformers"}
+    chain = build_embedding_chain(config)
+    assert chain.chain_names == ["sentence-transformers", "bm25"]
+
+
+def test_build_chain_legacy_none():
+    """Legacy embedding_provider: "none" → bm25 only."""
+    config = {"embedding_provider": "none"}
+    chain = build_embedding_chain(config)
+    assert chain.chain_names == ["bm25"]
+
+
+@patch("palaia.embeddings.detect_providers")
+def test_build_chain_legacy_auto(mock_detect):
+    """Legacy embedding_provider: "auto" → auto-detected chain."""
+    mock_detect.return_value = [
+        {"name": "ollama", "available": False},
+        {"name": "sentence-transformers", "available": True},
+        {"name": "fastembed", "available": False},
+        {"name": "openai", "available": True},
+        {"name": "voyage", "available": False},
+    ]
+    config = {"embedding_provider": "auto"}
+    chain = build_embedding_chain(config)
+    assert "sentence-transformers" in chain.chain_names
+    assert "openai" in chain.chain_names
+    assert chain.chain_names[-1] == "bm25"
+
+
+def test_build_chain_embedding_chain_overrides_provider():
+    """embedding_chain takes precedence over embedding_provider."""
+    config = {
+        "embedding_chain": ["openai", "bm25"],
+        "embedding_provider": "sentence-transformers",
+    }
+    chain = build_embedding_chain(config)
+    assert chain.chain_names == ["openai", "bm25"]
+    assert "sentence-transformers" not in chain.chain_names
+
+
+def test_build_chain_legacy_single_model_string():
+    """Legacy embedding_model as string maps to the provider."""
+    config = {
+        "embedding_provider": "openai",
+        "embedding_model": "text-embedding-3-large",
+    }
+    chain = build_embedding_chain(config)
+    assert chain.models.get("openai") == "text-embedding-3-large"
+
+
+def test_chain_provider_status():
+    """provider_status returns info for each chain member."""
+    chain = EmbeddingChain(["openai", "sentence-transformers", "bm25"])
+    with patch("palaia.embeddings.detect_providers") as mock_detect:
+        mock_detect.return_value = [
+            {"name": "openai", "available": True},
+            {"name": "sentence-transformers", "available": True},
+            {"name": "ollama", "available": False},
+            {"name": "fastembed", "available": False},
+            {"name": "voyage", "available": False},
+        ]
+        statuses = chain.provider_status()
+    assert len(statuses) == 3
+    assert statuses[0]["name"] == "openai"
+    assert statuses[0]["available"] is True
+    assert statuses[2]["name"] == "bm25"
+    assert statuses[2]["available"] is True


### PR DESCRIPTION
## Konfigurierbare Fallback-Kette

### Was ist neu?

**Embedding Chain** — Eine Prioritätsliste von Embedding-Providern. Palaia probiert den ersten; wenn der fehlschlägt (Rate-Limit, Timeout, Import-Error), nimmt es den nächsten. BM25 ist immer der letzte Fallback.

### Config

```json
{
  "embedding_chain": ["openai", "sentence-transformers", "bm25"],
  "embedding_model": {
    "openai": "text-embedding-3-large",
    "sentence-transformers": "all-MiniLM-L6-v2"
  }
}
```

### CLI

```bash
palaia config set-chain openai sentence-transformers bm25
palaia status   # zeigt Chain + Verfügbarkeit
palaia detect   # empfiehlt Chain + copy-paste Befehl
```

### Änderungen

- `EmbeddingChain` Klasse in `embeddings.py` mit automatischem Fallback
- `build_embedding_chain()` baut Chain aus Config
- `palaia config set-chain` CLI-Befehl
- `palaia status` zeigt Chain-Status mit Provider-Verfügbarkeit
- `palaia detect` empfiehlt Chain basierend auf Host
- Voll rückwärtskompatibel: `embedding_provider` funktioniert weiterhin
- SKILL.md: Neue Sektion "Setting Up Your Embedding Chain" mit Agent-Entscheidungsbaum
- 19 neue Tests (123 gesamt, alle grün)

### Rückwärtskompatibilität

- `embedding_provider: "auto"` → auto-detected chain (wie bisher)
- `embedding_provider: "sentence-transformers"` → chain mit einem Element
- `embedding_chain` hat Vorrang wenn beides gesetzt