### PR TITLE
docs: Plugin Activation section for OpenClaw memory backend

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -182,6 +182,45 @@ Check if `HEARTBEAT.md` exists in the workspace (`~/.openclaw/workspace/HEARTBEA
 
 Tell the user: "I've added a Palaia maintenance task to your heartbeat schedule. This keeps your memory organized automatically — nothing you need to do."
 
+## Plugin Activation (OpenClaw Memory Backend)
+
+After installing palaia, activate it as your memory backend:
+
+### 1. Install the OpenClaw plugin
+```bash
+npm install -g @byte5ai/palaia
+```
+
+### 2. Configure OpenClaw
+Patch your OpenClaw config (`openclaw.json`) to load and activate the plugin:
+
+```json
+{
+  "plugins": {
+    "load": {
+      "paths": ["<path-to-npm-global>/node_modules/@byte5ai/palaia"]
+    },
+    "allow": ["..existing..", "palaia"],
+    "slots": {
+      "memory": "palaia"
+    },
+    "entries": {
+      "palaia": { "enabled": true }
+    }
+  }
+}
+```
+
+Find your npm global path with: `npm root -g`
+
+### 3. Restart OpenClaw Gateway
+The config change requires a gateway restart to take effect.
+
+### What changes
+- `memory_search` and `memory_get` tools now search the Palaia store instead of MEMORY.md files
+- MEMORY.md and workspace files continue to be loaded as project context (unchanged)
+- All Palaia features (projects, scopes, tiering, semantic search) are available through the standard memory tools
+
 ## Commands Reference
 
 ### Basic Memory


### PR DESCRIPTION
## What

Adds a **Plugin Activation** section to SKILL.md that documents:
1. `npm install -g @byte5ai/palaia` for the OpenClaw plugin
2. `openclaw.json` configuration (load path, allow, slot, entries)
3. Gateway restart requirement
4. What changes when activated (memory_search/memory_get → Palaia store)

## Why

When agents run `clawhub install palaia`, they get the pip package but don't know how to wire it into OpenClaw as a memory backend. This section closes that gap.

## Notes
- No symlink/extensions method — load path is the clean way
- Metadata already had `plugin.slot: memory` and `plugin.package` — no changes needed there