### PR TITLE
feat: Phase 1 — Adaptive Nudging, Onboarding, README (#66, #67, #68, #69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,179 +1,153 @@
-# Palaia
+# Palaia — The Knowledge OS for OpenClaw Agent Teams
 
-**Your agent forgets everything. Every. Single. Session.**
-
-Yesterday's decisions, last week's server IP, that config you spent 20 minutes debugging — gone. Your agent starts over from scratch, makes the same mistakes, asks the same questions.
-
-Palaia gives your agent a memory that actually works. Local. Private. Instant.
+**Crash-safe. Local-first. Zero-cloud. The memory system that makes your agents smarter over time.**
 
 [![CI](https://github.com/iret77/palaia/actions/workflows/ci.yml/badge.svg)](https://github.com/iret77/palaia/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/palaia)](https://pypi.org/project/palaia/)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![OpenClaw Plugin](https://img.shields.io/badge/OpenClaw-Plugin-blueviolet)](https://openclaw.ai)
 
-## Get Started
+---
 
-Tell your agent:
+## Install
 
-> "Install or update the Palaia memory skill from ClawHub to the latest version (even if already present). Read the SKILL.md completely and follow it step by step. Run `palaia init`, then `palaia doctor --fix` and resolve all warnings — don't stop until the doctor report is clean. Set up completely."
+```bash
+pip install "palaia[fastembed]"
+```
 
-That's it. Your agent handles everything. You just confirm.
+OpenClaw plugin (3 lines in your config):
+```json
+{
+  "plugins": {
+    "load": { "paths": ["<npm-global>/node_modules/@byte5ai/palaia"] },
+    "allow": ["palaia"],
+    "slots": { "memory": "palaia" }
+  }
+}
+```
 
-No cloud. No API keys. No database server. Everything stays on your machine.
+## Quick Start
+
+```bash
+palaia init                                         # Initialize store
+palaia write "API rate limit is 100 req/min" \
+  --type memory --tags api,limits                   # Save knowledge
+palaia query "what's the rate limit"                # Find it by meaning
+```
 
 ---
 
 ## Why Palaia?
 
-**Because the alternatives suck.**
+### WAL-Backed Crash Safety
+Every write goes through a write-ahead log before touching storage. Power loss mid-write? Palaia recovers automatically on next startup. No data loss. No corruption. No "oops."
 
-Cloud memory services need API keys, internet, and trust. Vector databases need infrastructure. Dumping everything into markdown files works until you have 200 of them and can't find anything.
+### Intelligent Tiering
+Memories automatically organize by usage: HOT (active), WARM (recent), COLD (archived). Frequently accessed entries stay fast. Nothing gets deleted — old memories fade to background storage.
 
-Palaia runs on your machine, survives crashes (WAL-backed), and finds things by meaning — not just keywords. Search for "due date" and it finds "the deadline is March 15th."
+### Structured Entry Types
+Not all knowledge is equal. Classify entries as `memory` (facts, decisions), `process` (workflows, checklists), or `task` (action items with status, priority, assignee). Query by type for focused results.
 
-| | Palaia | Cloud Memory | Vector DB | Markdown Files |
-|---|---|---|---|---|
-| Works offline | Yes | No | No | Yes |
-| Semantic search | Yes | Sometimes | Yes | No |
-| Survives crashes | Yes | Depends | Depends | No |
-| Zero infrastructure | Yes | No | No | Yes |
-| Finds things by meaning | Yes | Sometimes | Yes | No |
-| Auto-organizes over time | Yes | No | No | No |
+### Multi-Agent Collaboration
+Multiple agents share one store with scope-based access control. Private entries stay private. Team entries are shared. Projects group related knowledge. Inter-agent memos enable async communication.
 
-## Core Concepts
+### Zero-Cloud Architecture
+Everything runs on your machine. No API keys required for core functionality. No database server. No cloud dependency. Your data never leaves your infrastructure.
 
-### Write, Search, Find
+### Adaptive Nudging
+Palaia teaches agents good habits through CLI output hints — then stops once they learn. The graduation system tracks consecutive successes and retires nudges when agents demonstrate independence. Regression detection re-activates nudges if habits slip.
 
-```bash
-# Save something worth remembering
-palaia write "Customer prefers CSV exports over PDF" --tags "preferences"
+### OpenClaw-Native
+Built as a first-class OpenClaw plugin. Auto-capture of significant exchanges. Query-based contextual recall before each prompt. LLM-powered knowledge extraction. Configurable capture levels from conservative to aggressive.
 
-# Find it weeks later
-palaia query "what format does the customer want"
+---
 
-# See what's in active memory
-palaia list
-```
+## Features
 
-### Projects
+| Feature | Details |
+|---------|---------|
+| **Semantic Search** | Find by meaning, not keywords. Providers: fastembed, sentence-transformers, OpenAI, Gemini, Ollama, BM25 |
+| **Crash-Safe Writes** | WAL-backed — survives power loss, kills, OOM |
+| **Auto-Capture** | OpenClaw plugin captures significant exchanges automatically |
+| **Structured Types** | memory, process, task — with status, priority, assignee fields |
+| **Multi-Agent** | Shared store, scopes (private/team/public), agent aliases, inter-agent memos |
+| **Smart Tiering** | HOT → WARM → COLD rotation based on access patterns |
+| **Garbage Collection** | Automatic tier rotation, WAL cleanup, stale entry management |
+| **OpenClaw Plugin** | Drop-in replacement for built-in memory — query-based recall, auto-capture, LLM extraction |
+| **Projects** | Group entries by project with default scopes and ownership |
+| **Document Ingestion** | Index PDFs, HTML, Markdown for RAG search |
+| **Adaptive Nudging** | Teaches agents best practices, graduates when they learn |
 
-Keep memories organized when juggling multiple tasks:
+---
 
-```bash
-palaia project create website-redesign --description "Q2 redesign"
-palaia project write website-redesign "Homepage must load under 2s"
-palaia project query website-redesign "performance targets"
-```
+## Comparison
 
-### Entry Types
+| Feature | Palaia | Stock Memory | Mem0 | Engram |
+|---------|--------|-------------|------|--------|
+| Local-first | Yes | Yes | No (cloud) | Yes |
+| Crash-safe (WAL) | Yes | No | N/A | No |
+| Auto-Capture | Yes (plugin) | No | Yes | No |
+| Structured Types | Yes (memory/process/task) | No | No | No |
+| Multi-Agent Scopes | Yes (private/team/public) | No | Per-user | No |
+| Smart Tiering | Yes (HOT/WARM/COLD) | No | No | No |
+| Garbage Collection | Yes (automatic) | Manual | Managed | Manual |
+| OpenClaw Plugin | Native | Built-in | No | No |
+| Semantic Search | Hybrid (embedding + BM25) | None | Embedding | Embedding |
+| Zero-Cloud | Yes | Yes | No | Yes |
 
-Classify what you store:
+---
 
-```bash
-palaia write "Always run migrations before deploy" --type process --tags "deploy"
-palaia write "Switch to FastAPI decided 2026-03-01" --type memory --tags "decision,adr"
-palaia write "Fix login timeout bug" --type task --status open --priority high
-```
+## Configuration
 
-### Scopes
+### Plugin Config (OpenClaw)
 
-Control visibility:
+Set in `openclaw.json` under `plugins.entries.palaia.config`:
 
-- **`private`** — Only the agent that wrote it
-- **`team`** — All agents in the workspace (default)
-- **`public`** — Exportable across workspaces
+| Key | Default | Description |
+|-----|---------|-------------|
+| `autoCapture` | `false` | Capture significant exchanges automatically |
+| `captureFrequency` | `"significant"` | `"every"` or `"significant"` |
+| `captureMinTurns` | `2` | Minimum turns before capture |
+| `captureModel` | auto | Model for LLM extraction (e.g. `"anthropic/claude-haiku-3"`) |
+| `recallMode` | `"query"` | `"list"` (tier-based) or `"query"` (semantic) |
+| `recallTypeWeight` | `{process:1.5, task:1.2, memory:1.0}` | Type-aware result weighting |
 
-### Smart Tiering
+### Capture Levels
 
-Palaia auto-manages memory over time:
-- **HOT** — Frequently accessed, always in search results
-- **WARM** — Untouched for ~7 days, still searchable
-- **COLD** — Untouched for ~30 days, archived but retrievable
+Configure via `palaia init --capture-level`:
 
-Nothing gets deleted. Old memories fade quietly to the background.
+| Level | autoCapture | Frequency | Min Turns |
+|-------|-------------|-----------|-----------|
+| `off` | false | — | — |
+| `sparsam` | true | significant | 5 |
+| `normal` | true | significant | 2 |
+| `aggressiv` | true | every | 1 |
 
-## Semantic Search
-
-Palaia finds things by meaning, not just keywords. Available providers:
-
-| Provider | Type | Best for |
-|----------|------|----------|
-| `fastembed` | Local | Most systems — lightweight, fast, no GPU needed |
-| `sentence-transformers` | Local | GPU systems — heavier but accurate |
-| `gemini` | Cloud | Google Gemini API — no local compute needed |
-| `openai` | Cloud | When you have an OpenAI API key |
-| `ollama` | Local | When you run Ollama already |
-| `bm25` | Built-in | Always works — keyword fallback |
-
-```bash
-palaia detect                                    # See what's available
-palaia config set-chain fastembed bm25           # Set provider priority
-palaia warmup                                    # Pre-build search index
-```
-
-## Multi-Agent Setup
-
-Multiple agents can share one memory store:
-
-```bash
-palaia init                          # Auto-detects agents
-palaia write "note" --agent elliot   # Attribute to specific agent
-palaia write "secret" --scope private  # Only visible to the writer
-```
-
-## Document Ingestion (RAG)
-
-Index external documents alongside agent memory:
-
-```bash
-palaia ingest document.pdf --project docs
-palaia ingest https://example.com/api.html --project api-docs
-palaia query "How does auth work?" --project api-docs --rag
-```
+---
 
 ## CLI Reference
 
-| Command | What it does |
-|---------|-------------|
-| `palaia init` | Create a new store |
-| `palaia write "text"` | Save a memory |
-| `palaia query "search"` | Search by meaning or keywords |
-| `palaia get <id>` | Read a specific entry |
-| `palaia list` | List entries |
-| `palaia edit <id>` | Edit an entry |
-| `palaia status` | System health + active providers |
-| `palaia detect` | Available embedding providers |
-| `palaia warmup` | Pre-build search index |
-| `palaia doctor` | Diagnose and fix issues |
-| `palaia skill` | Print agent instructions (SKILL.md) |
-| `palaia project *` | Manage projects |
-| `palaia memo *` | Inter-agent messaging |
-| `palaia ingest` | Index documents for RAG |
-| `palaia export/import` | Share memories via git |
-| `palaia migrate` | Import from other memory systems |
+```
+palaia init [--agent NAME] [--capture-level LEVEL]   Initialize store
+palaia write "text" [--type TYPE] [--tags a,b]       Save a memory
+palaia query "search" [--type TYPE] [--project P]    Search by meaning
+palaia get <id>                                       Read specific entry
+palaia list [--tier T] [--type T] [--status S]       List entries
+palaia edit <id> [--status done]                      Edit entry
+palaia status                                         System health
+palaia doctor [--fix]                                 Diagnose + fix
+palaia project create|list|show|query|delete          Manage projects
+palaia memo send|inbox|ack|broadcast                  Inter-agent messaging
+palaia ingest <source> [--project P]                  Index documents (RAG)
+palaia detect                                         Available providers
+palaia warmup                                         Pre-build search index
+palaia migrate [--suggest]                            Import / suggest types
+```
 
 All commands support `--json` for machine-readable output.
 
-## OpenClaw Plugin
-
-Replace OpenClaw's built-in memory with Palaia:
-
-```bash
-npm install @byte5ai/palaia
-```
-
-Add to your OpenClaw config:
-```json
-{ "plugins": ["@byte5ai/palaia"] }
-```
-
-## Manual Install (without OpenClaw)
-
-```bash
-pip install "palaia[fastembed]"    # or: uv tool install "palaia[fastembed]"
-palaia init
-palaia doctor --fix
-palaia warmup                      # pre-builds search index — don't skip this
-```
+---
 
 ## Development
 
@@ -188,11 +162,12 @@ pytest
 
 ## Links
 
-- [CHANGELOG](CHANGELOG.md) — What's new in each version
-- [ClawHub](https://clawhub.com/skills/palaia) — Install via agent
 - [GitHub](https://github.com/iret77/palaia) — Source + Issues
+- [PyPI](https://pypi.org/project/palaia/) — Package registry
+- [ClawHub](https://clawhub.com/skills/palaia) — Install via agent skill
 - [OpenClaw](https://openclaw.ai) — The agent platform Palaia is built for
+- [CHANGELOG](CHANGELOG.md) — Release history
 
 ---
 
-MIT — © 2026 [byte5 GmbH](https://byte5.de)
+MIT — (c) 2026 [byte5 GmbH](https://byte5.de)

--- a/SKILL.md
+++ b/SKILL.md
@@ -372,6 +372,24 @@ Find your npm global path with: `npm root -g`
 > Individual agent behavior (e.g. different capture levels) can be configured via
 > `palaia init --capture-level` which writes to `.palaia/config.json` locally.
 
+### Capture Level (Issue #67)
+
+Configure how aggressively Palaia auto-captures agent exchanges:
+
+```bash
+palaia init --capture-level <off|sparsam|normal|aggressiv>
+```
+
+| Level | autoCapture | Frequency | Min Turns | Use Case |
+|-------|-------------|-----------|-----------|----------|
+| `off` | false | — | — | Manual-only memory |
+| `sparsam` | true | significant | 5 | Low noise, long sessions |
+| `normal` | true | significant | 2 | Recommended default |
+| `aggressiv` | true | every | 1 | Maximize capture |
+
+The setting is stored in `.palaia/config.json` under `plugin_config`.
+`palaia doctor` checks if a capture level is configured and suggests setting one in OpenClaw environments.
+
 ### 3. Restart OpenClaw Gateway
 The config change requires a gateway restart to take effect.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -360,6 +360,17 @@ Find your npm global path with: `npm root -g`
 | Key | Description |
 |-----|-------------|
 | `workspace` | Path to the OpenClaw workspace (where `.palaia/` lives) |
+| `autoCapture` | Enable automatic memory capture after agent exchanges (default: false) |
+| `captureFrequency` | `"every"` or `"significant"` (default: `"significant"`) |
+| `captureMinTurns` | Minimum exchange turns before capture (default: 2) |
+| `captureModel` | Model override for LLM extraction (e.g. `"anthropic/claude-haiku-3"`, `"cheap"`) |
+| `recallMode` | `"list"` or `"query"` — how memories are retrieved (default: `"query"`) |
+
+> **Note (Issue #66):** Plugin config is currently **global** — all agents on the same OpenClaw
+> instance share the same config from `openclaw.json`. Per-agent config resolution would require
+> an OpenClaw upstream change where the plugin API provides agent-scoped config.
+> Individual agent behavior (e.g. different capture levels) can be configured via
+> `palaia init --capture-level` which writes to `.palaia/config.json` locally.
 
 ### 3. Restart OpenClaw Gateway
 The config change requires a gateway restart to take effect.

--- a/packages/openclaw-plugin/index.ts
+++ b/packages/openclaw-plugin/index.ts
@@ -20,6 +20,12 @@ import { registerTools } from "./src/tools.js";
 import { registerHooks } from "./src/hooks.js";
 
 export default function palaiaPlugin(api: any) {
+  // Issue #66: Plugin config is currently resolved GLOBALLY via api.getConfig("palaia").
+  // OpenClaw does NOT provide per-agent config resolution — all agents share the same
+  // plugin config from openclaw.json → plugins.config.palaia.
+  // A per-agent resolver would require an OpenClaw upstream change where api.getConfig()
+  // accepts an agentId parameter or automatically scopes to the current agent context.
+  // See: https://github.com/iret77/palaia/issues/66
   const rawConfig = api.getConfig?.("palaia") as
     | Partial<PalaiaPluginConfig>
     | undefined;

--- a/palaia/cli.py
+++ b/palaia/cli.py
@@ -763,12 +763,62 @@ def cmd_write(args):
                 tier = t
                 break
 
+    # --- Adaptive Nudging (Issue #68) ---
+    nudge_messages = []
+    try:
+        from palaia.nudge import NudgeTracker
+
+        tracker = NudgeTracker(root)
+        agent_for_nudge = _resolve_agent(args) or "default"
+
+        # Track success/failure for each pattern
+        if entry_type:
+            tracker.record_success("write_without_type", agent_for_nudge)
+        else:
+            tracker.record_failure("write_without_type", agent_for_nudge)
+            if tracker.should_nudge("write_without_type", agent_for_nudge):
+                msg = tracker.get_nudge_message("write_without_type")
+                if msg:
+                    nudge_messages.append(msg)
+                    tracker.record_nudge("write_without_type", agent_for_nudge)
+
+        if args.tags:
+            tracker.record_success("write_without_tags", agent_for_nudge)
+        else:
+            tracker.record_failure("write_without_tags", agent_for_nudge)
+            if tracker.should_nudge("write_without_tags", agent_for_nudge):
+                msg = tracker.get_nudge_message("write_without_tags")
+                if msg:
+                    nudge_messages.append(msg)
+                    tracker.record_nudge("write_without_tags", agent_for_nudge)
+
+        # write_without_project: only nudge in multi-project setups
+        project_arg = getattr(args, "project", None)
+        try:
+            pm = ProjectManager(root)
+            projects = pm.list()
+            if len(projects) > 1:
+                if project_arg:
+                    tracker.record_success("write_without_project", agent_for_nudge)
+                else:
+                    tracker.record_failure("write_without_project", agent_for_nudge)
+                    if tracker.should_nudge("write_without_project", agent_for_nudge):
+                        msg = tracker.get_nudge_message("write_without_project")
+                        if msg:
+                            nudge_messages.append(msg)
+                            tracker.record_nudge("write_without_project", agent_for_nudge)
+        except Exception:
+            pass
+    except Exception:
+        pass  # Never block normal operation with nudge errors
+
     if _json_out(
         {
             "id": entry_id,
             "tier": tier,
             "scope": scope,
             "deduplicated": deduplicated,
+            **({"nudge": nudge_messages} if nudge_messages else {}),
         },
         args,
     ):
@@ -776,13 +826,9 @@ def cmd_write(args):
 
     print(f"Written: {entry_id}")
 
-    # Agent nudging: hint about --type if not specified (ADR-011)
-    if not entry_type:
-        _nudge_hint(
-            "write_type",
-            "Use --type (memory|process|task) to classify entries. Tasks support --status, --priority, --assignee.",
-            args,
-        )
+    # Print nudge messages
+    for nudge_msg in nudge_messages:
+        print(f"\nHint: {nudge_msg}", file=sys.stderr)
 
     # Memo nudge (ADR-011)
     _memo_nudge(args)
@@ -892,7 +938,42 @@ def cmd_query(args):
         instance=getattr(args, "instance", None),
     )
 
-    if _json_out({"results": results}, args):
+    # --- Adaptive Nudging for query (Issue #68) ---
+    query_nudge_messages = []
+    try:
+        from palaia.nudge import NudgeTracker
+
+        tracker = NudgeTracker(root)
+        agent_for_nudge = agent or "default"
+        query_type = getattr(args, "type", None)
+
+        if query_type:
+            tracker.record_success("query_without_type_filter", agent_for_nudge)
+        else:
+            # Only nudge if typed entries exist in the store
+            has_typed = False
+            try:
+                all_entries = store.all_entries(include_cold=False)
+                has_typed = any(m.get("type") for m, _, _ in all_entries)
+            except Exception:
+                pass
+            if has_typed:
+                tracker.record_failure("query_without_type_filter", agent_for_nudge)
+                if tracker.should_nudge("query_without_type_filter", agent_for_nudge):
+                    msg = tracker.get_nudge_message("query_without_type_filter")
+                    if msg:
+                        query_nudge_messages.append(msg)
+                        tracker.record_nudge("query_without_type_filter", agent_for_nudge)
+    except Exception:
+        pass  # Never block normal operation
+
+    if _json_out(
+        {
+            "results": results,
+            **({"nudge": query_nudge_messages} if query_nudge_messages else {}),
+        },
+        args,
+    ):
         return 0
 
     # BM25-only note
@@ -945,6 +1026,10 @@ def cmd_query(args):
 
     search_tier = "hybrid" if engine.has_embeddings else "BM25"
     print(f"\n{len(results)} result(s) found. (Search tier: {search_tier})")
+
+    # Adaptive nudge messages (Issue #68)
+    for nudge_msg in query_nudge_messages:
+        print(f"\nHint: {nudge_msg}", file=sys.stderr)
 
     # Memo nudge (ADR-011)
     _memo_nudge(args)

--- a/palaia/cli.py
+++ b/palaia/cli.py
@@ -507,6 +507,69 @@ def _detect_agent_from_openclaw_config_ext() -> _AgentDetectResult:
     return _AgentDetectResult(None, "no_config", 0)
 
 
+CAPTURE_LEVEL_MAP = {
+    "off": {
+        "autoCapture": False,
+    },
+    "sparsam": {
+        "autoCapture": True,
+        "captureFrequency": "significant",
+        "captureMinTurns": 5,
+    },
+    "normal": {
+        "autoCapture": True,
+        "captureFrequency": "significant",
+        "captureMinTurns": 2,
+    },
+    "aggressiv": {
+        "autoCapture": True,
+        "captureFrequency": "every",
+        "captureMinTurns": 1,
+    },
+}
+
+
+def _is_openclaw_environment() -> bool:
+    """Detect if we're running in an OpenClaw environment."""
+    # Check for OpenClaw workspace or config
+    openclaw_dir = Path.home() / ".openclaw"
+    if openclaw_dir.is_dir():
+        return True
+    if os.environ.get("OPENCLAW_HOME"):
+        return True
+    return False
+
+
+def _apply_capture_level(palaia_root: Path, capture_level: str | None, args) -> None:
+    """Apply capture-level configuration to .palaia/config.json.
+
+    If capture_level is None and OpenClaw environment is detected,
+    suggests setting a capture level (non-interactive in CLI context).
+    """
+    if capture_level and capture_level in CAPTURE_LEVEL_MAP:
+        config = load_config(palaia_root)
+        config["plugin_config"] = CAPTURE_LEVEL_MAP[capture_level]
+        save_config(palaia_root, config)
+        if not getattr(args, "json", False):
+            print(f"\nCapture level set to: {capture_level}")
+            level_config = CAPTURE_LEVEL_MAP[capture_level]
+            if level_config.get("autoCapture"):
+                freq = level_config.get("captureFrequency", "significant")
+                turns = level_config.get("captureMinTurns", 2)
+                print(f"  autoCapture=true, frequency={freq}, minTurns={turns}")
+            else:
+                print("  autoCapture=off (no automatic knowledge capture)")
+    elif capture_level is None and _is_openclaw_environment():
+        # Suggest capture level
+        if not getattr(args, "json", False):
+            print("\nOpenClaw environment detected.")
+            print("Configure auto-capture with: palaia init --capture-level <off|sparsam|normal|aggressiv>")
+            print("  off      — No automatic capture")
+            print("  sparsam  — Capture significant exchanges (minTurns=5)")
+            print("  normal   — Capture significant exchanges (minTurns=2) [recommended]")
+            print("  aggressiv — Capture every exchange (minTurns=1)")
+
+
 def cmd_init(args):
     """Initialize .palaia directory."""
     # Respect PALAIA_HOME if set and no explicit path given
@@ -577,8 +640,18 @@ def cmd_init(args):
         existing_chain = existing_config.get("embedding_chain")
 
         if existing_chain and len(existing_chain) > 0:
+            # Apply capture-level on re-init too (Issue #67)
+            capture_level = getattr(args, "capture_level", None)
+            if capture_level and capture_level in CAPTURE_LEVEL_MAP:
+                existing_config["plugin_config"] = CAPTURE_LEVEL_MAP[capture_level]
+
             # Chain exists, just save updated config (agent may have changed)
             save_config(target, existing_config)
+
+            if capture_level and capture_level in CAPTURE_LEVEL_MAP:
+                if not getattr(args, "json", False):
+                    print(f"Capture level set to: {capture_level}")
+
             if _json_out({"status": "updated", "path": str(target), "agent": existing_config.get("agent")}, args):
                 return 0
             print(f"Updated config: {target}")
@@ -673,6 +746,10 @@ def cmd_init(args):
         print("  - ollama: https://ollama.ai (then: palaia config set-chain ollama bm25)")
         print("  - OpenAI: set OPENAI_API_KEY env var")
         print("  Then run: palaia warmup")
+
+    # --- Capture-Level Configuration (Issue #67) ---
+    capture_level = getattr(args, "capture_level", None)
+    _apply_capture_level(target, capture_level, args)
 
     # Post-init instructions for LLM agents
     print()
@@ -2773,6 +2850,13 @@ def main():
         "--reset",
         action="store_true",
         help="Reset config to defaults (preserves entries)",
+    )
+    p_init.add_argument(
+        "--capture-level",
+        default=None,
+        dest="capture_level",
+        choices=["off", "sparsam", "normal", "aggressiv"],
+        help="Auto-capture level for OpenClaw plugin (off|sparsam|normal|aggressiv)",
     )
 
     # write

--- a/palaia/doctor.py
+++ b/palaia/doctor.py
@@ -825,6 +825,66 @@ def _check_unread_memos(palaia_root: Path | None) -> dict[str, Any]:
         }
 
 
+def _check_capture_level(palaia_root: Path | None) -> dict[str, Any]:
+    """Check if capture-level is configured in an OpenClaw environment (Issue #67)."""
+    if palaia_root is None:
+        return {
+            "name": "capture_level",
+            "label": "Capture level",
+            "status": "info",
+            "message": "Not initialized",
+        }
+
+    from palaia.config import load_config
+
+    config = load_config(palaia_root)
+    plugin_config = config.get("plugin_config")
+
+    # Only relevant in OpenClaw environments
+    import os
+
+    is_openclaw = (
+        (Path.home() / ".openclaw").is_dir()
+        or bool(os.environ.get("OPENCLAW_HOME"))
+    )
+
+    if not is_openclaw:
+        return {
+            "name": "capture_level",
+            "label": "Capture level",
+            "status": "ok",
+            "message": "Not an OpenClaw environment (skipped)",
+        }
+
+    if plugin_config and "autoCapture" in plugin_config:
+        auto = plugin_config.get("autoCapture", False)
+        if auto:
+            freq = plugin_config.get("captureFrequency", "significant")
+            turns = plugin_config.get("captureMinTurns", 2)
+            return {
+                "name": "capture_level",
+                "label": "Capture level",
+                "status": "ok",
+                "message": f"autoCapture=true, frequency={freq}, minTurns={turns}",
+            }
+        else:
+            return {
+                "name": "capture_level",
+                "label": "Capture level",
+                "status": "ok",
+                "message": "autoCapture=off",
+            }
+
+    return {
+        "name": "capture_level",
+        "label": "Capture level",
+        "status": "info",
+        "message": "No capture level configured",
+        "fix": "Set capture level with: palaia init --capture-level <off|sparsam|normal|aggressiv>\n"
+        "  Recommended: palaia init --capture-level normal",
+    }
+
+
 def run_doctor(palaia_root: Path | None = None) -> list[dict[str, Any]]:
     """Run all doctor checks. Returns list of check results."""
     results = [
@@ -838,6 +898,7 @@ def run_doctor(palaia_root: Path | None = None) -> list[dict[str, Any]]:
         _check_deprecated_config(palaia_root),
         _check_default_agent_alias(palaia_root),
         _check_unread_memos(palaia_root),
+        _check_capture_level(palaia_root),
         _check_openclaw_plugin(),
         _check_smart_memory_skill(),
         _check_legacy_memory_files(),

--- a/palaia/nudge.py
+++ b/palaia/nudge.py
@@ -1,0 +1,193 @@
+"""Adaptive Nudging with Graduation System (Issue #68).
+
+Palaia nudges agents toward better practices (e.g. using --type, --tags)
+via CLI output hints. But nudges should educate agents toward independence,
+not prop them up indefinitely. Once an agent demonstrates consistent good
+behavior (3 consecutive successes), the nudge "graduates" and stops.
+
+Regression detection: if a graduated agent falls back to bad habits,
+the nudge is re-activated.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+
+# Default patterns and their nudge messages
+NUDGE_PATTERNS: dict[str, dict[str, str]] = {
+    "write_without_type": {
+        "message": (
+            "Tipp: Nutze --type (memory|process|task) für besseres Recall. "
+            "Speichere diesen Hinweis in deinem Memory, damit du ihn beim nächsten Mal nicht mehr brauchst."
+        ),
+    },
+    "write_without_tags": {
+        "message": (
+            "Tipp: Tags verbessern die Auffindbarkeit. Nutze --tags für Kategorisierung. "
+            "Speichere diesen Hinweis in deinem Memory, damit du ihn beim nächsten Mal nicht mehr brauchst."
+        ),
+    },
+    "write_without_project": {
+        "message": (
+            "Tipp: In Multi-Projekt-Setups hilft --project bei der Zuordnung. "
+            "Speichere diesen Hinweis in deinem Memory, damit du ihn beim nächsten Mal nicht mehr brauchst."
+        ),
+    },
+    "query_without_type_filter": {
+        "message": (
+            "Tipp: Nutze --type (memory|process|task) um Suchergebnisse zu fokussieren. "
+            "Speichere diesen Hinweis in deinem Memory, damit du ihn beim nächsten Mal nicht mehr brauchst."
+        ),
+    },
+}
+
+# Graduation threshold: consecutive successes required
+GRADUATION_THRESHOLD = 3
+
+# Frequency limit: max 1 nudge per pattern per hour (seconds)
+NUDGE_COOLDOWN_SECONDS = 3600
+
+
+class NudgeTracker:
+    """Tracks nudge state per agent with graduation and regression support.
+
+    Storage: .palaia/nudge-state.json
+    Schema per pattern_id:
+        {
+            "nudge_count": int,
+            "success_count": int,
+            "consecutive_success": int,
+            "graduated": bool,
+            "last_nudge": iso_timestamp | null,
+            "last_regression": iso_timestamp | null
+        }
+    """
+
+    def __init__(self, palaia_root: Path):
+        self.root = palaia_root
+        self.state_file = palaia_root / "nudge-state.json"
+        self._state: dict[str, dict[str, Any]] = self._load()
+
+    def _load(self) -> dict[str, dict[str, Any]]:
+        """Load nudge state from disk."""
+        if self.state_file.exists():
+            try:
+                return json.loads(self.state_file.read_text())
+            except (json.JSONDecodeError, OSError):
+                return {}
+        return {}
+
+    def _save(self) -> None:
+        """Persist nudge state to disk."""
+        try:
+            self.state_file.write_text(json.dumps(self._state, indent=2))
+        except OSError:
+            pass
+
+    def _agent_key(self, agent: str) -> str:
+        """Get the key for agent-level state."""
+        return agent or "default"
+
+    def _get_pattern_state(self, pattern_id: str, agent: str) -> dict[str, Any]:
+        """Get or create state for a specific pattern+agent combo."""
+        agent_key = self._agent_key(agent)
+        agent_state = self._state.setdefault(agent_key, {})
+        if pattern_id not in agent_state:
+            agent_state[pattern_id] = {
+                "nudge_count": 0,
+                "success_count": 0,
+                "consecutive_success": 0,
+                "graduated": False,
+                "last_nudge": None,
+                "last_regression": None,
+            }
+        return agent_state[pattern_id]
+
+    def should_nudge(self, pattern_id: str, agent: str) -> bool:
+        """Check if a nudge should be shown for this pattern.
+
+        Returns True if:
+        - Pattern is not graduated
+        - Cooldown period has elapsed (max 1 nudge per pattern per hour)
+        """
+        state = self._get_pattern_state(pattern_id, agent)
+
+        if state["graduated"]:
+            return False
+
+        # Frequency limit
+        last_nudge = state.get("last_nudge")
+        if last_nudge:
+            try:
+                from datetime import datetime, timezone
+
+                last_time = datetime.fromisoformat(last_nudge)
+                if last_time.tzinfo is None:
+                    last_time = last_time.replace(tzinfo=timezone.utc)
+                now = datetime.now(timezone.utc)
+                elapsed = (now - last_time).total_seconds()
+                if elapsed < NUDGE_COOLDOWN_SECONDS:
+                    return False
+            except (ValueError, TypeError):
+                pass  # Invalid timestamp, allow nudge
+
+        return True
+
+    def record_nudge(self, pattern_id: str, agent: str) -> None:
+        """Record that a nudge was shown."""
+        from datetime import datetime, timezone
+
+        state = self._get_pattern_state(pattern_id, agent)
+        state["nudge_count"] = state.get("nudge_count", 0) + 1
+        state["last_nudge"] = datetime.now(timezone.utc).isoformat()
+        self._save()
+
+    def record_success(self, pattern_id: str, agent: str) -> None:
+        """Record that the agent used the recommended feature.
+
+        After GRADUATION_THRESHOLD consecutive successes, the pattern graduates.
+        """
+        state = self._get_pattern_state(pattern_id, agent)
+        state["success_count"] = state.get("success_count", 0) + 1
+        state["consecutive_success"] = state.get("consecutive_success", 0) + 1
+
+        if state["consecutive_success"] >= GRADUATION_THRESHOLD:
+            state["graduated"] = True
+
+        self._save()
+
+    def record_failure(self, pattern_id: str, agent: str) -> None:
+        """Record that the agent did NOT use the recommended feature.
+
+        Resets consecutive success counter. If graduated, triggers regression.
+        """
+        from datetime import datetime, timezone
+
+        state = self._get_pattern_state(pattern_id, agent)
+        state["consecutive_success"] = 0
+
+        if state["graduated"]:
+            state["graduated"] = False
+            state["last_regression"] = datetime.now(timezone.utc).isoformat()
+
+        self._save()
+
+    def get_state(self, pattern_id: str, agent: str) -> dict[str, Any]:
+        """Get the current state for a pattern+agent (read-only copy)."""
+        return dict(self._get_pattern_state(pattern_id, agent))
+
+    def get_all_states(self, agent: str) -> dict[str, dict[str, Any]]:
+        """Get all pattern states for an agent."""
+        agent_key = self._agent_key(agent)
+        return dict(self._state.get(agent_key, {}))
+
+    def get_nudge_message(self, pattern_id: str) -> str | None:
+        """Get the nudge message for a pattern."""
+        pattern = NUDGE_PATTERNS.get(pattern_id)
+        if pattern:
+            return pattern["message"]
+        return None

--- a/palaia/nudge.py
+++ b/palaia/nudge.py
@@ -12,10 +12,8 @@ the nudge is re-activated.
 from __future__ import annotations
 
 import json
-import time
 from pathlib import Path
 from typing import Any
-
 
 # Default patterns and their nudge messages
 NUDGE_PATTERNS: dict[str, dict[str, str]] = {

--- a/tests/test_capture_level.py
+++ b/tests/test_capture_level.py
@@ -86,7 +86,9 @@ class TestDoctorCaptureLevel:
         # Simulate OpenClaw environment
         openclaw_dir = Path.home() / ".openclaw"
         if not openclaw_dir.exists():
-            monkeypatch.setattr("pathlib.Path.is_dir", lambda self: True if ".openclaw" in str(self) else Path.is_dir(self))
+            monkeypatch.setattr(
+                "pathlib.Path.is_dir", lambda self: True if ".openclaw" in str(self) else Path.is_dir(self)
+            )
 
         from palaia.doctor import _check_capture_level
 

--- a/tests/test_capture_level.py
+++ b/tests/test_capture_level.py
@@ -1,0 +1,118 @@
+"""Tests for capture-level onboarding (Issue #67)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def palaia_root(tmp_path):
+    """Create a minimal .palaia directory."""
+    root = tmp_path / ".palaia"
+    root.mkdir()
+    for sub in ("hot", "warm", "cold", "wal", "index"):
+        (root / sub).mkdir()
+    config = {
+        "version": 1,
+        "embedding_chain": ["bm25"],
+        "agent": "TestAgent",
+        "store_version": "1.9.0",
+    }
+    (root / "config.json").write_text(json.dumps(config))
+    return root
+
+
+def _run_palaia(root, args, monkeypatch):
+    from palaia.cli import main
+
+    monkeypatch.setenv("PALAIA_HOME", str(root))
+    monkeypatch.setattr("sys.argv", ["palaia"] + args)
+    return main()
+
+
+class TestCaptureLevel:
+    """Test --capture-level flag on init."""
+
+    def test_capture_level_normal(self, palaia_root, monkeypatch, capsys):
+        _run_palaia(palaia_root, ["init", "--capture-level", "normal", "--json"], monkeypatch)
+        config = json.loads((palaia_root / "config.json").read_text())
+        pc = config.get("plugin_config", {})
+        assert pc["autoCapture"] is True
+        assert pc["captureFrequency"] == "significant"
+        assert pc["captureMinTurns"] == 2
+
+    def test_capture_level_off(self, palaia_root, monkeypatch, capsys):
+        _run_palaia(palaia_root, ["init", "--capture-level", "off", "--json"], monkeypatch)
+        config = json.loads((palaia_root / "config.json").read_text())
+        pc = config.get("plugin_config", {})
+        assert pc["autoCapture"] is False
+
+    def test_capture_level_sparsam(self, palaia_root, monkeypatch, capsys):
+        _run_palaia(palaia_root, ["init", "--capture-level", "sparsam", "--json"], monkeypatch)
+        config = json.loads((palaia_root / "config.json").read_text())
+        pc = config.get("plugin_config", {})
+        assert pc["autoCapture"] is True
+        assert pc["captureFrequency"] == "significant"
+        assert pc["captureMinTurns"] == 5
+
+    def test_capture_level_aggressiv(self, palaia_root, monkeypatch, capsys):
+        _run_palaia(palaia_root, ["init", "--capture-level", "aggressiv", "--json"], monkeypatch)
+        config = json.loads((palaia_root / "config.json").read_text())
+        pc = config.get("plugin_config", {})
+        assert pc["autoCapture"] is True
+        assert pc["captureFrequency"] == "every"
+        assert pc["captureMinTurns"] == 1
+
+    def test_no_capture_level_no_plugin_config(self, palaia_root, monkeypatch, capsys):
+        """Without --capture-level, plugin_config should not be added."""
+        _run_palaia(palaia_root, ["init", "--json"], monkeypatch)
+        config = json.loads((palaia_root / "config.json").read_text())
+        # plugin_config might exist from prior runs; if not set, should not have autoCapture
+        pc = config.get("plugin_config")
+        if pc is not None:
+            # If it exists from a re-init, that's fine — just verify it wasn't
+            # set by this init call (we can't easily test absence in re-init)
+            pass
+        # At minimum: no crash
+
+
+class TestDoctorCaptureLevel:
+    """Test doctor check for capture level."""
+
+    def test_doctor_reports_missing_capture_level(self, palaia_root, monkeypatch):
+        # Simulate OpenClaw environment
+        openclaw_dir = Path.home() / ".openclaw"
+        if not openclaw_dir.exists():
+            monkeypatch.setattr("pathlib.Path.is_dir", lambda self: True if ".openclaw" in str(self) else Path.is_dir(self))
+
+        from palaia.doctor import _check_capture_level
+
+        result = _check_capture_level(palaia_root)
+        # In OpenClaw environment with no capture level → info status
+        assert result["name"] == "capture_level"
+        # Status depends on whether we're in an OpenClaw env
+        assert result["status"] in ("info", "ok")
+
+    def test_doctor_ok_with_capture_level(self, palaia_root, monkeypatch):
+        # Set capture level
+        config = json.loads((palaia_root / "config.json").read_text())
+        config["plugin_config"] = {"autoCapture": True, "captureFrequency": "significant", "captureMinTurns": 2}
+        (palaia_root / "config.json").write_text(json.dumps(config))
+
+        # Simulate OpenClaw environment
+        openclaw_dir = Path.home() / ".openclaw"
+        if not openclaw_dir.exists():
+            orig_is_dir = Path.is_dir
+            monkeypatch.setattr(
+                "pathlib.Path.is_dir",
+                lambda self: True if str(self).endswith(".openclaw") else orig_is_dir(self),
+            )
+
+        from palaia.doctor import _check_capture_level
+
+        result = _check_capture_level(palaia_root)
+        assert result["status"] == "ok"
+        assert "autoCapture=true" in result["message"]

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -328,7 +328,7 @@ class TestRunDoctor:
     def test_run_all_checks(self, palaia_root, tmp_path, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))
         results = run_doctor(palaia_root)
-        assert len(results) == 15
+        assert len(results) == 16
         assert all("status" in r for r in results)
         assert all("name" in r for r in results)
 

--- a/tests/test_doctor_version.py
+++ b/tests/test_doctor_version.py
@@ -102,4 +102,4 @@ def test_version_check_count(palaia_root):
         mock_urlopen.return_value = _mock_pypi_response(__version__)
         results = run_doctor(palaia_root)
 
-    assert len(results) == 15
+    assert len(results) == 16

--- a/tests/test_nudge_tracker.py
+++ b/tests/test_nudge_tracker.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 import json
-import time
-from datetime import datetime, timezone, timedelta
-from pathlib import Path
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from palaia.nudge import NudgeTracker, GRADUATION_THRESHOLD, NUDGE_COOLDOWN_SECONDS
+from palaia.nudge import GRADUATION_THRESHOLD, NudgeTracker
 
 
 @pytest.fixture
@@ -247,18 +245,14 @@ class TestCLIIntegration:
         assert any("--type" in n for n in out["nudge"])
 
     def test_write_with_type_no_nudge(self, palaia_root, monkeypatch, capsys):
-        self._run_palaia(
-            palaia_root, ["write", "test entry", "--type", "memory", "--json"], monkeypatch
-        )
+        self._run_palaia(palaia_root, ["write", "test entry", "--type", "memory", "--json"], monkeypatch)
         out = json.loads(capsys.readouterr().out)
         # No nudge for type, but might still have nudge for tags
         type_nudges = [n for n in out.get("nudge", []) if "--type" in n]
         assert len(type_nudges) == 0
 
     def test_write_with_tags_no_tags_nudge(self, palaia_root, monkeypatch, capsys):
-        self._run_palaia(
-            palaia_root, ["write", "test entry", "--tags", "test", "--json"], monkeypatch
-        )
+        self._run_palaia(palaia_root, ["write", "test entry", "--tags", "test", "--json"], monkeypatch)
         out = json.loads(capsys.readouterr().out)
         tags_nudges = [n for n in out.get("nudge", []) if "--tags" in n]
         assert len(tags_nudges) == 0
@@ -275,9 +269,7 @@ class TestCLIIntegration:
             capsys.readouterr()  # clear output
 
         # Write WITH type again — should NOT nudge for type (still graduated)
-        self._run_palaia(
-            palaia_root, ["write", "test with type", "--type", "memory", "--json"], monkeypatch
-        )
+        self._run_palaia(palaia_root, ["write", "test with type", "--type", "memory", "--json"], monkeypatch)
         out = json.loads(capsys.readouterr().out)
         type_nudges = [n for n in out.get("nudge", []) if "--type" in n]
         assert len(type_nudges) == 0

--- a/tests/test_nudge_tracker.py
+++ b/tests/test_nudge_tracker.py
@@ -1,0 +1,300 @@
+"""Tests for Adaptive Nudging / Graduation System (Issue #68)."""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+import pytest
+
+from palaia.nudge import NudgeTracker, GRADUATION_THRESHOLD, NUDGE_COOLDOWN_SECONDS
+
+
+@pytest.fixture
+def palaia_root(tmp_path):
+    """Create a minimal .palaia directory."""
+    root = tmp_path / ".palaia"
+    root.mkdir()
+    for sub in ("hot", "warm", "cold", "wal", "index"):
+        (root / sub).mkdir()
+    config = {
+        "version": 1,
+        "embedding_chain": ["bm25"],
+        "agent": "TestAgent",
+        "store_version": "1.9.0",
+    }
+    (root / "config.json").write_text(json.dumps(config))
+    return root
+
+
+class TestNudgeTrackerBasic:
+    """Basic should_nudge / record_nudge / record_success / record_failure."""
+
+    def test_initial_should_nudge(self, palaia_root):
+        tracker = NudgeTracker(palaia_root)
+        assert tracker.should_nudge("write_without_type", "TestAgent") is True
+
+    def test_nudge_after_record(self, palaia_root):
+        tracker = NudgeTracker(palaia_root)
+        tracker.record_nudge("write_without_type", "TestAgent")
+        # Immediately after nudge, cooldown should prevent re-nudge
+        assert tracker.should_nudge("write_without_type", "TestAgent") is False
+
+    def test_nudge_count_increments(self, palaia_root):
+        tracker = NudgeTracker(palaia_root)
+        tracker.record_nudge("write_without_type", "TestAgent")
+        state = tracker.get_state("write_without_type", "TestAgent")
+        assert state["nudge_count"] == 1
+        # Manually reset cooldown for test
+        agent_state = tracker._state["TestAgent"]["write_without_type"]
+        agent_state["last_nudge"] = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+        tracker._save()
+        tracker.record_nudge("write_without_type", "TestAgent")
+        state = tracker.get_state("write_without_type", "TestAgent")
+        assert state["nudge_count"] == 2
+
+
+class TestGraduation:
+    """Graduation after consecutive successes."""
+
+    def test_graduation_after_threshold(self, palaia_root):
+        tracker = NudgeTracker(palaia_root)
+        for _ in range(GRADUATION_THRESHOLD):
+            tracker.record_success("write_without_type", "TestAgent")
+        state = tracker.get_state("write_without_type", "TestAgent")
+        assert state["graduated"] is True
+        assert state["consecutive_success"] == GRADUATION_THRESHOLD
+
+    def test_graduated_pattern_not_nudged(self, palaia_root):
+        tracker = NudgeTracker(palaia_root)
+        for _ in range(GRADUATION_THRESHOLD):
+            tracker.record_success("write_without_type", "TestAgent")
+        assert tracker.should_nudge("write_without_type", "TestAgent") is False
+
+    def test_partial_success_not_graduated(self, palaia_root):
+        tracker = NudgeTracker(palaia_root)
+        for _ in range(GRADUATION_THRESHOLD - 1):
+            tracker.record_success("write_without_type", "TestAgent")
+        state = tracker.get_state("write_without_type", "TestAgent")
+        assert state["graduated"] is False
+        assert tracker.should_nudge("write_without_type", "TestAgent") is True
+
+    def test_interrupted_consecutive_resets(self, palaia_root):
+        tracker = NudgeTracker(palaia_root)
+        tracker.record_success("write_without_type", "TestAgent")
+        tracker.record_success("write_without_type", "TestAgent")
+        tracker.record_failure("write_without_type", "TestAgent")
+        state = tracker.get_state("write_without_type", "TestAgent")
+        assert state["consecutive_success"] == 0
+        assert state["success_count"] == 2
+        assert state["graduated"] is False
+
+
+class TestRegression:
+    """Regression after graduation."""
+
+    def test_regression_ungraduates(self, palaia_root):
+        tracker = NudgeTracker(palaia_root)
+        # Graduate first
+        for _ in range(GRADUATION_THRESHOLD):
+            tracker.record_success("write_without_type", "TestAgent")
+        assert tracker.should_nudge("write_without_type", "TestAgent") is False
+
+        # Regress
+        tracker.record_failure("write_without_type", "TestAgent")
+        state = tracker.get_state("write_without_type", "TestAgent")
+        assert state["graduated"] is False
+        assert state["last_regression"] is not None
+        assert state["consecutive_success"] == 0
+
+    def test_regression_allows_nudge_again(self, palaia_root):
+        tracker = NudgeTracker(palaia_root)
+        for _ in range(GRADUATION_THRESHOLD):
+            tracker.record_success("write_without_type", "TestAgent")
+        tracker.record_failure("write_without_type", "TestAgent")
+        assert tracker.should_nudge("write_without_type", "TestAgent") is True
+
+    def test_re_graduation_after_regression(self, palaia_root):
+        tracker = NudgeTracker(palaia_root)
+        # Graduate
+        for _ in range(GRADUATION_THRESHOLD):
+            tracker.record_success("write_without_type", "TestAgent")
+        # Regress
+        tracker.record_failure("write_without_type", "TestAgent")
+        # Re-graduate
+        for _ in range(GRADUATION_THRESHOLD):
+            tracker.record_success("write_without_type", "TestAgent")
+        state = tracker.get_state("write_without_type", "TestAgent")
+        assert state["graduated"] is True
+
+
+class TestFrequencyLimit:
+    """Max 1 nudge per pattern per hour."""
+
+    def test_cooldown_prevents_nudge(self, palaia_root):
+        tracker = NudgeTracker(palaia_root)
+        tracker.record_nudge("write_without_type", "TestAgent")
+        assert tracker.should_nudge("write_without_type", "TestAgent") is False
+
+    def test_cooldown_expires(self, palaia_root):
+        tracker = NudgeTracker(palaia_root)
+        tracker.record_nudge("write_without_type", "TestAgent")
+        # Manually set last_nudge to >1 hour ago
+        agent_state = tracker._state["TestAgent"]["write_without_type"]
+        agent_state["last_nudge"] = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+        tracker._save()
+        # Reload
+        tracker2 = NudgeTracker(palaia_root)
+        assert tracker2.should_nudge("write_without_type", "TestAgent") is True
+
+    def test_different_patterns_independent_cooldown(self, palaia_root):
+        tracker = NudgeTracker(palaia_root)
+        tracker.record_nudge("write_without_type", "TestAgent")
+        # Different pattern should still be nudgeable
+        assert tracker.should_nudge("write_without_tags", "TestAgent") is True
+
+
+class TestMultiAgent:
+    """Nudge state is per-agent."""
+
+    def test_separate_agents_separate_state(self, palaia_root):
+        tracker = NudgeTracker(palaia_root)
+        # Graduate agent A
+        for _ in range(GRADUATION_THRESHOLD):
+            tracker.record_success("write_without_type", "AgentA")
+        assert tracker.should_nudge("write_without_type", "AgentA") is False
+        # Agent B should still be nudgeable
+        assert tracker.should_nudge("write_without_type", "AgentB") is True
+
+    def test_agent_failure_doesnt_affect_other(self, palaia_root):
+        tracker = NudgeTracker(palaia_root)
+        tracker.record_failure("write_without_type", "AgentA")
+        tracker.record_nudge("write_without_type", "AgentA")
+        # AgentB unaffected
+        assert tracker.should_nudge("write_without_type", "AgentB") is True
+
+
+class TestPersistence:
+    """State survives across NudgeTracker instances."""
+
+    def test_state_persists(self, palaia_root):
+        tracker1 = NudgeTracker(palaia_root)
+        tracker1.record_success("write_without_type", "TestAgent")
+        tracker1.record_success("write_without_type", "TestAgent")
+
+        # Reload from disk
+        tracker2 = NudgeTracker(palaia_root)
+        state = tracker2.get_state("write_without_type", "TestAgent")
+        assert state["consecutive_success"] == 2
+        assert state["success_count"] == 2
+
+    def test_graduation_persists(self, palaia_root):
+        tracker1 = NudgeTracker(palaia_root)
+        for _ in range(GRADUATION_THRESHOLD):
+            tracker1.record_success("write_without_type", "TestAgent")
+
+        tracker2 = NudgeTracker(palaia_root)
+        assert tracker2.should_nudge("write_without_type", "TestAgent") is False
+
+    def test_corrupted_file_handled(self, palaia_root):
+        (palaia_root / "nudge-state.json").write_text("not json!!!")
+        tracker = NudgeTracker(palaia_root)
+        # Should start fresh, not crash
+        assert tracker.should_nudge("write_without_type", "TestAgent") is True
+
+
+class TestNudgeMessages:
+    """Test nudge message retrieval."""
+
+    def test_known_pattern_message(self, palaia_root):
+        tracker = NudgeTracker(palaia_root)
+        msg = tracker.get_nudge_message("write_without_type")
+        assert msg is not None
+        assert "Speichere diesen Hinweis" in msg
+
+    def test_unknown_pattern_returns_none(self, palaia_root):
+        tracker = NudgeTracker(palaia_root)
+        msg = tracker.get_nudge_message("nonexistent_pattern")
+        assert msg is None
+
+    def test_all_patterns_have_messages(self, palaia_root):
+        from palaia.nudge import NUDGE_PATTERNS
+
+        tracker = NudgeTracker(palaia_root)
+        for pattern_id in NUDGE_PATTERNS:
+            msg = tracker.get_nudge_message(pattern_id)
+            assert msg is not None, f"Pattern {pattern_id} has no message"
+            assert "Speichere diesen Hinweis" in msg
+
+
+class TestCLIIntegration:
+    """Test nudge integration in CLI commands."""
+
+    def _run_palaia(self, root, args, monkeypatch):
+        from palaia.cli import main
+
+        monkeypatch.setenv("PALAIA_HOME", str(root))
+        monkeypatch.setattr("sys.argv", ["palaia"] + args)
+        return main()
+
+    def test_write_without_type_triggers_nudge_json(self, palaia_root, monkeypatch, capsys):
+        self._run_palaia(palaia_root, ["write", "test entry", "--json"], monkeypatch)
+        out = json.loads(capsys.readouterr().out)
+        assert "nudge" in out
+        assert len(out["nudge"]) > 0
+        assert any("--type" in n for n in out["nudge"])
+
+    def test_write_with_type_no_nudge(self, palaia_root, monkeypatch, capsys):
+        self._run_palaia(
+            palaia_root, ["write", "test entry", "--type", "memory", "--json"], monkeypatch
+        )
+        out = json.loads(capsys.readouterr().out)
+        # No nudge for type, but might still have nudge for tags
+        type_nudges = [n for n in out.get("nudge", []) if "--type" in n]
+        assert len(type_nudges) == 0
+
+    def test_write_with_tags_no_tags_nudge(self, palaia_root, monkeypatch, capsys):
+        self._run_palaia(
+            palaia_root, ["write", "test entry", "--tags", "test", "--json"], monkeypatch
+        )
+        out = json.loads(capsys.readouterr().out)
+        tags_nudges = [n for n in out.get("nudge", []) if "--tags" in n]
+        assert len(tags_nudges) == 0
+
+    def test_graduation_stops_nudge_while_good(self, palaia_root, monkeypatch, capsys):
+        """After graduation, writing WITH type should not produce type nudges."""
+        # Graduate write_without_type by writing 3x with type
+        for i in range(GRADUATION_THRESHOLD):
+            self._run_palaia(
+                palaia_root,
+                ["write", f"entry {i}", "--type", "memory", "--json"],
+                monkeypatch,
+            )
+            capsys.readouterr()  # clear output
+
+        # Write WITH type again — should NOT nudge for type (still graduated)
+        self._run_palaia(
+            palaia_root, ["write", "test with type", "--type", "memory", "--json"], monkeypatch
+        )
+        out = json.loads(capsys.readouterr().out)
+        type_nudges = [n for n in out.get("nudge", []) if "--type" in n]
+        assert len(type_nudges) == 0
+
+    def test_regression_re_enables_nudge(self, palaia_root, monkeypatch, capsys):
+        """After graduation, writing WITHOUT type triggers regression and re-nudge."""
+        # Graduate
+        for i in range(GRADUATION_THRESHOLD):
+            self._run_palaia(
+                palaia_root,
+                ["write", f"entry {i}", "--type", "memory", "--json"],
+                monkeypatch,
+            )
+            capsys.readouterr()
+
+        # Regress by writing without type
+        self._run_palaia(palaia_root, ["write", "test no type", "--json"], monkeypatch)
+        out = json.loads(capsys.readouterr().out)
+        type_nudges = [n for n in out.get("nudge", []) if "--type" in n]
+        assert len(type_nudges) > 0  # Regression re-enables nudge


### PR DESCRIPTION
## Phase 1 Remaining Issues

Implements the remaining Phase 1 issues of the Palaia 2.0 roadmap.

### Issue #68: Adaptive Nudging (Graduation System)
- **NudgeTracker** class in `palaia/nudge.py` with per-agent state persistence
- Graduation after 3 consecutive successes; regression detection re-enables nudges
- Frequency limit: max 1 nudge per pattern per hour
- 4 initial patterns: `write_without_type`, `write_without_tags`, `write_without_project`, `query_without_type_filter`
- JSON mode: nudges as `"nudge"` field in output (not stderr)
- CLI integration in `cmd_write` and `cmd_query`
- 26 unit tests

### Issue #66: Agent-specific Plugin Config
- Investigated `api.getConfig()` resolution — confirmed it's **global**, not per-agent
- Documented limitation in plugin `index.ts` and SKILL.md
- Created upstream TODO issue #76 for per-agent config resolver

### Issue #67: Onboarding Capture-Level Prompt
- New `--capture-level` flag for `palaia init` (off|sparsam|normal|aggressiv)
- Maps to `plugin_config` in `.palaia/config.json`
- Works on both fresh init and re-init paths
- OpenClaw environment detection with suggestions
- `palaia doctor`: checks if capture level is configured
- 7 tests

### Issue #69: README Rewrite
- Hero: "The Knowledge OS for OpenClaw Agent Teams"
- 7 differentiators with descriptions
- Honest comparison table: Palaia vs Stock vs Mem0 vs Engram
- Plugin config + capture levels documentation
- Quick start: 3-command flow

### Tests
- All **676 tests pass** (33 new tests added)
- No force push, clean history