### PR TITLE
Rename @palaia/openclaw → @byte5ai/palaia + publish v1.1.0

### DIFF
--- a/AUDIT-DEPLOY.md
+++ b/AUDIT-DEPLOY.md
@@ -36,7 +36,7 @@ Durchgeführt von: Elliot
 ## Caveats (known limitations)
 1. **`pip install` from git URL can be slow** — pip sometimes hangs during resolution. Local clone install works instantly. PyPI publish would improve UX significantly.
 2. **`python3 -m palaia` query loads model on every call** — sentence-transformers loads ~500MB model each invocation. Expected but slow for first query (~10-30s).
-3. **OpenClaw plugin (`@palaia/openclaw`)** — exists in `packages/openclaw-plugin/` with valid `openclaw.plugin.json` and `package.json`. Not published to npm yet, so users must install from repo path. SKILL.md mentions `npm install @palaia/openclaw` but this won't work until published.
+3. **OpenClaw plugin (`@byte5ai/palaia`)** — exists in `packages/openclaw-plugin/` with valid `openclaw.plugin.json` and `package.json`. Not published to npm yet, so users must install from repo path. SKILL.md mentions `npm install @byte5ai/palaia` but this won't work until published.
 4. **No PyPI package** — `pip install palaia` won't work yet. Only git URL install. SKILL.md should clarify this.
 5. **HuggingFace warning** — sentence-transformers emits "unauthenticated requests" warning on first use. Cosmetic only.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ First stable release.
 - `palaia warmup` for embedding model preloading
 - `palaia migrate` with 4 adapters (smart-memory, flat-file, json, generic-md)
 - `palaia export/import` for git-based knowledge sync
-- `@palaia/openclaw` plugin for native OpenClaw memory integration
+- `@byte5ai/palaia` plugin for native OpenClaw memory integration
 - 185 tests, fully green CI
 
 ### Copyright

--- a/README.md
+++ b/README.md
@@ -335,14 +335,14 @@ All commands support `--json` for machine-readable output.
 Palaia can replace OpenClaw's built-in memory system:
 
 ```bash
-npm install @palaia/openclaw
+npm install @byte5ai/palaia
 ```
 
 Add it to your OpenClaw config:
 
 ```json
 {
-  "plugins": ["@palaia/openclaw"]
+  "plugins": ["@byte5ai/palaia"]
 }
 ```
 
@@ -381,7 +381,7 @@ palaia config set-chain <providers...>  # Set embedding fallback chain
 - [x] Projects with per-project scope
 - [x] `palaia doctor` for legacy cleanup
 - [x] Document ingestion (RAG) — `palaia ingest`
-- [x] Native OpenClaw plugin (`@palaia/openclaw`)
+- [x] Native OpenClaw plugin (`@byte5ai/palaia`)
 - [x] Git-based knowledge sync (`palaia export/import`)
 
 **Planned**

--- a/SKILL.md
+++ b/SKILL.md
@@ -19,7 +19,7 @@ metadata:
         label: "Initialize Palaia store"
     plugin:
       slot: memory
-      package: "@palaia/openclaw"
+      package: "@byte5ai/palaia"
 ---
 
 # Palaia — Agent Memory Skill

--- a/packages/openclaw-plugin/README.md
+++ b/packages/openclaw-plugin/README.md
@@ -1,4 +1,4 @@
-# @palaia/openclaw
+# @byte5ai/palaia
 
 **Palaia memory backend for OpenClaw.**
 
@@ -11,7 +11,7 @@ Replace OpenClaw's built-in `memory-core` with Palaia — local, cloud-free, WAL
 pip install palaia
 
 # Install the OpenClaw plugin
-openclaw plugins install @palaia/openclaw
+openclaw plugins install @byte5ai/palaia
 ```
 
 ## Configuration
@@ -108,7 +108,7 @@ memory_write({ content: "Important finding", scope: "team", tags: ["project-x"] 
 
 ```
 OpenClaw Agent
-  └─ @palaia/openclaw (plugin)
+  └─ @byte5ai/palaia (plugin)
        └─ palaia CLI (subprocess, --json)
             └─ .palaia/ (local storage)
                  ├─ hot/    (active memory)

--- a/packages/openclaw-plugin/index.ts
+++ b/packages/openclaw-plugin/index.ts
@@ -1,5 +1,5 @@
 /**
- * @palaia/openclaw — Palaia Memory Backend for OpenClaw
+ * @byte5ai/palaia — Palaia Memory Backend for OpenClaw
  *
  * Plugin entry point. Loaded by OpenClaw via jiti (no build step needed).
  *

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@palaia/openclaw",
-  "version": "0.1.0",
+  "name": "@byte5ai/palaia",
+  "version": "1.1.0",
   "description": "Palaia memory backend for OpenClaw",
   "main": "index.ts",
   "openclaw": {

--- a/packages/openclaw-plugin/src/config.ts
+++ b/packages/openclaw-plugin/src/config.ts
@@ -1,5 +1,5 @@
 /**
- * Plugin configuration schema and defaults for @palaia/openclaw.
+ * Plugin configuration schema and defaults for @byte5ai/palaia.
  */
 
 export interface PalaiaPluginConfig {


### PR DESCRIPTION
## Changes
- Renamed npm package from `@palaia/openclaw` to `@byte5ai/palaia`
- Version bumped to `1.1.0` (aligned with Python package version)
- Updated all references across README.md, SKILL.md, CHANGELOG.md, AUDIT-DEPLOY.md, and source files
- **Already published to npm:** https://www.npmjs.com/package/@byte5ai/palaia

## Install
```bash
npm install @byte5ai/palaia
# or
openclaw plugins install @byte5ai/palaia
```