### PR TITLE
feat: Inter-Agent Memo Subsystem (ADR-010)

### DIFF
--- a/palaia/cli.py
+++ b/palaia/cli.py
@@ -1280,6 +1280,96 @@ def cmd_unlock(args):
     return 0
 
 
+def cmd_memo(args):
+    """Manage inter-agent memos."""
+    from palaia.memo import MemoManager
+
+    root = get_root()
+    mm = MemoManager(root)
+    action = args.memo_action
+
+    if action == "send":
+        meta = mm.send(
+            to=args.to,
+            message=args.message,
+            from_agent=args.agent,
+            priority=args.priority,
+            ttl_hours=args.ttl_hours,
+        )
+        if _json_out(meta, args):
+            return 0
+        prio_icon = "🔴" if meta["priority"] == "high" else "📨"
+        print(f"{prio_icon} Memo sent to '{meta['to']}' (id: {meta['id'][:8]}…)")
+        return 0
+
+    if action == "broadcast":
+        meta = mm.broadcast(
+            message=args.message,
+            from_agent=args.agent,
+            priority=args.priority,
+            ttl_hours=args.ttl_hours,
+        )
+        if _json_out(meta, args):
+            return 0
+        print(f"📢 Broadcast sent (id: {meta['id'][:8]}…)")
+        return 0
+
+    if action == "inbox":
+        memos = mm.inbox(agent=args.agent, include_read=args.all)
+        if _json_out(
+            [{"meta": m, "body": b} for m, b in memos],
+            args,
+        ):
+            return 0
+        if not memos:
+            print("📭 No memos.")
+            return 0
+        print(f"📬 {len(memos)} memo(s):\n")
+        for meta, body in memos:
+            prio = " 🔴" if meta.get("priority") == "high" else ""
+            read_mark = " ✓" if meta.get("read") else ""
+            print(f"  [{meta['id'][:8]}…] from {meta.get('from', '?')}{prio}{read_mark}")
+            print(f"    {meta.get('sent', '?')}")
+            # Show first line of body
+            first_line = body.split("\n")[0][:80] if body else ""
+            print(f"    {first_line}")
+            print()
+        return 0
+
+    if action == "ack":
+        if args.all:
+            count = mm.ack_all(agent=args.agent)
+            if _json_out({"acked": count}, args):
+                return 0
+            print(f"✅ Acknowledged {count} memo(s).")
+            return 0
+        if not args.memo_id:
+            print("Error: memo ID required (or use --all)", file=sys.stderr)
+            return 1
+        ok = mm.ack(args.memo_id)
+        if _json_out({"acked": ok, "id": args.memo_id}, args):
+            return 0
+        if ok:
+            print(f"✅ Memo {args.memo_id[:8]}… acknowledged.")
+        else:
+            print(f"Memo {args.memo_id} not found.", file=sys.stderr)
+            return 1
+        return 0
+
+    if action == "gc":
+        stats = mm.gc()
+        if _json_out(stats, args):
+            return 0
+        print(
+            f"🧹 GC: removed {stats['removed_expired']} expired, "
+            f"{stats['removed_read']} read ({stats['total_removed']} total)"
+        )
+        return 0
+
+    print("Unknown memo action. Use: send, broadcast, inbox, ack, gc", file=sys.stderr)
+    return 1
+
+
 def _detect_current_agent() -> str | None:
     """Try to detect the current agent name from env or config."""
     import os
@@ -1424,6 +1514,42 @@ def main():
     p_proj_delete.add_argument("name", help="Project name")
     p_proj_delete.add_argument("--json", action="store_true", help="Output as JSON")
 
+    # memo
+    p_memo = sub.add_parser("memo", help="Inter-agent messaging")
+    memo_sub = p_memo.add_subparsers(dest="memo_action")
+
+    p_memo_send = memo_sub.add_parser("send", help="Send a memo to an agent")
+    p_memo_send.add_argument("to", help="Recipient agent name")
+    p_memo_send.add_argument("message", help="Message body")
+    p_memo_send.add_argument("--priority", default="normal", choices=["normal", "high"],
+                             help="Priority level")
+    p_memo_send.add_argument("--ttl-hours", type=int, default=72, help="TTL in hours (default: 72)")
+    p_memo_send.add_argument("--agent", default=None, help="Sender agent name")
+    p_memo_send.add_argument("--json", action="store_true", help="Output as JSON")
+
+    p_memo_broadcast = memo_sub.add_parser("broadcast", help="Broadcast memo to all agents")
+    p_memo_broadcast.add_argument("message", help="Message body")
+    p_memo_broadcast.add_argument("--priority", default="normal", choices=["normal", "high"],
+                                  help="Priority level")
+    p_memo_broadcast.add_argument("--ttl-hours", type=int, default=72,
+                                  help="TTL in hours (default: 72)")
+    p_memo_broadcast.add_argument("--agent", default=None, help="Sender agent name")
+    p_memo_broadcast.add_argument("--json", action="store_true", help="Output as JSON")
+
+    p_memo_inbox = memo_sub.add_parser("inbox", help="Show inbox")
+    p_memo_inbox.add_argument("--all", action="store_true", help="Include read memos")
+    p_memo_inbox.add_argument("--agent", default=None, help="Agent name")
+    p_memo_inbox.add_argument("--json", action="store_true", help="Output as JSON")
+
+    p_memo_ack = memo_sub.add_parser("ack", help="Acknowledge memo(s)")
+    p_memo_ack.add_argument("memo_id", nargs="?", default=None, help="Memo ID to acknowledge")
+    p_memo_ack.add_argument("--all", action="store_true", help="Acknowledge all unread memos")
+    p_memo_ack.add_argument("--agent", default=None, help="Agent name (for --all)")
+    p_memo_ack.add_argument("--json", action="store_true", help="Output as JSON")
+
+    p_memo_gc = memo_sub.add_parser("gc", help="Remove expired and read memos")
+    p_memo_gc.add_argument("--json", action="store_true", help="Output as JSON")
+
     # lock — first positional is action_or_project (allows "palaia lock <project>" shorthand)
     p_lock = sub.add_parser("lock", help="Manage project locks")
     p_lock.add_argument("action_or_project", nargs="?", default=None,
@@ -1540,6 +1666,7 @@ def main():
         "config": cmd_config,
         "warmup": cmd_warmup,
         "project": cmd_project,
+        "memo": cmd_memo,
         "lock": cmd_lock,
         "unlock": cmd_unlock,
     }

--- a/palaia/memo.py
+++ b/palaia/memo.py
@@ -1,0 +1,278 @@
+"""Inter-Agent Messaging Subsystem (ADR-010).
+
+Memos are lightweight messages between agents stored as markdown files
+in `.palaia/memos/`. They are NOT entries — they have their own lifecycle:
+no tiering, auto-expire via TTL, read/unread state, and GC cleanup.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n?", re.DOTALL)
+
+DEFAULT_TTL_HOURS = 72
+
+
+def _parse_yaml_simple(text: str) -> dict:
+    """Minimal YAML-like parser for memo frontmatter."""
+    result = {}
+    for line in text.strip().split("\n"):
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip()
+        value = value.strip()
+        if value == "true":
+            result[key] = True
+        elif value == "false":
+            result[key] = False
+        elif value == "null":
+            result[key] = None
+        elif value.isdigit():
+            result[key] = int(value)
+        elif (value.startswith('"') and value.endswith('"')) or (
+            value.startswith("'") and value.endswith("'")
+        ):
+            result[key] = value[1:-1]
+        else:
+            result[key] = value
+    return result
+
+
+def _to_yaml_simple(data: dict) -> str:
+    """Minimal dict -> YAML-like frontmatter string."""
+    lines = []
+    for k, v in data.items():
+        if v is None:
+            lines.append(f"{k}: null")
+        elif isinstance(v, bool):
+            lines.append(f"{k}: {'true' if v else 'false'}")
+        elif isinstance(v, int):
+            lines.append(f"{k}: {v}")
+        else:
+            lines.append(f"{k}: {v}")
+    return "\n".join(lines)
+
+
+def _parse_memo(text: str) -> tuple[dict, str]:
+    """Parse a memo file into (metadata, body)."""
+    m = FRONTMATTER_RE.match(text)
+    if not m:
+        return {}, text.strip()
+    meta = _parse_yaml_simple(m.group(1))
+    body = text[m.end():].strip()
+    return meta, body
+
+
+def _serialize_memo(meta: dict, body: str) -> str:
+    """Serialize memo metadata and body to file format."""
+    fm = _to_yaml_simple(meta)
+    return f"---\n{fm}\n---\n\n{body}\n"
+
+
+def _detect_agent() -> str | None:
+    """Detect current agent from PALAIA_AGENT env var."""
+    return os.environ.get("PALAIA_AGENT")
+
+
+class MemoManager:
+    """Manages inter-agent memos in .palaia/memos/."""
+
+    def __init__(self, palaia_root: Path):
+        self.root = palaia_root
+        self.memos_dir = palaia_root / "memos"
+        self.memos_dir.mkdir(exist_ok=True)
+
+    def send(
+        self,
+        to: str,
+        message: str,
+        from_agent: str | None = None,
+        priority: str = "normal",
+        ttl_hours: int = DEFAULT_TTL_HOURS,
+    ) -> dict:
+        """Send a memo to a specific agent. Returns memo metadata."""
+        if not to:
+            raise ValueError("Recipient ('to') is required")
+        if not message:
+            raise ValueError("Message body is required")
+        if priority not in ("normal", "high"):
+            raise ValueError(f"Invalid priority: {priority}. Must be 'normal' or 'high'")
+
+        sender = from_agent or _detect_agent() or "unknown"
+        now = datetime.now(timezone.utc)
+        memo_id = str(uuid.uuid4())
+        expires = now + timedelta(hours=ttl_hours)
+
+        meta = {
+            "id": memo_id,
+            "from": sender,
+            "to": to,
+            "sent": now.isoformat(),
+            "read": False,
+            "read_at": None,
+            "priority": priority,
+            "expires": expires.isoformat(),
+        }
+
+        content = _serialize_memo(meta, message)
+        memo_path = self.memos_dir / f"{memo_id}.md"
+        memo_path.write_text(content, encoding="utf-8")
+
+        return meta
+
+    def broadcast(
+        self,
+        message: str,
+        from_agent: str | None = None,
+        priority: str = "normal",
+        ttl_hours: int = DEFAULT_TTL_HOURS,
+    ) -> dict:
+        """Broadcast a memo to all agents. Uses '_broadcast' as recipient."""
+        return self.send(
+            to="_broadcast",
+            message=message,
+            from_agent=from_agent,
+            priority=priority,
+            ttl_hours=ttl_hours,
+        )
+
+    def get(self, memo_id: str) -> tuple[dict, str] | None:
+        """Read a single memo by ID. Returns (meta, body) or None."""
+        memo_path = self.memos_dir / f"{memo_id}.md"
+        if not memo_path.exists():
+            return None
+        text = memo_path.read_text(encoding="utf-8")
+        return _parse_memo(text)
+
+    def inbox(
+        self,
+        agent: str | None = None,
+        include_read: bool = False,
+    ) -> list[tuple[dict, str]]:
+        """List memos for an agent (including broadcasts).
+
+        Args:
+            agent: Agent name. If None, uses PALAIA_AGENT env var.
+            include_read: If True, include already-read memos.
+
+        Returns:
+            List of (meta, body) tuples sorted by sent time (newest first).
+        """
+        target = agent or _detect_agent()
+        if not target:
+            raise ValueError(
+                "Agent name required. Use --agent flag or set PALAIA_AGENT env var."
+            )
+
+        now = datetime.now(timezone.utc)
+        results = []
+
+        for memo_file in self.memos_dir.glob("*.md"):
+            text = memo_file.read_text(encoding="utf-8")
+            meta, body = _parse_memo(text)
+            if not meta.get("id"):
+                continue
+
+            # Check expiry
+            expires_str = meta.get("expires")
+            if expires_str:
+                try:
+                    expires_dt = datetime.fromisoformat(expires_str)
+                    if expires_dt < now:
+                        continue
+                except (ValueError, TypeError):
+                    pass
+
+            # Check recipient: must be addressed to agent or broadcast
+            to = meta.get("to", "")
+            if to != target and to != "_broadcast":
+                continue
+
+            # Filter read/unread
+            if not include_read and meta.get("read") is True:
+                continue
+
+            results.append((meta, body))
+
+        # Sort: high priority first, then by sent time descending
+        high = [r for r in results if r[0].get("priority") == "high"]
+        normal = [r for r in results if r[0].get("priority") != "high"]
+        high.sort(key=lambda x: x[0].get("sent", ""), reverse=True)
+        normal.sort(key=lambda x: x[0].get("sent", ""), reverse=True)
+        return high + normal
+
+    def ack(self, memo_id: str) -> bool:
+        """Mark a memo as read. Returns True if memo was found and updated."""
+        memo_path = self.memos_dir / f"{memo_id}.md"
+        if not memo_path.exists():
+            return False
+
+        text = memo_path.read_text(encoding="utf-8")
+        meta, body = _parse_memo(text)
+        meta["read"] = True
+        meta["read_at"] = datetime.now(timezone.utc).isoformat()
+
+        memo_path.write_text(_serialize_memo(meta, body), encoding="utf-8")
+        return True
+
+    def ack_all(self, agent: str | None = None) -> int:
+        """Mark all unread memos for agent as read. Returns count of acked memos."""
+        unread = self.inbox(agent=agent, include_read=False)
+        count = 0
+        for meta, _body in unread:
+            if self.ack(meta["id"]):
+                count += 1
+        return count
+
+    def gc(self) -> dict:
+        """Remove expired and read memos. Returns stats."""
+        now = datetime.now(timezone.utc)
+        removed_expired = 0
+        removed_read = 0
+
+        for memo_file in list(self.memos_dir.glob("*.md")):
+            text = memo_file.read_text(encoding="utf-8")
+            meta, _body = _parse_memo(text)
+
+            # Remove expired
+            expires_str = meta.get("expires")
+            if expires_str:
+                try:
+                    expires_dt = datetime.fromisoformat(expires_str)
+                    if expires_dt < now:
+                        memo_file.unlink()
+                        removed_expired += 1
+                        continue
+                except (ValueError, TypeError):
+                    pass
+
+            # Remove read
+            if meta.get("read") is True:
+                memo_file.unlink()
+                removed_read += 1
+
+        return {
+            "removed_expired": removed_expired,
+            "removed_read": removed_read,
+            "total_removed": removed_expired + removed_read,
+        }
+
+    def _all_memos(self) -> list[tuple[dict, str]]:
+        """List ALL memos (no filtering). For orchestrator use."""
+        results = []
+        for memo_file in self.memos_dir.glob("*.md"):
+            text = memo_file.read_text(encoding="utf-8")
+            meta, body = _parse_memo(text)
+            if meta.get("id"):
+                results.append((meta, body))
+        results.sort(key=lambda x: x[0].get("sent", ""), reverse=True)
+        return results

--- a/tests/test_memo.py
+++ b/tests/test_memo.py
@@ -1,0 +1,375 @@
+"""Tests for the inter-agent memo subsystem (ADR-010)."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from palaia.config import DEFAULT_CONFIG, save_config
+from palaia.memo import MemoManager
+
+
+@pytest.fixture
+def palaia_root(tmp_path):
+    root = tmp_path / ".palaia"
+    root.mkdir()
+    for sub in ("hot", "warm", "cold", "wal", "index"):
+        (root / sub).mkdir()
+    save_config(root, DEFAULT_CONFIG)
+    return root
+
+
+@pytest.fixture
+def mm(palaia_root):
+    return MemoManager(palaia_root)
+
+
+# --- Test 1: Send and inbox ---
+def test_send_and_inbox(mm):
+    """Sent memo appears in recipient's inbox."""
+    mm.send("elliot", "PR #13 needs review", from_agent="cyberclaw")
+    inbox = mm.inbox(agent="elliot")
+    assert len(inbox) == 1
+    meta, body = inbox[0]
+    assert body == "PR #13 needs review"
+    assert meta["from"] == "cyberclaw"
+    assert meta["to"] == "elliot"
+    assert meta["read"] is False
+
+
+# --- Test 2: Send, ack, inbox ---
+def test_send_ack_inbox(mm):
+    """Acked memo disappears from default inbox."""
+    meta = mm.send("elliot", "check this", from_agent="cyberclaw")
+    mm.ack(meta["id"])
+
+    inbox = mm.inbox(agent="elliot")
+    assert len(inbox) == 0
+
+    # But visible with include_read
+    inbox_all = mm.inbox(agent="elliot", include_read=True)
+    assert len(inbox_all) == 1
+    assert inbox_all[0][0]["read"] is True
+    assert inbox_all[0][0]["read_at"] is not None
+
+
+# --- Test 3: Broadcast ---
+def test_broadcast_visible_to_all(mm):
+    """Broadcast memo visible to any agent."""
+    mm.broadcast("deploy freeze until 18:00", from_agent="cyberclaw")
+
+    inbox_elliot = mm.inbox(agent="elliot")
+    inbox_tars = mm.inbox(agent="tars")
+
+    assert len(inbox_elliot) == 1
+    assert len(inbox_tars) == 1
+    assert inbox_elliot[0][0]["to"] == "_broadcast"
+
+
+# --- Test 4: Priority flag ---
+def test_priority_flag(mm):
+    """High priority memo has correct flag."""
+    meta = mm.send("elliot", "urgent!", from_agent="cyberclaw", priority="high")
+    assert meta["priority"] == "high"
+
+    inbox = mm.inbox(agent="elliot")
+    assert inbox[0][0]["priority"] == "high"
+
+
+# --- Test 5: Priority sort order ---
+def test_priority_sort_order(mm):
+    """High priority memos appear before normal in inbox."""
+    mm.send("elliot", "normal msg", from_agent="cyberclaw", priority="normal")
+    mm.send("elliot", "urgent msg", from_agent="cyberclaw", priority="high")
+
+    inbox = mm.inbox(agent="elliot")
+    assert len(inbox) == 2
+    assert inbox[0][0]["priority"] == "high"
+    assert inbox[1][0]["priority"] == "normal"
+
+
+# --- Test 6: TTL expiry ---
+def test_ttl_expiry(mm):
+    """Expired memo does not appear in inbox."""
+    # Send with 0 TTL (expires immediately)
+    meta = mm.send("elliot", "ephemeral", from_agent="cyberclaw", ttl_hours=0)
+
+    # Need to wait a tiny bit for expiry
+    time.sleep(0.01)
+    inbox = mm.inbox(agent="elliot")
+    assert len(inbox) == 0
+
+
+# --- Test 7: ack_all ---
+def test_ack_all(mm):
+    """ack_all marks all unread memos as read."""
+    mm.send("elliot", "msg 1", from_agent="cyberclaw")
+    mm.send("elliot", "msg 2", from_agent="cyberclaw")
+    mm.send("elliot", "msg 3", from_agent="cyberclaw")
+
+    count = mm.ack_all(agent="elliot")
+    assert count == 3
+
+    inbox = mm.inbox(agent="elliot")
+    assert len(inbox) == 0
+
+
+# --- Test 8: gc removes expired ---
+def test_gc_removes_expired(mm):
+    """GC removes expired memos."""
+    mm.send("elliot", "temp", from_agent="cyberclaw", ttl_hours=0)
+    time.sleep(0.01)
+
+    stats = mm.gc()
+    assert stats["removed_expired"] >= 1
+    assert stats["total_removed"] >= 1
+
+    # Verify file is gone
+    memos = list(mm.memos_dir.glob("*.md"))
+    assert len(memos) == 0
+
+
+# --- Test 9: gc removes read ---
+def test_gc_removes_read(mm):
+    """GC removes read memos."""
+    meta = mm.send("elliot", "read me", from_agent="cyberclaw")
+    mm.ack(meta["id"])
+
+    stats = mm.gc()
+    assert stats["removed_read"] >= 1
+
+
+# --- Test 10: Agent filtering ---
+def test_agent_filtering(mm):
+    """Agent A does not see memos addressed to Agent B."""
+    mm.send("elliot", "for elliot only", from_agent="cyberclaw")
+    mm.send("tars", "for tars only", from_agent="cyberclaw")
+
+    inbox_elliot = mm.inbox(agent="elliot")
+    inbox_tars = mm.inbox(agent="tars")
+
+    assert len(inbox_elliot) == 1
+    assert inbox_elliot[0][1] == "for elliot only"
+    assert len(inbox_tars) == 1
+    assert inbox_tars[0][1] == "for tars only"
+
+
+# --- Test 11: Get single memo ---
+def test_get_memo(mm):
+    """get() returns a specific memo by ID."""
+    meta = mm.send("elliot", "specific msg", from_agent="cyberclaw")
+    result = mm.get(meta["id"])
+    assert result is not None
+    m, body = result
+    assert body == "specific msg"
+    assert m["id"] == meta["id"]
+
+
+# --- Test 12: Get nonexistent memo ---
+def test_get_nonexistent(mm):
+    """get() returns None for missing memo."""
+    assert mm.get("nonexistent-id") is None
+
+
+# --- Test 13: Invalid priority ---
+def test_invalid_priority(mm):
+    """Invalid priority raises ValueError."""
+    with pytest.raises(ValueError, match="Invalid priority"):
+        mm.send("elliot", "bad", from_agent="cyberclaw", priority="critical")
+
+
+# --- Test 14: Empty message ---
+def test_empty_message(mm):
+    """Empty message raises ValueError."""
+    with pytest.raises(ValueError, match="Message body is required"):
+        mm.send("elliot", "", from_agent="cyberclaw")
+
+
+# --- Test 15: Empty recipient ---
+def test_empty_recipient(mm):
+    """Empty recipient raises ValueError."""
+    with pytest.raises(ValueError, match="Recipient"):
+        mm.send("", "hello", from_agent="cyberclaw")
+
+
+# --- Test 16: Memos dir created automatically ---
+def test_memos_dir_autocreate(palaia_root):
+    """MemoManager creates .palaia/memos/ if missing."""
+    memos_dir = palaia_root / "memos"
+    assert not memos_dir.exists()
+    MemoManager(palaia_root)
+    assert memos_dir.exists()
+
+
+# --- Test 17: PALAIA_AGENT env var ---
+def test_agent_env_var(mm, monkeypatch):
+    """PALAIA_AGENT env var used as default agent."""
+    monkeypatch.setenv("PALAIA_AGENT", "elliot")
+    mm.send("elliot", "env test", from_agent="cyberclaw")
+    inbox = mm.inbox()  # No agent param — uses env
+    assert len(inbox) == 1
+
+
+# --- Test 18: Inbox without agent raises ---
+def test_inbox_no_agent(mm, monkeypatch):
+    """inbox() without agent and no env var raises ValueError."""
+    monkeypatch.delenv("PALAIA_AGENT", raising=False)
+    with pytest.raises(ValueError, match="Agent name required"):
+        mm.inbox()
+
+
+# --- Test 19: Ack returns False for missing ---
+def test_ack_missing_memo(mm):
+    """ack() returns False for nonexistent memo."""
+    assert mm.ack("does-not-exist") is False
+
+
+# --- Test 20: Multiple memos ordering ---
+def test_multiple_memos_newest_first(mm):
+    """Multiple memos returned newest first within same priority."""
+    mm.send("elliot", "first", from_agent="cyberclaw")
+    time.sleep(0.01)
+    mm.send("elliot", "second", from_agent="cyberclaw")
+
+    inbox = mm.inbox(agent="elliot")
+    assert len(inbox) == 2
+    # Newest first
+    assert inbox[0][1] == "second"
+    assert inbox[1][1] == "first"
+
+
+# --- Test 21: Broadcast + direct in same inbox ---
+def test_broadcast_and_direct_mixed(mm):
+    """Agent sees both direct memos and broadcasts."""
+    mm.send("elliot", "direct msg", from_agent="cyberclaw")
+    mm.broadcast("broadcast msg", from_agent="cyberclaw")
+
+    inbox = mm.inbox(agent="elliot")
+    assert len(inbox) == 2
+    bodies = {b for _, b in inbox}
+    assert "direct msg" in bodies
+    assert "broadcast msg" in bodies
+
+
+# --- Test 22: CLI JSON output for send ---
+def test_cli_send_json(palaia_root, capsys):
+    """CLI memo send --json returns valid JSON."""
+    import argparse
+
+    from palaia.cli import cmd_memo
+
+    args = argparse.Namespace(
+        memo_action="send",
+        to="elliot",
+        message="test msg",
+        priority="normal",
+        ttl_hours=72,
+        agent="cyberclaw",
+        json=True,
+    )
+    # Need to mock get_root
+    import palaia.cli
+
+    original_get_root = palaia.cli.get_root
+    palaia.cli.get_root = lambda: palaia_root
+    try:
+        result = cmd_memo(args)
+        assert result == 0
+        output = capsys.readouterr().out
+        data = json.loads(output)
+        assert "id" in data
+        assert data["to"] == "elliot"
+    finally:
+        palaia.cli.get_root = original_get_root
+
+
+# --- Test 23: CLI JSON output for inbox ---
+def test_cli_inbox_json(palaia_root, capsys):
+    """CLI memo inbox --json returns valid JSON array."""
+    import argparse
+
+    from palaia.cli import cmd_memo
+
+    mm = MemoManager(palaia_root)
+    mm.send("elliot", "inbox test", from_agent="cyberclaw")
+
+    import palaia.cli
+
+    original_get_root = palaia.cli.get_root
+    palaia.cli.get_root = lambda: palaia_root
+    try:
+        args = argparse.Namespace(
+            memo_action="inbox",
+            agent="elliot",
+            all=False,
+            json=True,
+        )
+        result = cmd_memo(args)
+        assert result == 0
+        output = capsys.readouterr().out
+        data = json.loads(output)
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["body"] == "inbox test"
+    finally:
+        palaia.cli.get_root = original_get_root
+
+
+# --- Test 24: CLI JSON output for ack ---
+def test_cli_ack_json(palaia_root, capsys):
+    """CLI memo ack --json returns valid JSON."""
+    import argparse
+
+    from palaia.cli import cmd_memo
+
+    mm = MemoManager(palaia_root)
+    meta = mm.send("elliot", "ack test", from_agent="cyberclaw")
+
+    import palaia.cli
+
+    original_get_root = palaia.cli.get_root
+    palaia.cli.get_root = lambda: palaia_root
+    try:
+        args = argparse.Namespace(
+            memo_action="ack",
+            memo_id=meta["id"],
+            all=False,
+            agent=None,
+            json=True,
+        )
+        result = cmd_memo(args)
+        assert result == 0
+        output = capsys.readouterr().out
+        data = json.loads(output)
+        assert data["acked"] is True
+    finally:
+        palaia.cli.get_root = original_get_root
+
+
+# --- Test 25: CLI JSON output for gc ---
+def test_cli_gc_json(palaia_root, capsys):
+    """CLI memo gc --json returns valid JSON with stats."""
+    import argparse
+
+    from palaia.cli import cmd_memo
+
+    import palaia.cli
+
+    original_get_root = palaia.cli.get_root
+    palaia.cli.get_root = lambda: palaia_root
+    try:
+        args = argparse.Namespace(
+            memo_action="gc",
+            json=True,
+        )
+        result = cmd_memo(args)
+        assert result == 0
+        output = capsys.readouterr().out
+        data = json.loads(output)
+        assert "total_removed" in data
+    finally:
+        palaia.cli.get_root = original_get_root


### PR DESCRIPTION
## Inter-Agent Messaging Subsystem

Implements file-based inter-agent messaging as a dedicated subsystem within Palaia.

### What
- **`palaia/memo.py`** — `MemoManager` class with send, broadcast, inbox, ack, ack_all, gc, get
- **CLI commands** — `palaia memo send|broadcast|inbox|ack|gc` with full `--json` support
- **25 tests** in `tests/test_memo.py` — all passing

### Design (ADR-010)
- Memos stored in `.palaia/memos/<uuid>.md` with YAML frontmatter
- **NOT entries** — own lifecycle: no tiering, auto-expire via TTL (default 72h), read/unread state
- Agent detection via `--agent` flag or `PALAIA_AGENT` env var
- Broadcasts use `_broadcast` as recipient — visible to all agents
- Priority levels: `normal` / `high` (high sorts first in inbox)
- GC removes expired + read memos

### CLI
```bash
palaia memo send elliot "PR #13 needs review" --priority high
palaia memo broadcast "deploy freeze until 18:00"
palaia memo inbox --agent elliot
palaia memo ack <id>
palaia memo ack --all --agent elliot
palaia memo gc
```

All commands support `--json` for machine-readable output.

### Tests
311 tests passing (286 existing + 25 new memo tests). `ruff check` clean on new code.

Closes #14