### PR TITLE
feat: init onboarding output + PALAIA_HOME env support

### DIFF
--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byte5ai/palaia",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "description": "Palaia memory backend for OpenClaw",
   "main": "index.ts",
   "openclaw": {

--- a/packages/openclaw-plugin/src/runner.ts
+++ b/packages/openclaw-plugin/src/runner.ts
@@ -121,7 +121,10 @@ function execCommand(
         timeout,
         maxBuffer: 1024 * 1024, // 1MB
         cwd: opts.cwd,
-        env: { ...process.env },
+        env: {
+          ...process.env,
+          ...(opts.cwd ? { PALAIA_HOME: opts.cwd } : {}),
+        },
       },
       (error, stdout, stderr) => {
         if (error && (error as any).killed) {

--- a/palaia/__init__.py
+++ b/palaia/__init__.py
@@ -4,5 +4,5 @@ Palaia — Local, cloud-free memory for OpenClaw agents.
 
 from __future__ import annotations
 
-__version__ = "1.4.0"
+__version__ = "1.4.2"
 __author__ = "byte5 GmbH"

--- a/palaia/cli.py
+++ b/palaia/cli.py
@@ -122,6 +122,21 @@ def cmd_init(args):
         print("   • OpenAI: set OPENAI_API_KEY env var")
         print("   Then run: palaia warmup")
 
+    # Post-init instructions for LLM agents
+    print()
+    print("⚠️  SETUP REQUIRED — Continue with these steps:")
+    print("1. Run: palaia doctor --fix")
+    print("   (Checks your system, fixes common issues, configures version tracking)")
+    print("2. Run: palaia detect")
+    print("   (Finds available search providers on your system)")
+    print("3. Run: palaia warmup")
+    print("   (Pre-downloads embedding models for instant search)")
+    print("4. Read the palaia SKILL.md section 'Plugin Activation' and configure the OpenClaw memory plugin")
+    print("   (npm install -g @byte5ai/palaia, then patch openclaw.json, then restart gateway)")
+    print("5. Report your setup results to the user")
+    print()
+    print("Do NOT skip these steps. The memory system is not fully operational until all steps are complete.")
+
     return 0
 
 

--- a/palaia/config.py
+++ b/palaia/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 DEFAULT_CONFIG = {
@@ -23,8 +24,23 @@ DEFAULT_CONFIG = {
 
 
 def find_palaia_root(start: str = ".") -> Path | None:
-    """Walk up from start to find .palaia directory."""
+    """Walk up from start to find .palaia directory.
 
+    Checks PALAIA_HOME env var first, then walks up from start.
+    """
+    # Check PALAIA_HOME env var first
+    env_home = os.environ.get("PALAIA_HOME")
+    if env_home:
+        env_path = Path(env_home)
+        # PALAIA_HOME points directly to a .palaia directory
+        if env_path.is_dir() and env_path.name == ".palaia":
+            return env_path
+        # PALAIA_HOME points to parent dir containing .palaia
+        candidate = env_path / ".palaia"
+        if candidate.is_dir():
+            return candidate
+
+    # Walk up from start directory
     current = Path(start).resolve()
     while True:
         candidate = current / ".palaia"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "palaia"
-version = "1.4.0"
+version = "1.4.2"
 description = "Local, cloud-free memory for OpenClaw agents."
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,59 @@
+"""Tests for palaia.config module."""
+
+import importlib
+
+import pytest
+
+
+def test_palaia_home_env_overrides_cwd(tmp_path, monkeypatch):
+    """PALAIA_HOME env var should override CWD-based search."""
+    # Create .palaia in a custom location
+    store = tmp_path / "custom" / ".palaia"
+    store.mkdir(parents=True)
+    (store / "config.json").write_text("{}")
+
+    monkeypatch.setenv("PALAIA_HOME", str(store))
+
+    from palaia.config import find_palaia_root
+
+    # Reload to pick up env change
+    import palaia.config
+    importlib.reload(palaia.config)
+    from palaia.config import find_palaia_root
+
+    result = find_palaia_root(start="/tmp/nowhere")
+    assert result == store
+
+
+def test_palaia_home_parent_dir(tmp_path, monkeypatch):
+    """PALAIA_HOME pointing to parent dir containing .palaia."""
+    parent = tmp_path / "workspace"
+    store = parent / ".palaia"
+    store.mkdir(parents=True)
+    (store / "config.json").write_text("{}")
+
+    monkeypatch.setenv("PALAIA_HOME", str(parent))
+
+    import palaia.config
+    importlib.reload(palaia.config)
+    from palaia.config import find_palaia_root
+
+    result = find_palaia_root(start="/tmp/nowhere")
+    assert result == store
+
+
+def test_palaia_home_invalid_ignored(tmp_path, monkeypatch):
+    """Invalid PALAIA_HOME should fall back to CWD walk."""
+    monkeypatch.setenv("PALAIA_HOME", "/nonexistent/path")
+
+    # Create .palaia in tmp_path
+    store = tmp_path / ".palaia"
+    store.mkdir()
+    (store / "config.json").write_text("{}")
+
+    import palaia.config
+    importlib.reload(palaia.config)
+    from palaia.config import find_palaia_root
+
+    result = find_palaia_root(start=str(tmp_path))
+    assert result == store


### PR DESCRIPTION
## Changes

### 1. palaia init Output (cli.py)
After successful init, prints full onboarding steps instructing LLM agents to run `doctor --fix`, `detect`, `warmup`, configure the OpenClaw plugin, and report results. This ensures agents don't stop after seeing 'Initialized'.

### 2. PALAIA_HOME Environment Variable (config.py)
`find_palaia_root()` now checks `PALAIA_HOME` env var before walking up from CWD. Supports both pointing directly to `.palaia` dir or to parent dir containing `.palaia`.

### 3. Plugin Runner (runner.ts)
`execCommand` now sets `PALAIA_HOME` to `opts.cwd` so the plugin finds the store regardless of process CWD.

### 4. Version bump → 1.4.2

### Tests
3 new tests for PALAIA_HOME behavior. All 314 tests pass.