### PR TITLE
release: v1.4.0 — Project Locking, Inter-Agent Messaging, CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,60 +1,42 @@
 # Changelog
 
-All notable changes to Palaia will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [1.1.0] - 2026-03-11
+## [1.4.0] — 2026-03-12
 
 ### Added
-- **Document Ingestion (RAG):** `palaia ingest <file/url/dir>` — chunk, embed, and store external documents
-- Supported formats: `.txt`, `.md`, `.html`, URLs, directories, `.pdf` (optional `pdfplumber` dep)
-- Sliding-window chunking with configurable size and overlap, respecting sentence boundaries
-- Source attribution in entry frontmatter (`source`, `source_page`, `chunk_index`, `chunk_total`, `ingested_at`)
-- `palaia query --rag` output format for LLM context injection
-- `--dry-run` flag for ingestion preview
-- ADR-009: RAG Ingestion architecture decision
-- 20+ new tests for ingestion, chunking, RAG output, and edge cases
+- **Project Locking** — `palaia lock/unlock` prevents concurrent agent work on the same project. TTL-based with auto-expire. (#15, #19)
+- **Inter-Agent Messaging** — `palaia memo send/inbox/ack/broadcast/gc` for async agent communication with priority and auto-expire. (#14, #21)
+- **Plugin Activation docs** — SKILL.md now guides agents through full OpenClaw plugin setup. (#20)
 
-### Copyright
-© 2026 byte5 GmbH — MIT License
+## [1.3.0] — 2026-03-12
 
-## [1.0.0] - 2026-03-11
+### Added
+- **`--agent` flag on all CLI commands** — query, list, get, export now support agent-scoped access. (#7)
+- **Onboarding experience** — SKILL.md install block, multi-agent detection in `palaia init`, README multi-agent guide. (#8)
+- **`palaia doctor`** — Health checks, version tracking, upgrade guidance. (#13)
+- **`palaia setup --multi-agent`** — Auto-detect and configure agent directories. (#10, #13)
+- **List filters** — `palaia list --tag/--scope/--agent` for browsing without search. (#12, #13)
+- **Auto-create projects** — `--project` flag auto-creates projects on write/ingest. (#9, #13)
+- **Migration safety** — DO NOT DELETE warnings for system files, `palaia migrate` detects and protects operational config. (#16)
+- **`@byte5ai/palaia` npm plugin** — OpenClaw memory backend, published on npm. (#17)
 
-First stable release.
+### Changed
+- Version tracking in store config (`store_version` field). (#13)
+- SKILL.md updated with full onboarding flow and post-update guidance.
 
-### Features
-- WAL-backed, crash-safe persistent memory store
-- HOT/WARM/COLD tiering with configurable decay
-- Multi-provider semantic search (OpenAI, sentence-transformers, fastembed, ollama)
+## [1.1.0] — 2026-03-11
+
+### Added
+- Document ingestion / RAG support (`palaia ingest`)
+- First-class projects with scope cascade
 - Configurable embedding fallback chain
-- Projects: organize memory by project with per-project default scope
-- Scope system: private, team, public with cascade
-- `palaia doctor` for legacy system detection and cleanup guidance
-- `palaia warmup` for embedding model preloading
-- `palaia migrate` with 4 adapters (smart-memory, flat-file, json, generic-md)
-- `palaia export/import` for git-based knowledge sync
-- `@byte5ai/palaia` plugin for native OpenClaw memory integration
-- 185 tests, fully green CI
+- Multi-provider embeddings (Ollama, SentenceTransformers, FastEmbed, OpenAI)
+- ClawHub published, PyPI published
 
-### Copyright
-© 2026 byte5 GmbH — MIT License
-
-## [0.1.0] - 2026-03-11
+## [1.0.0] — 2026-03-10
 
 ### Added
-- CLI with commands: `init`, `write`, `query`, `list`, `status`, `gc`, `export`, `import`
-- Write-Ahead Log (WAL) for crash-safe writes
-- HOT/WARM/COLD tiering with automatic decay-based rotation
-- BM25 keyword search (zero dependencies)
-- Scope tags: `private`, `team`, `shared:<name>`, `public`
-- Content-hash deduplication
-- `fcntl`-based file locking for multi-agent safety
-- `palaia export` / `palaia import` for cross-team knowledge transfer via git
-- Embedding cache infrastructure (`.palaia/index/embeddings.json`)
-- CI/CD: GitHub Actions for testing (Python 3.9–3.12) and PyPI release
-- Documentation: Getting Started, CLI Reference, Architecture, 7 ADRs
-- Community: CONTRIBUTING.md, issue templates, PR template
-
-[0.1.0]: https://github.com/iret77/palaia/releases/tag/v0.1.0
+- Core memory store with WAL and crash safety
+- Hybrid search (BM25 + semantic embeddings)
+- Tiered storage (HOT/WARM/COLD) with decay-based rotation
+- Scope system (private/team/public)
+- CLI with write, query, get, list, status, gc, export, import, migrate, recover

--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ Persistent, local memory for AI agents — write something today, find it next w
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Released March 2026](https://img.shields.io/badge/released-March%202026-brightgreen.svg)]()
 
+## What's New in 1.4.0
+
+- 🔒 **Project Locking** — Prevent multiple agents from working on the same project (`palaia lock/unlock`)
+- 💬 **Inter-Agent Messaging** — Async memos between agents (`palaia memo send/inbox/ack`)
+- 🔌 **OpenClaw Plugin** — Full setup guide for `@byte5ai/palaia` memory backend
+- 🩺 **Health Checks** — `palaia doctor` with version tracking and upgrade guidance
+- 📋 **List Filters** — Browse by `--tag`, `--scope`, `--agent` without search queries
+
+See [CHANGELOG.md](CHANGELOG.md) for full details.
+
 ## What Palaia Does
 
 AI agents forget everything between sessions. Every restart is a blank slate — context from yesterday, decisions from last week, lessons learned an hour ago — all gone. Palaia fixes that.

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byte5ai/palaia",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Palaia memory backend for OpenClaw",
   "main": "index.ts",
   "openclaw": {

--- a/palaia/__init__.py
+++ b/palaia/__init__.py
@@ -4,5 +4,5 @@ Palaia — Local, cloud-free memory for OpenClaw agents.
 
 from __future__ import annotations
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 __author__ = "byte5 GmbH"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "palaia"
-version = "1.3.0"
+version = "1.4.0"
 description = "Local, cloud-free memory for OpenClaw agents."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Release v1.4.0

### Changes
- **Version bump** to 1.4.0 in `pyproject.toml`, `palaia/__init__.py`, `packages/openclaw-plugin/package.json`
- **CHANGELOG.md** — Full changelog covering v1.0.0 → v1.4.0
- **README.md** — Added "What's New in 1.4.0" section

### New in 1.4.0
- 🔒 Project Locking (`palaia lock/unlock`) — TTL-based with auto-expire (#15, #19)
- 💬 Inter-Agent Messaging (`palaia memo send/inbox/ack/broadcast/gc`) (#14, #21)
- 🔌 Plugin Activation docs in SKILL.md (#20)

### Post-merge
1. `git tag v1.4.0 && git push origin v1.4.0` (triggers PyPI publish)
2. `cd packages/openclaw-plugin && npm publish --access public`
3. ClawHub publish