### PR TITLE
feat: Phase 2 — Intelligence Edge (#33, #70, #71, #72)

### DIFF
--- a/palaia/__init__.py
+++ b/palaia/__init__.py
@@ -4,5 +4,5 @@ Palaia — Local, cloud-free memory for OpenClaw agents.
 
 from __future__ import annotations
 
-__version__ = "1.9.0"
+__version__ = "2.0.0"
 __author__ = "byte5 GmbH"

--- a/palaia/cli.py
+++ b/palaia/cli.py
@@ -115,6 +115,7 @@ GATED_COMMANDS = frozenset(
         "recover",
         "status",
         "project",
+        "process",
         "lock",
         "unlock",
         "setup",
@@ -889,6 +890,17 @@ def cmd_write(args):
     except Exception:
         pass  # Never block normal operation with nudge errors
 
+    # --- Significance auto-detection (Issue #70) ---
+    significance_detected: list[str] = []
+    if not args.tags:
+        # Only auto-detect when user hasn't explicitly set tags
+        try:
+            from palaia.significance import detect_significance
+
+            significance_detected = detect_significance(args.text)
+        except Exception:
+            pass
+
     if _json_out(
         {
             "id": entry_id,
@@ -896,12 +908,21 @@ def cmd_write(args):
             "scope": scope,
             "deduplicated": deduplicated,
             **({"nudge": nudge_messages} if nudge_messages else {}),
+            **({"significance": significance_detected} if significance_detected else {}),
         },
         args,
     ):
         return 0
 
     print(f"Written: {entry_id}")
+
+    # Significance suggestion (Issue #70)
+    if significance_detected:
+        tags_str = ", ".join(significance_detected)
+        print(
+            f"\nDetected significance: [{tags_str}]. Use --tags to confirm.",
+            file=sys.stderr,
+        )
 
     # Print nudge messages
     for nudge_msg in nudge_messages:
@@ -1538,6 +1559,20 @@ def cmd_status(args):
     if info.get("index_hint"):
         print(info["index_hint"], file=sys.stderr)
 
+    # Budget info (Issue #71)
+    budget_info = info.get("budget")
+    if budget_info:
+        print(section("Budget"))
+        budget_rows = []
+        if "max_entries_per_tier" in budget_info:
+            budget_rows.append(("Max entries/tier", str(budget_info["max_entries_per_tier"])))
+            for t, usage in budget_info.get("tier_usage", {}).items():
+                budget_rows.append((f"  {t}", usage))
+        if "max_total_chars" in budget_info:
+            budget_rows.append(("Max total chars", str(budget_info["max_total_chars"])))
+            budget_rows.append(("  Usage", budget_info.get("chars_usage", "?")))
+        print(table_kv(budget_rows))
+
     # BM25-only warning
     has_embed = any(s["available"] and s["name"] != "bm25" for s in statuses)
     bm25_only = all(s["name"] == "bm25" for s in statuses) or not has_embed
@@ -1945,21 +1980,45 @@ def cmd_gc(args):
     store = Store(root)
     store.recover()
 
-    result = store.gc()
+    dry_run = getattr(args, "dry_run", False)
+    budget = getattr(args, "budget", False)
+
+    result = store.gc(dry_run=dry_run, budget=budget)
 
     if _json_out(result, args):
         return 0
 
-    total_moves = sum(v for k, v in result.items() if k != "wal_cleaned")
+    if dry_run:
+        candidates = result.get("candidates", [])
+        if not candidates:
+            print("No entries found.")
+            return 0
+        from palaia.ui import table_multi as _tm
+
+        rows = [(c["id"], c["title"][:30], f"{c['score']:.4f}", c["tier"], c["reason"]) for c in candidates]
+        print(
+            _tm(
+                headers=("ID", "Title", "Score", "Tier", "Reason"),
+                rows=rows,
+                min_widths=(8, 30, 8, 4, 20),
+            )
+        )
+        print(f"\n{len(candidates)} entries scored. Lowest score = first prune candidate.")
+        return 0
+
+    skip_keys = {"wal_cleaned", "pruned", "pruned_entries"}
+    total_moves = sum(v for k, v in result.items() if k not in skip_keys and isinstance(v, int))
     print("GC complete.")
     if total_moves:
         for k, v in result.items():
-            if v and k != "wal_cleaned":
+            if v and k not in skip_keys and isinstance(v, int):
                 print(f"  {k}: {v}")
     else:
         print("  No tier changes needed.")
     if result.get("wal_cleaned"):
         print(f"  WAL cleaned: {result['wal_cleaned']} old entries")
+    if result.get("pruned"):
+        print(f"  Pruned (budget): {result['pruned']} entries")
     return 0
 
 
@@ -2803,6 +2862,125 @@ def _detect_current_agent() -> str | None:
     return None
 
 
+def cmd_process(args):
+    """Manage process execution runs (Issue #72)."""
+    root = get_root()
+    store = Store(root)
+    store.recover()
+
+    action = args.process_action
+
+    if action == "run":
+        from palaia.process_runner import ProcessRunManager
+
+        prm = ProcessRunManager(root)
+        entry_id = args.entry_id
+
+        # Resolve short ID
+        if len(entry_id) < 36:
+            entry_id = _resolve_short_id(store, entry_id)
+            if entry_id is None:
+                msg = f"No entry found matching: {args.entry_id}"
+                if _json_out({"error": msg}, args):
+                    return 1
+                print(msg, file=sys.stderr)
+                return 1
+
+        # Read the entry
+        agent = _resolve_agent(args)
+        entry = store.read(entry_id, agent=agent)
+        if entry is None:
+            msg = f"Entry not found: {entry_id}"
+            if _json_out({"error": msg}, args):
+                return 1
+            print(msg, file=sys.stderr)
+            return 1
+
+        meta, body = entry
+        if meta.get("type") != "process":
+            msg = f"Entry {entry_id[:8]} is not a process (type: {meta.get('type', 'memory')})"
+            if _json_out({"error": msg}, args):
+                return 1
+            print(msg, file=sys.stderr)
+            return 1
+
+        run = prm.start(entry_id, body)
+
+        # Handle --step N --done
+        step_idx = getattr(args, "step", None)
+        if step_idx is not None:
+            if getattr(args, "done", False):
+                if not run.mark_done(step_idx):
+                    msg = f"Invalid step index: {step_idx}"
+                    if _json_out({"error": msg}, args):
+                        return 1
+                    print(msg, file=sys.stderr)
+                    return 1
+                prm.save(run)
+
+        if _json_out(run.to_dict(), args):
+            return 0
+
+        # Human-readable output
+        title = meta.get("title", "(untitled)")
+        print(f"Process: {title} ({entry_id[:8]})")
+        print(f"Progress: {run.progress_summary()}")
+        print()
+        for s in run.steps:
+            marker = "[x]" if s["done"] else "[ ]"
+            print(f"  {s['index']}. {marker} {s['text']}")
+        if run.completed:
+            print("\nAll steps completed!")
+        return 0
+
+    elif action == "list":
+        from palaia.process_runner import ProcessRunManager
+
+        prm = ProcessRunManager(root)
+        runs = prm.list_runs()
+
+        if _json_out({"runs": [r.to_dict() for r in runs]}, args):
+            return 0
+
+        if not runs:
+            print("No active process runs.")
+            return 0
+
+        rows = []
+        for r in runs:
+            # Try to get title from store
+            entry = store.read(r.entry_id)
+            title = "(unknown)"
+            if entry:
+                meta, _ = entry
+                title = meta.get("title", "(untitled)")
+            rows.append(
+                (
+                    r.entry_id[:8],
+                    title[:30],
+                    r.progress_summary(),
+                    "yes" if r.completed else "no",
+                    r.started_at[:10] if r.started_at else "?",
+                )
+            )
+
+        from palaia.ui import table_multi as _tm
+
+        print(
+            _tm(
+                headers=("ID", "Title", "Progress", "Done", "Started"),
+                rows=rows,
+                min_widths=(8, 30, 15, 4, 10),
+            )
+        )
+        print(f"\n{len(runs)} process run(s).")
+        return 0
+
+    else:
+        print("Unknown process action. Use: run, list", file=sys.stderr)
+        return 1
+
+
 def cmd_skill(args):
     """Print the embedded SKILL.md documentation."""
     skill_path = Path(__file__).parent / "SKILL.md"
@@ -2970,6 +3148,8 @@ def main():
 
     # gc
     p_gc = sub.add_parser("gc", help="Run garbage collection / tier rotation")
+    p_gc.add_argument("--dry-run", action="store_true", help="Show what would be pruned without changing anything")
+    p_gc.add_argument("--budget", action="store_true", help="Prune entries to meet configured budget limits")
     p_gc.add_argument("--json", action="store_true", help="Output as JSON")
 
     # project
@@ -3145,6 +3325,20 @@ def main():
     p_config_remove_alias.add_argument("from_name", help="Alias source name to remove")
     p_config_remove_alias.add_argument("--json", action="store_true", help="Output as JSON")
 
+    # process (Issue #72)
+    p_process = sub.add_parser("process", help="Manage process execution runs")
+    process_sub = p_process.add_subparsers(dest="process_action")
+
+    p_proc_run = process_sub.add_parser("run", help="Run or inspect a process entry")
+    p_proc_run.add_argument("entry_id", help="Entry UUID or short prefix")
+    p_proc_run.add_argument("--step", type=int, default=None, help="Step index (0-based)")
+    p_proc_run.add_argument("--done", action="store_true", help="Mark step as done (requires --step)")
+    p_proc_run.add_argument("--agent", default=None, help="Agent name")
+    p_proc_run.add_argument("--json", action="store_true", help="Output as JSON")
+
+    p_proc_list = process_sub.add_parser("list", help="List active process runs")
+    p_proc_list.add_argument("--json", action="store_true", help="Output as JSON")
+
     # skill
     p_skill = sub.add_parser("skill", help="Print the SKILL.md agent documentation")
     p_skill.add_argument("--json", action="store_true", help="Output as JSON")
@@ -3193,6 +3387,7 @@ def main():
         "config": cmd_config,
         "warmup": cmd_warmup,
         "project": cmd_project,
+        "process": cmd_process,
         "memo": cmd_memo,
         "lock": cmd_lock,
         "unlock": cmd_unlock,

--- a/palaia/config.py
+++ b/palaia/config.py
@@ -24,6 +24,10 @@ DEFAULT_CONFIG = {
     "embedding_provider": "auto",
     "embedding_model": "",
     "store_version": "",  # Set to palaia __version__ on init/upgrade
+    # Bounded memory (Issue #71)
+    "max_entries_per_tier": None,  # None = unlimited
+    "max_total_chars": None,  # None = unlimited
+    "gc_type_weights": {"process": 2.0, "task": 1.5, "memory": 1.0},
 }
 
 

--- a/palaia/decay.py
+++ b/palaia/decay.py
@@ -13,12 +13,18 @@ def decay_score(
 ) -> float:
     """Calculate decay score. Higher = more relevant.
 
-    score = recency_factor * log(1 + access_count)
-    recency_factor = exp(-lambda * days_since_access)
+    Formula (ADR-004, Issue #33):
+        final_score = time_decay * hit_rate_bonus
+        time_decay   = exp(-lambda * days_since_access)
+        hit_rate_bonus = 1 + log(1 + access_count)
+
+    access_count=0  → bonus 1.0  (no boost)
+    access_count=10 → bonus ~3.4
+    access_count=100 → bonus ~5.6
     """
     recency = math.exp(-lambda_val * days_since_access)
-    frequency = math.log(1 + access_count)
-    return round(recency * frequency, 6)
+    hit_rate_bonus = 1.0 + math.log(1 + access_count)
+    return round(recency * hit_rate_bonus, 6)
 
 
 def classify_tier(

--- a/palaia/process_runner.py
+++ b/palaia/process_runner.py
@@ -1,0 +1,173 @@
+"""Process runner for executing process-type entries step by step (Issue #72).
+
+Parses steps from process entries (numbered lists or markdown checkboxes),
+tracks execution state, and persists progress.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Step parsing patterns
+_NUMBERED_RE = re.compile(r"^\s*(\d+)[.)]\s+(.+)$")
+_CHECKBOX_RE = re.compile(r"^\s*-\s*\[([ xX])\]\s+(.+)$")
+
+
+def parse_steps(content: str) -> list[dict]:
+    """Parse steps from markdown content.
+
+    Supports:
+    - Numbered lists: "1. Do something" or "1) Do something"
+    - Checkboxes: "- [ ] Do something" or "- [x] Already done"
+
+    Returns list of {"index": int, "text": str, "done": bool, "done_at": None|str}.
+    """
+    steps: list[dict] = []
+    for line in content.split("\n"):
+        line = line.rstrip()
+        if not line.strip():
+            continue
+
+        # Try checkbox first
+        m = _CHECKBOX_RE.match(line)
+        if m:
+            checked = m.group(1).lower() == "x"
+            steps.append(
+                {
+                    "index": len(steps),
+                    "text": m.group(2).strip(),
+                    "done": checked,
+                    "done_at": None,
+                }
+            )
+            continue
+
+        # Try numbered list
+        m = _NUMBERED_RE.match(line)
+        if m:
+            steps.append(
+                {
+                    "index": len(steps),
+                    "text": m.group(2).strip(),
+                    "done": False,
+                    "done_at": None,
+                }
+            )
+            continue
+
+    return steps
+
+
+class ProcessRun:
+    """State for a single process execution run."""
+
+    def __init__(self, entry_id: str, steps: list[dict], started_at: str | None = None):
+        self.entry_id = entry_id
+        self.steps = steps
+        self.started_at = started_at or datetime.now(timezone.utc).isoformat()
+        self.completed = all(s["done"] for s in steps) if steps else False
+
+    def mark_done(self, step_index: int) -> bool:
+        """Mark a step as done. Returns True if step existed.
+
+        Args:
+            step_index: 0-based step index.
+        """
+        if step_index < 0 or step_index >= len(self.steps):
+            return False
+        self.steps[step_index]["done"] = True
+        self.steps[step_index]["done_at"] = datetime.now(timezone.utc).isoformat()
+        self.completed = all(s["done"] for s in self.steps)
+        return True
+
+    def to_dict(self) -> dict:
+        return {
+            "entry_id": self.entry_id,
+            "started_at": self.started_at,
+            "steps": self.steps,
+            "completed": self.completed,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ProcessRun":
+        run = cls(
+            entry_id=data["entry_id"],
+            steps=data.get("steps", []),
+            started_at=data.get("started_at"),
+        )
+        run.completed = data.get("completed", False)
+        return run
+
+    def progress_summary(self) -> str:
+        """Human-readable progress summary."""
+        done = sum(1 for s in self.steps if s["done"])
+        total = len(self.steps)
+        return f"{done}/{total} steps completed"
+
+
+class ProcessRunManager:
+    """Manages process run states on disk."""
+
+    def __init__(self, palaia_root: Path):
+        self.runs_dir = palaia_root / "process-runs"
+        self.runs_dir.mkdir(parents=True, exist_ok=True)
+
+    def _run_path(self, entry_id: str) -> Path:
+        return self.runs_dir / f"{entry_id}.json"
+
+    def get(self, entry_id: str) -> ProcessRun | None:
+        """Load an existing process run state."""
+        path = self._run_path(entry_id)
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return ProcessRun.from_dict(data)
+        except (json.JSONDecodeError, KeyError, OSError):
+            return None
+
+    def start(self, entry_id: str, content: str) -> ProcessRun:
+        """Start a new process run (or return existing).
+
+        Parses steps from the entry content and creates a run state.
+        """
+        existing = self.get(entry_id)
+        if existing is not None:
+            return existing
+
+        steps = parse_steps(content)
+        run = ProcessRun(entry_id=entry_id, steps=steps)
+        self._save(run)
+        return run
+
+    def save(self, run: ProcessRun) -> None:
+        """Save a process run to disk."""
+        self._save(run)
+
+    def _save(self, run: ProcessRun) -> None:
+        path = self._run_path(run.entry_id)
+        path.write_text(json.dumps(run.to_dict(), indent=2, ensure_ascii=False), encoding="utf-8")
+
+    def list_runs(self) -> list[ProcessRun]:
+        """List all process runs."""
+        runs: list[ProcessRun] = []
+        if not self.runs_dir.exists():
+            return runs
+        for p in sorted(self.runs_dir.glob("*.json")):
+            try:
+                data = json.loads(p.read_text(encoding="utf-8"))
+                runs.append(ProcessRun.from_dict(data))
+            except (json.JSONDecodeError, KeyError, OSError):
+                continue
+        return runs
+
+    def delete(self, entry_id: str) -> bool:
+        """Delete a process run state."""
+        path = self._run_path(entry_id)
+        if path.exists():
+            path.unlink()
+            return True
+        return False

--- a/palaia/significance.py
+++ b/palaia/significance.py
@@ -1,0 +1,111 @@
+"""Significance tagging with auto-detection (Issue #70).
+
+Standard taxonomy of significance tags for memory entries.
+Heuristic detection via keyword and pattern matching.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Canonical significance tags
+SIGNIFICANCE_TAGS: tuple[str, ...] = (
+    "decision",
+    "lesson",
+    "surprise",
+    "commitment",
+    "correction",
+    "preference",
+    "fact",
+)
+
+# Patterns per category: list of (compiled_regex, weight).
+# Weight is unused for now but allows future ranking.
+_PATTERNS: dict[str, list[tuple[re.Pattern[str], float]]] = {
+    "decision": [
+        (re.compile(r"\b(decided|decision|entschieden|entscheidung|chose|chosen|we\s+went\s+with)\b", re.I), 1.0),
+        (re.compile(r"\b(will\s+use|going\s+with|picked|selected|opted\s+for)\b", re.I), 0.8),
+        (re.compile(r"\b(wir\s+nehmen|wir\s+nutzen|festgelegt|beschlossen)\b", re.I), 0.9),
+        (re.compile(r"\bADR\b", re.I), 1.0),
+    ],
+    "lesson": [
+        (re.compile(r"\b(learned|lesson|takeaway|erkenntnis|gelernt|learning)\b", re.I), 1.0),
+        (re.compile(r"\b(never\s+again|next\s+time|in\s+future|in\s+zukunft)\b", re.I), 0.9),
+        (re.compile(r"\b(mistake\s+was|fehler\s+war|turned\s+out|stellte\s+sich\s+heraus)\b", re.I), 0.8),
+        (re.compile(r"\b(insight|einsicht|realization)\b", re.I), 0.8),
+    ],
+    "surprise": [
+        (re.compile(r"\b(surprising|unexpected|unerwartet|überraschend|didn't\s+expect)\b", re.I), 1.0),
+        (re.compile(r"\b(turns\s+out|it\s+seems|actually|tatsächlich)\b", re.I), 0.6),
+        (re.compile(r"\b(plot\s+twist|who\s+knew|wow)\b", re.I), 0.7),
+    ],
+    "commitment": [
+        (re.compile(r"\b(promise|commit|commitment|versprechen|zusage|verpflichtung)\b", re.I), 1.0),
+        (re.compile(r"\b(will\s+do|must\s+do|agreed\s+to|zugesagt|vereinbart)\b", re.I), 0.8),
+        (re.compile(r"\b(deadline|due\s+by|bis\s+zum|fällig)\b", re.I), 0.7),
+        (re.compile(r"\b(i\s+will|we\s+will|ich\s+werde|wir\s+werden)\b", re.I), 0.5),
+    ],
+    "correction": [
+        (re.compile(r"\b(correction|corrected|korrektur|korrigiert|was\s+wrong|war\s+falsch)\b", re.I), 1.0),
+        (re.compile(r"\b(fix|fixed|gefixt|behoben|actually\s+it's|eigentlich\s+ist)\b", re.I), 0.7),
+        (re.compile(r"\b(retract|widerrufen|update:\s|nachtrag)\b", re.I), 0.8),
+        (re.compile(r"\b(nicht\s+wie\s+gedacht|not\s+as\s+expected)\b", re.I), 0.8),
+    ],
+    "preference": [
+        (re.compile(r"\b(prefer|preference|bevorzug|präferenz|like\s+better|lieber)\b", re.I), 1.0),
+        (re.compile(r"\b(favorite|favourit|lieblings|my\s+go-to)\b", re.I), 0.8),
+        (re.compile(r"\b(always\s+use|immer\s+nutzen|standard\s+is|default\s+ist)\b", re.I), 0.7),
+        (re.compile(r"\b(i\s+like|i\s+don't\s+like|mag\s+ich|mag\s+ich\s+nicht)\b", re.I), 0.6),
+    ],
+    "fact": [
+        (re.compile(r"\b(fact|tatsache|note\s+to\s+self|merke|remember\s+that)\b", re.I), 1.0),
+        (re.compile(r"\b(config|konfiguration|password|passwort|token)\b", re.I), 0.8),
+        (re.compile(r"api[_\s-]?key", re.I), 0.8),
+        (re.compile(r"\b(located\s+at|zu\s+finden|ip\s+address|version\s+is)\b", re.I), 0.7),
+        (re.compile(r"\b(specification|spezifikation|requirement|anforderung)\b", re.I), 0.7),
+    ],
+}
+
+
+def detect_significance(text: str) -> list[str]:
+    """Detect significance tags from text content.
+
+    Uses keyword and pattern matching. Returns a list of matching
+    significance tag names (may be empty).
+
+    Args:
+        text: The text content to analyze.
+
+    Returns:
+        List of significance tag strings, e.g. ["decision", "lesson"].
+    """
+    if not text or not text.strip():
+        return []
+
+    detected: list[str] = []
+    for tag, patterns in _PATTERNS.items():
+        for regex, _weight in patterns:
+            if regex.search(text):
+                detected.append(tag)
+                break  # One match per category is enough
+
+    return detected
+
+
+def significance_weight(tags: list[str] | None) -> float:
+    """Calculate GC significance weight from tags.
+
+    Entries with significance tags get a higher weight (survive GC longer).
+    Formula: 1.0 + 0.2 * count_of_significance_tags_present
+
+    Args:
+        tags: List of entry tags (may include non-significance tags).
+
+    Returns:
+        Weight >= 1.0. Higher = more important for GC retention.
+    """
+    if not tags:
+        return 1.0
+    sig_set = set(SIGNIFICANCE_TAGS)
+    count = sum(1 for t in tags if t in sig_set)
+    return 1.0 + 0.2 * count

--- a/palaia/store.py
+++ b/palaia/store.py
@@ -340,10 +340,88 @@ class Store:
                     continue
         return results
 
-    def gc(self) -> dict:
-        """Garbage collect: rotate tiers based on decay scores."""
+    def gc_score_entry(self, meta: dict, body: str, config: dict | None = None) -> float:
+        """Calculate the holistic GC score for an entry.
+
+        Formula (Issue #33, #70, #71):
+            gc_score = decay_score * hit_rate_bonus * significance_weight * type_weight
+
+        Higher gc_score = more important = survives GC longer.
+        Lowest gc_score = first pruning candidate.
+        """
+        from palaia.significance import significance_weight as sig_weight
+
+        if config is None:
+            config = self.config
+
+        accessed = meta.get("accessed", meta.get("created", ""))
+        if not accessed:
+            return 0.0
+
+        d = days_since(accessed)
+        ac = meta.get("access_count", 1)
+        base_score = decay_score(d, ac, config["decay_lambda"])
+
+        # Significance weight from tags
+        tags = meta.get("tags", [])
+        sw = sig_weight(tags)
+
+        # Type weight
+        type_weights = config.get("gc_type_weights", {"process": 2.0, "task": 1.5, "memory": 1.0})
+        if isinstance(type_weights, dict):
+            entry_type = meta.get("type", "memory")
+            tw = type_weights.get(entry_type, 1.0)
+        else:
+            tw = 1.0
+
+        return round(base_score * sw * tw, 6)
+
+    def gc(self, dry_run: bool = False, budget: bool = False) -> dict:
+        """Garbage collect: rotate tiers based on decay scores.
+
+        Args:
+            dry_run: If True, report what would happen without changing anything.
+            budget: If True, prune entries to meet configured budget limits.
+        """
         moves = {"hot_to_warm": 0, "warm_to_cold": 0, "cold_to_warm": 0, "warm_to_hot": 0}
         config = self.config
+        pruned_entries: list[dict] = []  # For dry-run and budget reporting
+
+        if dry_run:
+            # Collect all entries with scores for dry-run report
+            candidates = []
+            for tier in TIERS:
+                tier_dir = self.root / tier
+                if not tier_dir.exists():
+                    continue
+                for p in tier_dir.glob("*.md"):
+                    try:
+                        text = p.read_text(encoding="utf-8")
+                        meta, body = parse_entry(text)
+                    except (OSError, UnicodeDecodeError):
+                        continue
+                    gc_s = self.gc_score_entry(meta, body, config)
+                    reason_parts = []
+                    if gc_s < 0.1:
+                        reason_parts.append("low decay")
+                    if meta.get("access_count", 1) <= 1:
+                        reason_parts.append("no hits")
+                    from palaia.significance import SIGNIFICANCE_TAGS
+
+                    tags = meta.get("tags", [])
+                    if not any(t in SIGNIFICANCE_TAGS for t in tags):
+                        reason_parts.append("no significance")
+                    candidates.append(
+                        {
+                            "id": meta.get("id", p.stem)[:8],
+                            "title": meta.get("title", "(untitled)"),
+                            "score": gc_s,
+                            "tier": tier,
+                            "reason": ", ".join(reason_parts) if reason_parts else "ok",
+                        }
+                    )
+            candidates.sort(key=lambda x: x["score"])
+            return {"dry_run": True, "candidates": candidates}
 
         with self.lock:
             for tier in TIERS:
@@ -365,6 +443,10 @@ class Store:
                     ac = meta.get("access_count", 1)
                     score = decay_score(d, ac, config["decay_lambda"])
                     meta["decay_score"] = score
+
+                    # Store holistic GC score as well
+                    gc_s = self.gc_score_entry(meta, body, config)
+                    meta["gc_score"] = gc_s
 
                     new_tier = classify_tier(
                         d,
@@ -397,6 +479,10 @@ class Store:
                         with open(p, "w") as f:
                             f.write(new_text)
 
+            # Budget enforcement (Issue #71)
+            if budget:
+                pruned_entries = self._enforce_budget(config)
+
         # WAL cleanup
         wal_cleaned = self.wal.cleanup(config["wal_retention_days"])
         moves["wal_cleaned"] = wal_cleaned
@@ -412,28 +498,130 @@ class Store:
         if stale:
             moves["embeddings_cleaned"] = stale
 
+        if pruned_entries:
+            moves["pruned"] = len(pruned_entries)
+            moves["pruned_entries"] = pruned_entries
+
         return moves
+
+    def _enforce_budget(self, config: dict) -> list[dict]:
+        """Prune entries to meet budget limits. Returns list of pruned entry info.
+
+        Must be called inside a lock context.
+        """
+        max_per_tier = config.get("max_entries_per_tier")
+        max_chars = config.get("max_total_chars")
+
+        if max_per_tier is None and max_chars is None:
+            return []
+
+        pruned: list[dict] = []
+
+        # Collect all entries with GC scores
+        all_entries: list[tuple[Path, dict, str, float]] = []
+        for tier in TIERS:
+            tier_dir = self.root / tier
+            if not tier_dir.exists():
+                continue
+            for p in tier_dir.glob("*.md"):
+                try:
+                    text = p.read_text(encoding="utf-8")
+                    meta, body = parse_entry(text)
+                except (OSError, UnicodeDecodeError):
+                    continue
+                gc_s = self.gc_score_entry(meta, body, config)
+                all_entries.append((p, meta, body, gc_s))
+
+        # Sort by gc_score ascending (lowest first = prune first)
+        all_entries.sort(key=lambda x: x[3])
+
+        # Enforce max_entries_per_tier
+        if max_per_tier is not None:
+            for tier in TIERS:
+                tier_entries = [(p, m, b, s) for p, m, b, s in all_entries if str(p).startswith(str(self.root / tier))]
+                if len(tier_entries) > max_per_tier:
+                    # Already sorted by gc_score asc, prune from the front
+                    to_prune = tier_entries[: len(tier_entries) - max_per_tier]
+                    for p, meta, _body, gc_s in to_prune:
+                        pruned.append(
+                            {
+                                "id": meta.get("id", p.stem)[:8],
+                                "title": meta.get("title", "(untitled)"),
+                                "score": gc_s,
+                                "reason": "budget:max_entries_per_tier",
+                            }
+                        )
+                        rel = str(p.relative_to(self.root))
+                        self.delete_raw(rel)
+                        self.embedding_cache.invalidate(meta.get("id", p.stem))
+                        all_entries = [(ep, em, eb, es) for ep, em, eb, es in all_entries if ep != p]
+
+        # Enforce max_total_chars
+        if max_chars is not None:
+            total_chars = sum(len(b) for _, _, b, _ in all_entries)
+            while total_chars > max_chars and all_entries:
+                p, meta, body, gc_s = all_entries[0]
+                pruned.append(
+                    {
+                        "id": meta.get("id", p.stem)[:8],
+                        "title": meta.get("title", "(untitled)"),
+                        "score": gc_s,
+                        "reason": "budget:max_total_chars",
+                    }
+                )
+                rel = str(p.relative_to(self.root))
+                self.delete_raw(rel)
+                self.embedding_cache.invalidate(meta.get("id", p.stem))
+                total_chars -= len(body)
+                all_entries = all_entries[1:]
+
+        return pruned
 
     def status(self) -> dict:
         """Get system status info."""
         counts = {}
+        total_chars = 0
         for tier in TIERS:
             tier_dir = self.root / tier
             if tier_dir.exists():
-                counts[tier] = len(list(tier_dir.glob("*.md")))
+                entries = list(tier_dir.glob("*.md"))
+                counts[tier] = len(entries)
+                for p in entries:
+                    try:
+                        text = p.read_text(encoding="utf-8")
+                        _, body = parse_entry(text)
+                        total_chars += len(body)
+                    except (OSError, UnicodeDecodeError):
+                        pass
             else:
                 counts[tier] = 0
 
         wal_dir = self.root / "wal"
         pending = len(self.wal.get_pending()) if wal_dir.exists() else 0
 
-        return {
+        result = {
             "palaia_root": str(self.root),
             "entries": counts,
             "total": sum(counts.values()),
+            "total_chars": total_chars,
             "wal_pending": pending,
             "config": self.config,
         }
+
+        # Budget info (Issue #71)
+        max_per_tier = self.config.get("max_entries_per_tier")
+        max_total_chars = self.config.get("max_total_chars")
+        if max_per_tier is not None or max_total_chars is not None:
+            budget = {}
+            if max_per_tier is not None:
+                budget["max_entries_per_tier"] = max_per_tier
+                budget["tier_usage"] = {t: f"{counts.get(t, 0)}/{max_per_tier}" for t in TIERS}
+            if max_total_chars is not None:
+                budget["max_total_chars"] = max_total_chars
+                budget["chars_usage"] = f"{total_chars}/{max_total_chars}"
+            result["budget"] = budget
+
+        return result
 
     def _find_entry(self, entry_id: str) -> Path | None:
         """Find an entry file across tiers."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "palaia"
-version = "1.9.0"
+version = "2.0.0"
 description = "Local, cloud-free memory for OpenClaw agents."
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_bounded_gc.py
+++ b/tests/test_bounded_gc.py
@@ -1,0 +1,162 @@
+"""Tests for bounded memory and intelligent GC (Issues #33, #70, #71)."""
+
+import json
+
+from palaia.store import Store
+
+
+def _make_store(tmp_path, config_extra=None):
+    """Create a minimal store for testing."""
+    root = tmp_path / ".palaia"
+    root.mkdir()
+    for d in ("hot", "warm", "cold", "wal", "index"):
+        (root / d).mkdir()
+    config = {"agent": "test"}
+    if config_extra:
+        config.update(config_extra)
+    (root / "config.json").write_text(json.dumps(config))
+    return Store(root)
+
+
+class TestGCScore:
+    def test_gc_score_basic(self, tmp_path):
+        store = _make_store(tmp_path)
+        eid = store.write("Basic entry", agent="test")
+        from palaia.entry import parse_entry
+
+        text = (store.root / "hot" / f"{eid}.md").read_text()
+        meta, body = parse_entry(text)
+        score = store.gc_score_entry(meta, body)
+        assert score > 0
+
+    def test_gc_score_process_higher_than_memory(self, tmp_path):
+        store = _make_store(tmp_path)
+        id_mem = store.write("Memory entry", agent="test", entry_type="memory")
+        id_proc = store.write("1. Step one\n2. Step two", agent="test", entry_type="process")
+
+        from palaia.entry import parse_entry
+
+        meta_mem, body_mem = parse_entry((store.root / "hot" / f"{id_mem}.md").read_text())
+        meta_proc, body_proc = parse_entry((store.root / "hot" / f"{id_proc}.md").read_text())
+
+        score_mem = store.gc_score_entry(meta_mem, body_mem)
+        score_proc = store.gc_score_entry(meta_proc, body_proc)
+
+        # Process entries should have higher GC score (type_weight: 2.0 vs 1.0)
+        assert score_proc > score_mem
+
+    def test_gc_score_with_significance_tags(self, tmp_path):
+        store = _make_store(tmp_path)
+        id_plain = store.write("Plain entry", agent="test")
+        id_tagged = store.write("Important decision", agent="test", tags=["decision", "lesson"])
+
+        from palaia.entry import parse_entry
+
+        meta_p, body_p = parse_entry((store.root / "hot" / f"{id_plain}.md").read_text())
+        meta_t, body_t = parse_entry((store.root / "hot" / f"{id_tagged}.md").read_text())
+
+        score_p = store.gc_score_entry(meta_p, body_p)
+        score_t = store.gc_score_entry(meta_t, body_t)
+
+        # Tagged entry should have higher score (significance_weight > 1.0)
+        assert score_t > score_p
+
+
+class TestGCDryRun:
+    def test_dry_run_returns_candidates(self, tmp_path):
+        store = _make_store(tmp_path)
+        store.write("Entry one", agent="test")
+        store.write("Entry two", agent="test")
+
+        result = store.gc(dry_run=True)
+        assert result["dry_run"] is True
+        assert len(result["candidates"]) == 2
+
+    def test_dry_run_does_not_modify(self, tmp_path):
+        store = _make_store(tmp_path)
+        eid = store.write("Entry", agent="test")
+
+        before = (store.root / "hot" / f"{eid}.md").read_text()
+
+        store.gc(dry_run=True)
+
+        after = (store.root / "hot" / f"{eid}.md").read_text()
+        assert before == after
+
+    def test_dry_run_candidates_sorted_by_score(self, tmp_path):
+        store = _make_store(tmp_path)
+        store.write("Plain entry", agent="test")
+        store.write("Decision entry", agent="test", tags=["decision"])
+
+        result = store.gc(dry_run=True)
+        candidates = result["candidates"]
+        scores = [c["score"] for c in candidates]
+        assert scores == sorted(scores)  # Ascending order
+
+
+class TestBudgetEnforcement:
+    def test_max_entries_per_tier(self, tmp_path):
+        store = _make_store(tmp_path, {"max_entries_per_tier": 2})
+        # Write 4 entries to hot tier
+        store.write("Entry 1", agent="test")
+        store.write("Entry 2", agent="test")
+        store.write("Entry 3", agent="test")
+        store.write("Entry 4", agent="test")
+
+        result = store.gc(budget=True)
+        assert result.get("pruned", 0) == 2  # Should prune 2 to meet limit of 2
+
+        # Verify only 2 remain in hot
+        remaining = list((store.root / "hot").glob("*.md"))
+        assert len(remaining) == 2
+
+    def test_max_total_chars(self, tmp_path):
+        store = _make_store(tmp_path, {"max_total_chars": 100})
+        # Write entries with known content sizes
+        store.write("A" * 60, agent="test")
+        store.write("B" * 60, agent="test")
+        store.write("C" * 60, agent="test")
+
+        result = store.gc(budget=True)
+        assert result.get("pruned", 0) > 0
+
+    def test_budget_preserves_high_score_entries(self, tmp_path):
+        store = _make_store(tmp_path, {"max_entries_per_tier": 1})
+        store.write("Low importance entry", agent="test")
+        id_high = store.write("High importance decision", agent="test", tags=["decision", "lesson"])
+
+        store.gc(budget=True)
+
+        # High-scored entry should survive
+        remaining = list((store.root / "hot").glob("*.md"))
+        assert len(remaining) == 1
+        assert remaining[0].stem == id_high
+
+    def test_no_budget_no_pruning(self, tmp_path):
+        store = _make_store(tmp_path)  # No budget limits set
+        store.write("Entry 1", agent="test")
+        store.write("Entry 2", agent="test")
+
+        result = store.gc(budget=True)
+        assert result.get("pruned", 0) == 0
+
+
+class TestStatusBudget:
+    def test_status_shows_budget_when_configured(self, tmp_path):
+        store = _make_store(tmp_path, {"max_entries_per_tier": 50, "max_total_chars": 10000})
+        store.write("Test entry", agent="test")
+        status = store.status()
+        assert "budget" in status
+        assert status["budget"]["max_entries_per_tier"] == 50
+        assert status["budget"]["max_total_chars"] == 10000
+
+    def test_status_no_budget_when_unconfigured(self, tmp_path):
+        store = _make_store(tmp_path)
+        status = store.status()
+        assert "budget" not in status
+
+    def test_status_includes_total_chars(self, tmp_path):
+        store = _make_store(tmp_path)
+        store.write("Hello world", agent="test")
+        status = store.status()
+        assert status["total_chars"] > 0

--- a/tests/test_hit_decay.py
+++ b/tests/test_hit_decay.py
@@ -1,0 +1,82 @@
+"""Tests for retrieval-hit decay (Issue #33)."""
+
+import math
+
+from palaia.decay import decay_score
+
+
+def test_access_count_zero_gives_factor_one():
+    """access_count=0 → hit_rate_bonus = 1.0 (no boost)."""
+    score = decay_score(0, access_count=0)
+    # time_decay=1.0, bonus=1+log(1+0)=1+0=1.0
+    assert abs(score - 1.0) < 0.001
+
+
+def test_access_count_10_gives_approx_3_4():
+    """access_count=10 → bonus ≈ 3.4."""
+    expected_bonus = 1 + math.log(1 + 10)  # ≈ 3.397
+    score = decay_score(0, access_count=10)
+    assert abs(score - expected_bonus) < 0.01
+
+
+def test_access_count_100_gives_approx_5_6():
+    """access_count=100 → bonus ≈ 5.6."""
+    expected_bonus = 1 + math.log(1 + 100)  # ≈ 5.620
+    score = decay_score(0, access_count=100)
+    assert abs(score - expected_bonus) < 0.01
+
+
+def test_hit_rate_slows_decay():
+    """Entries with high access_count decay slower than low-access entries."""
+    score_low = decay_score(30, access_count=0)
+    score_high = decay_score(30, access_count=50)
+    assert score_high > score_low * 3  # Significant difference
+
+
+def test_fresh_entry_no_access_equals_one():
+    """Fresh entry with 0 days and 0 access = 1.0."""
+    score = decay_score(0, access_count=0)
+    assert score == 1.0
+
+
+def test_old_high_access_beats_old_low_access():
+    """Old frequently-accessed entry beats old rarely-accessed entry."""
+    score_rarely = decay_score(60, access_count=1)
+    score_frequent = decay_score(60, access_count=100)
+    assert score_frequent > score_rarely
+
+
+def test_gc_score_includes_hit_rate(tmp_path):
+    """GC score uses the updated decay formula with hit rate bonus."""
+    from palaia.store import Store
+
+    root = tmp_path / ".palaia"
+    root.mkdir()
+    for d in ("hot", "warm", "cold", "wal", "index"):
+        (root / d).mkdir()
+    import json
+
+    (root / "config.json").write_text(json.dumps({"agent": "test"}))
+
+    store = Store(root)
+
+    # Write two entries
+    id1 = store.write("Low access entry", agent="test")
+    id2 = store.write("High access entry", agent="test")
+
+    # Simulate high access on id2
+    path2 = root / "hot" / f"{id2}.md"
+    text = path2.read_text()
+    text = text.replace("access_count: 1", "access_count: 50")
+    path2.write_text(text)
+
+    from palaia.entry import parse_entry
+
+    meta2, body2 = parse_entry(path2.read_text())
+    meta1, body1 = parse_entry((root / "hot" / f"{id1}.md").read_text())
+
+    score1 = store.gc_score_entry(meta1, body1)
+    score2 = store.gc_score_entry(meta2, body2)
+
+    # High access entry should have higher GC score
+    assert score2 > score1

--- a/tests/test_process_runner.py
+++ b/tests/test_process_runner.py
@@ -1,0 +1,188 @@
+"""Tests for process runner (Issue #72)."""
+
+from palaia.process_runner import ProcessRun, ProcessRunManager, parse_steps
+
+
+class TestParseSteps:
+    def test_numbered_list(self):
+        content = """1. First step
+2. Second step
+3. Third step"""
+        steps = parse_steps(content)
+        assert len(steps) == 3
+        assert steps[0]["text"] == "First step"
+        assert steps[0]["index"] == 0
+        assert steps[0]["done"] is False
+        assert steps[2]["text"] == "Third step"
+
+    def test_numbered_list_with_parens(self):
+        content = """1) Step A
+2) Step B"""
+        steps = parse_steps(content)
+        assert len(steps) == 2
+        assert steps[0]["text"] == "Step A"
+
+    def test_checkboxes_unchecked(self):
+        content = """- [ ] Do this
+- [ ] Do that
+- [ ] Do the other"""
+        steps = parse_steps(content)
+        assert len(steps) == 3
+        assert all(not s["done"] for s in steps)
+
+    def test_checkboxes_mixed(self):
+        content = """- [x] Already done
+- [ ] Not yet
+- [X] Also done"""
+        steps = parse_steps(content)
+        assert len(steps) == 3
+        assert steps[0]["done"] is True
+        assert steps[1]["done"] is False
+        assert steps[2]["done"] is True
+
+    def test_empty_content(self):
+        assert parse_steps("") == []
+
+    def test_no_steps_in_content(self):
+        content = "This is just a paragraph with no steps."
+        steps = parse_steps(content)
+        assert steps == []
+
+    def test_mixed_content(self):
+        content = """# My Process
+
+Some intro text.
+
+1. Step one
+2. Step two
+
+Some more text.
+
+3. Step three"""
+        steps = parse_steps(content)
+        assert len(steps) == 3
+
+    def test_steps_with_blank_lines(self):
+        content = """1. First
+
+2. Second
+
+3. Third"""
+        steps = parse_steps(content)
+        assert len(steps) == 3
+
+
+class TestProcessRun:
+    def test_create(self):
+        steps = [
+            {"index": 0, "text": "Step 1", "done": False, "done_at": None},
+            {"index": 1, "text": "Step 2", "done": False, "done_at": None},
+        ]
+        run = ProcessRun(entry_id="test-123", steps=steps)
+        assert run.completed is False
+        assert run.progress_summary() == "0/2 steps completed"
+
+    def test_mark_done(self):
+        steps = [
+            {"index": 0, "text": "Step 1", "done": False, "done_at": None},
+            {"index": 1, "text": "Step 2", "done": False, "done_at": None},
+        ]
+        run = ProcessRun(entry_id="test-123", steps=steps)
+        assert run.mark_done(0) is True
+        assert run.steps[0]["done"] is True
+        assert run.steps[0]["done_at"] is not None
+        assert run.completed is False
+
+    def test_mark_all_done_completes(self):
+        steps = [
+            {"index": 0, "text": "Step 1", "done": False, "done_at": None},
+        ]
+        run = ProcessRun(entry_id="test-123", steps=steps)
+        run.mark_done(0)
+        assert run.completed is True
+
+    def test_mark_invalid_step(self):
+        run = ProcessRun(entry_id="test-123", steps=[])
+        assert run.mark_done(0) is False
+        assert run.mark_done(-1) is False
+
+    def test_serialization_roundtrip(self):
+        steps = [
+            {"index": 0, "text": "Step 1", "done": True, "done_at": "2025-01-01T00:00:00+00:00"},
+            {"index": 1, "text": "Step 2", "done": False, "done_at": None},
+        ]
+        original = ProcessRun(entry_id="abc-123", steps=steps, started_at="2025-01-01T00:00:00+00:00")
+        data = original.to_dict()
+        restored = ProcessRun.from_dict(data)
+        assert restored.entry_id == "abc-123"
+        assert len(restored.steps) == 2
+        assert restored.steps[0]["done"] is True
+
+
+class TestProcessRunManager:
+    def test_start_and_get(self, tmp_path):
+        root = tmp_path / ".palaia"
+        root.mkdir()
+        prm = ProcessRunManager(root)
+
+        run = prm.start("entry-1", "1. First\n2. Second")
+        assert len(run.steps) == 2
+
+        loaded = prm.get("entry-1")
+        assert loaded is not None
+        assert len(loaded.steps) == 2
+
+    def test_start_idempotent(self, tmp_path):
+        root = tmp_path / ".palaia"
+        root.mkdir()
+        prm = ProcessRunManager(root)
+
+        run1 = prm.start("entry-1", "1. First\n2. Second")
+        run1.mark_done(0)
+        prm.save(run1)
+
+        run2 = prm.start("entry-1", "1. First\n2. Second")
+        assert run2.steps[0]["done"] is True  # Preserves state
+
+    def test_list_runs(self, tmp_path):
+        root = tmp_path / ".palaia"
+        root.mkdir()
+        prm = ProcessRunManager(root)
+
+        prm.start("entry-1", "1. A\n2. B")
+        prm.start("entry-2", "1. C\n2. D")
+
+        runs = prm.list_runs()
+        assert len(runs) == 2
+
+    def test_delete(self, tmp_path):
+        root = tmp_path / ".palaia"
+        root.mkdir()
+        prm = ProcessRunManager(root)
+
+        prm.start("entry-1", "1. A")
+        assert prm.delete("entry-1") is True
+        assert prm.get("entry-1") is None
+        assert prm.delete("entry-1") is False
+
+    def test_get_nonexistent(self, tmp_path):
+        root = tmp_path / ".palaia"
+        root.mkdir()
+        prm = ProcessRunManager(root)
+        assert prm.get("nonexistent") is None
+
+    def test_persistence(self, tmp_path):
+        root = tmp_path / ".palaia"
+        root.mkdir()
+        prm = ProcessRunManager(root)
+
+        run = prm.start("entry-1", "1. Step A\n2. Step B")
+        run.mark_done(0)
+        prm.save(run)
+
+        # Create new manager instance (simulates restart)
+        prm2 = ProcessRunManager(root)
+        loaded = prm2.get("entry-1")
+        assert loaded is not None
+        assert loaded.steps[0]["done"] is True
+        assert loaded.steps[1]["done"] is False

--- a/tests/test_significance.py
+++ b/tests/test_significance.py
@@ -1,0 +1,93 @@
+"""Tests for significance tagging (Issue #70)."""
+
+from palaia.significance import SIGNIFICANCE_TAGS, detect_significance, significance_weight
+
+
+class TestDetectSignificance:
+    def test_empty_text(self):
+        assert detect_significance("") == []
+        assert detect_significance("   ") == []
+
+    def test_decision_english(self):
+        tags = detect_significance("We decided to use PostgreSQL for the main database.")
+        assert "decision" in tags
+
+    def test_decision_german(self):
+        tags = detect_significance("Wir haben uns entschieden, Redis zu nutzen.")
+        assert "decision" in tags
+
+    def test_lesson_english(self):
+        tags = detect_significance("Key lesson learned: always test with production data.")
+        assert "lesson" in tags
+
+    def test_lesson_german(self):
+        tags = detect_significance("Erkenntnis: Nie ohne Backup deployen.")
+        assert "lesson" in tags
+
+    def test_surprise(self):
+        tags = detect_significance("Surprising result: the old algorithm was 2x faster.")
+        assert "surprise" in tags
+
+    def test_commitment(self):
+        tags = detect_significance("I promised to deliver the report by Friday deadline.")
+        assert "commitment" in tags
+
+    def test_correction(self):
+        tags = detect_significance("Correction: the API endpoint was wrong, corrected now.")
+        assert "correction" in tags
+
+    def test_preference(self):
+        tags = detect_significance("I prefer dark mode for all coding environments.")
+        assert "preference" in tags
+
+    def test_fact(self):
+        tags = detect_significance("The API key for production is stored in vault.")
+        assert "fact" in tags
+
+    def test_multiple_categories(self):
+        text = "We decided to switch. Lesson learned: test first. This was unexpected."
+        tags = detect_significance(text)
+        assert "decision" in tags
+        assert "lesson" in tags
+        assert "surprise" in tags
+
+    def test_no_match(self):
+        tags = detect_significance("The weather is nice today.")
+        assert tags == []
+
+    def test_adr_detected_as_decision(self):
+        tags = detect_significance("ADR-005: Use event sourcing for audit trail.")
+        assert "decision" in tags
+
+    def test_case_insensitive(self):
+        tags = detect_significance("DECIDED to go with option B")
+        assert "decision" in tags
+
+
+class TestSignificanceWeight:
+    def test_no_tags(self):
+        assert significance_weight(None) == 1.0
+        assert significance_weight([]) == 1.0
+
+    def test_no_significance_tags(self):
+        assert significance_weight(["python", "backend"]) == 1.0
+
+    def test_one_significance_tag(self):
+        assert significance_weight(["decision"]) == 1.2
+
+    def test_two_significance_tags(self):
+        assert significance_weight(["decision", "lesson"]) == 1.4
+
+    def test_mixed_tags(self):
+        # Only significance tags count
+        assert significance_weight(["python", "decision", "backend", "lesson"]) == 1.4
+
+    def test_all_significance_tags(self):
+        expected = 1.0 + 0.2 * len(SIGNIFICANCE_TAGS)
+        assert significance_weight(list(SIGNIFICANCE_TAGS)) == expected
+
+
+class TestSignificanceTags:
+    def test_all_expected_tags_present(self):
+        expected = {"decision", "lesson", "surprise", "commitment", "correction", "preference", "fact"}
+        assert set(SIGNIFICANCE_TAGS) == expected


### PR DESCRIPTION
## Phase 2: Intelligence Edge

Implements the Palaia 2.0 Intelligence Edge — four interconnected features that make memory smarter.

### Issue #33: Retrieval-Hit Decay
- Updated decay formula: `final_score = time_decay * (1 + log(1 + access_count))`
- Entries with high hit-rate decay slower and survive GC longer
- access_count=0 → factor 1.0, access_count=10 → ~3.4, access_count=100 → ~5.6

### Issue #70: Significance Tagging
- 7 significance tags: decision, lesson, surprise, commitment, correction, preference, fact
- `detect_significance()` heuristic with EN/DE keyword + pattern matching
- Auto-detection in write command (suggestions when no explicit tags)
- GC integration: `significance_weight = 1.0 + 0.2 * len(significance_tags)`

### Issue #71: Bounded Memory + Intelligent GC
- Config: `max_entries_per_tier`, `max_total_chars`, `gc_type_weights`
- Holistic GC score: `decay_score * hit_rate_bonus * significance_weight * type_weight`
- `palaia gc --dry-run`: preview scored candidates without modifying
- `palaia gc --budget`: prune lowest-scored entries to meet limits
- `palaia status`: shows budget usage when configured

### Issue #72: Process Runner
- `palaia process run <id>`: execute process entries step-by-step
- `palaia process run <id> --step N --done`: mark steps complete
- `palaia process list`: show all active process runs
- Supports numbered lists and markdown checkboxes
- State persisted in `.palaia/process-runs/`

### Version
- Bumped to **2.0.0**

### Tests
- 60 new tests (736 total, all green)
- ruff check + format clean