### PR TITLE
fix: wording corrections for SKILL.md + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See [CHANGELOG.md](CHANGELOG.md) for full details.
 ```
 clawhub install palaia
 ```
-Then tell your agent: **"Set up Palaia"** — it will handle the rest.
+Then tell your agent: **"Install the Palaia memory skill from ClawHub and set it up completely"**
 
 ### Manual install
 ```bash

--- a/SKILL.md
+++ b/SKILL.md
@@ -3,7 +3,7 @@ name: palaia
 description: >
   Local, crash-safe persistent memory for OpenClaw agents.
   Replaces built-in memory-core with semantic search, projects, and scope-based access control.
-  After installing, tell your agent: "Set up Palaia" to complete the onboarding.
+  After installing or updating, run: palaia doctor --fix to complete setup.
 metadata:
   openclaw:
     emoji: 🧠


### PR DESCRIPTION
- SKILL.md description: agent-facing instruction instead of 'tell your agent'
- README: combined prompt for install + setup