### PR TITLE
feat: Phase 4 — Knowledge OS (#73, #74, #38)

### DIFF
--- a/palaia/cli.py
+++ b/palaia/cli.py
@@ -44,6 +44,7 @@ from palaia.config import (  # noqa: E402
 from palaia.doctor import apply_fixes, format_doctor_report, run_doctor  # noqa: E402
 from palaia.ingest import DocumentIngestor, format_rag_output  # noqa: E402
 from palaia.migrate import format_result, migrate  # noqa: E402
+from palaia.packages import PackageManager  # noqa: E402
 from palaia.project import ProjectManager  # noqa: E402
 from palaia.search import SearchEngine  # noqa: E402
 from palaia.store import Store  # noqa: E402
@@ -116,6 +117,7 @@ GATED_COMMANDS = frozenset(
         "status",
         "project",
         "process",
+        "package",
         "lock",
         "unlock",
         "setup",
@@ -1034,6 +1036,9 @@ def cmd_query(args):
         priority=getattr(args, "priority", None),
         assignee=getattr(args, "assignee", None),
         instance=getattr(args, "instance", None),
+        before=getattr(args, "before", None),
+        after=getattr(args, "after", None),
+        cross_project=getattr(args, "cross_project", False),
     )
 
     # --- Adaptive Nudging for query (Issue #68) ---
@@ -1325,7 +1330,8 @@ def cmd_list(args):
     assignee_filter = getattr(args, "assignee", None)
     instance_filter = getattr(args, "instance", None)
 
-    if project_filter:
+    cross_project = getattr(args, "cross_project", False)
+    if project_filter and not cross_project:
         entries_with_tier = [(m, b, t) for m, b, t in entries_with_tier if m.get("project") == project_filter]
     if tag_filters:
         # AND logic: entry must have ALL specified tags
@@ -1346,6 +1352,17 @@ def cmd_list(args):
         entries_with_tier = [(m, b, t) for m, b, t in entries_with_tier if m.get("assignee") == assignee_filter]
     if instance_filter:
         entries_with_tier = [(m, b, t) for m, b, t in entries_with_tier if m.get("instance") == instance_filter]
+
+    # Temporal filters (Issue #74)
+    before_filter = getattr(args, "before", None)
+    after_filter = getattr(args, "after", None)
+    if before_filter:
+        entries_with_tier = [(m, b, t) for m, b, t in entries_with_tier if m.get("created", "") < before_filter]
+    if after_filter:
+        entries_with_tier = [(m, b, t) for m, b, t in entries_with_tier if m.get("created", "") > after_filter]
+
+    # Cross-project: if set, don't filter by project (Issue #38)
+    # (project_filter is already applied above, but cross_project skips it via argparse logic)
 
     if _json_out(
         {
@@ -2981,6 +2998,72 @@ def cmd_process(args):
         return 1
 
 
+def cmd_package(args):
+    """Manage knowledge packages (Issue #73)."""
+    root = get_root()
+    store = Store(root)
+    store.recover()
+
+    action = args.package_action
+
+    if action == "export":
+        pm_pkg = PackageManager(store)
+        types_filter = None
+        if getattr(args, "types", None):
+            types_filter = [t.strip() for t in args.types.split(",")]
+        result = pm_pkg.export_package(
+            project=args.project,
+            output_path=getattr(args, "output", None),
+            include_types=types_filter,
+        )
+        if _json_out(result, args):
+            return 0
+        print(f"Exported {result['entry_count']} entries from project '{result['project']}'")
+        print(f"  Package: {result['path']}")
+        return 0
+
+    elif action == "import":
+        pm_pkg = PackageManager(store)
+        result = pm_pkg.import_package(
+            input_path=args.file,
+            target_project=getattr(args, "project", None),
+            merge_strategy=getattr(args, "merge", "skip"),
+        )
+        if _json_out(result, args):
+            return 0
+        print(f"Imported {result['imported']} entries into project '{result['project']}'")
+        if result["skipped"]:
+            print(f"  Skipped (duplicates): {result['skipped']}")
+        if result.get("overwritten"):
+            print(f"  Overwritten: {result['overwritten']}")
+        return 0
+
+    elif action == "info":
+        pm_pkg = PackageManager(store)
+        try:
+            info = pm_pkg.package_info(args.file)
+        except (FileNotFoundError, ValueError) as e:
+            if _json_out({"error": str(e)}, args):
+                return 1
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+        if _json_out(info, args):
+            return 0
+        print(f"Package: {args.file}")
+        print(f"  Format: v{info['palaia_package']}")
+        print(f"  Palaia version: {info['palaia_version']}")
+        print(f"  Project: {info['project']}")
+        print(f"  Exported: {info['exported_at']}")
+        print(f"  Entries: {info['entry_count']}")
+        if info.get("type_breakdown"):
+            types_str = ", ".join(f"{v} {k}" for k, v in info["type_breakdown"].items())
+            print(f"  Types: {types_str}")
+        return 0
+
+    print("Unknown package action. Use: export, import, info", file=sys.stderr)
+    return 1
+
+
 def cmd_skill(args):
     """Print the embedded SKILL.md documentation."""
     skill_path = Path(__file__).parent / "SKILL.md"
@@ -3091,6 +3174,11 @@ def main():
     )
     p_query.add_argument("--assignee", default=None, help="Filter by assignee")
     p_query.add_argument("--instance", default=None, help="Filter by session identity")
+    p_query.add_argument("--before", default=None, help="Only entries created before this ISO timestamp")
+    p_query.add_argument("--after", default=None, help="Only entries created after this ISO timestamp")
+    p_query.add_argument(
+        "--cross-project", action="store_true", dest="cross_project", help="Search across all projects"
+    )
     p_query.add_argument("--rag", action="store_true", help="Output as RAG context block")
     p_query.add_argument("--json", action="store_true", help="Output as JSON")
 
@@ -3136,6 +3224,9 @@ def main():
     )
     p_list.add_argument("--assignee", default=None, help="Filter by assignee")
     p_list.add_argument("--instance", default=None, help="Filter by session identity")
+    p_list.add_argument("--before", default=None, help="Only entries created before this ISO timestamp")
+    p_list.add_argument("--after", default=None, help="Only entries created after this ISO timestamp")
+    p_list.add_argument("--cross-project", action="store_true", dest="cross_project", help="List across all projects")
     p_list.add_argument("--json", action="store_true", help="Output as JSON")
 
     # status
@@ -3339,6 +3430,26 @@ def main():
     p_proc_list = process_sub.add_parser("list", help="List active process runs")
     p_proc_list.add_argument("--json", action="store_true", help="Output as JSON")
 
+    # package (Issue #73)
+    p_package = sub.add_parser("package", help="Export/import knowledge packages")
+    package_sub = p_package.add_subparsers(dest="package_action")
+
+    p_pkg_export = package_sub.add_parser("export", help="Export project knowledge as package")
+    p_pkg_export.add_argument("project", help="Project name to export")
+    p_pkg_export.add_argument("--output", default=None, help="Output file path")
+    p_pkg_export.add_argument("--types", default=None, help="Comma-separated entry types to include")
+    p_pkg_export.add_argument("--json", action="store_true", help="Output as JSON")
+
+    p_pkg_import = package_sub.add_parser("import", help="Import knowledge package")
+    p_pkg_import.add_argument("file", help="Package file path")
+    p_pkg_import.add_argument("--project", default=None, help="Override target project")
+    p_pkg_import.add_argument("--merge", default="skip", choices=["skip", "overwrite", "append"], help="Merge strategy")
+    p_pkg_import.add_argument("--json", action="store_true", help="Output as JSON")
+
+    p_pkg_info = package_sub.add_parser("info", help="Show package metadata")
+    p_pkg_info.add_argument("file", help="Package file path")
+    p_pkg_info.add_argument("--json", action="store_true", help="Output as JSON")
+
     # skill
     p_skill = sub.add_parser("skill", help="Print the SKILL.md agent documentation")
     p_skill.add_argument("--json", action="store_true", help="Output as JSON")
@@ -3388,6 +3499,7 @@ def main():
         "warmup": cmd_warmup,
         "project": cmd_project,
         "process": cmd_process,
+        "package": cmd_package,
         "memo": cmd_memo,
         "lock": cmd_lock,
         "unlock": cmd_unlock,

--- a/palaia/packages.py
+++ b/palaia/packages.py
@@ -1,0 +1,210 @@
+"""Knowledge Packages — export/import project knowledge (Issue #73)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from palaia import __version__
+from palaia.entry import content_hash
+from palaia.store import Store
+
+PACKAGE_FORMAT_VERSION = "1.0"
+PACKAGE_EXTENSION = ".palaia-pkg.json"
+
+
+class PackageManager:
+    """Export and import knowledge packages for projects."""
+
+    def __init__(self, store: Store):
+        self.store = store
+
+    def export_package(
+        self,
+        project: str,
+        output_path: str | None = None,
+        include_types: list[str] | None = None,
+    ) -> dict:
+        """Export all entries of a project as a knowledge package.
+
+        Args:
+            project: Project name to export.
+            output_path: Output file path. Defaults to <project>.palaia-pkg.json.
+            include_types: Optional list of entry types to include (e.g. ["memory", "process"]).
+
+        Returns:
+            Package metadata dict with keys: path, entry_count, project.
+        """
+        # Collect entries for this project across all tiers
+        all_entries = self.store.all_entries(include_cold=True)
+        project_entries = [(meta, body, tier) for meta, body, tier in all_entries if meta.get("project") == project]
+
+        # Filter by type if requested
+        if include_types:
+            project_entries = [
+                (meta, body, tier)
+                for meta, body, tier in project_entries
+                if meta.get("type", "memory") in include_types
+            ]
+
+        # Build entries array
+        entries = []
+        for meta, body, _tier in project_entries:
+            entry_data: dict = {"content": body}
+            # Copy relevant metadata
+            for key in ("type", "tags", "scope", "title", "created", "significance_tags"):
+                if key in meta and meta[key]:
+                    entry_data[key] = meta[key]
+            # Ensure type is always present
+            if "type" not in entry_data:
+                entry_data["type"] = "memory"
+            entries.append(entry_data)
+
+        # Build package
+        package = {
+            "palaia_package": PACKAGE_FORMAT_VERSION,
+            "palaia_version": __version__,
+            "project": project,
+            "exported_at": datetime.now(timezone.utc).isoformat(),
+            "entry_count": len(entries),
+            "entries": entries,
+        }
+
+        # Write to file
+        if output_path is None:
+            output_path = f"{project}{PACKAGE_EXTENSION}"
+        out = Path(output_path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(package, ensure_ascii=False, indent=2), encoding="utf-8")
+
+        return {
+            "path": str(out),
+            "entry_count": len(entries),
+            "project": project,
+        }
+
+    def import_package(
+        self,
+        input_path: str,
+        target_project: str | None = None,
+        merge_strategy: str = "skip",
+    ) -> dict:
+        """Import entries from a knowledge package.
+
+        Args:
+            input_path: Path to the .palaia-pkg.json file.
+            target_project: Override project name (default: use package's project).
+            merge_strategy: "skip" (skip duplicates), "overwrite" (overwrite duplicates),
+                          "append" (always create new entries).
+
+        Returns:
+            Import stats dict.
+        """
+        if merge_strategy not in ("skip", "overwrite", "append"):
+            raise ValueError(f"Invalid merge strategy: {merge_strategy}. Use: skip, overwrite, append")
+
+        pkg_path = Path(input_path)
+        if not pkg_path.exists():
+            raise FileNotFoundError(f"Package file not found: {input_path}")
+
+        package = json.loads(pkg_path.read_text(encoding="utf-8"))
+
+        if "palaia_package" not in package:
+            raise ValueError(f"Not a valid Palaia package: {input_path}")
+
+        project = target_project or package.get("project", "imported")
+        entries = package.get("entries", [])
+
+        # Build a set of existing content hashes for dedup
+        existing_hashes: dict[str, str] = {}  # hash -> entry_id
+        if merge_strategy in ("skip", "overwrite"):
+            all_entries = self.store.all_entries(include_cold=True)
+            for meta, body, _tier in all_entries:
+                if meta.get("project") == project:
+                    h = meta.get("content_hash") or content_hash(body)
+                    existing_hashes[h] = meta.get("id", "")
+
+        imported = 0
+        skipped = 0
+        overwritten = 0
+
+        for entry_data in entries:
+            content = entry_data.get("content", "")
+            if not content or not content.strip():
+                skipped += 1
+                continue
+
+            h = content_hash(content)
+
+            if h in existing_hashes:
+                if merge_strategy == "skip":
+                    skipped += 1
+                    continue
+                elif merge_strategy == "overwrite":
+                    # Delete existing entry, then write new one
+                    existing_id = existing_hashes[h]
+                    if existing_id:
+                        path = self.store._find_entry(existing_id)
+                        if path:
+                            rel = str(path.relative_to(self.store.root))
+                            self.store.delete_raw(rel)
+                    overwritten += 1
+                # append: fall through to write
+
+            # Write the entry
+            tags = entry_data.get("tags")
+            entry_type = entry_data.get("type")
+            scope = entry_data.get("scope")
+            title = entry_data.get("title")
+
+            self.store.write(
+                body=content,
+                scope=scope,
+                tags=tags,
+                title=title,
+                project=project,
+                entry_type=entry_type,
+            )
+            imported += 1
+
+        return {
+            "imported": imported,
+            "skipped": skipped,
+            "overwritten": overwritten,
+            "project": project,
+            "total_in_package": len(entries),
+        }
+
+    def package_info(self, input_path: str) -> dict:
+        """Show package metadata without importing.
+
+        Args:
+            input_path: Path to the .palaia-pkg.json file.
+
+        Returns:
+            Package metadata dict.
+        """
+        pkg_path = Path(input_path)
+        if not pkg_path.exists():
+            raise FileNotFoundError(f"Package file not found: {input_path}")
+
+        package = json.loads(pkg_path.read_text(encoding="utf-8"))
+
+        if "palaia_package" not in package:
+            raise ValueError(f"Not a valid Palaia package: {input_path}")
+
+        # Type breakdown
+        type_counts: dict[str, int] = {}
+        for entry in package.get("entries", []):
+            t = entry.get("type", "memory")
+            type_counts[t] = type_counts.get(t, 0) + 1
+
+        return {
+            "palaia_package": package.get("palaia_package"),
+            "palaia_version": package.get("palaia_version"),
+            "project": package.get("project"),
+            "exported_at": package.get("exported_at"),
+            "entry_count": package.get("entry_count", 0),
+            "type_breakdown": type_counts,
+        }

--- a/palaia/search.py
+++ b/palaia/search.py
@@ -172,16 +172,22 @@ class SearchEngine:
         priority: str | None = None,
         assignee: str | None = None,
         instance: str | None = None,
+        before: str | None = None,
+        after: str | None = None,
+        cross_project: bool = False,
     ) -> list[dict]:
         """Search memories using hybrid ranking (BM25 + embeddings when available).
 
         Structured filters (type, status, priority, assignee, instance) use exact match,
         not embeddings.
+
+        Temporal filters (before, after) filter by entry created timestamp.
+        cross_project=True ignores project filter and searches across all projects.
         """
         docs_with_meta = self.build_index(include_cold=include_cold, agent=agent)
 
         # Apply structured filters (exact match, pre-BM25)
-        if project:
+        if project and not cross_project:
             docs_with_meta = [(did, text, meta) for did, text, meta in docs_with_meta if meta.get("project") == project]
         if entry_type:
             docs_with_meta = [
@@ -202,7 +208,17 @@ class SearchEngine:
                 (did, text, meta) for did, text, meta in docs_with_meta if meta.get("instance") == instance
             ]
 
-        if project or entry_type or status or priority or assignee or instance:
+        # Temporal filters (Issue #74)
+        if before:
+            docs_with_meta = [
+                (did, text, meta) for did, text, meta in docs_with_meta if meta.get("created", "") < before
+            ]
+        if after:
+            docs_with_meta = [
+                (did, text, meta) for did, text, meta in docs_with_meta if meta.get("created", "") > after
+            ]
+
+        if project or entry_type or status or priority or assignee or instance or before or after:
             # Rebuild BM25 index with filtered docs
             self.bm25.index([(did, text) for did, text, meta in docs_with_meta])
 
@@ -292,6 +308,8 @@ class SearchEngine:
                     result_entry["due_date"] = meta["due_date"]
                 if meta.get("instance"):
                     result_entry["instance"] = meta["instance"]
+                if meta.get("project"):
+                    result_entry["project"] = meta["project"]
                 output.append(result_entry)
         return output
 

--- a/tests/test_cross_project.py
+++ b/tests/test_cross_project.py
@@ -1,0 +1,113 @@
+"""Tests for Cross-Project Queries (Issue #38)."""
+
+from __future__ import annotations
+
+import pytest
+
+from palaia.config import DEFAULT_CONFIG, save_config
+from palaia.search import SearchEngine
+from palaia.store import Store
+
+
+@pytest.fixture
+def palaia_root(tmp_path):
+    root = tmp_path / ".palaia"
+    root.mkdir()
+    for d in ("hot", "warm", "cold", "wal", "index"):
+        (root / d).mkdir()
+    config = dict(DEFAULT_CONFIG)
+    config["store_version"] = "2.0.0"
+    save_config(root, config)
+    return root
+
+
+@pytest.fixture
+def store(palaia_root):
+    return Store(palaia_root)
+
+
+@pytest.fixture
+def multi_project_store(store):
+    """Store with entries across multiple projects."""
+    id1 = store.write(
+        "Deploy to production using Docker", project="frontend", tags=["deployment"], title="Frontend Deploy"
+    )
+    id2 = store.write(
+        "Deploy backend services via Kubernetes", project="backend", tags=["deployment"], title="Backend Deploy"
+    )
+    id3 = store.write("Database migration strategy", project="backend", tags=["database"], title="DB Migration")
+    id4 = store.write(
+        "General deployment checklist",
+        project="ops",
+        tags=["deployment", "checklist"],
+        entry_type="process",
+        title="Deploy Checklist",
+    )
+    return store, [id1, id2, id3, id4]
+
+
+class TestCrossProjectSearch:
+    def test_cross_project_finds_all(self, multi_project_store):
+        store, ids = multi_project_store
+        engine = SearchEngine(store)
+        results = engine.search("deployment", cross_project=True)
+
+        result_ids = [r["id"] for r in results]
+        # Should find entries from frontend, backend, and ops
+        assert ids[0] in result_ids  # frontend
+        assert ids[1] in result_ids  # backend
+        assert ids[3] in result_ids  # ops
+
+    def test_cross_project_includes_project_field(self, multi_project_store):
+        store, ids = multi_project_store
+        engine = SearchEngine(store)
+        results = engine.search("deployment", cross_project=True)
+
+        projects_found = {r.get("project") for r in results if r.get("project")}
+        assert "frontend" in projects_found
+        assert "backend" in projects_found
+        assert "ops" in projects_found
+
+    def test_normal_search_respects_project(self, multi_project_store):
+        store, ids = multi_project_store
+        engine = SearchEngine(store)
+        results = engine.search("deployment", project="frontend")
+
+        result_ids = [r["id"] for r in results]
+        assert ids[0] in result_ids
+        assert ids[1] not in result_ids  # backend only
+        assert ids[3] not in result_ids  # ops only
+
+    def test_cross_project_ignores_project_filter(self, multi_project_store):
+        store, ids = multi_project_store
+        engine = SearchEngine(store)
+        # Even with project="frontend", cross_project=True should search everywhere
+        results = engine.search("deployment", project="frontend", cross_project=True)
+
+        result_ids = [r["id"] for r in results]
+        assert ids[0] in result_ids
+        assert ids[1] in result_ids
+        assert ids[3] in result_ids
+
+    def test_cross_project_with_type_filter(self, multi_project_store):
+        store, ids = multi_project_store
+        engine = SearchEngine(store)
+        results = engine.search("deployment", cross_project=True, entry_type="process")
+
+        result_ids = [r["id"] for r in results]
+        # Only the process entry should match
+        assert ids[3] in result_ids
+        assert ids[0] not in result_ids
+        assert ids[1] not in result_ids
+
+    def test_cross_project_no_entries_without_project(self, palaia_root):
+        """Entries without a project are still found in cross-project search."""
+        store = Store(palaia_root)
+        store.write("orphan entry about deployment", title="Orphan")
+        store.write("project entry about deployment", project="proj1", title="Proj1")
+
+        engine = SearchEngine(store)
+        results = engine.search("deployment", cross_project=True)
+        titles = [r["title"] for r in results]
+        assert "Orphan" in titles
+        assert "Proj1" in titles

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -1,0 +1,192 @@
+"""Tests for Knowledge Packages — export/import (Issue #73)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from palaia.config import DEFAULT_CONFIG, save_config
+from palaia.packages import PackageManager
+from palaia.store import Store
+
+
+@pytest.fixture
+def palaia_root(tmp_path):
+    root = tmp_path / ".palaia"
+    root.mkdir()
+    for d in ("hot", "warm", "cold", "wal", "index"):
+        (root / d).mkdir()
+    config = dict(DEFAULT_CONFIG)
+    config["store_version"] = "2.0.0"
+    save_config(root, config)
+    return root
+
+
+@pytest.fixture
+def store(palaia_root):
+    return Store(palaia_root)
+
+
+@pytest.fixture
+def populated_store(store):
+    """Store with entries in two projects."""
+    store.write(
+        "Architecture decision: use PostgreSQL",
+        project="alpha",
+        tags=["decision"],
+        entry_type="memory",
+        title="DB Choice",
+    )
+    store.write(
+        "Deploy via Docker Compose", project="alpha", tags=["deployment"], entry_type="process", title="Deploy Process"
+    )
+    store.write("Fix login bug", project="alpha", entry_type="task", title="Login Bug")
+    store.write("Beta project note", project="beta", entry_type="memory", title="Beta Note")
+    return store
+
+
+class TestExportPackage:
+    def test_export_all_entries(self, populated_store, tmp_path):
+        pm = PackageManager(populated_store)
+        out = str(tmp_path / "alpha.palaia-pkg.json")
+        result = pm.export_package("alpha", output_path=out)
+
+        assert result["entry_count"] == 3
+        assert result["project"] == "alpha"
+
+        pkg = json.loads((tmp_path / "alpha.palaia-pkg.json").read_text())
+        assert pkg["palaia_package"] == "1.0"
+        assert pkg["entry_count"] == 3
+        assert pkg["project"] == "alpha"
+        assert len(pkg["entries"]) == 3
+
+    def test_export_filtered_by_type(self, populated_store, tmp_path):
+        pm = PackageManager(populated_store)
+        out = str(tmp_path / "alpha-mem.palaia-pkg.json")
+        result = pm.export_package("alpha", output_path=out, include_types=["memory"])
+
+        assert result["entry_count"] == 1
+        pkg = json.loads((tmp_path / "alpha-mem.palaia-pkg.json").read_text())
+        assert all(e["type"] == "memory" for e in pkg["entries"])
+
+    def test_export_default_filename(self, populated_store):
+        pm = PackageManager(populated_store)
+        result = pm.export_package("alpha")
+        assert result["path"] == "alpha.palaia-pkg.json"
+        import os
+
+        os.unlink("alpha.palaia-pkg.json")  # cleanup
+
+    def test_export_empty_project(self, populated_store, tmp_path):
+        pm = PackageManager(populated_store)
+        out = str(tmp_path / "empty.palaia-pkg.json")
+        result = pm.export_package("nonexistent", output_path=out)
+        assert result["entry_count"] == 0
+
+    def test_entry_format(self, populated_store, tmp_path):
+        pm = PackageManager(populated_store)
+        out = str(tmp_path / "alpha.palaia-pkg.json")
+        pm.export_package("alpha", output_path=out)
+        pkg = json.loads((tmp_path / "alpha.palaia-pkg.json").read_text())
+
+        for entry in pkg["entries"]:
+            assert "content" in entry
+            assert "type" in entry
+            assert entry["content"].strip()  # non-empty
+
+
+class TestImportPackage:
+    def test_import_roundtrip(self, populated_store, tmp_path):
+        pm = PackageManager(populated_store)
+        out = str(tmp_path / "alpha.palaia-pkg.json")
+        pm.export_package("alpha", output_path=out)
+
+        # Import into a new project
+        result = pm.import_package(out, target_project="alpha-copy", merge_strategy="append")
+        assert result["imported"] == 3
+        assert result["project"] == "alpha-copy"
+
+    def test_import_skip_duplicates(self, populated_store, tmp_path):
+        pm = PackageManager(populated_store)
+        out = str(tmp_path / "alpha.palaia-pkg.json")
+        pm.export_package("alpha", output_path=out)
+
+        # Import into same project — should skip all (same content)
+        result = pm.import_package(out, target_project="alpha", merge_strategy="skip")
+        assert result["skipped"] == 3
+        assert result["imported"] == 0
+
+    def test_import_overwrite(self, populated_store, tmp_path):
+        pm = PackageManager(populated_store)
+        out = str(tmp_path / "alpha.palaia-pkg.json")
+        pm.export_package("alpha", output_path=out)
+
+        # Import with overwrite into same project
+        result = pm.import_package(out, target_project="alpha", merge_strategy="overwrite")
+        assert result["overwritten"] == 3
+
+    def test_import_append_always(self, populated_store, tmp_path):
+        pm = PackageManager(populated_store)
+        out = str(tmp_path / "alpha.palaia-pkg.json")
+        pm.export_package("alpha", output_path=out)
+
+        # Append creates duplicates
+        result = pm.import_package(out, target_project="alpha", merge_strategy="append")
+        assert result["imported"] == 3
+
+    def test_import_uses_package_project(self, populated_store, tmp_path):
+        pm = PackageManager(populated_store)
+        out = str(tmp_path / "alpha.palaia-pkg.json")
+        pm.export_package("alpha", output_path=out)
+
+        result = pm.import_package(out, merge_strategy="append")
+        assert result["project"] == "alpha"
+
+    def test_import_invalid_merge_strategy(self, populated_store, tmp_path):
+        pm = PackageManager(populated_store)
+        out = str(tmp_path / "alpha.palaia-pkg.json")
+        pm.export_package("alpha", output_path=out)
+
+        with pytest.raises(ValueError, match="Invalid merge strategy"):
+            pm.import_package(out, merge_strategy="invalid")
+
+    def test_import_file_not_found(self, populated_store):
+        pm = PackageManager(populated_store)
+        with pytest.raises(FileNotFoundError):
+            pm.import_package("/nonexistent/file.json")
+
+    def test_import_invalid_package(self, populated_store, tmp_path):
+        bad_file = tmp_path / "bad.json"
+        bad_file.write_text('{"not": "a package"}')
+        pm = PackageManager(populated_store)
+        with pytest.raises(ValueError, match="Not a valid Palaia package"):
+            pm.import_package(str(bad_file))
+
+
+class TestPackageInfo:
+    def test_info_shows_metadata(self, populated_store, tmp_path):
+        pm = PackageManager(populated_store)
+        out = str(tmp_path / "alpha.palaia-pkg.json")
+        pm.export_package("alpha", output_path=out)
+
+        info = pm.package_info(out)
+        assert info["palaia_package"] == "1.0"
+        assert info["project"] == "alpha"
+        assert info["entry_count"] == 3
+        assert "exported_at" in info
+        assert info["type_breakdown"]["memory"] == 1
+        assert info["type_breakdown"]["process"] == 1
+        assert info["type_breakdown"]["task"] == 1
+
+    def test_info_file_not_found(self, populated_store):
+        pm = PackageManager(populated_store)
+        with pytest.raises(FileNotFoundError):
+            pm.package_info("/nonexistent/file.json")
+
+    def test_info_invalid_package(self, populated_store, tmp_path):
+        bad_file = tmp_path / "bad.json"
+        bad_file.write_text('{"hello": "world"}')
+        pm = PackageManager(populated_store)
+        with pytest.raises(ValueError):
+            pm.package_info(str(bad_file))

--- a/tests/test_temporal_queries.py
+++ b/tests/test_temporal_queries.py
@@ -1,0 +1,110 @@
+"""Tests for Temporal Queries — point-in-time snapshots (Issue #74)."""
+
+from __future__ import annotations
+
+import pytest
+
+from palaia.config import DEFAULT_CONFIG, save_config
+from palaia.entry import parse_entry, serialize_entry
+from palaia.search import SearchEngine
+from palaia.store import Store
+
+
+@pytest.fixture
+def palaia_root(tmp_path):
+    root = tmp_path / ".palaia"
+    root.mkdir()
+    for d in ("hot", "warm", "cold", "wal", "index"):
+        (root / d).mkdir()
+    config = dict(DEFAULT_CONFIG)
+    config["store_version"] = "2.0.0"
+    save_config(root, config)
+    return root
+
+
+@pytest.fixture
+def store(palaia_root):
+    return Store(palaia_root)
+
+
+def _backdate_entry(store, entry_id, iso_timestamp):
+    """Helper: change the created timestamp of an entry."""
+    path = store._find_entry(entry_id)
+    text = path.read_text(encoding="utf-8")
+    meta, body = parse_entry(text)
+    meta["created"] = iso_timestamp
+    path.write_text(serialize_entry(meta, body), encoding="utf-8")
+
+
+@pytest.fixture
+def temporal_store(store):
+    """Store with entries at different timestamps."""
+    id1 = store.write("Early architecture decision", tags=["architecture"], title="Early Decision")
+    _backdate_entry(store, id1, "2026-01-15T10:00:00+00:00")
+
+    id2 = store.write("Mid-project update", tags=["update"], title="Mid Update")
+    _backdate_entry(store, id2, "2026-02-15T10:00:00+00:00")
+
+    id3 = store.write("Late deployment plan", tags=["deployment"], title="Late Plan")
+    _backdate_entry(store, id3, "2026-03-15T10:00:00+00:00")
+
+    return store, [id1, id2, id3]
+
+
+class TestTemporalSearch:
+    def test_before_filter(self, temporal_store):
+        store, ids = temporal_store
+        engine = SearchEngine(store)
+        results = engine.search("decision update plan", before="2026-02-01")
+        # Only the Jan entry should match
+        result_ids = [r["id"] for r in results]
+        assert ids[0] in result_ids
+        assert ids[1] not in result_ids
+        assert ids[2] not in result_ids
+
+    def test_after_filter(self, temporal_store):
+        store, ids = temporal_store
+        engine = SearchEngine(store)
+        results = engine.search("decision update plan", after="2026-03-01")
+        result_ids = [r["id"] for r in results]
+        assert ids[2] in result_ids
+        assert ids[0] not in result_ids
+        assert ids[1] not in result_ids
+
+    def test_time_window(self, temporal_store):
+        store, ids = temporal_store
+        engine = SearchEngine(store)
+        results = engine.search("decision update plan", after="2026-02-01", before="2026-03-01")
+        result_ids = [r["id"] for r in results]
+        assert ids[1] in result_ids
+        assert ids[0] not in result_ids
+        assert ids[2] not in result_ids
+
+    def test_no_results_in_window(self, temporal_store):
+        store, ids = temporal_store
+        engine = SearchEngine(store)
+        results = engine.search("decision update plan", after="2026-04-01")
+        assert len(results) == 0
+
+    def test_future_before(self, temporal_store):
+        store, ids = temporal_store
+        engine = SearchEngine(store)
+        results = engine.search("decision update plan", before="2027-01-01")
+        # All entries should match
+        assert len(results) == 3
+
+    def test_exact_boundary_excluded(self, temporal_store):
+        store, ids = temporal_store
+        engine = SearchEngine(store)
+        # before is exclusive (< not <=)
+        results = engine.search("Early Decision", before="2026-01-15T10:00:00+00:00")
+        result_ids = [r["id"] for r in results]
+        assert ids[0] not in result_ids
+
+    def test_after_boundary_excluded(self, temporal_store):
+        store, ids = temporal_store
+        engine = SearchEngine(store)
+        # after is exclusive (> not >=)
+        results = engine.search("Late Plan", after="2026-03-15T10:00:00+00:00")
+        result_ids = [r["id"] for r in results]
+        assert ids[2] not in result_ids


### PR DESCRIPTION
## Phase 4: Knowledge OS

### Knowledge Packages (#73)
- `palaia/packages.py`: PackageManager class with export/import/info
- CLI: `palaia package export|import|info`
- Format: `.palaia-pkg.json` with metadata + entries array
- Merge strategies: skip, overwrite, append
- Duplikat-Erkennung via content_hash
- 19 tests

### Temporal Queries (#74)
- `--before` and `--after` ISO-timestamp filters for `palaia query` and `palaia list`
- Filters by entry `created` timestamp
- Combinable for time windows
- 7 tests

### Cross-Project Queries (#38)
- `--cross-project` flag for `palaia query` and `palaia list`
- Ignores project filter, searches across ALL projects
- Results include `project` field for attribution
- 6 tests

All 773 tests green (744 existing + 29 new). ruff clean.