### PR TITLE
fix: README beginner install = one prompt, no CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ See [CHANGELOG.md](CHANGELOG.md) for full details.
 ## Installation
 
 ### For OpenClaw users (recommended)
-```
-clawhub install palaia
-```
-Then tell your agent: **"Set up Palaia completely"**
+
+Tell your agent:
+
+> "Install the Palaia memory skill from ClawHub and set it up completely"
+
+Your agent will handle installation, configuration, and onboarding automatically.
 
 ### Manual install
 ```bash


### PR DESCRIPTION
OpenClaw users talk to their agent via Telegram/Discord/etc. They don't run CLI commands. The recommended install path should be one sentence the user tells their agent. Manual/expert path stays below.