### PR TITLE
feat: Project-level locking for multi-agent coordination (ADR-011)

### DIFF
--- a/palaia/__main__.py
+++ b/palaia/__main__.py
@@ -1,6 +1,8 @@
 """Allow running palaia as `python3 -m palaia`."""
 
+import sys
+
 from palaia.cli import main
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/palaia/cli.py
+++ b/palaia/cli.py
@@ -1088,6 +1088,220 @@ def cmd_project(args):
         return 1
 
 
+def _format_lock_human(lock_data: dict) -> str:
+    """Format lock info for human-readable output."""
+    from datetime import datetime
+
+    agent = lock_data.get("agent", "unknown")
+    acquired = lock_data.get("acquired", "?")
+    reason = lock_data.get("reason", "")
+    age = lock_data.get("age_seconds", 0)
+
+    # Format age
+    if age >= 3600:
+        age_str = f"{age // 3600}h {(age % 3600) // 60}min ago"
+    elif age >= 60:
+        age_str = f"{age // 60}min ago"
+    else:
+        age_str = f"{age}s ago"
+
+    # Format acquired time (show HH:MM)
+    try:
+        dt = datetime.fromisoformat(acquired)
+        time_str = dt.strftime("%H:%M")
+    except (ValueError, TypeError):
+        time_str = acquired
+
+    result = f"🔒 Locked by {agent} since {time_str} ({age_str})"
+    if reason:
+        result += f"\n   Reason: {reason}"
+    return result
+
+
+def cmd_lock(args):
+    """Manage project locks."""
+    from palaia.locking import ProjectLockError, ProjectLockManager
+
+    root = get_root()
+    lm = ProjectLockManager(root)
+
+    # Parse action_or_project: if it's a known subcommand, use it; otherwise treat as project name
+    known_actions = {"status", "renew", "break", "list"}
+    aop = getattr(args, "action_or_project", None)
+    project_arg = getattr(args, "project", None)
+
+    if aop in known_actions:
+        action = aop
+        project = project_arg  # may be None for status/list
+    elif aop is not None:
+        # It's a project name → acquire shorthand
+        action = "acquire"
+        project = aop
+    else:
+        action = None
+        project = None
+
+    if action == "acquire":
+        agent = getattr(args, "agent", None) or _detect_current_agent()
+        reason = getattr(args, "reason", "") or ""
+        ttl = getattr(args, "ttl", None)
+
+        if not agent:
+            if _json_out({"error": "No agent specified. Use --agent or set PALAIA_AGENT env var."}, args):
+                return 1
+            print("Error: No agent specified. Use --agent or set PALAIA_AGENT env var.", file=sys.stderr)
+            return 1
+
+        try:
+            lock_data = lm.acquire(project, agent, reason, ttl)
+        except ProjectLockError as e:
+            if _json_out({"error": str(e), "locked": True}, args):
+                return 1
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+
+        if _json_out(lock_data, args):
+            return 0
+        print(f"🔒 Locked project '{project}' for agent '{agent}'")
+        if reason:
+            print(f"   Reason: {reason}")
+        ttl_min = lock_data.get("ttl_seconds", 1800) // 60
+        print(f"   TTL: {ttl_min} minutes (expires {lock_data['expires']})")
+        return 0
+
+    elif action == "status":
+        if project:
+            info = lm.status(project)
+            if info is None:
+                if _json_out({"project": project, "locked": False}, args):
+                    return 0
+                print(f"Project '{project}' is not locked.")
+                return 0
+            if _json_out(info, args):
+                return 0
+            print(_format_lock_human(info))
+            return 0
+        else:
+            # All projects
+            locks = lm.list_locks()
+            if _json_out({"locks": locks}, args):
+                return 0
+            if not locks:
+                print("No active locks.")
+                return 0
+            for lock in locks:
+                print(f"  {lock['project']}: {_format_lock_human(lock)}")
+            print(f"\n{len(locks)} active lock(s).")
+            return 0
+
+    elif action == "renew":
+        if not project:
+            if _json_out({"error": "Project name required"}, args):
+                return 1
+            print("Error: Project name required.", file=sys.stderr)
+            return 1
+        try:
+            lock_data = lm.renew(project)
+        except ProjectLockError as e:
+            if _json_out({"error": str(e)}, args):
+                return 1
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+        if _json_out(lock_data, args):
+            return 0
+        ttl_min = lock_data.get("ttl_seconds", 1800) // 60
+        print(f"🔄 Lock renewed for project '{project}' — expires {lock_data['expires']} ({ttl_min}min)")
+        return 0
+
+    elif action == "break":
+        if not project:
+            if _json_out({"error": "Project name required"}, args):
+                return 1
+            print("Error: Project name required.", file=sys.stderr)
+            return 1
+        old = lm.break_lock(project)
+        if old:
+            if _json_out({"broken": True, "previous_lock": old}, args):
+                return 0
+            print(f"⚠️  Lock for project '{project}' force-broken (was held by {old.get('agent', '?')})")
+        else:
+            if _json_out({"broken": False, "project": project}, args):
+                return 0
+            print(f"No lock found for project '{project}'.")
+        return 0
+
+    elif action == "list":
+        locks = lm.list_locks()
+        if _json_out({"locks": locks}, args):
+            return 0
+        if not locks:
+            print("No active locks.")
+            return 0
+        for lock in locks:
+            print(f"  {lock['project']}: {_format_lock_human(lock)}")
+        print(f"\n{len(locks)} active lock(s).")
+        return 0
+
+    elif action is None:
+        # palaia lock (no args) — show all lock statuses
+        locks = lm.list_locks()
+        if _json_out({"locks": locks}, args):
+            return 0
+        if not locks:
+            print("No active locks.")
+            return 0
+        for lock in locks:
+            print(f"  {lock['project']}: {_format_lock_human(lock)}")
+        print(f"\n{len(locks)} active lock(s).")
+        return 0
+
+    else:
+        print("Unknown lock action. Use: acquire, status, renew, break, list", file=sys.stderr)
+        return 1
+
+
+def cmd_unlock(args):
+    """Release a project lock."""
+    from palaia.locking import ProjectLockManager
+
+    root = get_root()
+    lm = ProjectLockManager(root)
+    project = args.project
+
+    removed = lm.release(project)
+    if removed:
+        if _json_out({"unlocked": True, "project": project}, args):
+            return 0
+        print(f"🔓 Unlocked project '{project}'")
+    else:
+        if _json_out({"unlocked": False, "project": project}, args):
+            return 0
+        print(f"Project '{project}' was not locked.")
+    return 0
+
+
+def _detect_current_agent() -> str | None:
+    """Try to detect the current agent name from env or config."""
+    import os
+
+    # Check environment variable first
+    agent = os.environ.get("PALAIA_AGENT")
+    if agent:
+        return agent
+
+    # Try to read from OpenClaw agent config
+    agent_config = Path.home() / ".openclaw" / "config.json"
+    if agent_config.exists():
+        try:
+            with open(agent_config, "r") as f:
+                cfg = json.load(f)
+            return cfg.get("agent_name")
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    return None
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="palaia",
@@ -1210,6 +1424,22 @@ def main():
     p_proj_delete.add_argument("name", help="Project name")
     p_proj_delete.add_argument("--json", action="store_true", help="Output as JSON")
 
+    # lock — first positional is action_or_project (allows "palaia lock <project>" shorthand)
+    p_lock = sub.add_parser("lock", help="Manage project locks")
+    p_lock.add_argument("action_or_project", nargs="?", default=None,
+                        help="Subcommand (status|renew|break|list) or project name for acquire shorthand")
+    p_lock.add_argument("project", nargs="?", default=None,
+                        help="Project name (for status/renew/break subcommands)")
+    p_lock.add_argument("--agent", default=None, help="Agent name")
+    p_lock.add_argument("--reason", default="", help="Reason for locking")
+    p_lock.add_argument("--ttl", type=int, default=None, help="TTL in seconds")
+    p_lock.add_argument("--json", action="store_true", help="Output as JSON")
+
+    # unlock (shorthand for lock release)
+    p_unlock = sub.add_parser("unlock", help="Release a project lock")
+    p_unlock.add_argument("project", help="Project name")
+    p_unlock.add_argument("--json", action="store_true", help="Output as JSON")
+
     # setup
     p_setup = sub.add_parser("setup", help="Multi-agent setup")
     p_setup.add_argument("--multi-agent", default=None, help="Path to agents directory")
@@ -1310,6 +1540,8 @@ def main():
         "config": cmd_config,
         "warmup": cmd_warmup,
         "project": cmd_project,
+        "lock": cmd_lock,
+        "unlock": cmd_unlock,
     }
     try:
         return commands[args.command](args)

--- a/palaia/locking.py
+++ b/palaia/locking.py
@@ -1,0 +1,184 @@
+"""Project-level locking for multi-agent coordination (ADR-011).
+
+Provides advisory locks so multiple agents don't work on the same
+project simultaneously. Lock files live in .palaia/locks/<project>.lock.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TTL_SECONDS = 1800  # 30 minutes
+
+
+class ProjectLockError(Exception):
+    """Raised when a lock cannot be acquired."""
+
+    pass
+
+
+class ProjectLockManager:
+    """Manage project-level advisory locks."""
+
+    def __init__(self, palaia_root: Path):
+        self.palaia_root = palaia_root
+        self.locks_dir = palaia_root / "locks"
+
+    def _lock_path(self, project: str) -> Path:
+        return self.locks_dir / f"{project}.lock"
+
+    def _now(self) -> datetime:
+        return datetime.now(timezone.utc)
+
+    def _read_lock(self, project: str) -> dict | None:
+        """Read lock file, return dict or None if missing/corrupt."""
+        path = self._lock_path(project)
+        if not path.exists():
+            return None
+        try:
+            with open(path, "r") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return None
+
+    def _is_expired(self, lock_data: dict) -> bool:
+        """Check if a lock has expired based on its expires field."""
+        expires_str = lock_data.get("expires")
+        if not expires_str:
+            return True
+        expires = datetime.fromisoformat(expires_str)
+        return self._now() >= expires
+
+    def acquire(
+        self,
+        project: str,
+        agent: str,
+        reason: str = "",
+        ttl: int | None = None,
+    ) -> dict:
+        """Acquire a project lock. Returns lock data on success.
+
+        Raises ProjectLockError if already locked by another agent.
+        """
+        if ttl is None:
+            ttl = DEFAULT_TTL_SECONDS
+
+        existing = self._read_lock(project)
+        if existing and not self._is_expired(existing):
+            if existing.get("agent") == agent:
+                # Same agent re-acquiring — just renew
+                return self.renew(project, ttl=ttl)
+            raise ProjectLockError(
+                f"Project '{project}' is locked by {existing['agent']} "
+                f"since {existing['acquired']} — reason: {existing.get('reason', 'n/a')}"
+            )
+
+        # Acquire
+        self.locks_dir.mkdir(parents=True, exist_ok=True)
+        now = self._now()
+        lock_data = {
+            "project": project,
+            "agent": agent,
+            "reason": reason,
+            "acquired": now.isoformat(),
+            "ttl_seconds": ttl,
+            "expires": (now + timedelta(seconds=ttl)).isoformat(),
+        }
+        with open(self._lock_path(project), "w") as f:
+            json.dump(lock_data, f, ensure_ascii=False, indent=2)
+        return lock_data
+
+    def release(self, project: str) -> bool:
+        """Release a project lock. Returns True if removed, False if not found."""
+        path = self._lock_path(project)
+        if path.exists():
+            path.unlink()
+            return True
+        return False
+
+    def status(self, project: str) -> dict | None:
+        """Get lock status for a project. Returns lock data or None.
+
+        Expired locks return None (treated as unlocked).
+        """
+        lock_data = self._read_lock(project)
+        if lock_data is None:
+            return None
+        if self._is_expired(lock_data):
+            return None
+        # Add computed fields
+        acquired = datetime.fromisoformat(lock_data["acquired"])
+        age_seconds = (self._now() - acquired).total_seconds()
+        lock_data["active"] = True
+        lock_data["age_seconds"] = int(age_seconds)
+        return lock_data
+
+    def renew(self, project: str, ttl: int | None = None) -> dict:
+        """Extend the TTL of an existing lock.
+
+        Raises ProjectLockError if no active lock exists.
+        """
+        lock_data = self._read_lock(project)
+        if lock_data is None:
+            raise ProjectLockError(f"No lock found for project '{project}'")
+        if self._is_expired(lock_data):
+            raise ProjectLockError(f"Lock for project '{project}' has expired")
+
+        if ttl is None:
+            ttl = lock_data.get("ttl_seconds", DEFAULT_TTL_SECONDS)
+
+        now = self._now()
+        lock_data["ttl_seconds"] = ttl
+        lock_data["expires"] = (now + timedelta(seconds=ttl)).isoformat()
+
+        with open(self._lock_path(project), "w") as f:
+            json.dump(lock_data, f, ensure_ascii=False, indent=2)
+        return lock_data
+
+    def break_lock(self, project: str) -> dict | None:
+        """Force-remove a lock with warning log. Returns old lock data."""
+        lock_data = self._read_lock(project)
+        path = self._lock_path(project)
+        if path.exists():
+            path.unlink()
+        if lock_data:
+            logger.warning(
+                "Lock for project '%s' force-broken (was held by %s since %s)",
+                project,
+                lock_data.get("agent", "unknown"),
+                lock_data.get("acquired", "unknown"),
+            )
+        return lock_data
+
+    def is_locked(self, project: str) -> bool:
+        """Check if a project is currently locked (non-expired)."""
+        return self.status(project) is not None
+
+    def list_locks(self) -> list[dict]:
+        """List all active (non-expired) locks."""
+        if not self.locks_dir.exists():
+            return []
+        locks = []
+        for lock_file in sorted(self.locks_dir.glob("*.lock")):
+            project = lock_file.stem
+            info = self.status(project)
+            if info is not None:
+                locks.append(info)
+        return locks
+
+    def gc(self) -> list[str]:
+        """Remove expired lock files. Returns list of cleaned project names."""
+        if not self.locks_dir.exists():
+            return []
+        cleaned = []
+        for lock_file in list(self.locks_dir.glob("*.lock")):
+            lock_data = self._read_lock(lock_file.stem)
+            if lock_data and self._is_expired(lock_data):
+                lock_file.unlink()
+                cleaned.append(lock_file.stem)
+        return cleaned

--- a/tests/test_locking.py
+++ b/tests/test_locking.py
@@ -1,0 +1,285 @@
+"""Tests for project locking (ADR-011)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from palaia.locking import DEFAULT_TTL_SECONDS, ProjectLockError, ProjectLockManager
+
+
+@pytest.fixture
+def palaia_root(tmp_path):
+    """Create a minimal .palaia directory."""
+    root = tmp_path / ".palaia"
+    root.mkdir()
+    for sub in ("hot", "warm", "cold", "wal", "index"):
+        (root / sub).mkdir()
+    config = {"version": 1, "embedding_chain": ["bm25"]}
+    (root / "config.json").write_text(json.dumps(config))
+    return root
+
+
+@pytest.fixture
+def lm(palaia_root):
+    """Create a ProjectLockManager."""
+    return ProjectLockManager(palaia_root)
+
+
+class TestAcquireRelease:
+    def test_acquire_creates_lock_file(self, lm, palaia_root):
+        lock = lm.acquire("myproject", "elliot", "testing")
+        assert lock["project"] == "myproject"
+        assert lock["agent"] == "elliot"
+        assert lock["reason"] == "testing"
+        assert lock["ttl_seconds"] == DEFAULT_TTL_SECONDS
+        assert (palaia_root / "locks" / "myproject.lock").exists()
+
+    def test_release_removes_lock_file(self, lm, palaia_root):
+        lm.acquire("myproject", "elliot")
+        assert lm.release("myproject") is True
+        assert not (palaia_root / "locks" / "myproject.lock").exists()
+
+    def test_release_nonexistent(self, lm):
+        assert lm.release("nope") is False
+
+    def test_acquire_when_already_locked_by_other(self, lm):
+        lm.acquire("proj", "elliot", "working")
+        with pytest.raises(ProjectLockError, match="locked by elliot"):
+            lm.acquire("proj", "cyberclaw", "also want to work")
+
+    def test_acquire_same_agent_renews(self, lm):
+        lm.acquire("proj", "elliot", "first")
+        lock = lm.acquire("proj", "elliot", "second")
+        # Should succeed (renew)
+        assert lock["agent"] == "elliot"
+
+
+class TestTTLExpiry:
+    def test_expired_lock_is_unlocked(self, lm):
+        lm.acquire("proj", "elliot", ttl=1)
+        # Manually set expires to the past
+        lock_path = lm._lock_path("proj")
+        data = json.loads(lock_path.read_text())
+        data["expires"] = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
+        lock_path.write_text(json.dumps(data))
+
+        assert lm.is_locked("proj") is False
+        assert lm.status("proj") is None
+
+    def test_expired_lock_allows_new_acquire(self, lm):
+        lm.acquire("proj", "elliot", ttl=1)
+        # Expire it
+        lock_path = lm._lock_path("proj")
+        data = json.loads(lock_path.read_text())
+        data["expires"] = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
+        lock_path.write_text(json.dumps(data))
+
+        # Another agent can now acquire
+        lock = lm.acquire("proj", "cyberclaw", "taking over")
+        assert lock["agent"] == "cyberclaw"
+
+
+class TestRenew:
+    def test_renew_extends_ttl(self, lm):
+        lm.acquire("proj", "elliot", ttl=600)
+        old_lock = lm.status("proj")
+        lock = lm.renew("proj", ttl=1800)
+        assert lock["ttl_seconds"] == 1800
+        # New expires should be later
+        new_expires = datetime.fromisoformat(lock["expires"])
+        old_expires = datetime.fromisoformat(old_lock["expires"])
+        assert new_expires > old_expires
+
+    def test_renew_no_lock(self, lm):
+        with pytest.raises(ProjectLockError, match="No lock found"):
+            lm.renew("nope")
+
+    def test_renew_expired_lock(self, lm):
+        lm.acquire("proj", "elliot", ttl=1)
+        lock_path = lm._lock_path("proj")
+        data = json.loads(lock_path.read_text())
+        data["expires"] = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
+        lock_path.write_text(json.dumps(data))
+
+        with pytest.raises(ProjectLockError, match="expired"):
+            lm.renew("proj")
+
+
+class TestBreakLock:
+    def test_break_removes_lock(self, lm, palaia_root):
+        lm.acquire("proj", "elliot")
+        old = lm.break_lock("proj")
+        assert old["agent"] == "elliot"
+        assert not (palaia_root / "locks" / "proj.lock").exists()
+
+    def test_break_nonexistent(self, lm):
+        result = lm.break_lock("nope")
+        assert result is None
+
+
+class TestStatus:
+    def test_status_active(self, lm):
+        lm.acquire("proj", "elliot", "working")
+        info = lm.status("proj")
+        assert info is not None
+        assert info["agent"] == "elliot"
+        assert info["active"] is True
+        assert "age_seconds" in info
+
+    def test_status_expired(self, lm):
+        lm.acquire("proj", "elliot", ttl=1)
+        lock_path = lm._lock_path("proj")
+        data = json.loads(lock_path.read_text())
+        data["expires"] = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
+        lock_path.write_text(json.dumps(data))
+
+        assert lm.status("proj") is None
+
+    def test_status_not_found(self, lm):
+        assert lm.status("nope") is None
+
+
+class TestListLocks:
+    def test_list_empty(self, lm):
+        assert lm.list_locks() == []
+
+    def test_list_active_only(self, lm):
+        lm.acquire("proj1", "elliot")
+        lm.acquire("proj2", "cyberclaw")
+        # Expire proj2
+        lock_path = lm._lock_path("proj2")
+        data = json.loads(lock_path.read_text())
+        data["expires"] = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
+        lock_path.write_text(json.dumps(data))
+
+        locks = lm.list_locks()
+        assert len(locks) == 1
+        assert locks[0]["project"] == "proj1"
+
+
+class TestGC:
+    def test_gc_removes_expired(self, lm):
+        lm.acquire("proj1", "elliot")
+        lm.acquire("proj2", "cyberclaw")
+        # Expire proj2
+        lock_path = lm._lock_path("proj2")
+        data = json.loads(lock_path.read_text())
+        data["expires"] = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
+        lock_path.write_text(json.dumps(data))
+
+        cleaned = lm.gc()
+        assert "proj2" in cleaned
+        assert not lock_path.exists()
+        assert lm._lock_path("proj1").exists()
+
+
+class TestIsLocked:
+    def test_locked(self, lm):
+        lm.acquire("proj", "elliot")
+        assert lm.is_locked("proj") is True
+
+    def test_not_locked(self, lm):
+        assert lm.is_locked("proj") is False
+
+
+class TestCLIIntegration:
+    """Test CLI commands via subprocess."""
+
+    def _run(self, tmp_path, *args, env_extra=None):
+        """Run palaia CLI command."""
+        import os
+
+        env = os.environ.copy()
+        if env_extra:
+            env.update(env_extra)
+        result = subprocess.run(
+            [sys.executable, "-m", "palaia", *args],
+            capture_output=True,
+            text=True,
+            cwd=str(tmp_path),
+            env=env,
+        )
+        return result
+
+    def test_lock_unlock_cycle(self, tmp_path):
+        self._run(tmp_path, "init")
+        r = self._run(tmp_path, "lock", "myproj", "--agent", "elliot", "--reason", "testing", "--json")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert data["project"] == "myproj"
+        assert data["agent"] == "elliot"
+
+        # Status
+        r = self._run(tmp_path, "lock", "status", "myproj", "--json")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert data["agent"] == "elliot"
+        assert data["active"] is True
+
+        # Unlock
+        r = self._run(tmp_path, "unlock", "myproj", "--json")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert data["unlocked"] is True
+
+        # Status after unlock
+        r = self._run(tmp_path, "lock", "status", "myproj", "--json")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert data["locked"] is False
+
+    def test_lock_shorthand(self, tmp_path):
+        """palaia lock <project> --agent should work as acquire shorthand."""
+        self._run(tmp_path, "init")
+        r = self._run(tmp_path, "lock", "myproj", "--agent", "elliot", "--json")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert data["project"] == "myproj"
+
+    def test_lock_conflict_json(self, tmp_path):
+        self._run(tmp_path, "init")
+        self._run(tmp_path, "lock", "myproj", "--agent", "elliot")
+        r = self._run(tmp_path, "lock", "myproj", "--agent", "cyberclaw", "--json")
+        assert r.returncode == 1
+        data = json.loads(r.stdout)
+        assert "error" in data
+        assert "elliot" in data["error"]
+
+    def test_lock_list_json(self, tmp_path):
+        self._run(tmp_path, "init")
+        self._run(tmp_path, "lock", "proj1", "--agent", "elliot")
+        self._run(tmp_path, "lock", "proj2", "--agent", "cyberclaw")
+        r = self._run(tmp_path, "lock", "list", "--json")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert len(data["locks"]) == 2
+
+    def test_lock_renew_json(self, tmp_path):
+        self._run(tmp_path, "init")
+        self._run(tmp_path, "lock", "myproj", "--agent", "elliot")
+        r = self._run(tmp_path, "lock", "renew", "myproj", "--json")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert data["ttl_seconds"] == DEFAULT_TTL_SECONDS
+
+    def test_lock_break_json(self, tmp_path):
+        self._run(tmp_path, "init")
+        self._run(tmp_path, "lock", "myproj", "--agent", "elliot")
+        r = self._run(tmp_path, "lock", "break", "myproj", "--json")
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert data["broken"] is True
+        assert data["previous_lock"]["agent"] == "elliot"
+
+    def test_env_agent(self, tmp_path):
+        """PALAIA_AGENT env var should be used when --agent not given."""
+        self._run(tmp_path, "init")
+        r = self._run(tmp_path, "lock", "myproj", "--json", env_extra={"PALAIA_AGENT": "desmond"})
+        assert r.returncode == 0
+        data = json.loads(r.stdout)
+        assert data["agent"] == "desmond"


### PR DESCRIPTION
## Summary

Implements advisory project locks so multiple agents don't work on the same project simultaneously. Designed per ADR-011.

### New module: `palaia/locking.py` (ProjectLockManager)
- `acquire(project, agent, reason, ttl)` → write lock file
- `release(project)` → delete lock file
- `status(project)` → lock info or None (expired = None)
- `renew(project, ttl)` → extend TTL
- `break_lock(project)` → force-remove with warning log
- `list_locks()` → all active (non-expired) locks
- `is_locked(project)` → bool for orchestrators
- `gc()` → clean up expired lock files

### Lock format (`.palaia/locks/<project>.lock`)
```json
{
  "project": "clawsy",
  "agent": "elliot",
  "reason": "implementing feat/onboarding PR",
  "acquired": "2026-03-12T14:05:00Z",
  "ttl_seconds": 1800,
  "expires": "2026-03-12T14:35:00Z"
}
```

### CLI commands
- `palaia lock <project> [--agent] [--reason] [--ttl] [--json]` — acquire
- `palaia lock status [project] [--json]` — show lock status
- `palaia lock renew <project> [--json]` — extend TTL
- `palaia lock break <project> [--json]` — force-override
- `palaia lock list [--json]` — all active locks
- `palaia unlock <project> [--json]` — release
- `PALAIA_AGENT` env var support for auto-detection

### Stale lock handling
- Default TTL: 30 min (configurable per-lock)
- Expired locks auto-ignored (treated as unlocked)
- `palaia lock break` force-removes with warning

### Tests
27 new tests covering: acquire/release, TTL expiry, renew, break, status (active/expired/missing), concurrent lock conflicts, list, GC, is_locked, and full CLI integration with JSON output.

### Bonus fix
`__main__.py` now propagates exit codes via `sys.exit()`.

**All 286 tests pass. ruff clean on new files.**

Closes #15 — ADR-011 reference