### PR TITLE
feat: palaia doctor checks for unread memos (#42)

### DIFF
--- a/palaia/doctor.py
+++ b/palaia/doctor.py
@@ -684,6 +684,66 @@ def _check_default_agent_alias(palaia_root: Path | None) -> dict[str, Any]:
     }
 
 
+def _check_unread_memos(palaia_root: Path | None) -> dict[str, Any]:
+    """Check for unread memos addressed to the current agent."""
+    if palaia_root is None:
+        return {
+            "name": "unread_memos",
+            "label": "Unread memos",
+            "status": "ok",
+            "message": "Not initialized",
+        }
+
+    try:
+        from palaia.config import get_agent, get_aliases
+        from palaia.memo import MemoManager
+
+        agent = get_agent(palaia_root)
+        if not agent:
+            agent = "default"
+
+        mm = MemoManager(palaia_root)
+        try:
+            aliases = get_aliases(palaia_root)
+        except Exception:
+            aliases = None
+
+        unread = mm.inbox(agent=agent, include_read=False, aliases=aliases or None)
+        count = len(unread)
+
+        if count == 0:
+            return {
+                "name": "unread_memos",
+                "label": "Unread memos",
+                "status": "ok",
+                "message": "No unread memos",
+            }
+
+        # Collect preview of unread memos for --fix display
+        previews = []
+        for meta, body in unread:
+            sender = meta.get("from", "?")
+            prio = " [high]" if meta.get("priority") == "high" else ""
+            first_line = body.split("\n")[0][:60] if body else ""
+            previews.append(f"From {sender}{prio}: {first_line}")
+
+        return {
+            "name": "unread_memos",
+            "label": "Unread memos",
+            "status": "warn",
+            "message": f"{count} unread memo(s)",
+            "fix": "Run: palaia memo inbox",
+            "details": {"count": count, "previews": previews},
+        }
+    except Exception:
+        return {
+            "name": "unread_memos",
+            "label": "Unread memos",
+            "status": "ok",
+            "message": "Could not check memos",
+        }
+
+
 def run_doctor(palaia_root: Path | None = None) -> list[dict[str, Any]]:
     """Run all doctor checks. Returns list of check results."""
     results = [
@@ -695,6 +755,7 @@ def run_doctor(palaia_root: Path | None = None) -> list[dict[str, Any]]:
         _check_projects_usage(palaia_root),
         _check_deprecated_config(palaia_root),
         _check_default_agent_alias(palaia_root),
+        _check_unread_memos(palaia_root),
         _check_openclaw_plugin(),
         _check_smart_memory_skill(),
         _check_legacy_memory_files(),

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -328,7 +328,7 @@ class TestRunDoctor:
     def test_run_all_checks(self, palaia_root, tmp_path, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))
         results = run_doctor(palaia_root)
-        assert len(results) == 13
+        assert len(results) == 14
         assert all("status" in r for r in results)
         assert all("name" in r for r in results)
 

--- a/tests/test_doctor_memos.py
+++ b/tests/test_doctor_memos.py
@@ -1,0 +1,109 @@
+"""Tests for doctor unread memos check (#42)."""
+
+import pytest
+
+from palaia.config import DEFAULT_CONFIG, save_config
+from palaia.doctor import run_doctor
+from palaia.memo import MemoManager
+
+
+@pytest.fixture
+def palaia_root(tmp_path):
+    root = tmp_path / ".palaia"
+    root.mkdir()
+    for sub in ("hot", "warm", "cold", "wal", "index", "memos"):
+        (root / sub).mkdir()
+    config = dict(DEFAULT_CONFIG)
+    config["agent"] = "testbot"
+    save_config(root, config)
+    return root
+
+
+def _find_check(results, name):
+    """Find a specific check result by name."""
+    for r in results:
+        if r["name"] == name:
+            return r
+    return None
+
+
+def test_doctor_no_memos(palaia_root):
+    """Doctor reports ok when no memos exist."""
+    results = run_doctor(palaia_root)
+    check = _find_check(results, "unread_memos")
+    assert check is not None
+    assert check["status"] == "ok"
+    assert "No unread" in check["message"]
+
+
+def test_doctor_unread_memos(palaia_root):
+    """Doctor warns when unread memos exist."""
+    mm = MemoManager(palaia_root)
+    mm.send(to="testbot", message="Hey testbot, check this!", from_agent="cyberclaw")
+
+    results = run_doctor(palaia_root)
+    check = _find_check(results, "unread_memos")
+    assert check is not None
+    assert check["status"] == "warn"
+    assert "1 unread" in check["message"]
+    assert check["fix"] == "Run: palaia memo inbox"
+
+
+def test_doctor_multiple_unread_memos(palaia_root):
+    """Doctor shows count of multiple unread memos."""
+    mm = MemoManager(palaia_root)
+    mm.send(to="testbot", message="First memo", from_agent="agent1")
+    mm.send(to="testbot", message="Second memo", from_agent="agent2")
+    mm.send(to="_broadcast", message="Broadcast memo", from_agent="agent3")
+
+    results = run_doctor(palaia_root)
+    check = _find_check(results, "unread_memos")
+    assert check is not None
+    assert check["status"] == "warn"
+    assert "3 unread" in check["message"]
+
+
+def test_doctor_read_memos_not_counted(palaia_root):
+    """Doctor doesn't count already-read memos."""
+    mm = MemoManager(palaia_root)
+    meta = mm.send(to="testbot", message="Read this", from_agent="cyberclaw")
+    mm.ack(meta["id"])
+
+    results = run_doctor(palaia_root)
+    check = _find_check(results, "unread_memos")
+    assert check is not None
+    assert check["status"] == "ok"
+
+
+def test_doctor_memos_for_other_agent(palaia_root):
+    """Doctor doesn't count memos addressed to other agents."""
+    mm = MemoManager(palaia_root)
+    mm.send(to="otheragent", message="Not for you", from_agent="cyberclaw")
+
+    results = run_doctor(palaia_root)
+    check = _find_check(results, "unread_memos")
+    assert check is not None
+    assert check["status"] == "ok"
+
+
+def test_doctor_memo_previews_in_details(palaia_root):
+    """Doctor includes memo previews in details for --fix display."""
+    mm = MemoManager(palaia_root)
+    mm.send(to="testbot", message="Important update about deployment", from_agent="cyberclaw", priority="high")
+
+    results = run_doctor(palaia_root)
+    check = _find_check(results, "unread_memos")
+    assert check is not None
+    assert "previews" in check.get("details", {})
+    previews = check["details"]["previews"]
+    assert len(previews) == 1
+    assert "cyberclaw" in previews[0]
+    assert "[high]" in previews[0]
+
+
+def test_doctor_no_init(tmp_path):
+    """Doctor handles uninitialized state gracefully."""
+    results = run_doctor(None)
+    check = _find_check(results, "unread_memos")
+    assert check is not None
+    assert check["status"] == "ok"


### PR DESCRIPTION
Closes #42

## Changes
- New `_check_unread_memos()` doctor check
- Warns when agent has unread memos with count
- Fix hint: `Run: palaia memo inbox`
- Details include previews (sender, priority, first line) for `--fix` display
- Respects agent aliases, ignores memos for other agents, ignores read memos

## Token-Oekonomie
Since agents run `palaia doctor` at session start (per SKILL.md), this ensures memos are actually seen — making the entire memo feature useful.

## Tests
7 new tests covering all edge cases.