### PR TITLE
fix: Add DO NOT DELETE warnings for system files after migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ palaia write "The deploy server is at 10.0.1.5" --tags "infra,servers"
 palaia query "where is the server"
 ```
 
+> **⚠️ Important:** Palaia supplements your existing files — it does not replace them.
+> Files like `CONTEXT.md`, `SOUL.md`, and `MEMORY.md` are living documents read by agents
+> at runtime. `palaia ingest` and `palaia migrate` create searchable copies, but the
+> originals must stay on disk. See [Migration Guide](docs/migration-guide.md) for details.
+
 ## Features
 
 ### Memory Entries
@@ -151,6 +156,8 @@ palaia query "How does X work?" --project api-docs --rag
 ```
 
 Documents are chunked, embedded, and stored as regular Palaia entries. They appear in search results with source attribution (file, page, URL). Use `--rag` for a formatted context block ready for LLM injection.
+
+**Note:** `ingest` creates a copy in the Palaia store. Source files are NOT modified or deleted.
 
 PDF support requires an optional dependency: `pip install 'palaia[pdf]'`
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -1,0 +1,69 @@
+# Migration Guide
+
+This guide covers migrating from OpenClaw's built-in smart-memory (or other formats) to Palaia.
+
+## Quick Migration
+
+```bash
+# 1. Install Palaia
+pip install git+https://github.com/iret77/palaia.git
+
+# 2. Initialize
+palaia init
+
+# 3. Preview what would be imported
+palaia migrate . --dry-run
+
+# 4. Run the migration
+palaia migrate .
+
+# 5. Verify
+palaia status
+palaia list
+```
+
+Supported formats: `smart-memory`, `flat-file`, `json-memory`, `generic-md`.
+Palaia auto-detects the format, or you can force it with `--format`.
+
+## ⚠️ Important: Do NOT Delete System Files
+
+After migrating to Palaia, these files MUST remain on disk — they are living documents read by agents at runtime, not historical data:
+
+- `CONTEXT.md` (project context, injected into subagent prompts)
+- `SOUL.md` (agent personality/identity)
+- `MEMORY.md` (orchestrator core memory)
+- `AGENTS.md` (workspace config)
+- `TOOLS.md` (tool config)
+- `USER.md` (user preferences)
+- `IDENTITY.md` (agent identity)
+
+`palaia ingest` creates a **searchable copy** in the store. The original file continues to be the source of truth. Deleting it breaks agent workflows.
+
+**Safe to archive after migration:**
+- Daily logs (`memory/YYYY-MM-DD.md`) — historical, not read at runtime
+- Old chat logs (`memory/chat-*.md`)
+- One-off notes that have been fully ingested
+
+## What Happens During Migration
+
+`palaia migrate` reads your existing memory files, converts them to Palaia entries, and stores them in the Palaia database. **Source files are NOT modified or deleted.**
+
+For smart-memory format, files are mapped as follows:
+
+| Source File | Palaia Tier | Scope |
+|---|---|---|
+| `MEMORY.md` | HOT | team |
+| `memory/active-context.md` | HOT (per block) | team |
+| `memory/projects/*/CONTEXT.md` | HOT | shared:{project} |
+| `memory/agents/*.md` | WARM | team |
+| `memory/YYYY-MM-DD.md` | COLD | team |
+
+## Post-Migration
+
+After migration, Palaia and your existing files coexist:
+
+- **Palaia** provides semantic search across all your memory
+- **Original files** continue to be loaded by OpenClaw at agent startup
+- Both systems work together — Palaia supplements, it does not replace
+
+Do **not** "clean up" by deleting source files. See the system files list above.

--- a/palaia/cli.py
+++ b/palaia/cli.py
@@ -1001,7 +1001,7 @@ def main():
     p_query.add_argument("--json", action="store_true", help="Output as JSON")
 
     # ingest
-    p_ingest = sub.add_parser("ingest", help="Ingest documents for RAG search")
+    p_ingest = sub.add_parser("ingest", help="Ingest documents for RAG search (creates a copy; source files are NOT modified or deleted)")
     p_ingest.add_argument("source", help="File path, URL, or directory to ingest")
     p_ingest.add_argument("--project", default=None, help="Assign to project")
     p_ingest.add_argument("--scope", default=None, help="Scope (default: private)")

--- a/palaia/migrate.py
+++ b/palaia/migrate.py
@@ -12,6 +12,24 @@ from palaia.entry import content_hash
 from palaia.store import Store
 
 
+# System files that agents read at runtime — must never be deleted after migration.
+SYSTEM_FILE_PATTERNS = {
+    "CONTEXT.md",
+    "SOUL.md",
+    "MEMORY.md",
+    "AGENTS.md",
+    "TOOLS.md",
+    "USER.md",
+    "IDENTITY.md",
+}
+
+
+def is_system_file(path_str: str) -> bool:
+    """Check if a path refers to an agent system file."""
+    basename = Path(path_str).name
+    return basename in SYSTEM_FILE_PATTERNS
+
+
 class MigrationEntry:
     """A single entry extracted by an adapter."""
 
@@ -399,11 +417,14 @@ def migrate(
     tier_counts = {"hot": 0, "warm": 0, "cold": 0}
     scope_counts: dict[str, int] = {}
     files_seen: set[str] = set()
+    system_files_detected: list[str] = []
     for e in entries:
         tier_counts[e.tier] = tier_counts.get(e.tier, 0) + 1
         scope_counts[e.scope] = scope_counts.get(e.scope, 0) + 1
         if e.source_file:
             files_seen.add(e.source_file)
+            if is_system_file(e.source_file) and e.source_file not in system_files_detected:
+                system_files_detected.append(e.source_file)
 
     result = {
         "format": detected,
@@ -414,6 +435,7 @@ def migrate(
         "imported": 0,
         "skipped_dedup": 0,
         "dry_run": dry_run,
+        "system_files_detected": system_files_detected,
     }
 
     if dry_run:
@@ -466,5 +488,16 @@ def format_result(result: dict) -> str:
     else:
         lines.append("")
         lines.append(f"Done. {result['imported']} entries imported, {result['skipped_dedup']} duplicates skipped.")
+
+    # Warn about system files that were processed
+    system_files = result.get("system_files_detected", [])
+    if system_files:
+        lines.append("")
+        for sf in system_files:
+            lines.append(f"⚠️  System file detected: {sf}")
+            lines.append("    This file is used at runtime by agents. It was copied to Palaia but NOT deleted.")
+            lines.append("    Do not remove it manually.")
+        lines.append("")
+        lines.append("See: https://github.com/iret77/palaia/blob/main/docs/migration-guide.md")
 
     return "\n".join(lines)

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -276,3 +276,58 @@ def test_migrate_flat_file(store, flat_file_source):
 def test_migrate_not_found(store, tmp_path):
     with pytest.raises(FileNotFoundError):
         migrate(tmp_path / "nonexistent", store)
+
+
+# === System file detection ===
+
+
+def test_migrate_detects_system_files(store, smart_memory_source):
+    """System files like MEMORY.md and CONTEXT.md should be flagged in result."""
+    result = migrate(smart_memory_source, store)
+    sys_files = result.get("system_files_detected", [])
+    assert "MEMORY.md" in sys_files
+    # CONTEXT.md is inside memory/projects/clawsy/
+    assert any("CONTEXT.md" in f for f in sys_files)
+
+
+def test_migrate_system_files_in_dry_run(store, smart_memory_source):
+    """System files should also be flagged in dry-run mode."""
+    result = migrate(smart_memory_source, store, dry_run=True)
+    sys_files = result.get("system_files_detected", [])
+    assert len(sys_files) > 0
+    assert "MEMORY.md" in sys_files
+
+
+def test_is_system_file():
+    from palaia.migrate import is_system_file
+
+    assert is_system_file("MEMORY.md") is True
+    assert is_system_file("CONTEXT.md") is True
+    assert is_system_file("memory/projects/clawsy/CONTEXT.md") is True
+    assert is_system_file("SOUL.md") is True
+    assert is_system_file("AGENTS.md") is True
+    assert is_system_file("TOOLS.md") is True
+    assert is_system_file("USER.md") is True
+    assert is_system_file("IDENTITY.md") is True
+    assert is_system_file("2026-03-10.md") is False
+    assert is_system_file("random-notes.md") is False
+
+
+def test_format_result_shows_system_file_warnings():
+    from palaia.migrate import format_result
+
+    result = {
+        "format": "smart-memory",
+        "total_entries": 6,
+        "files_scanned": 5,
+        "tiers": {"hot": 4, "warm": 1, "cold": 1},
+        "scopes": {"team": 5, "shared:clawsy": 1},
+        "imported": 6,
+        "skipped_dedup": 0,
+        "dry_run": False,
+        "system_files_detected": ["MEMORY.md", "memory/projects/clawsy/CONTEXT.md"],
+    }
+    output = format_result(result)
+    assert "⚠️  System file detected: MEMORY.md" in output
+    assert "⚠️  System file detected: memory/projects/clawsy/CONTEXT.md" in output
+    assert "Do not remove it manually" in output


### PR DESCRIPTION
## Problem

We lost `CONTEXT.md` files during our own migration because the workflow was too vague about post-migration cleanup. The phrase "archive or remove old files" led to deleting runtime system files that agents need at startup.

These files (`CONTEXT.md`, `SOUL.md`, `MEMORY.md`, `AGENTS.md`, `TOOLS.md`, `USER.md`, `IDENTITY.md`) are **living documents** read by agents every session — not historical data. `palaia ingest` and `palaia migrate` create searchable copies, but the originals must stay on disk.

## Changes

### 1. New Migration Guide (`docs/migration-guide.md`)
- Step-by-step migration instructions
- Explicit **DO NOT DELETE** list of system files with explanations
- Clear separation: what's safe to archive vs. what must stay

### 2. README Updates
- Added prominent ⚠️ Important box after Getting Started
- Added note under `ingest` section: source files are NOT modified or deleted

### 3. `palaia migrate` System File Warnings (`palaia/migrate.py`)
- New `SYSTEM_FILE_PATTERNS` constant and `is_system_file()` helper
- Migration now detects system files and includes them in the result dict
- `format_result()` emits per-file warnings:
  ```
  ⚠️  System file detected: MEMORY.md
      This file is used at runtime by agents. It was copied to Palaia but NOT deleted.
      Do not remove it manually.
  ```

### 4. CLI Help Text (`palaia/cli.py`)
- `palaia ingest` help now states: "creates a copy; source files are NOT modified or deleted"

## Tests
- 4 new tests in `tests/test_migrate.py`
- All 225 tests pass ✅