### PR TITLE
feat: update nag, doctor hint, install docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.4.3] — 2026-03-13
+
+### Added
+- **Update nag** — CLI warns on `query`, `write`, `list`, `status` when store version doesn't match CLI version.
+- **Doctor upgrade hint** — `palaia doctor` always suggests checking for updates.
+- **README install section** — Clear instructions for OpenClaw and manual install, including "tell your agent" hint.
+- **ClawHub description** — Now includes post-install instruction.
+
 ## [1.4.2] — 2026-03-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Persistent, local memory for AI agents — write something today, find it next w
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Released March 2026](https://img.shields.io/badge/released-March%202026-brightgreen.svg)]()
 
-## What's New in 1.4.2
+## What's New in 1.4.3
 
 - 🔒 **Project Locking** — Prevent multiple agents from working on the same project (`palaia lock/unlock`)
 - 💬 **Inter-Agent Messaging** — Async memos between agents (`palaia memo send/inbox/ack`)
@@ -17,6 +17,28 @@ Persistent, local memory for AI agents — write something today, find it next w
 - 🩺 **Health Checks** — `palaia doctor` with version tracking and upgrade guidance
 
 See [CHANGELOG.md](CHANGELOG.md) for full details.
+
+## Installation
+
+### For OpenClaw users (recommended)
+```
+clawhub install palaia
+```
+Then tell your agent: **"Set up Palaia"** — it will handle the rest.
+
+### Manual install
+```bash
+pip install palaia
+palaia init
+palaia doctor --fix
+```
+
+### After updating
+```bash
+pip install --upgrade palaia
+palaia doctor --fix
+```
+Your agent can also do this — just say: **"Update Palaia"**
 
 ## What Palaia Does
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -3,6 +3,7 @@ name: palaia
 description: >
   Local, crash-safe persistent memory for OpenClaw agents.
   Replaces built-in memory-core with semantic search, projects, and scope-based access control.
+  After installing, tell your agent: "Set up Palaia" to complete the onboarding.
 metadata:
   openclaw:
     emoji: 🧠

--- a/palaia/__init__.py
+++ b/palaia/__init__.py
@@ -4,5 +4,5 @@ Palaia — Local, cloud-free memory for OpenClaw agents.
 
 from __future__ import annotations
 
-__version__ = "1.4.2"
+__version__ = "1.4.3"
 __author__ = "byte5 GmbH"

--- a/palaia/cli.py
+++ b/palaia/cli.py
@@ -18,6 +18,37 @@ from palaia.store import Store
 from palaia.sync import export_entries, import_entries
 
 
+def check_version_nag():
+    """Warn if installed palaia version is newer than store version."""
+    try:
+        from palaia import __version__
+        from palaia.config import find_palaia_root
+
+        root = find_palaia_root()
+        if not root:
+            return
+
+        config_path = root / "config.json"
+        if not config_path.exists():
+            return
+
+        config = json.loads(config_path.read_text())
+        store_version = config.get("store_version", "")
+
+        if not store_version:
+            # No store version = needs palaia doctor
+            print("⚠️  Palaia store has no version stamp. Run: palaia doctor --fix", file=sys.stderr)
+            return
+
+        if store_version != __version__:
+            print(
+                f"⚠️  Palaia CLI is v{__version__} but store is v{store_version}. Run: palaia doctor --fix",
+                file=sys.stderr,
+            )
+    except Exception:
+        pass  # Never block normal operation
+
+
 def _json_out(data, args):
     """Print JSON if --json flag is set, return True if printed."""
     if getattr(args, "json", False):
@@ -151,6 +182,7 @@ def cmd_init(args):
 
 def cmd_write(args):
     """Write a memory entry."""
+    check_version_nag()
     root = get_root()
     store = Store(root)
 
@@ -199,6 +231,7 @@ def cmd_write(args):
 
 def cmd_query(args):
     """Search memories."""
+    check_version_nag()
     root = get_root()
     store = Store(root)
     store.recover()
@@ -412,6 +445,7 @@ def cmd_recover(args):
 
 def cmd_list(args):
     """List memories in a tier."""
+    check_version_nag()
     root = get_root()
     store = Store(root)
     store.recover()
@@ -474,6 +508,7 @@ def cmd_list(args):
 
 def cmd_status(args):
     """Show system status."""
+    check_version_nag()
     root = get_root()
     store = Store(root)
     recovered = store.recover()
@@ -1661,22 +1696,6 @@ def main():
     if not args.command:
         parser.print_help()
         return 1
-
-    # Version drift warning (skip for init/doctor/detect)
-    if args.command not in ("init", "doctor", "detect") and not getattr(args, "json", False):
-        try:
-            root = find_palaia_root()
-            if root:
-                cfg = load_config(root)
-                store_ver = cfg.get("store_version", "")
-                if store_ver and store_ver != __version__:
-                    print(
-                        f"⚠️  Store created with v{store_ver}, running v{__version__}. "
-                        "Run `palaia doctor` for upgrade checks.",
-                        file=sys.stderr,
-                    )
-        except Exception:
-            pass
 
     commands = {
         "init": cmd_init,

--- a/palaia/doctor.py
+++ b/palaia/doctor.py
@@ -502,4 +502,7 @@ def format_doctor_report(results: list[dict[str, Any]], show_fix: bool = False) 
     else:
         lines.append("All clear! Palaia is healthy. 🎉")
 
+    lines.append("")
+    lines.append("💡 To check for updates: pip install --upgrade palaia")
+
     return "\n".join(lines)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "palaia"
-version = "1.4.2"
+version = "1.4.3"
 description = "Local, cloud-free memory for OpenClaw agents."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Changes

### Update Nag (cli.py)
- New `check_version_nag()` function warns on stderr when store version != CLI version
- Called at start of `query`, `write`, `list`, `status` commands
- Not called for `init`, `doctor`, `--version`, `--help`
- Removed old inline version drift check from `main()` (replaced by dedicated function)

### Doctor Upgrade Hint (doctor.py)
- `palaia doctor` always outputs `pip install --upgrade palaia` hint at the end
- Agents will see this and know how to update

### README Installation Section
- New Installation section after What's New, before What Palaia Does
- OpenClaw install (`clawhub install palaia`)
- Manual install + after updating instructions
- "Tell your agent" hints for both install and update

### SKILL.md Description
- Added post-install instruction to ClawHub description

### Version Bump
- `pyproject.toml`: 1.4.2 → 1.4.3
- `palaia/__init__.py`: 1.4.2 → 1.4.3
- CHANGELOG.md updated

### Pre-push checks
- `ruff check`: passed
- `ruff format`: no changes needed
- `pytest`: 314 passed