### PR TITLE
release: v1.5.0 — Project Ownership, Update Nag, Auto-Onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.5.0] — 2026-03-13
+
+### Added
+- **Project Ownership** — `palaia project create --owner`, `project set-owner`, `project list --owner`. Each project can have one owner, contributors are auto-aggregated from entries. (#30, #31)
+- **Update nag** — CLI warns on `query`, `write`, `list`, `status` when store version doesn't match CLI version. (#26)
+- **Doctor upgrade hint** — `palaia doctor` always suggests checking for updates. (#26)
+
+### Fixed
+- **Init triggers onboarding** — `palaia init` outputs step-by-step setup instructions for LLM agents. (#23)
+- **`PALAIA_HOME` env variable** — Override `.palaia` store location; plugin sets it automatically. (#23)
+- **Ruff lint errors** in test_memo.py fixed. (#25)
+- **SKILL.md auto-check** — Agents run `palaia doctor` on every skill load. (#24)
+- **README beginner flow** — One prompt install for OpenClaw users, no CLI required. (#28, #29)
+
 ## [1.4.3] — 2026-03-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Persistent, local memory for AI agents — write something today, find it next w
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Released March 2026](https://img.shields.io/badge/released-March%202026-brightgreen.svg)]()
 
-## What's New in 1.4.3
+## What's New in 1.5.0
 
-- 🔒 **Project Locking** — Prevent multiple agents from working on the same project (`palaia lock/unlock`)
-- 💬 **Inter-Agent Messaging** — Async memos between agents (`palaia memo send/inbox/ack`)
-- 🔌 **OpenClaw Plugin** — Full setup guide + automatic activation for `@byte5ai/palaia`
-- 🚀 **Auto-Onboarding** — `palaia init` guides agents through complete setup automatically
-- 🏠 **`PALAIA_HOME`** — Environment variable to override store location
-- 🩺 **Health Checks** — `palaia doctor` with version tracking and upgrade guidance
+- 👤 **Project Ownership** — Assign owners to projects, list by owner, auto-track contributors
+- 🔒 **Project Locking** — Prevent concurrent agent work on the same project
+- 💬 **Inter-Agent Messaging** — Async memos between agents (`palaia memo`)
+- 🔌 **OpenClaw Plugin** — Automatic activation and setup
+- 🚀 **Auto-Onboarding** — `palaia init` guides agents through complete setup
+- 🩺 **Health Checks** — `palaia doctor` with version tracking and upgrade nag
 
 See [CHANGELOG.md](CHANGELOG.md) for full details.
 

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byte5ai/palaia",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "Palaia memory backend for OpenClaw",
   "main": "index.ts",
   "openclaw": {

--- a/palaia/__init__.py
+++ b/palaia/__init__.py
@@ -4,5 +4,5 @@ Palaia — Local, cloud-free memory for OpenClaw agents.
 
 from __future__ import annotations
 
-__version__ = "1.4.3"
+__version__ = "1.5.0"
 __author__ = "byte5 GmbH"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "palaia"
-version = "1.4.3"
+version = "1.5.0"
 description = "Local, cloud-free memory for OpenClaw agents."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## v1.5.0

### Added
- **Project Ownership** — `palaia project create --owner`, `project set-owner`, `project list --owner`. (#30, #31)
- **Update nag** — CLI warns when store version doesn't match CLI version. (#26)
- **Doctor upgrade hint** — `palaia doctor` always suggests checking for updates. (#26)

### Fixed
- **Init triggers onboarding** — `palaia init` outputs step-by-step setup instructions. (#23)
- **`PALAIA_HOME` env variable** — Override store location; plugin sets it automatically. (#23)
- **Ruff lint errors** in test_memo.py fixed. (#25)
- **SKILL.md auto-check** — Agents run `palaia doctor` on every skill load. (#24)
- **README beginner flow** — One prompt install for OpenClaw users. (#28, #29)

---
All checks pass: ruff check ✅ | ruff format ✅ | pytest 330/330 ✅