### PR TITLE
docs: catch up CHANGELOG, README, SKILL.md for 1.4.1/1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.4.2] — 2026-03-12
+
+### Added
+- **Init triggers onboarding** — `palaia init` now outputs step-by-step setup instructions that guide LLM agents through the complete onboarding (doctor, detect, warmup, plugin config). (#23)
+- **`PALAIA_HOME` env variable** — Override `.palaia` store location. Plugin runner sets it automatically. (#23)
+
+### Fixed
+- OpenClaw plugin now finds `.palaia` store reliably regardless of working directory. (#23)
+
+## [1.4.1] — 2026-03-12
+
+### Added
+- **Auto-Check section in SKILL.md** — Agents run `palaia doctor` every time the skill is loaded.
+- **`postUpdate` hook in SKILL.md metadata** — `clawhub update` triggers automatic upgrade + health check.
+
 ## [1.4.0] — 2026-03-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ Persistent, local memory for AI agents — write something today, find it next w
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Released March 2026](https://img.shields.io/badge/released-March%202026-brightgreen.svg)]()
 
-## What's New in 1.4.0
+## What's New in 1.4.2
 
 - 🔒 **Project Locking** — Prevent multiple agents from working on the same project (`palaia lock/unlock`)
 - 💬 **Inter-Agent Messaging** — Async memos between agents (`palaia memo send/inbox/ack`)
-- 🔌 **OpenClaw Plugin** — Full setup guide for `@byte5ai/palaia` memory backend
+- 🔌 **OpenClaw Plugin** — Full setup guide + automatic activation for `@byte5ai/palaia`
+- 🚀 **Auto-Onboarding** — `palaia init` guides agents through complete setup automatically
+- 🏠 **`PALAIA_HOME`** — Environment variable to override store location
 - 🩺 **Health Checks** — `palaia doctor` with version tracking and upgrade guidance
-- 📋 **List Filters** — Browse by `--tag`, `--scope`, `--agent` without search queries
 
 See [CHANGELOG.md](CHANGELOG.md) for full details.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -17,12 +17,19 @@ metadata:
     postInstall:
       - command: "palaia init"
         label: "Initialize Palaia store"
+    postUpdate:
+      - command: "pip install --upgrade palaia && palaia doctor --fix"
+        label: "Upgrade Palaia and run health checks"
     plugin:
       slot: memory
       package: "@byte5ai/palaia"
 ---
 
 # Palaia — Agent Memory Skill
+
+## Auto-Check (run every time this skill is loaded)
+
+**[INSTRUCTION for LLM]:** Before doing anything else with Palaia, run `palaia doctor` silently. If it reports ANY warnings (version mismatch, missing providers, legacy patterns, incomplete setup), address them immediately by following `palaia doctor --fix` recommendations. Do not proceed with other Palaia tasks until doctor reports no issues. This ensures the memory system is always up-to-date and correctly configured.
 
 ## Communication During Setup
 


### PR DESCRIPTION
Pure documentation catch-up — no code changes, no version bump.

### Changes
- **CHANGELOG.md**: Added 1.4.1 and 1.4.2 entries above existing 1.4.0
- **README.md**: Updated "What's New" section to 1.4.2 (auto-onboarding, PALAIA_HOME, plugin activation)
- **SKILL.md**: Added `postUpdate` hook (auto-upgrade + doctor) and Auto-Check section (run doctor on every skill load)

Ref: #23