### PR TITLE
chore: bump version to 1.3.0

### DIFF
--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byte5ai/palaia",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "description": "Palaia memory backend for OpenClaw",
   "main": "index.ts",
   "openclaw": {

--- a/palaia/__init__.py
+++ b/palaia/__init__.py
@@ -4,5 +4,5 @@ Palaia — Local, cloud-free memory for OpenClaw agents.
 
 from __future__ import annotations
 
-__version__ = "1.1.1"
+__version__ = "1.3.0"
 __author__ = "byte5 GmbH"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "palaia"
-version = "1.1.1"
+version = "1.3.0"
 description = "Local, cloud-free memory for OpenClaw agents."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Bump all version references to 1.3.0:
- pyproject.toml: 1.1.1 → 1.3.0
- palaia/__init__.py: 1.1.1 → 1.3.0
- packages/openclaw-plugin/package.json: 1.1.0 → 1.3.0

Tests: 257 passed, 2 pre-existing failures (unrelated to version bump).