### PR TITLE
fix: README prompt wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See [CHANGELOG.md](CHANGELOG.md) for full details.
 ```
 clawhub install palaia
 ```
-Then tell your agent: **"Install the Palaia memory skill from ClawHub and set it up completely"**
+Then tell your agent: **"Set up Palaia completely"**
 
 ### Manual install
 ```bash


### PR DESCRIPTION
Separate clawhub install command from post-install prompt. Was redundant: told user to say 'Install from ClawHub' after already showing the install command.