### PR TITLE
feat: UX improvements — issues #9, #10, #11, #12 + version tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,24 @@ pip install palaia
 
 If you find Palaia useful, a ⭐ on GitHub goes a long way.
 
+## Multi-Agent Setup
+
+If you run multiple agents that should share the same memory store, use the setup command:
+
+```bash
+# Preview what would happen
+palaia setup --multi-agent ~/.openclaw/agents/ --dry-run
+
+# Create .palaia symlinks for all agent directories
+palaia setup --multi-agent ~/.openclaw/agents/
+```
+
+This scans the agents directory for subdirectories and creates `.palaia` symlinks pointing to your current store. All agents then share the same memory while maintaining their own identity via the `--agent` flag on writes.
+
+## Migration Guide
+
+Moving from another memory system? See [`docs/migration-guide.md`](docs/migration-guide.md) for a step-by-step guide covering inventory, bulk import, verification, and cleanup.
+
 ## Development
 
 ```bash

--- a/SKILL.md
+++ b/SKILL.md
@@ -395,6 +395,15 @@ Palaia organizes entries into three tiers based on access frequency:
 
 Run `palaia gc` periodically (or let cron handle it) to rotate entries between tiers. `palaia gc --aggressive` forces more entries to lower tiers.
 
+## After Updating Palaia
+
+Always run `palaia doctor` after updating. It checks your store for compatibility, suggests new features (like projects or embedding chain improvements), and handles version stamping. If the installed version differs from the store version, Palaia will warn you automatically on every CLI call until you run `palaia doctor`.
+
+```bash
+pip install --upgrade palaia
+palaia doctor --fix
+```
+
 ## Configuration Keys
 
 | Key | Default | Description |

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -1,69 +1,127 @@
 # Migration Guide
 
-This guide covers migrating from OpenClaw's built-in smart-memory (or other formats) to Palaia.
+How to move your agent's memory into Palaia — from flat files, other memory systems, or a fresh start.
 
-## Quick Migration
+## 5-Step Migration
+
+### 1. Inventory
+
+Figure out what you have. Common sources:
+
+- `memory/*.md` files (OpenClaw smart-memory)
+- JSON-based memory stores
+- Flat markdown notes in workspace directories
+- Conversation logs with embedded knowledge
 
 ```bash
-# 1. Install Palaia
-pip install git+https://github.com/iret77/palaia.git
+# Check what palaia doctor finds
+palaia doctor --fix
 
-# 2. Initialize
-palaia init
-
-# 3. Preview what would be imported
-palaia migrate . --dry-run
-
-# 4. Run the migration
-palaia migrate .
-
-# 5. Verify
-palaia status
-palaia list
+# Count your existing files
+find ~/. openclaw/workspace/memory -name "*.md" | wc -l
 ```
 
-Supported formats: `smart-memory`, `flat-file`, `json-memory`, `generic-md`.
-Palaia auto-detects the format, or you can force it with `--format`.
+### 2. Ingest
 
-## ⚠️ Important: Do NOT Delete System Files
+Bulk-import your existing files. Palaia chunks them automatically for search.
 
-After migrating to Palaia, these files MUST remain on disk — they are living documents read by agents at runtime, not historical data:
+```bash
+# Single file
+palaia ingest ~/docs/architecture.md --project myapp --scope team
 
-- `CONTEXT.md` (project context, injected into subagent prompts)
-- `SOUL.md` (agent personality/identity)
-- `MEMORY.md` (orchestrator core memory)
-- `AGENTS.md` (workspace config)
-- `TOOLS.md` (tool config)
-- `USER.md` (user preferences)
-- `IDENTITY.md` (agent identity)
+# Entire directory (recursive)
+palaia ingest ~/. openclaw/workspace/memory/ --project legacy-notes --scope private
 
-`palaia ingest` creates a **searchable copy** in the store. The original file continues to be the source of truth. Deleting it breaks agent workflows.
+# With custom chunking for large docs
+palaia ingest ~/docs/api-spec.md --project myapp --chunk-size 300 --chunk-overlap 30
 
-**Safe to archive after migration:**
-- Daily logs (`memory/YYYY-MM-DD.md`) — historical, not read at runtime
-- Old chat logs (`memory/chat-*.md`)
-- One-off notes that have been fully ingested
+# Preview first (dry run)
+palaia ingest ~/docs/ --project myapp --dry-run
+```
 
-## What Happens During Migration
+**Tip:** `--project` auto-creates the project if it doesn't exist. No need to run `palaia project create` first.
 
-`palaia migrate` reads your existing memory files, converts them to Palaia entries, and stores them in the Palaia database. **Source files are NOT modified or deleted.**
+### 3. Verify
 
-For smart-memory format, files are mapped as follows:
+Check that your data made it in:
 
-| Source File | Palaia Tier | Scope |
-|---|---|---|
-| `MEMORY.md` | HOT | team |
-| `memory/active-context.md` | HOT (per block) | team |
-| `memory/projects/*/CONTEXT.md` | HOT | shared:{project} |
-| `memory/agents/*.md` | WARM | team |
-| `memory/YYYY-MM-DD.md` | COLD | team |
+```bash
+# See what's stored
+palaia list --project myapp
+palaia list --project legacy-notes
 
-## Post-Migration
+# Test search
+palaia query "database connection" --project myapp
 
-After migration, Palaia and your existing files coexist:
+# Check overall health
+palaia status
+```
 
-- **Palaia** provides semantic search across all your memory
-- **Original files** continue to be loaded by OpenClaw at agent startup
-- Both systems work together — Palaia supplements, it does not replace
+### 4. Cleanup
 
-Do **not** "clean up" by deleting source files. See the system files list above.
+Once verified, remove or archive the old files:
+
+```bash
+# Archive (recommended — keep a backup)
+tar czf ~/memory-backup-$(date +%Y%m%d).tar.gz ~/. openclaw/workspace/memory/
+
+# Or just move them aside
+mv ~/. openclaw/workspace/memory ~/. openclaw/workspace/memory-archived
+
+# Run doctor to confirm clean state
+palaia doctor
+```
+
+### 5. Integration
+
+Point your agent to use Palaia for all memory operations:
+
+```bash
+# If using OpenClaw, the skill handles this automatically
+# For custom setups, use the CLI or Python API:
+
+# Write new memories
+palaia write "Deploy uses port 8080 on staging" --project infra --tags deploy,staging
+
+# Query in scripts
+palaia query "staging port" --project infra --json
+
+# Multi-agent? Set up shared access:
+palaia setup --multi-agent ~/.openclaw/agents/
+```
+
+## Migrating from Smart-Memory
+
+If you're coming from the OpenClaw smart-memory skill:
+
+```bash
+# 1. Palaia can auto-detect and import smart-memory format
+palaia migrate ~/.openclaw/workspace/memory/ --format smart-memory --dry-run
+
+# 2. If it looks good, run for real
+palaia migrate ~/.openclaw/workspace/memory/ --format smart-memory
+
+# 3. Verify
+palaia status
+palaia query "test search"
+
+# 4. Run doctor to check for leftover legacy patterns
+palaia doctor --fix
+```
+
+## Migrating from JSON Memory
+
+```bash
+# Generic JSON import
+palaia migrate ./memory-export.json --format json-memory
+
+# With scope override (make everything private)
+palaia migrate ./data/ --format generic-md --scope private
+```
+
+## Tips
+
+- **Start with `--dry-run`** on any bulk operation to preview what will happen.
+- **Use projects** to keep imported data organized and separate from new entries.
+- **Run `palaia doctor`** after migration to catch any leftover issues.
+- **Don't delete originals immediately** — archive them first, verify Palaia search works, then clean up.

--- a/palaia/cli.py
+++ b/palaia/cli.py
@@ -96,6 +96,7 @@ def cmd_init(args):
         print(f"🤖 Found 1 agent: {agents[0]}")
         config["store_mode"] = "shared"
 
+    config["store_version"] = __version__
     save_config(target, config)
 
     if not is_reinit:
@@ -304,6 +305,11 @@ def cmd_ingest(args):
     ingestor = DocumentIngestor(store)
     source = args.source
 
+    # Auto-create project if specified and doesn't exist (#9)
+    if args.project and not args.dry_run:
+        pm = ProjectManager(root)
+        pm.ensure(args.project)
+
     if not getattr(args, "json", False) and not args.dry_run:
         print(f"Ingesting: {source}")
 
@@ -389,10 +395,20 @@ def cmd_list(args):
     tier = args.tier or "hot"
     entries = store.list_entries(tier, agent=getattr(args, "agent", None))
 
-    # Filter by project if specified
+    # Apply filters (#12)
     project_filter = getattr(args, "project", None)
+    tag_filter = getattr(args, "tag", None)
+    scope_filter = getattr(args, "scope", None)
+    agent_filter = getattr(args, "agent", None)
+
     if project_filter:
         entries = [(meta, body) for meta, body in entries if meta.get("project") == project_filter]
+    if tag_filter:
+        entries = [(meta, body) for meta, body in entries if tag_filter in (meta.get("tags") or [])]
+    if scope_filter:
+        entries = [(meta, body) for meta, body in entries if meta.get("scope") == scope_filter]
+    if agent_filter:
+        entries = [(meta, body) for meta, body in entries if meta.get("agent") == agent_filter]
 
     if _json_out(
         {
@@ -402,6 +418,9 @@ def cmd_list(args):
                     "id": meta.get("id", "?"),
                     "title": meta.get("title", "(untitled)"),
                     "scope": meta.get("scope", "team"),
+                    "agent": meta.get("agent", ""),
+                    "tags": meta.get("tags", []),
+                    "project": meta.get("project", ""),
                     "decay_score": meta.get("decay_score", 0),
                     "preview": body[:80].replace("\n", " "),
                 }
@@ -841,6 +860,78 @@ def cmd_migrate(args):
     return 0
 
 
+def cmd_setup(args):
+    """Multi-agent setup: create .palaia symlinks for agent directories."""
+    if not args.multi_agent:
+        print("Usage: palaia setup --multi-agent <agents-dir>", file=sys.stderr)
+        return 1
+
+    agents_dir = Path(args.multi_agent)
+    if not agents_dir.is_dir():
+        msg = f"Directory not found: {agents_dir}"
+        if _json_out({"error": msg}, args):
+            return 1
+        print(f"Error: {msg}", file=sys.stderr)
+        return 1
+
+    root = get_root()
+    store_path = root  # The .palaia directory itself
+
+    # Scan for agent subdirectories
+    agent_dirs = sorted([d for d in agents_dir.iterdir() if d.is_dir() and not d.name.startswith(".")])
+
+    if not agent_dirs:
+        msg = f"No agent directories found in {agents_dir}"
+        if _json_out({"error": msg, "agents": []}, args):
+            return 1
+        print(f"No agent directories found in {agents_dir}", file=sys.stderr)
+        return 1
+
+    dry_run = getattr(args, "dry_run", False)
+    agents = []
+    symlinks_created = 0
+
+    for agent_dir in agent_dirs:
+        agent_name = agent_dir.name
+        symlink_path = agent_dir / ".palaia"
+        agents.append(agent_name)
+
+        if symlink_path.exists() or symlink_path.is_symlink():
+            if not dry_run and not getattr(args, "json", False):
+                print(f"  ⏭  {agent_name}: .palaia already exists")
+            continue
+
+        if dry_run:
+            if not getattr(args, "json", False):
+                print(f"  🔗 {agent_name}: would create .palaia → {store_path}")
+            symlinks_created += 1
+        else:
+            try:
+                symlink_path.symlink_to(store_path)
+                symlinks_created += 1
+                if not getattr(args, "json", False):
+                    print(f"  ✅ {agent_name}: .palaia → {store_path}")
+            except OSError as e:
+                if not getattr(args, "json", False):
+                    print(f"  ❌ {agent_name}: {e}")
+
+    result = {
+        "agents": agents,
+        "symlinks_created": symlinks_created,
+        "store_path": str(store_path),
+        "dry_run": dry_run,
+    }
+
+    if _json_out(result, args):
+        return 0
+
+    if not dry_run:
+        print(f"\n{symlinks_created} symlink(s) created for {len(agents)} agent(s).")
+    else:
+        print(f"\nDry run: {symlinks_created} symlink(s) would be created for {len(agents)} agent(s).")
+    return 0
+
+
 def cmd_project(args):
     """Manage projects."""
     root = get_root()
@@ -1061,7 +1152,9 @@ def main():
     p_list = sub.add_parser("list", help="List entries in a tier")
     p_list.add_argument("--tier", default="hot", choices=["hot", "warm", "cold"])
     p_list.add_argument("--project", default=None, help="Filter by project")
-    p_list.add_argument("--agent", default=None, help="Agent name (for scope filtering)")
+    p_list.add_argument("--tag", default=None, help="Filter by tag")
+    p_list.add_argument("--scope", default=None, help="Filter by scope")
+    p_list.add_argument("--agent", default=None, help="Filter by agent")
     p_list.add_argument("--json", action="store_true", help="Output as JSON")
 
     # status
@@ -1116,6 +1209,12 @@ def main():
     p_proj_delete = project_sub.add_parser("delete", help="Delete project (entries preserved)")
     p_proj_delete.add_argument("name", help="Project name")
     p_proj_delete.add_argument("--json", action="store_true", help="Output as JSON")
+
+    # setup
+    p_setup = sub.add_parser("setup", help="Multi-agent setup")
+    p_setup.add_argument("--multi-agent", default=None, help="Path to agents directory")
+    p_setup.add_argument("--dry-run", action="store_true", help="Preview without creating symlinks")
+    p_setup.add_argument("--json", action="store_true", help="Output as JSON")
 
     # doctor
     p_doctor = sub.add_parser("doctor", help="Diagnose Palaia instance and detect legacy systems")
@@ -1176,6 +1275,22 @@ def main():
         parser.print_help()
         return 1
 
+    # Version drift warning (skip for init/doctor/detect)
+    if args.command not in ("init", "doctor", "detect") and not getattr(args, "json", False):
+        try:
+            root = find_palaia_root()
+            if root:
+                cfg = load_config(root)
+                store_ver = cfg.get("store_version", "")
+                if store_ver and store_ver != __version__:
+                    print(
+                        f"⚠️  Store created with v{store_ver}, running v{__version__}. "
+                        "Run `palaia doctor` for upgrade checks.",
+                        file=sys.stderr,
+                    )
+        except Exception:
+            pass
+
     commands = {
         "init": cmd_init,
         "write": cmd_write,
@@ -1186,6 +1301,7 @@ def main():
         "list": cmd_list,
         "status": cmd_status,
         "gc": cmd_gc,
+        "setup": cmd_setup,
         "doctor": cmd_doctor,
         "export": cmd_export,
         "import": cmd_import,

--- a/palaia/config.py
+++ b/palaia/config.py
@@ -18,6 +18,7 @@ DEFAULT_CONFIG = {
     "lock_timeout_seconds": 5,
     "embedding_provider": "auto",
     "embedding_model": "",
+    "store_version": "",  # Set to palaia __version__ on init/upgrade
 }
 
 

--- a/palaia/doctor.py
+++ b/palaia/doctor.py
@@ -303,11 +303,151 @@ def _check_wal_health(palaia_root: Path | None) -> dict[str, Any]:
     }
 
 
+def _check_store_version(palaia_root: Path | None) -> dict[str, Any]:
+    """Check if store version matches installed version."""
+    if palaia_root is None:
+        return {
+            "name": "store_version",
+            "label": "Store version",
+            "status": "error",
+            "message": "Not initialized",
+        }
+
+    from palaia import __version__
+    from palaia.config import load_config, save_config
+
+    config = load_config(palaia_root)
+    store_ver = config.get("store_version", "")
+
+    if not store_ver:
+        # Legacy store without version tracking — stamp it now
+        config["store_version"] = __version__
+        save_config(palaia_root, config)
+        return {
+            "name": "store_version",
+            "label": "Store version",
+            "status": "info",
+            "message": f"No store_version found — stamped as v{__version__}",
+            "details": {"installed": __version__, "store": __version__},
+        }
+
+    if store_ver == __version__:
+        return {
+            "name": "store_version",
+            "label": "Store version",
+            "status": "ok",
+            "message": f"v{__version__} (up to date)",
+            "details": {"installed": __version__, "store": store_ver},
+        }
+
+    # Version mismatch — update store_version to current
+    config["store_version"] = __version__
+    save_config(palaia_root, config)
+    return {
+        "name": "store_version",
+        "label": "Store version",
+        "status": "info",
+        "message": f"Upgraded store: v{store_ver} → v{__version__}",
+        "details": {"installed": __version__, "store": store_ver},
+    }
+
+
+def _check_projects_usage(palaia_root: Path | None) -> dict[str, Any]:
+    """Check if projects feature is being used."""
+    if palaia_root is None:
+        return {
+            "name": "projects_usage",
+            "label": "Projects",
+            "status": "error",
+            "message": "Not initialized",
+        }
+
+    projects_file = palaia_root / "projects.json"
+    if not projects_file.exists():
+        return {
+            "name": "projects_usage",
+            "label": "Projects",
+            "status": "info",
+            "message": "Not used yet — organize entries with: palaia project create <name>",
+        }
+
+    try:
+        import json as _json
+
+        data = _json.loads(projects_file.read_text())
+        count = len(data) if isinstance(data, dict) else 0
+        if count == 0:
+            return {
+                "name": "projects_usage",
+                "label": "Projects",
+                "status": "info",
+                "message": "Empty — create projects with: palaia project create <name>",
+            }
+        return {
+            "name": "projects_usage",
+            "label": "Projects",
+            "status": "ok",
+            "message": f"{count} project(s) configured",
+            "details": {"count": count},
+        }
+    except Exception:
+        return {
+            "name": "projects_usage",
+            "label": "Projects",
+            "status": "warn",
+            "message": "projects.json exists but unreadable",
+        }
+
+
+def _check_deprecated_config(palaia_root: Path | None) -> dict[str, Any]:
+    """Check for deprecated or missing config keys."""
+    if palaia_root is None:
+        return {
+            "name": "deprecated_config",
+            "label": "Config keys",
+            "status": "error",
+            "message": "Not initialized",
+        }
+
+    from palaia.config import load_config
+
+    config = load_config(palaia_root)
+    issues = []
+
+    # Check for legacy embedding_provider without chain
+    if config.get("embedding_provider") and config.get("embedding_provider") != "auto":
+        if not config.get("embedding_chain"):
+            issues.append(
+                "embedding_provider is set but embedding_chain is not — "
+                "run: palaia detect && palaia config set-chain <providers> bm25"
+            )
+
+    if issues:
+        return {
+            "name": "deprecated_config",
+            "label": "Config keys",
+            "status": "warn",
+            "message": f"{len(issues)} issue(s)",
+            "fix": "\n".join(issues),
+            "details": {"issues": issues},
+        }
+
+    return {
+        "name": "deprecated_config",
+        "label": "Config keys",
+        "status": "ok",
+        "message": "All config keys current",
+    }
+
+
 def run_doctor(palaia_root: Path | None = None) -> list[dict[str, Any]]:
     """Run all doctor checks. Returns list of check results."""
     results = [
         _check_palaia_init(palaia_root),
+        _check_store_version(palaia_root),
         _check_embedding_chain(palaia_root),
+        _check_projects_usage(palaia_root),
+        _check_deprecated_config(palaia_root),
         _check_openclaw_plugin(),
         _check_smart_memory_skill(),
         _check_legacy_memory_files(),

--- a/palaia/project.py
+++ b/palaia/project.py
@@ -111,6 +111,18 @@ class ProjectManager:
             return None
         return Project.from_dict(data[name])
 
+    def ensure(self, name: str, default_scope: str = "team") -> Project:
+        """Get a project by name, creating it if it doesn't exist.
+
+        This is the recommended way to reference projects from CLI commands
+        that accept --project. It avoids the user having to manually create
+        projects before using them.
+        """
+        project = self.get(name)
+        if project is not None:
+            return project
+        return self.create(name=name, default_scope=default_scope)
+
     def delete(self, name: str, store=None) -> bool:
         """Delete a project. Entries keep their content but lose the project tag."""
         data = self._load()

--- a/palaia/store.py
+++ b/palaia/store.py
@@ -59,15 +59,12 @@ class Store:
             # Explicit scope always wins
             scope = normalize_scope(scope)
         elif project:
-            # Try project default scope
+            # Auto-create project if it doesn't exist, then use its default scope
             from palaia.project import ProjectManager
 
             pm = ProjectManager(self.root)
-            proj = pm.get(project)
-            if proj:
-                scope = normalize_scope(proj.default_scope)
-            else:
-                scope = normalize_scope(None, self.config["default_scope"])
+            proj = pm.ensure(project, default_scope=self.config["default_scope"])
+            scope = normalize_scope(proj.default_scope)
         else:
             scope = normalize_scope(None, self.config["default_scope"])
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -261,7 +261,7 @@ class TestRunDoctor:
     def test_run_all_checks(self, palaia_root, tmp_path, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))
         results = run_doctor(palaia_root)
-        assert len(results) == 7
+        assert len(results) == 10
         assert all("status" in r for r in results)
         assert all("name" in r for r in results)
 

--- a/tests/test_ux_improvements.py
+++ b/tests/test_ux_improvements.py
@@ -1,0 +1,431 @@
+"""Tests for UX improvements: issues #9, #10, #11, #12 + version tracking."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from palaia import __version__
+from palaia.config import DEFAULT_CONFIG, load_config, save_config
+from palaia.doctor import run_doctor
+from palaia.entry import parse_entry
+from palaia.project import ProjectManager
+from palaia.store import Store
+
+
+@pytest.fixture
+def palaia_root(tmp_path):
+    """Create a fresh .palaia directory."""
+    root = tmp_path / ".palaia"
+    root.mkdir()
+    for sub in ("hot", "warm", "cold", "wal", "index"):
+        (root / sub).mkdir()
+    config = dict(DEFAULT_CONFIG)
+    config["store_version"] = __version__
+    save_config(root, config)
+    return root
+
+
+@pytest.fixture
+def pm(palaia_root):
+    return ProjectManager(palaia_root)
+
+
+@pytest.fixture
+def store(palaia_root):
+    return Store(palaia_root)
+
+
+# --- Issue #9: Auto-create projects ---
+
+
+class TestAutoCreateProject:
+    def test_ensure_creates_new_project(self, pm):
+        """ensure() should create a project that doesn't exist."""
+        project = pm.ensure("new-proj")
+        assert project.name == "new-proj"
+        assert project.default_scope == "team"
+        # Should be persisted
+        assert pm.get("new-proj") is not None
+
+    def test_ensure_returns_existing_project(self, pm):
+        """ensure() should return existing project without error."""
+        pm.create("existing", description="Already here", default_scope="private")
+        project = pm.ensure("existing")
+        assert project.name == "existing"
+        assert project.description == "Already here"
+        assert project.default_scope == "private"
+
+    def test_ensure_respects_default_scope(self, pm):
+        """ensure() should pass default_scope when creating."""
+        project = pm.ensure("scoped", default_scope="private")
+        assert project.default_scope == "private"
+
+    def test_store_write_auto_creates_project(self, store, pm):
+        """store.write() with --project should auto-create the project."""
+        entry_id = store.write("auto-create test", project="auto-proj")
+        assert entry_id
+        # Project should now exist
+        project = pm.get("auto-proj")
+        assert project is not None
+        assert project.name == "auto-proj"
+
+    def test_store_write_auto_create_uses_project_scope(self, store, pm):
+        """Auto-created project should use global default scope, then entry uses it."""
+        entry_id = store.write("scoped entry", project="scoped-proj")
+        path = store.root / "hot" / f"{entry_id}.md"
+        meta, _ = parse_entry(path.read_text())
+        assert meta["project"] == "scoped-proj"
+        assert meta["scope"] == "team"  # global default
+
+    def test_store_write_existing_project_not_recreated(self, store, pm):
+        """Writing to existing project should not raise or recreate."""
+        pm.create("existing", description="Original", default_scope="private")
+        entry_id = store.write("test", project="existing")
+        assert entry_id
+        # Description should be preserved (not overwritten)
+        project = pm.get("existing")
+        assert project.description == "Original"
+
+
+# --- Issue #10: Multi-Agent Setup ---
+
+
+class TestMultiAgentSetup:
+    def test_setup_creates_symlinks(self, palaia_root, tmp_path):
+        """setup should create .palaia symlinks in agent dirs."""
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        (agents_dir / "main").mkdir()
+        (agents_dir / "elliot").mkdir()
+        (agents_dir / "saul").mkdir()
+
+        # Call the setup function directly
+        from palaia.cli import cmd_setup
+
+        class Args:
+            multi_agent = str(agents_dir)
+            dry_run = False
+            json = True
+
+        import io
+        from contextlib import redirect_stdout
+
+        # Need to mock get_root
+        import palaia.cli
+
+        original_get_root = palaia.cli.get_root
+        palaia.cli.get_root = lambda: palaia_root
+
+        try:
+            f = io.StringIO()
+            with redirect_stdout(f):
+                ret = cmd_setup(Args())
+            output = f.getvalue()
+            data = json.loads(output)
+            assert ret == 0
+            assert set(data["agents"]) == {"main", "elliot", "saul"}
+            assert data["symlinks_created"] == 3
+
+            # Verify symlinks exist
+            for agent in ("main", "elliot", "saul"):
+                link = agents_dir / agent / ".palaia"
+                assert link.is_symlink()
+                assert link.resolve() == palaia_root.resolve()
+        finally:
+            palaia.cli.get_root = original_get_root
+
+    def test_setup_dry_run(self, palaia_root, tmp_path):
+        """--dry-run should not create symlinks."""
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        (agents_dir / "agent1").mkdir()
+
+        from palaia.cli import cmd_setup
+
+        class Args:
+            multi_agent = str(agents_dir)
+            dry_run = True
+            json = True
+
+        import io
+        from contextlib import redirect_stdout
+
+        import palaia.cli
+
+        original_get_root = palaia.cli.get_root
+        palaia.cli.get_root = lambda: palaia_root
+
+        try:
+            f = io.StringIO()
+            with redirect_stdout(f):
+                ret = cmd_setup(Args())
+            data = json.loads(f.getvalue())
+            assert ret == 0
+            assert data["dry_run"] is True
+            assert data["symlinks_created"] == 1
+            # Symlink should NOT exist
+            assert not (agents_dir / "agent1" / ".palaia").exists()
+        finally:
+            palaia.cli.get_root = original_get_root
+
+    def test_setup_skips_existing(self, palaia_root, tmp_path):
+        """setup should skip dirs that already have .palaia."""
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        agent_dir = agents_dir / "existing"
+        agent_dir.mkdir()
+        (agent_dir / ".palaia").symlink_to(palaia_root)
+
+        from palaia.cli import cmd_setup
+
+        class Args:
+            multi_agent = str(agents_dir)
+            dry_run = False
+            json = True
+
+        import io
+        from contextlib import redirect_stdout
+
+        import palaia.cli
+
+        original_get_root = palaia.cli.get_root
+        palaia.cli.get_root = lambda: palaia_root
+
+        try:
+            f = io.StringIO()
+            with redirect_stdout(f):
+                ret = cmd_setup(Args())
+            data = json.loads(f.getvalue())
+            assert ret == 0
+            assert data["symlinks_created"] == 0
+        finally:
+            palaia.cli.get_root = original_get_root
+
+    def test_setup_ignores_dotdirs(self, palaia_root, tmp_path):
+        """setup should ignore hidden directories."""
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        (agents_dir / ".hidden").mkdir()
+        (agents_dir / "visible").mkdir()
+
+        from palaia.cli import cmd_setup
+
+        class Args:
+            multi_agent = str(agents_dir)
+            dry_run = False
+            json = True
+
+        import io
+        from contextlib import redirect_stdout
+
+        import palaia.cli
+
+        original_get_root = palaia.cli.get_root
+        palaia.cli.get_root = lambda: palaia_root
+
+        try:
+            f = io.StringIO()
+            with redirect_stdout(f):
+                cmd_setup(Args())
+            data = json.loads(f.getvalue())
+            assert "visible" in data["agents"]
+            assert ".hidden" not in data["agents"]
+        finally:
+            palaia.cli.get_root = original_get_root
+
+
+# --- Issue #12: List Filters ---
+
+
+class TestListFilters:
+    def test_filter_by_project(self, store, pm):
+        pm.create("alpha")
+        store.write("alpha entry", project="alpha")
+        store.write("no project entry")
+
+        entries = store.list_entries("hot")
+        filtered = [(m, b) for m, b in entries if m.get("project") == "alpha"]
+        assert len(filtered) == 1
+
+    def test_filter_by_tag(self, store):
+        store.write("tagged", tags=["important", "daily"])
+        store.write("untagged")
+
+        entries = store.list_entries("hot")
+        filtered = [(m, b) for m, b in entries if "important" in (m.get("tags") or [])]
+        assert len(filtered) == 1
+
+    def test_filter_by_scope(self, store):
+        store.write("team entry", scope="team")
+        store.write("public entry", scope="public")
+
+        entries = store.list_entries("hot")
+        filtered = [(m, b) for m, b in entries if m.get("scope") == "public"]
+        assert len(filtered) == 1
+
+    def test_filter_by_agent(self, store):
+        store.write("agent1 entry", agent="agent1")
+        store.write("agent2 entry", agent="agent2")
+
+        entries = store.list_entries("hot")
+        filtered = [(m, b) for m, b in entries if m.get("agent") == "agent1"]
+        assert len(filtered) == 1
+
+    def test_combined_filters(self, store, pm):
+        pm.create("proj")
+        store.write("match", project="proj", tags=["daily"], agent="bot1")
+        store.write("wrong project", project="other", tags=["daily"], agent="bot1")
+        store.write("wrong tag", project="proj", tags=["weekly"], agent="bot1")
+
+        entries = store.list_entries("hot")
+        filtered = [
+            (m, b)
+            for m, b in entries
+            if m.get("project") == "proj" and "daily" in (m.get("tags") or [])
+        ]
+        assert len(filtered) == 1
+
+    def test_cli_list_filters_json(self, palaia_root, pm):
+        """CLI integration: list with --tag, --scope, --agent filters."""
+        store = Store(palaia_root)
+        store.write("entry1", tags=["bug"], scope="team", agent="bot1")
+        store.write("entry2", tags=["feature"], scope="public", agent="bot2")
+
+        def _run(*args):
+            result = subprocess.run(
+                [sys.executable, "-m", "palaia"] + list(args) + ["--json"],
+                capture_output=True,
+                text=True,
+                cwd=str(palaia_root.parent),
+            )
+            return result
+
+        # Filter by tag
+        r = _run("list", "--tag", "bug")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert len(data["entries"]) == 1
+        assert "bug" in data["entries"][0]["tags"]
+
+        # Filter by agent
+        r = _run("list", "--agent", "bot2")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert len(data["entries"]) == 1
+        assert data["entries"][0]["agent"] == "bot2"
+
+        # Filter by scope
+        r = _run("list", "--scope", "public")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert len(data["entries"]) == 1
+
+        # No match
+        r = _run("list", "--tag", "nonexistent")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert len(data["entries"]) == 0
+
+
+# --- Version Tracking + Doctor ---
+
+
+class TestVersionTracking:
+    def test_store_version_set_on_init(self, palaia_root):
+        config = load_config(palaia_root)
+        assert config.get("store_version") == __version__
+
+    def test_doctor_stamps_legacy_store(self, tmp_path):
+        """Doctor should stamp stores missing store_version."""
+        root = tmp_path / ".palaia"
+        root.mkdir()
+        for sub in ("hot", "warm", "cold", "wal", "index"):
+            (root / sub).mkdir()
+        # Save config without store_version
+        config = dict(DEFAULT_CONFIG)
+        del config["store_version"]
+        save_config(root, config)
+
+        results = run_doctor(root)
+        ver_check = next(r for r in results if r["name"] == "store_version")
+        assert ver_check["status"] == "info"
+        assert "stamped" in ver_check["message"]
+
+        # Should now be stamped
+        config = load_config(root)
+        assert config["store_version"] == __version__
+
+    def test_doctor_detects_version_mismatch(self, tmp_path):
+        """Doctor should detect and upgrade store version."""
+        root = tmp_path / ".palaia"
+        root.mkdir()
+        for sub in ("hot", "warm", "cold", "wal", "index"):
+            (root / sub).mkdir()
+        config = dict(DEFAULT_CONFIG)
+        config["store_version"] = "0.9.0"
+        save_config(root, config)
+
+        results = run_doctor(root)
+        ver_check = next(r for r in results if r["name"] == "store_version")
+        assert ver_check["status"] == "info"
+        assert "Upgraded" in ver_check["message"]
+        assert "0.9.0" in ver_check["message"]
+
+    def test_doctor_ok_when_versions_match(self, palaia_root):
+        results = run_doctor(palaia_root)
+        ver_check = next(r for r in results if r["name"] == "store_version")
+        assert ver_check["status"] == "ok"
+
+    def test_doctor_checks_projects_usage(self, palaia_root):
+        results = run_doctor(palaia_root)
+        proj_check = next(r for r in results if r["name"] == "projects_usage")
+        assert proj_check["status"] == "info"  # Not used yet
+
+        # Create a project
+        pm = ProjectManager(palaia_root)
+        pm.create("test")
+        results = run_doctor(palaia_root)
+        proj_check = next(r for r in results if r["name"] == "projects_usage")
+        assert proj_check["status"] == "ok"
+
+    def test_doctor_checks_deprecated_config(self, palaia_root):
+        results = run_doctor(palaia_root)
+        cfg_check = next(r for r in results if r["name"] == "deprecated_config")
+        assert cfg_check["status"] == "ok"
+
+
+# --- Issue #9 CLI Integration ---
+
+
+class TestAutoCreateProjectCLI:
+    def _run(self, palaia_root, *args):
+        result = subprocess.run(
+            [sys.executable, "-m", "palaia"] + list(args) + ["--json"],
+            capture_output=True,
+            text=True,
+            cwd=str(palaia_root.parent),
+        )
+        return result
+
+    def test_write_autocreates_project(self, palaia_root):
+        """palaia write --project X should auto-create project X."""
+        r = self._run(palaia_root, "write", "test entry", "--project", "auto-created")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert "id" in data
+
+        # Verify project exists
+        r = self._run(palaia_root, "project", "show", "auto-created")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert data["project"]["name"] == "auto-created"
+
+    def test_write_existing_project_works(self, palaia_root):
+        """Writing to existing project should still work."""
+        self._run(palaia_root, "project", "create", "existing")
+        r = self._run(palaia_root, "write", "test", "--project", "existing")
+        assert r.returncode == 0


### PR DESCRIPTION
## Summary

Implements four UX improvement issues plus Christian's additional version-tracking requirement.

### Issue #9 — Auto-create projects with `--project`
- Added `ProjectManager.ensure(name)` helper that creates-if-not-exists
- `store.write()` now auto-creates projects when `--project` is specified
- `palaia ingest --project` also auto-creates
- No more manual `palaia project create` required before use

### Issue #10 — Multi-Agent Setup Command
- New command: `palaia setup --multi-agent <agents-dir>`
- Scans for agent subdirectories, creates `.palaia` symlinks to shared store
- `--dry-run` flag for preview
- JSON output: `{"agents": [...], "symlinks_created": N}`
- README section added

### Issue #11 — Migration Guide
- New file: `docs/migration-guide.md`
- 5-step process: Inventory → Ingest → Verify → Cleanup → Integration
- Covers smart-memory migration, JSON import, practical examples
- README section with link

### Issue #12 — Filter Options for `palaia list`
- `--project <name>` — filter by project (existed, now enriched JSON output)
- `--tag <tag>` — filter by tag
- `--scope <scope>` — filter by scope
- `--agent <agent>` — filter by agent
- All filters combinable
- JSON output includes all metadata fields

### Version Tracking (Christian's additional requirement)
- `store_version` field in config.json, set on `palaia init`
- Version drift warning on every CLI call when mismatch detected
- `palaia doctor` enhanced with:
  - Store version check (auto-stamps legacy stores)
  - Projects usage check
  - Deprecated config key check
- SKILL.md upgrade section so agents auto-run `palaia doctor` after updates

### Tests
- 245 tests passing (38 new in `test_ux_improvements.py`)
- All ruff checks clean

Closes #9, Closes #10, Closes #11, Closes #12