### PR TITLE
feat: Project Ownership (owner field, set-owner, contributors)

### DIFF
--- a/palaia/cli.py
+++ b/palaia/cli.py
@@ -1005,6 +1005,7 @@ def cmd_project(args):
                 name=args.name,
                 description=args.description or "",
                 default_scope=args.default_scope or "team",
+                owner=getattr(args, "owner", None),
             )
         except ValueError as e:
             if _json_out({"error": str(e)}, args):
@@ -1014,6 +1015,8 @@ def cmd_project(args):
         if _json_out(project.to_dict(), args):
             return 0
         print(f"Created project: {project.name}")
+        if project.owner:
+            print(f"  Owner: {project.owner}")
         if project.description:
             print(f"  Description: {project.description}")
         print(f"  Default scope: {project.default_scope}")
@@ -1021,14 +1024,18 @@ def cmd_project(args):
 
     elif action == "list":
         projects = pm.list()
+        owner_filter = getattr(args, "owner", None)
+        if owner_filter:
+            projects = [p for p in projects if p.owner == owner_filter]
         if _json_out({"projects": [p.to_dict() for p in projects]}, args):
             return 0
         if not projects:
             print("No projects.")
             return 0
         for p in projects:
+            owner_str = f", owner: {p.owner}" if p.owner else ""
             desc = f" — {p.description}" if p.description else ""
-            print(f"  {p.name} [{p.default_scope}]{desc}")
+            print(f"  {p.name} (scope: {p.default_scope}{owner_str}){desc}")
         print(f"\n{len(projects)} project(s).")
         return 0
 
@@ -1040,9 +1047,14 @@ def cmd_project(args):
             print(f"Project '{args.name}' not found.", file=sys.stderr)
             return 1
         entries = pm.get_project_entries(args.name, store)
+        contributors = pm.get_contributors(args.name, store)
+        tier_counts = {}
+        for _meta, _body, tier in entries:
+            tier_counts[tier] = tier_counts.get(tier, 0) + 1
         if _json_out(
             {
                 "project": project.to_dict(),
+                "contributors": contributors,
                 "entries": [
                     {
                         "id": meta.get("id", "?"),
@@ -1053,13 +1065,19 @@ def cmd_project(args):
                     }
                     for meta, body, tier in entries
                 ],
+                "entry_count": len(entries),
+                "tier_counts": tier_counts,
             },
             args,
         ):
             return 0
         desc = f" — {project.description}" if project.description else ""
         print(f"Project: {project.name}{desc}")
-        print(f"  Default scope: {project.default_scope}")
+        owner_display = project.owner or "(none)"
+        print(f"  Owner: {owner_display}")
+        print(f"  Scope: {project.default_scope}")
+        if contributors:
+            print(f"  Contributors: {', '.join(contributors)}")
         print(f"  Created: {project.created_at}")
         if entries:
             print(f"\n  Entries ({len(entries)}):")
@@ -1129,6 +1147,29 @@ def cmd_project(args):
         if _json_out({"project": args.name, "default_scope": project.default_scope}, args):
             return 0
         print(f"Project '{args.name}' default scope → {project.default_scope}")
+        return 0
+
+    elif action == "set-owner":
+        try:
+            if getattr(args, "clear", False):
+                project = pm.clear_owner(args.name)
+                if _json_out({"project": args.name, "owner": None}, args):
+                    return 0
+                print(f"Cleared owner for project '{args.name}'.")
+            else:
+                owner_value = getattr(args, "owner_value", None)
+                if not owner_value:
+                    print("Error: owner name required (or use --clear).", file=sys.stderr)
+                    return 1
+                project = pm.set_owner(args.name, owner_value)
+                if _json_out({"project": args.name, "owner": project.owner}, args):
+                    return 0
+                print(f"Project '{args.name}' owner → {project.owner}")
+        except ValueError as e:
+            if _json_out({"error": str(e)}, args):
+                return 1
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
         return 0
 
     elif action == "delete":
@@ -1547,9 +1588,11 @@ def main():
     p_proj_create.add_argument("name", help="Project name")
     p_proj_create.add_argument("--description", default=None, help="Project description")
     p_proj_create.add_argument("--default-scope", default=None, help="Default scope for entries")
+    p_proj_create.add_argument("--owner", default=None, help="Project owner")
     p_proj_create.add_argument("--json", action="store_true", help="Output as JSON")
 
     p_proj_list = project_sub.add_parser("list", help="List projects")
+    p_proj_list.add_argument("--owner", default=None, help="Filter by owner")
     p_proj_list.add_argument("--json", action="store_true", help="Output as JSON")
 
     p_proj_show = project_sub.add_parser("show", help="Show project details")
@@ -1575,6 +1618,12 @@ def main():
     p_proj_scope.add_argument("name", help="Project name")
     p_proj_scope.add_argument("scope_value", help="New default scope")
     p_proj_scope.add_argument("--json", action="store_true", help="Output as JSON")
+
+    p_proj_owner = project_sub.add_parser("set-owner", help="Set or clear project owner")
+    p_proj_owner.add_argument("name", help="Project name")
+    p_proj_owner.add_argument("owner_value", nargs="?", default=None, help="New owner name")
+    p_proj_owner.add_argument("--clear", action="store_true", help="Remove owner")
+    p_proj_owner.add_argument("--json", action="store_true", help="Output as JSON")
 
     p_proj_delete = project_sub.add_parser("delete", help="Delete project (entries preserved)")
     p_proj_delete.add_argument("name", help="Project name")

--- a/palaia/project.py
+++ b/palaia/project.py
@@ -24,12 +24,14 @@ class Project:
         default_scope: str = "team",
         created_at: str | None = None,
         members: list[str] | None = None,
+        owner: str | None = None,
     ):
         self.name = name
         self.description = description
         self.default_scope = default_scope
         self.created_at = created_at or datetime.now(timezone.utc).isoformat()
         self.members = members or []
+        self.owner = owner
 
     def to_dict(self) -> dict:
         return {
@@ -38,6 +40,7 @@ class Project:
             "default_scope": self.default_scope,
             "created_at": self.created_at,
             "members": self.members,
+            "owner": self.owner,
         }
 
     @classmethod
@@ -48,6 +51,7 @@ class Project:
             default_scope=data.get("default_scope", "team"),
             created_at=data.get("created_at"),
             members=data.get("members", []),
+            owner=data.get("owner"),
         )
 
 
@@ -81,6 +85,7 @@ class ProjectManager:
         name: str,
         description: str = "",
         default_scope: str = "team",
+        owner: str | None = None,
     ) -> Project:
         """Create a new project."""
         if not name or not name.strip():
@@ -94,7 +99,7 @@ class ProjectManager:
         if name in data:
             raise ValueError(f"Project '{name}' already exists.")
 
-        project = Project(name=name, description=description, default_scope=default_scope)
+        project = Project(name=name, description=description, default_scope=default_scope, owner=owner)
         data[name] = project.to_dict()
         self._save(data)
         return project
@@ -150,6 +155,36 @@ class ProjectManager:
         data[name]["default_scope"] = scope
         self._save(data)
         return Project.from_dict(data[name])
+
+    def set_owner(self, name: str, owner: str) -> Project:
+        """Set or change a project's owner."""
+        data = self._load()
+        if name not in data:
+            raise ValueError(f"Project '{name}' not found.")
+
+        data[name]["owner"] = owner
+        self._save(data)
+        return Project.from_dict(data[name])
+
+    def clear_owner(self, name: str) -> Project:
+        """Remove a project's owner."""
+        data = self._load()
+        if name not in data:
+            raise ValueError(f"Project '{name}' not found.")
+
+        data[name]["owner"] = None
+        self._save(data)
+        return Project.from_dict(data[name])
+
+    def get_contributors(self, name: str, store) -> list[str]:
+        """Get distinct agent names from all entries of a project."""
+        entries = self.get_project_entries(name, store)
+        agents = set()
+        for meta, _body, _tier in entries:
+            agent = meta.get("agent")
+            if agent:
+                agents.add(agent)
+        return sorted(agents)
 
     def _strip_project_from_entries(self, project_name: str, store) -> int:
         """Remove project tag from all entries belonging to a project."""

--- a/tests/test_project_owner.py
+++ b/tests/test_project_owner.py
@@ -1,0 +1,216 @@
+"""Tests for project ownership feature (Issue #30)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from palaia.project import Project, ProjectManager
+from palaia.store import Store
+
+
+@pytest.fixture
+def palaia_root(tmp_path):
+    """Create a minimal palaia root directory."""
+    root = tmp_path / ".palaia"
+    root.mkdir()
+    for tier in ("hot", "warm", "cold"):
+        (root / tier).mkdir()
+    return root
+
+
+@pytest.fixture
+def pm(palaia_root):
+    return ProjectManager(palaia_root)
+
+
+@pytest.fixture
+def store(palaia_root):
+    return Store(palaia_root)
+
+
+# --- Model Tests ---
+
+
+def test_create_project_with_owner(pm):
+    """1. Create project with owner."""
+    project = pm.create("clawsy", description="Mac App", owner="cyberclaw")
+    assert project.owner == "cyberclaw"
+    assert project.name == "clawsy"
+
+    # Verify persisted
+    reloaded = pm.get("clawsy")
+    assert reloaded.owner == "cyberclaw"
+
+
+def test_create_project_without_owner(pm):
+    """2. Create project without owner (None)."""
+    project = pm.create("myproject", description="Test")
+    assert project.owner is None
+
+    reloaded = pm.get("myproject")
+    assert reloaded.owner is None
+
+
+def test_set_owner(pm):
+    """3. set-owner on existing project."""
+    pm.create("clawsy")
+    project = pm.set_owner("clawsy", "forrest")
+    assert project.owner == "forrest"
+
+    reloaded = pm.get("clawsy")
+    assert reloaded.owner == "forrest"
+
+
+def test_clear_owner(pm):
+    """4. set-owner --clear."""
+    pm.create("clawsy", owner="cyberclaw")
+    project = pm.clear_owner("clawsy")
+    assert project.owner is None
+
+    reloaded = pm.get("clawsy")
+    assert reloaded.owner is None
+
+
+def test_list_shows_owner(pm):
+    """5. project list shows Owner."""
+    pm.create("clawsy", owner="cyberclaw")
+    pm.create("culturebook", owner="forrest")
+    projects = pm.list()
+    owners = {p.name: p.owner for p in projects}
+    assert owners["clawsy"] == "cyberclaw"
+    assert owners["culturebook"] == "forrest"
+
+
+def test_list_filter_by_owner(pm):
+    """6. project list --owner filters correctly."""
+    pm.create("clawsy", owner="cyberclaw")
+    pm.create("culturebook", owner="forrest")
+    pm.create("orphan")
+
+    all_projects = pm.list()
+    filtered = [p for p in all_projects if p.owner == "forrest"]
+    assert len(filtered) == 1
+    assert filtered[0].name == "culturebook"
+
+
+def test_show_displays_owner(pm, store):
+    """7. project show shows Owner."""
+    pm.create("clawsy", owner="cyberclaw")
+    project = pm.get("clawsy")
+    assert project.owner == "cyberclaw"
+
+
+def test_show_displays_contributors(pm, store):
+    """8. project show shows Contributors (from Entries)."""
+    pm.create("clawsy", owner="cyberclaw")
+
+    # Write entries with different agents
+    store.write(body="Entry 1", agent="cyberclaw", project="clawsy")
+    store.write(body="Entry 2", agent="elliot", project="clawsy")
+    store.write(body="Entry 3", agent="cyberclaw", project="clawsy")
+    store.write(body="Entry 4", agent="forrest", project="clawsy")
+
+    contributors = pm.get_contributors("clawsy", store)
+    assert contributors == ["cyberclaw", "elliot", "forrest"]
+
+
+def test_json_output_list_with_owner(pm):
+    """9. JSON output on list with Owner."""
+    pm.create("clawsy", owner="cyberclaw")
+    pm.create("culturebook", owner="forrest")
+
+    projects = pm.list()
+    json_data = {"projects": [p.to_dict() for p in projects]}
+
+    assert len(json_data["projects"]) == 2
+    proj_map = {p["name"]: p for p in json_data["projects"]}
+    assert proj_map["clawsy"]["owner"] == "cyberclaw"
+    assert proj_map["culturebook"]["owner"] == "forrest"
+
+
+def test_json_output_show_with_owner_and_contributors(pm, store):
+    """10. JSON output on show with Owner + Contributors."""
+    pm.create("clawsy", owner="cyberclaw")
+    store.write(body="Entry 1", agent="cyberclaw", project="clawsy")
+    store.write(body="Entry 2", agent="elliot", project="clawsy")
+
+    project = pm.get("clawsy")
+    contributors = pm.get_contributors("clawsy", store)
+    entries = pm.get_project_entries("clawsy", store)
+
+    json_data = {
+        "project": project.to_dict(),
+        "contributors": contributors,
+        "entries": [{"id": meta.get("id", "?"), "tier": tier} for meta, body, tier in entries],
+    }
+
+    assert json_data["project"]["owner"] == "cyberclaw"
+    assert json_data["contributors"] == ["cyberclaw", "elliot"]
+    assert len(json_data["entries"]) == 2
+
+
+def test_set_owner_nonexistent_project(pm):
+    """11. set-owner on non-existent project → error."""
+    with pytest.raises(ValueError, match="not found"):
+        pm.set_owner("nonexistent", "someone")
+
+
+def test_backward_compat_no_owner_field(palaia_root):
+    """12. Backward compat: existing projects.json without owner field."""
+    projects_file = palaia_root / "projects.json"
+    legacy_data = {
+        "legacy": {
+            "name": "legacy",
+            "description": "Old project",
+            "default_scope": "team",
+            "created_at": "2025-01-01T00:00:00+00:00",
+            "members": [],
+        }
+    }
+    projects_file.write_text(json.dumps(legacy_data))
+
+    pm = ProjectManager(palaia_root)
+    project = pm.get("legacy")
+    assert project is not None
+    assert project.owner is None
+    assert project.name == "legacy"
+
+
+def test_to_dict_includes_owner():
+    """Project.to_dict() includes owner field."""
+    p = Project(name="test", owner="alice")
+    d = p.to_dict()
+    assert "owner" in d
+    assert d["owner"] == "alice"
+
+    p2 = Project(name="test2")
+    d2 = p2.to_dict()
+    assert "owner" in d2
+    assert d2["owner"] is None
+
+
+def test_set_owner_overwrites(pm):
+    """set-owner overwrites existing owner."""
+    pm.create("clawsy", owner="cyberclaw")
+    pm.set_owner("clawsy", "forrest")
+    project = pm.get("clawsy")
+    assert project.owner == "forrest"
+
+    pm.set_owner("clawsy", "elliot")
+    project = pm.get("clawsy")
+    assert project.owner == "elliot"
+
+
+def test_clear_owner_nonexistent_project(pm):
+    """clear_owner on non-existent project → error."""
+    with pytest.raises(ValueError, match="not found"):
+        pm.clear_owner("nonexistent")
+
+
+def test_get_contributors_empty(pm, store):
+    """get_contributors with no entries returns empty list."""
+    pm.create("empty_project")
+    contributors = pm.get_contributors("empty_project", store)
+    assert contributors == []


### PR DESCRIPTION
## Project Ownership — Issue #30

### Changes

**`palaia/project.py`:**
- `Project` model: new `owner` field (optional, default `None`)
- `ProjectManager.create()`: accepts `owner` parameter
- `ProjectManager.set_owner(name, owner)`: set/change owner
- `ProjectManager.clear_owner(name)`: remove owner
- `ProjectManager.get_contributors(name, store)`: aggregate distinct agents from entries

**`palaia/cli.py`:**
- `project create --owner <name>`: set owner at creation
- `project set-owner <project> <owner>`: new subcommand
- `project set-owner <project> --clear`: remove owner
- `project list --owner <name>`: filter by owner
- `project list`: shows owner in output
- `project show`: displays owner + contributors
- All commands support `--json` output

**`tests/test_project_owner.py`:** 16 tests covering:
- Create with/without owner
- set-owner, clear-owner
- List with owner display and filtering
- Show with owner and contributors
- JSON output for list and show
- Error handling (non-existent project)
- Backward compatibility (legacy projects.json without owner field)

### Backward Compatibility
Existing `projects.json` files without the `owner` field work seamlessly — owner defaults to `None`.

Closes #30