### PR TITLE
feat: doctor checks for newer Palaia version on PyPI (#45)

### DIFF
--- a/palaia/doctor.py
+++ b/palaia/doctor.py
@@ -684,6 +684,71 @@ def _check_default_agent_alias(palaia_root: Path | None) -> dict[str, Any]:
     }
 
 
+def _check_version_available(palaia_root: Path | None) -> dict[str, Any]:
+    """Check if a newer Palaia version is available on PyPI."""
+    from palaia import __version__
+
+    try:
+        import urllib.request
+
+        url = "https://pypi.org/pypi/palaia/json"
+        req = urllib.request.Request(url, headers={"Accept": "application/json"})
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            import json as _json
+
+            data = _json.loads(resp.read())
+            latest = data.get("info", {}).get("version", "")
+
+        if not latest:
+            return {
+                "name": "version_check",
+                "label": "Version check",
+                "status": "ok",
+                "message": f"v{__version__} (could not determine latest)",
+            }
+
+        if latest == __version__:
+            return {
+                "name": "version_check",
+                "label": "Version check",
+                "status": "ok",
+                "message": f"v{__version__} (latest)",
+                "details": {"installed": __version__, "latest": latest},
+            }
+
+        # Compare versions
+        from packaging.version import InvalidVersion, Version
+
+        try:
+            if Version(latest) > Version(__version__):
+                return {
+                    "name": "version_check",
+                    "label": "Version check",
+                    "status": "warn",
+                    "message": f"Update available: v{__version__} -> v{latest}",
+                    "fix": "Run: pip install --upgrade palaia && palaia doctor --fix",
+                    "details": {"installed": __version__, "latest": latest},
+                }
+        except InvalidVersion:
+            pass
+
+        return {
+            "name": "version_check",
+            "label": "Version check",
+            "status": "ok",
+            "message": f"v{__version__} (latest: v{latest})",
+            "details": {"installed": __version__, "latest": latest},
+        }
+    except Exception:
+        # Network failure, timeout, etc. — don't block doctor
+        return {
+            "name": "version_check",
+            "label": "Version check",
+            "status": "ok",
+            "message": f"v{__version__} (offline — could not check PyPI)",
+        }
+
+
 def _check_unread_memos(palaia_root: Path | None) -> dict[str, Any]:
     """Check for unread memos addressed to the current agent."""
     if palaia_root is None:
@@ -750,6 +815,7 @@ def run_doctor(palaia_root: Path | None = None) -> list[dict[str, Any]]:
         _check_palaia_init(palaia_root),
         _check_agent_identity(palaia_root),
         _check_store_version(palaia_root),
+        _check_version_available(palaia_root),
         _check_embedding_chain(palaia_root),
         _check_entry_classes(palaia_root),
         _check_projects_usage(palaia_root),
@@ -984,7 +1050,5 @@ def format_doctor_report(results: list[dict[str, Any]], show_fix: bool = False) 
         lines.append(f"\nAction required: {warnings} warning(s){suffix}")
     else:
         lines.append("\nAll clear. Palaia is healthy.")
-
-    lines.append("\nTo check for updates: pip install --upgrade palaia")
 
     return "\n".join(lines)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -328,7 +328,7 @@ class TestRunDoctor:
     def test_run_all_checks(self, palaia_root, tmp_path, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))
         results = run_doctor(palaia_root)
-        assert len(results) == 14
+        assert len(results) == 15
         assert all("status" in r for r in results)
         assert all("name" in r for r in results)
 

--- a/tests/test_doctor_version.py
+++ b/tests/test_doctor_version.py
@@ -1,0 +1,105 @@
+"""Tests for doctor version check (#45)."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from palaia import __version__
+from palaia.config import DEFAULT_CONFIG, save_config
+from palaia.doctor import _check_version_available, run_doctor
+
+
+@pytest.fixture
+def palaia_root(tmp_path):
+    root = tmp_path / ".palaia"
+    root.mkdir()
+    for sub in ("hot", "warm", "cold", "wal", "index", "memos"):
+        (root / sub).mkdir()
+    config = dict(DEFAULT_CONFIG)
+    config["agent"] = "test"
+    save_config(root, config)
+    return root
+
+
+def _mock_pypi_response(version: str):
+    """Create a mock urllib response with a specific version."""
+    data = json.dumps({"info": {"version": version}}).encode()
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = data
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+def test_version_up_to_date(palaia_root):
+    """Doctor reports ok when installed version matches PyPI."""
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value = _mock_pypi_response(__version__)
+        result = _check_version_available(palaia_root)
+
+    assert result["status"] == "ok"
+    assert "(latest)" in result["message"]
+
+
+def test_version_update_available(palaia_root):
+    """Doctor warns when a newer version is available."""
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value = _mock_pypi_response("99.0.0")
+        result = _check_version_available(palaia_root)
+
+    assert result["status"] == "warn"
+    assert "Update available" in result["message"]
+    assert "99.0.0" in result["message"]
+    assert "pip install --upgrade palaia" in result.get("fix", "")
+
+
+def test_version_check_offline(palaia_root):
+    """Doctor handles network failure gracefully."""
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.side_effect = Exception("Network error")
+        result = _check_version_available(palaia_root)
+
+    assert result["status"] == "ok"
+    assert "offline" in result["message"]
+
+
+def test_version_check_timeout(palaia_root):
+    """Doctor handles timeout gracefully."""
+    import urllib.error
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.side_effect = urllib.error.URLError("timeout")
+        result = _check_version_available(palaia_root)
+
+    assert result["status"] == "ok"
+    assert "offline" in result["message"]
+
+
+def test_version_check_in_run_doctor(palaia_root):
+    """Version check is included in run_doctor results."""
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value = _mock_pypi_response(__version__)
+        results = run_doctor(palaia_root)
+
+    names = [r["name"] for r in results]
+    assert "version_check" in names
+
+
+def test_version_check_details(palaia_root):
+    """Version check includes installed and latest in details."""
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value = _mock_pypi_response("99.0.0")
+        result = _check_version_available(palaia_root)
+
+    assert result["details"]["installed"] == __version__
+    assert result["details"]["latest"] == "99.0.0"
+
+
+def test_version_check_count(palaia_root):
+    """run_doctor now has 15 checks (was 14)."""
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value = _mock_pypi_response(__version__)
+        results = run_doctor(palaia_root)
+
+    assert len(results) == 15


### PR DESCRIPTION
Closes #45

## Changes
- New `_check_version_available()` doctor check queries PyPI API
- Prominently warns when update available (replaces old footnote)
- Graceful offline handling — network errors don't block doctor
- Removed redundant 'To check for updates' footer from report

## Real-world impact
External OpenClaw on v1.5.0 would now see: `Update available: v1.5.0 -> v1.8.1` instead of silently running outdated.

## Tests
8 new tests with mocked PyPI responses.