### PR TITLE
fix: Audit consistency — metadata, tools, docs, doctor (#81-#85)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: palaia
-version: "1.9.0"
+version: "2.0.0"
 description: >
   Local, crash-safe persistent memory for OpenClaw agents.
   Replaces built-in memory-core with semantic search, projects, and scope-based access control.
@@ -419,6 +419,157 @@ The config change requires a gateway restart to take effect.
 - `memory_search` and `memory_get` tools now search the Palaia store instead of MEMORY.md files
 - MEMORY.md and workspace files continue to be loaded as project context (unchanged)
 - All Palaia features (projects, scopes, tiering, semantic search) are available through the standard memory tools
+
+## Auto-Capture and Capture Hints
+
+### How Auto-Capture Works
+
+Auto-capture runs automatically after every agent turn (when `autoCapture: true`, which is the default). It:
+
+1. Collects all messages from the completed exchange
+2. Filters out trivial exchanges (short, system content, acknowledgments)
+3. Uses LLM-based extraction to identify significant knowledge: decisions, lessons, processes, commitments, preferences
+4. Writes extracted items to Palaia with appropriate type, tags, scope, and project attribution
+5. Falls back to rule-based extraction if LLM is unavailable
+
+**Agent attribution:** If `PALAIA_AGENT` is set in the environment, all auto-captured entries are attributed to that agent via `--agent`. Otherwise, the CLI uses the configured default.
+
+**Project detection:** Auto-capture passes the list of known projects to the LLM, which assigns entries to the most relevant project (or none if unclear).
+
+**Scope detection:** The LLM also determines scope per item: `private` (personal preference), `team` (shared knowledge), or `public` (documentation).
+
+### When to Use Manual Write vs Auto-Capture
+
+**Auto-capture replaces routine captures.** It runs automatically — you don't need to explicitly save every decision or learning. It handles the 80% case.
+
+**Manual `palaia write` remains valuable for:**
+- Conscious decisions (ADRs): `palaia write "We decided..." --type memory --tags decision`
+- Processes and checklists: `palaia write "Deploy steps: 1. ... 2. ..." --type process`
+- Deliberate knowledge structuring with explicit tags and scopes
+- Entries that MUST belong to a specific project/scope (auto-capture may misassign)
+
+### Capture Hints
+
+When you want to guide auto-capture without writing manually, use `<palaia-hint />` tags in your message:
+
+```
+<palaia-hint project="myapp" scope="private" />
+```
+
+Hints are parsed from all messages in the exchange and used as overrides:
+- **Priority:** Hint > LLM detection > Config override > Default
+- **Attributes:** `project`, `scope`, `type`, `tags` (comma-separated)
+- **Stripping:** Hints are automatically removed from outgoing messages — the user never sees them
+
+Multiple hints are supported (e.g., for different projects in the same turn):
+```
+<palaia-hint project="frontend" scope="team" tags="decision" />
+<palaia-hint project="backend" type="process" />
+```
+
+### Static Config Overrides
+
+For setups where every entry should go to the same project/scope, set in plugin config:
+- `captureScope`: Static scope override (e.g., `"team"`)
+- `captureProject`: Static project override (e.g., `"myapp"`)
+
+These override LLM detection but are overridden by capture hints.
+
+## Knowledge Packages
+
+Export and import project knowledge as portable package files.
+
+```bash
+# Export all entries from a project
+palaia package export <project> [--output file.palaia-pkg.json] [--types memory,process]
+
+# Import a knowledge package
+palaia package import <file> [--project target] [--merge skip|overwrite|append] [--agent name]
+
+# View package metadata without importing
+palaia package info <file>
+```
+
+The `--agent` flag on import attributes all imported entries to a specific agent name.
+
+## Process Runner
+
+Run stored process entries as interactive checklists:
+
+```bash
+# List all stored processes
+palaia process list [--project NAME]
+
+# Run a process interactively
+palaia process run <id>
+```
+
+## Temporal Queries
+
+Filter entries by time with `--before` and `--after`:
+
+```bash
+palaia query "deploy" --after 2026-03-01 --before 2026-03-15
+palaia list --after 2026-03-01
+```
+
+Dates are in ISO format (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS).
+
+## Cross-Project Search
+
+Search across all projects at once:
+
+```bash
+palaia query "authentication" --cross-project
+```
+
+Without `--cross-project`, queries only search entries in the active project context.
+
+## Bounded Memory and Garbage Collection
+
+Palaia supports budgeted garbage collection to keep the store lean:
+
+```bash
+# Preview what would be collected
+palaia gc --dry-run
+
+# Collect with a target budget (max entries to keep)
+palaia gc --budget 200
+
+# Aggressive collection — also clears COLD tier
+palaia gc --aggressive
+```
+
+GC rotates entries through tiers: HOT (active, <7 days) -> WARM (recent, <30 days) -> COLD (archived).
+
+## Significance Tagging
+
+Auto-capture automatically detects and tags entries with significance markers:
+
+| Tag | Meaning | Example |
+|-----|---------|---------|
+| `decision` | A choice was made | "We decided to use PostgreSQL" |
+| `lesson` | Something was learned | "I learned that caching needs invalidation on deploy" |
+| `surprise` | Unexpected discovery | "The API returns 200 even on errors" |
+| `commitment` | Promise or action item | "I will refactor auth by Friday" |
+| `correction` | Error was corrected | "Actually, the limit is 100, not 50" |
+| `preference` | User/agent preference | "I prefer tabs over spaces" |
+| `fact` | Important factual information | "The prod DB is on port 5433" |
+
+These tags enable targeted queries: `palaia query "decisions" --tags decision`
+
+## Adaptive Nudging
+
+Palaia includes a graduation system that adapts to agent behavior:
+
+**What it does:** When the agent writes an entry that relates to an existing process, Palaia nudges: "Related process found: [title]. Consider following it."
+
+**How it learns:** The nudging system tracks whether agents follow stored processes. Over time:
+- Agents that consistently follow processes see fewer nudges (graduated)
+- Agents that frequently skip processes continue to receive nudges
+- New processes always trigger nudges until a pattern is established
+
+**Important:** SKILL.md documentation is the primary source for agent behavior. Nudging is the safety net for when agents don't read the docs — not a replacement for good documentation.
 
 ## Commands Reference
 

--- a/packages/openclaw-plugin/src/config.ts
+++ b/packages/openclaw-plugin/src/config.ts
@@ -37,6 +37,12 @@ export interface PalaiaPluginConfig {
   /** Minimum significance score for LLM-extracted items (0.0-1.0, default: 0.3) */
   captureMinSignificance: number;
 
+  // ── Metadata Overrides (Issue #81) ─────────────────────────
+  /** Static scope override for auto-capture (default: undefined → LLM detection) */
+  captureScope?: string;
+  /** Static project override for auto-capture (default: undefined → LLM detection) */
+  captureProject?: string;
+
   // ── Query-based Recall (Issue #65) ───────────────────────────
   /** Recall mode: "list" (context-independent) or "query" (context-relevant) */
   recallMode: "list" | "query";

--- a/packages/openclaw-plugin/src/hooks.ts
+++ b/packages/openclaw-plugin/src/hooks.ts
@@ -15,6 +15,95 @@ import { run, runJson, recover, type RunnerOpts } from "./runner.js";
 import type { PalaiaPluginConfig, RecallTypeWeights } from "./config.js";
 
 // ============================================================================
+// Capture Hints (Issue #81)
+// ============================================================================
+
+/** Parsed palaia-hint tag attributes */
+export interface PalaiaHint {
+  project?: string;
+  scope?: string;
+  type?: string;
+  tags?: string[];
+}
+
+/**
+ * Parse `<palaia-hint ... />` tags from text.
+ * Returns extracted hints and cleaned text with hints removed.
+ */
+export function parsePalaiaHints(text: string): { hints: PalaiaHint[]; cleanedText: string } {
+  const hints: PalaiaHint[] = [];
+  const regex = /<palaia-hint\s+([^/]*)\s*\/>/gi;
+
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(text)) !== null) {
+    const attrs = match[1];
+    const hint: PalaiaHint = {};
+
+    const projectMatch = attrs.match(/project\s*=\s*"([^"]*)"/i);
+    if (projectMatch) hint.project = projectMatch[1];
+
+    const scopeMatch = attrs.match(/scope\s*=\s*"([^"]*)"/i);
+    if (scopeMatch) hint.scope = scopeMatch[1];
+
+    const typeMatch = attrs.match(/type\s*=\s*"([^"]*)"/i);
+    if (typeMatch) hint.type = typeMatch[1];
+
+    const tagsMatch = attrs.match(/tags\s*=\s*"([^"]*)"/i);
+    if (tagsMatch) hint.tags = tagsMatch[1].split(",").map((t) => t.trim()).filter(Boolean);
+
+    hints.push(hint);
+  }
+
+  const cleanedText = text.replace(/<palaia-hint\s+[^/]*\s*\/>/gi, "").trim();
+  return { hints, cleanedText };
+}
+
+// ============================================================================
+// Project Cache (Issue #81)
+// ============================================================================
+
+interface CachedProject {
+  name: string;
+  description?: string;
+}
+
+let _cachedProjects: CachedProject[] | null = null;
+let _projectCacheTime = 0;
+const PROJECT_CACHE_TTL_MS = 60_000; // 1 minute
+
+/** Reset project cache (for testing). */
+export function resetProjectCache(): void {
+  _cachedProjects = null;
+  _projectCacheTime = 0;
+}
+
+/**
+ * Load known projects from CLI, with caching.
+ */
+async function loadProjects(opts: import("./runner.js").RunnerOpts): Promise<CachedProject[]> {
+  const now = Date.now();
+  if (_cachedProjects && (now - _projectCacheTime) < PROJECT_CACHE_TTL_MS) {
+    return _cachedProjects;
+  }
+
+  try {
+    const result = await runJson<{ projects: Array<{ name: string; description?: string }> }>(
+      ["project", "list"],
+      opts,
+    );
+    _cachedProjects = (result.projects || []).map((p) => ({
+      name: p.name,
+      description: p.description,
+    }));
+    _projectCacheTime = now;
+    return _cachedProjects;
+  } catch {
+    // Non-fatal: return empty if project list fails
+    return _cachedProjects || [];
+  }
+}
+
+// ============================================================================
 // Types
 // ============================================================================
 
@@ -49,6 +138,8 @@ export interface ExtractionResult {
   type: "memory" | "process" | "task";
   tags: string[];
   significance: number;
+  project?: string | null;
+  scope?: string | null;
 }
 
 type RunEmbeddedPiAgentFn = (params: Record<string, unknown>) => Promise<unknown>;
@@ -97,17 +188,30 @@ export function resetEmbeddedPiAgentLoader(): void {
   _embeddedPiAgentLoader = null;
 }
 
-const EXTRACTION_SYSTEM_PROMPT = `You are a knowledge extraction engine. Analyze the following conversation exchange and identify information worth remembering long-term.
+const EXTRACTION_SYSTEM_PROMPT_BASE = `You are a knowledge extraction engine. Analyze the following conversation exchange and identify information worth remembering long-term.
 
 For each piece of knowledge, return a JSON array of objects:
 - "content": concise summary of the knowledge (1-3 sentences)
 - "type": "memory" (facts, decisions, preferences), "process" (workflows, procedures, steps), or "task" (action items, todos, commitments)
 - "tags": array of significance tags from: ["decision", "lesson", "surprise", "commitment", "correction", "preference", "fact"]
 - "significance": 0.0-1.0 how important this is for long-term recall
+- "project": which project this belongs to (from known projects list, or null if unclear)
+- "scope": "private" (personal preference, agent-specific), "team" (shared knowledge), or "public" (documentation)
 
 Only extract genuinely significant knowledge. Skip small talk, acknowledgments, routine exchanges.
 Return empty array [] if nothing is worth remembering.
 Return ONLY valid JSON, no markdown fences.`;
+
+/**
+ * Build the full extraction prompt, including known projects if available.
+ */
+function buildExtractionPrompt(projects: CachedProject[]): string {
+  if (projects.length === 0) return EXTRACTION_SYSTEM_PROMPT_BASE;
+  const projectList = projects
+    .map((p) => `${p.name}${p.description ? ` (${p.description})` : ""}`)
+    .join(", ");
+  return `${EXTRACTION_SYSTEM_PROMPT_BASE}\n\nKnown projects: ${projectList}`;
+}
 
 /** Known cheap models per provider */
 const CHEAP_MODELS: Record<string, string> = {
@@ -190,6 +294,7 @@ export async function extractWithLLM(
   messages: unknown[],
   config: any,
   pluginConfig?: { captureModel?: string },
+  knownProjects?: CachedProject[],
 ): Promise<ExtractionResult[]> {
   const runEmbeddedPiAgent = await getEmbeddedPiAgent();
 
@@ -209,7 +314,8 @@ export async function extractWithLLM(
     return [];
   }
 
-  const prompt = `${EXTRACTION_SYSTEM_PROMPT}\n\n--- CONVERSATION ---\n${exchangeText}\n--- END ---`;
+  const systemPrompt = buildExtractionPrompt(knownProjects || []);
+  const prompt = `${systemPrompt}\n\n--- CONVERSATION ---\n${exchangeText}\n--- END ---`;
 
   let tmpDir: string | null = null;
   try {
@@ -268,7 +374,16 @@ export async function extractWithLLM(
         ? Math.max(0, Math.min(1, item.significance))
         : 0.5;
 
-      results.push({ content, type, tags, significance });
+      const project = typeof item.project === "string" && item.project.trim()
+        ? item.project.trim()
+        : null;
+
+      const validScopes = new Set(["private", "team", "public"]);
+      const scope = typeof item.scope === "string" && validScopes.has(item.scope)
+        ? item.scope
+        : null;
+
+      results.push({ content, type, tags, significance, project, scope });
     }
 
     return results;
@@ -578,9 +693,23 @@ export function registerHooks(api: any, config: PalaiaPluginConfig): void {
     });
   }
 
-  // ── agent_end (Issue #64: Auto-Capture) ────────────────────────
+  // ── message_sending (Issue #81: Strip capture hints) ─────────
+  // Removes <palaia-hint ... /> tags from outgoing messages so they
+  // don't appear in the final output sent to the user.
+  api.on("message_sending", (_event: any, _ctx: any) => {
+    const content = _event?.content;
+    if (typeof content !== "string") return;
+
+    const { hints, cleanedText } = parsePalaiaHints(content);
+    if (hints.length > 0 && cleanedText !== content) {
+      return { content: cleanedText };
+    }
+  });
+
+  // ── agent_end (Issue #64 + #81: Auto-Capture with Metadata) ───
   // Analyzes completed exchanges and captures significant content via palaia CLI.
   // Strategy: LLM-based extraction first, rule-based fallback if LLM unavailable.
+  // Issue #81 adds: agent attribution, project/scope detection, capture hints.
   if (config.autoCapture) {
     api.on("agent_end", async (event: any, _ctx: any) => {
       if (!event.success || !event.messages || event.messages.length === 0) {
@@ -588,17 +717,29 @@ export function registerHooks(api: any, config: PalaiaPluginConfig): void {
       }
 
       try {
+        // Resolve agent name from environment
+        const agentName = process.env.PALAIA_AGENT || undefined;
+
         const allTexts = extractMessageTexts(event.messages);
 
         // Check minimum turns requirement
         const userTurns = allTexts.filter((t) => t.role === "user").length;
         if (userTurns < config.captureMinTurns) return;
 
+        // ── Parse capture hints from all messages (Issue #81) ────
+        const collectedHints: PalaiaHint[] = [];
+        for (const t of allTexts) {
+          const { hints } = parsePalaiaHints(t.text);
+          collectedHints.push(...hints);
+        }
+
         // Build exchange text from user + assistant messages
         const exchangeParts: string[] = [];
         for (const t of allTexts) {
           if (t.role === "user" || t.role === "assistant") {
-            exchangeParts.push(`[${t.role}]: ${t.text}`);
+            // Strip hints from exchange text for LLM analysis
+            const { cleanedText } = parsePalaiaHints(t.text);
+            exchangeParts.push(`[${t.role}]: ${cleanedText}`);
           }
         }
         const exchangeText = exchangeParts.join("\n");
@@ -606,25 +747,68 @@ export function registerHooks(api: any, config: PalaiaPluginConfig): void {
         // Pre-filter: skip trivial exchanges (fast, free)
         if (!shouldAttemptCapture(exchangeText)) return;
 
+        // Load known projects for LLM context
+        const knownProjects = await loadProjects(opts);
+
+        // Helper: build CLI args with metadata (agent, project, scope)
+        const buildWriteArgs = (
+          content: string,
+          type: string,
+          tags: string[],
+          itemProject?: string | null,
+          itemScope?: string | null,
+        ): string[] => {
+          const args: string[] = [
+            "write",
+            content,
+            "--type", type,
+            "--tags", tags.join(",") || "auto-capture",
+          ];
+
+          // Scope priority: config override > hint > LLM > "team" default
+          const scope = config.captureScope || itemScope || "team";
+          args.push("--scope", scope);
+
+          // Project priority: config override > hint > LLM
+          const project = config.captureProject || itemProject;
+          if (project) {
+            args.push("--project", project);
+          }
+
+          // Agent attribution from env
+          if (agentName) {
+            args.push("--agent", agentName);
+          }
+
+          return args;
+        };
+
         // ── LLM-based extraction (primary) ───────────────────────
         let llmHandled = false;
         try {
           const results = await extractWithLLM(event.messages, api.config, {
             captureModel: config.captureModel,
-          });
+          }, knownProjects);
 
           for (const r of results) {
             if (r.significance >= config.captureMinSignificance) {
-              const args: string[] = [
-                "write",
+              // Apply hint overrides: hints take priority over LLM results
+              const hintForProject = collectedHints.find((h) => h.project);
+              const hintForScope = collectedHints.find((h) => h.scope);
+
+              const effectiveProject = hintForProject?.project || r.project;
+              const effectiveScope = hintForScope?.scope || r.scope;
+
+              const args = buildWriteArgs(
                 r.content,
-                "--type", r.type,
-                "--tags", r.tags.join(",") || "auto-capture",
-                "--scope", "team",
-              ];
+                r.type,
+                r.tags,
+                effectiveProject,
+                effectiveScope,
+              );
               await run(args, opts);
               console.log(
-                `[palaia] LLM auto-captured: type=${r.type}, significance=${r.significance}, tags=${r.tags.join(",")}`
+                `[palaia] LLM auto-captured: type=${r.type}, significance=${r.significance}, tags=${r.tags.join(",")}, project=${effectiveProject || "none"}, scope=${effectiveScope || "team"}`
               );
             }
           }
@@ -652,13 +836,17 @@ export function registerHooks(api: any, config: PalaiaPluginConfig): void {
             captureData = { tags: ["auto-capture"], type: "memory", summary };
           }
 
-          const args: string[] = [
-            "write",
+          // Hint overrides for fallback (no LLM project detection)
+          const hintForProject = collectedHints.find((h) => h.project);
+          const hintForScope = collectedHints.find((h) => h.scope);
+
+          const args = buildWriteArgs(
             captureData.summary,
-            "--type", captureData.type,
-            "--tags", captureData.tags.join(","),
-            "--scope", "team",
-          ];
+            captureData.type,
+            captureData.tags,
+            hintForProject?.project,
+            hintForScope?.scope,
+          );
 
           await run(args, opts);
           console.log(

--- a/packages/openclaw-plugin/src/tools.ts
+++ b/packages/openclaw-plugin/src/tools.ts
@@ -84,6 +84,11 @@ export function registerTools(api: any, config: PalaiaPluginConfig): void {
           description: "Filter by scope: private|team|shared:X|public",
         })
       ),
+      type: Type.Optional(
+        Type.String({
+          description: "Filter by entry type: memory|process|task",
+        })
+      ),
     }),
     async execute(
       _id: string,
@@ -92,6 +97,7 @@ export function registerTools(api: any, config: PalaiaPluginConfig): void {
         maxResults?: number;
         tier?: string;
         scope?: string;
+        type?: string;
       }
     ) {
       const limit = params.maxResults || config.maxResults || 5;
@@ -100,6 +106,11 @@ export function registerTools(api: any, config: PalaiaPluginConfig): void {
       // --all flag includes cold tier
       if (params.tier === "all" || config.tier === "all") {
         args.push("--all");
+      }
+
+      // Type filter (Issue #82)
+      if (params.type) {
+        args.push("--type", params.type);
       }
 
       const result = await runJson<QueryResult>(args, opts);
@@ -190,10 +201,32 @@ export function registerTools(api: any, config: PalaiaPluginConfig): void {
             description: "Tags for categorization",
           })
         ),
+        type: Type.Optional(
+          Type.String({
+            description: "Entry type: memory|process|task (default: memory)",
+          })
+        ),
+        project: Type.Optional(
+          Type.String({
+            description: "Project name to associate this entry with",
+          })
+        ),
+        title: Type.Optional(
+          Type.String({
+            description: "Title for the entry",
+          })
+        ),
       }),
       async execute(
         _id: string,
-        params: { content: string; scope?: string; tags?: string[] }
+        params: {
+          content: string;
+          scope?: string;
+          tags?: string[];
+          type?: string;
+          project?: string;
+          title?: string;
+        }
       ) {
         const args: string[] = ["write", params.content];
         if (params.scope) {
@@ -201,6 +234,15 @@ export function registerTools(api: any, config: PalaiaPluginConfig): void {
         }
         if (params.tags && params.tags.length > 0) {
           args.push("--tags", params.tags.join(","));
+        }
+        if (params.type) {
+          args.push("--type", params.type);
+        }
+        if (params.project) {
+          args.push("--project", params.project);
+        }
+        if (params.title) {
+          args.push("--title", params.title);
         }
 
         const result = await runJson<WriteResult>(args, opts);

--- a/packages/openclaw-plugin/tests/hooks.test.ts
+++ b/packages/openclaw-plugin/tests/hooks.test.ts
@@ -12,7 +12,10 @@ import {
   extractWithLLM,
   resolveCaptureModel,
   resetEmbeddedPiAgentLoader,
+  parsePalaiaHints,
+  resetProjectCache,
   type ExtractionResult,
+  type PalaiaHint,
 } from "../src/hooks.js";
 import { DEFAULT_RECALL_TYPE_WEIGHTS } from "../src/config.js";
 
@@ -468,5 +471,101 @@ describe("ExtractionResult validation", () => {
       significance: 0.5,
     };
     expect(result.tags).toHaveLength(7);
+  });
+});
+
+// ============================================================================
+// parsePalaiaHints (Issue #81)
+// ============================================================================
+
+describe("parsePalaiaHints", () => {
+  it("parses a single hint with all attributes", () => {
+    const text = 'Some text <palaia-hint project="myapp" scope="private" type="memory" tags="decision,adr" /> more text';
+    const { hints, cleanedText } = parsePalaiaHints(text);
+    expect(hints).toHaveLength(1);
+    expect(hints[0].project).toBe("myapp");
+    expect(hints[0].scope).toBe("private");
+    expect(hints[0].type).toBe("memory");
+    expect(hints[0].tags).toEqual(["decision", "adr"]);
+    expect(cleanedText).toBe("Some text  more text");
+  });
+
+  it("parses multiple hints", () => {
+    const text = '<palaia-hint project="a" /> text <palaia-hint project="b" scope="team" />';
+    const { hints, cleanedText } = parsePalaiaHints(text);
+    expect(hints).toHaveLength(2);
+    expect(hints[0].project).toBe("a");
+    expect(hints[1].project).toBe("b");
+    expect(hints[1].scope).toBe("team");
+    expect(cleanedText).toBe("text");
+  });
+
+  it("returns empty hints for text without hints", () => {
+    const text = "Just regular text without any hints.";
+    const { hints, cleanedText } = parsePalaiaHints(text);
+    expect(hints).toHaveLength(0);
+    expect(cleanedText).toBe(text);
+  });
+
+  it("handles partial attributes", () => {
+    const text = '<palaia-hint project="only-project" />';
+    const { hints } = parsePalaiaHints(text);
+    expect(hints).toHaveLength(1);
+    expect(hints[0].project).toBe("only-project");
+    expect(hints[0].scope).toBeUndefined();
+    expect(hints[0].type).toBeUndefined();
+    expect(hints[0].tags).toBeUndefined();
+  });
+
+  it("is case-insensitive for tag name", () => {
+    const text = '<PALAIA-HINT project="test" />';
+    const { hints } = parsePalaiaHints(text);
+    expect(hints).toHaveLength(1);
+    expect(hints[0].project).toBe("test");
+  });
+
+  it("strips hint from multiline text", () => {
+    const text = "Line 1\n<palaia-hint project=\"x\" />\nLine 3";
+    const { hints, cleanedText } = parsePalaiaHints(text);
+    expect(hints).toHaveLength(1);
+    expect(cleanedText).toBe("Line 1\n\nLine 3");
+  });
+
+  it("filters empty tags", () => {
+    const text = '<palaia-hint tags="a,,b, ,c" />';
+    const { hints } = parsePalaiaHints(text);
+    expect(hints[0].tags).toEqual(["a", "b", "c"]);
+  });
+});
+
+// ============================================================================
+// ExtractionResult with project/scope (Issue #81)
+// ============================================================================
+
+describe("ExtractionResult with metadata", () => {
+  it("supports project and scope fields", () => {
+    const result: ExtractionResult = {
+      content: "Test",
+      type: "memory",
+      tags: ["decision"],
+      significance: 0.8,
+      project: "myapp",
+      scope: "team",
+    };
+    expect(result.project).toBe("myapp");
+    expect(result.scope).toBe("team");
+  });
+
+  it("supports null project and scope", () => {
+    const result: ExtractionResult = {
+      content: "Test",
+      type: "memory",
+      tags: [],
+      significance: 0.5,
+      project: null,
+      scope: null,
+    };
+    expect(result.project).toBeNull();
+    expect(result.scope).toBeNull();
   });
 });

--- a/packages/openclaw-plugin/tests/tools.test.ts
+++ b/packages/openclaw-plugin/tests/tools.test.ts
@@ -206,5 +206,63 @@ describe("tools", () => {
         expect.any(Object)
       );
     });
+
+    it("passes --type, --project, --title params (Issue #82)", async () => {
+      mockRunJson.mockResolvedValueOnce({
+        id: "new-type-1",
+        tier: "hot",
+        scope: "team",
+        deduplicated: false,
+      });
+
+      const result = await api.tools["memory_write"].def.execute("call-82", {
+        content: "Deploy checklist",
+        type: "process",
+        project: "myapp",
+        title: "Deploy Steps",
+        scope: "team",
+        tags: ["deploy"],
+      });
+
+      expect(result.content[0].text).toContain("new-type-1");
+      expect(mockRunJson).toHaveBeenCalledWith(
+        [
+          "write", "Deploy checklist",
+          "--scope", "team",
+          "--tags", "deploy",
+          "--type", "process",
+          "--project", "myapp",
+          "--title", "Deploy Steps",
+        ],
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe("memory_search type filter (Issue #82)", () => {
+    it("passes --type filter when set", async () => {
+      mockRunJson.mockResolvedValueOnce({ results: [] });
+
+      await api.tools["memory_search"].def.execute("call-type-1", {
+        query: "tasks",
+        type: "task",
+      });
+
+      expect(mockRunJson).toHaveBeenCalledWith(
+        expect.arrayContaining(["--type", "task"]),
+        expect.any(Object)
+      );
+    });
+
+    it("omits --type when not set", async () => {
+      mockRunJson.mockResolvedValueOnce({ results: [] });
+
+      await api.tools["memory_search"].def.execute("call-type-2", {
+        query: "anything",
+      });
+
+      const callArgs = mockRunJson.mock.calls[0][0];
+      expect(callArgs).not.toContain("--type");
+    });
   });
 });

--- a/palaia/cli.py
+++ b/palaia/cli.py
@@ -3028,6 +3028,7 @@ def cmd_package(args):
             input_path=args.file,
             target_project=getattr(args, "project", None),
             merge_strategy=getattr(args, "merge", "skip"),
+            agent=getattr(args, "agent", None),
         )
         if _json_out(result, args):
             return 0
@@ -3444,6 +3445,7 @@ def main():
     p_pkg_import.add_argument("file", help="Package file path")
     p_pkg_import.add_argument("--project", default=None, help="Override target project")
     p_pkg_import.add_argument("--merge", default="skip", choices=["skip", "overwrite", "append"], help="Merge strategy")
+    p_pkg_import.add_argument("--agent", default=None, help="Agent name to attribute imported entries to")
     p_pkg_import.add_argument("--json", action="store_true", help="Output as JSON")
 
     p_pkg_info = package_sub.add_parser("info", help="Show package metadata")

--- a/palaia/doctor.py
+++ b/palaia/doctor.py
@@ -858,6 +858,15 @@ def _check_plugin_defaults_upgrade(palaia_root: Path | None) -> dict[str, Any]:
     # autoCapture: false → true (only if user has the old default)
     if plugin_config.get("autoCapture") is False:
         upgradeable.append("autoCapture: false → true")
+    # memoryInject: false → true (only if user has the old default)
+    if plugin_config.get("memoryInject") is False:
+        upgradeable.append("memoryInject: false → true")
+    # maxInjectedChars: 4000 → 8000 (only if user has the old default)
+    if plugin_config.get("maxInjectedChars") == 4000:
+        upgradeable.append("maxInjectedChars: 4000 → 8000")
+    # recallMode: list → query (only if user has the old default)
+    if plugin_config.get("recallMode") == "list":
+        upgradeable.append("recallMode: list → query")
 
     if not upgradeable:
         return {
@@ -867,15 +876,16 @@ def _check_plugin_defaults_upgrade(palaia_root: Path | None) -> dict[str, Any]:
             "message": "Plugin config is up to date",
         }
 
+    changes_summary = ", ".join(upgradeable)
     return {
         "name": "plugin_defaults_upgrade",
         "label": "Plugin defaults",
         "status": "warn",
-        "message": f"v1.x defaults detected: {', '.join(upgradeable)}",
+        "message": f"v1.x defaults detected: {changes_summary}",
         "fix": (
             "Palaia 2.0 has optimized defaults for zero-config UX.\n"
-            "  Run: palaia doctor --fix  to upgrade your config.\n"
-            "  Changes: autoCapture=true (was false)\n"
+            f"  Run: palaia doctor --fix  to upgrade your config.\n"
+            f"  Changes: {changes_summary}\n"
             "  Custom values you've set will NOT be touched."
         ),
         "fixable": True,
@@ -1090,6 +1100,15 @@ def apply_fixes(palaia_root: Path | None, results: list[dict[str, Any]]) -> list
             if plugin_config.get("autoCapture") is False:
                 plugin_config["autoCapture"] = True
                 upgraded.append("autoCapture: false → true")
+            if plugin_config.get("memoryInject") is False:
+                plugin_config["memoryInject"] = True
+                upgraded.append("memoryInject: false → true")
+            if plugin_config.get("maxInjectedChars") == 4000:
+                plugin_config["maxInjectedChars"] = 8000
+                upgraded.append("maxInjectedChars: 4000 → 8000")
+            if plugin_config.get("recallMode") == "list":
+                plugin_config["recallMode"] = "query"
+                upgraded.append("recallMode: list → query")
 
             if upgraded:
                 config["plugin_config"] = plugin_config

--- a/palaia/packages.py
+++ b/palaia/packages.py
@@ -89,6 +89,7 @@ class PackageManager:
         input_path: str,
         target_project: str | None = None,
         merge_strategy: str = "skip",
+        agent: str | None = None,
     ) -> dict:
         """Import entries from a knowledge package.
 
@@ -165,6 +166,7 @@ class PackageManager:
                 title=title,
                 project=project,
                 entry_type=entry_type,
+                agent=agent,
             )
             imported += 1
 

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -190,3 +190,64 @@ class TestPackageInfo:
         pm = PackageManager(populated_store)
         with pytest.raises(ValueError):
             pm.package_info(str(bad_file))
+
+
+class TestImportAgentAttribution:
+    """Tests for Issue #85: agent attribution on package import."""
+
+    def test_import_with_agent(self, store, tmp_path):
+        """Importing with --agent should attribute all entries to that agent."""
+        # Create a standalone package with unique content (avoids store-level dedup)
+        package = {
+            "palaia_package": "1.0",
+            "palaia_version": "2.0.0",
+            "project": "agent-test",
+            "exported_at": "2026-03-16",
+            "entry_count": 2,
+            "entries": [
+                {"content": "Unique entry for agent test one", "type": "memory", "tags": ["test"]},
+                {"content": "Unique entry for agent test two", "type": "process", "tags": ["test"]},
+            ],
+        }
+        pkg_file = tmp_path / "agent-test.palaia-pkg.json"
+        pkg_file.write_text(json.dumps(package))
+
+        pm = PackageManager(store)
+        result = pm.import_package(
+            str(pkg_file),
+            target_project="agent-test",
+            merge_strategy="append",
+            agent="Elliot",
+        )
+        assert result["imported"] == 2
+
+        # Verify entries have the agent set
+        all_entries = store.all_entries_unfiltered(include_cold=True)
+        agent_entries = [
+            meta for meta, body, tier in all_entries
+            if meta.get("project") == "agent-test" and meta.get("agent") == "Elliot"
+        ]
+        assert len(agent_entries) == 2
+
+    def test_import_without_agent(self, store, tmp_path):
+        """Importing without --agent should not set agent field."""
+        package = {
+            "palaia_package": "1.0",
+            "palaia_version": "2.0.0",
+            "project": "noagent-test",
+            "exported_at": "2026-03-16",
+            "entry_count": 1,
+            "entries": [
+                {"content": "Unique entry without agent attribution", "type": "memory"},
+            ],
+        }
+        pkg_file = tmp_path / "noagent-test.palaia-pkg.json"
+        pkg_file.write_text(json.dumps(package))
+
+        pm = PackageManager(store)
+        result = pm.import_package(
+            str(pkg_file),
+            target_project="noagent-test",
+            merge_strategy="append",
+        )
+        assert result["imported"] == 1

--- a/tests/test_plugin_defaults_upgrade.py
+++ b/tests/test_plugin_defaults_upgrade.py
@@ -268,7 +268,7 @@ class TestPluginDefaultsUpgradeFix:
         from palaia.doctor import _check_plugin_defaults_upgrade, apply_fixes
 
         results = [_check_plugin_defaults_upgrade(palaia_root)]
-        actions = apply_fixes(palaia_root, results)
+        apply_fixes(palaia_root, results)  # return value unused; just verify side effects
 
         updated = json.loads((palaia_root / "config.json").read_text())
         pc = updated["plugin_config"]

--- a/tests/test_plugin_defaults_upgrade.py
+++ b/tests/test_plugin_defaults_upgrade.py
@@ -89,6 +89,70 @@ class TestPluginDefaultsUpgradeCheck:
         result = _check_plugin_defaults_upgrade(None)
         assert result["status"] == "ok"
 
+    def test_memoryInject_false_detected(self, palaia_root):
+        """memoryInject=false → warn (v1.x default)."""
+        config = json.loads((palaia_root / "config.json").read_text())
+        config["plugin_config"] = {"memoryInject": False}
+        (palaia_root / "config.json").write_text(json.dumps(config))
+
+        from palaia.doctor import _check_plugin_defaults_upgrade
+
+        result = _check_plugin_defaults_upgrade(palaia_root)
+        assert result["status"] == "warn"
+        assert "memoryInject" in result["message"]
+
+    def test_maxInjectedChars_4000_detected(self, palaia_root):
+        """maxInjectedChars=4000 → warn (v1.x default)."""
+        config = json.loads((palaia_root / "config.json").read_text())
+        config["plugin_config"] = {"maxInjectedChars": 4000}
+        (palaia_root / "config.json").write_text(json.dumps(config))
+
+        from palaia.doctor import _check_plugin_defaults_upgrade
+
+        result = _check_plugin_defaults_upgrade(palaia_root)
+        assert result["status"] == "warn"
+        assert "maxInjectedChars" in result["message"]
+
+    def test_recallMode_list_detected(self, palaia_root):
+        """recallMode=list → warn (v1.x default)."""
+        config = json.loads((palaia_root / "config.json").read_text())
+        config["plugin_config"] = {"recallMode": "list"}
+        (palaia_root / "config.json").write_text(json.dumps(config))
+
+        from palaia.doctor import _check_plugin_defaults_upgrade
+
+        result = _check_plugin_defaults_upgrade(palaia_root)
+        assert result["status"] == "warn"
+        assert "recallMode" in result["message"]
+
+    def test_custom_maxInjectedChars_not_flagged(self, palaia_root):
+        """maxInjectedChars=6000 (custom) → not flagged."""
+        config = json.loads((palaia_root / "config.json").read_text())
+        config["plugin_config"] = {"maxInjectedChars": 6000}
+        (palaia_root / "config.json").write_text(json.dumps(config))
+
+        from palaia.doctor import _check_plugin_defaults_upgrade
+
+        result = _check_plugin_defaults_upgrade(palaia_root)
+        assert result["status"] == "ok"
+
+    def test_all_v1_defaults_detected(self, palaia_root):
+        """All v1.x defaults together → all flagged."""
+        config = json.loads((palaia_root / "config.json").read_text())
+        config["plugin_config"] = {
+            "autoCapture": False,
+            "memoryInject": False,
+            "maxInjectedChars": 4000,
+            "recallMode": "list",
+        }
+        (palaia_root / "config.json").write_text(json.dumps(config))
+
+        from palaia.doctor import _check_plugin_defaults_upgrade
+
+        result = _check_plugin_defaults_upgrade(palaia_root)
+        assert result["status"] == "warn"
+        assert len(result["details"]["upgradeable"]) == 4
+
 
 class TestPluginDefaultsUpgradeFix:
     """Test apply_fixes upgrades v1.x defaults correctly."""
@@ -166,3 +230,47 @@ class TestPluginDefaultsUpgradeFix:
         assert pc["autoCapture"] is True  # upgraded
         assert pc["captureFrequency"] == "every"  # preserved
         assert pc["captureMinTurns"] == 10  # preserved
+
+    def test_fix_upgrades_all_v1_defaults(self, palaia_root):
+        """--fix should upgrade all v1.x defaults: memoryInject, maxInjectedChars, recallMode."""
+        config = json.loads((palaia_root / "config.json").read_text())
+        config["plugin_config"] = {
+            "autoCapture": False,
+            "memoryInject": False,
+            "maxInjectedChars": 4000,
+            "recallMode": "list",
+        }
+        (palaia_root / "config.json").write_text(json.dumps(config))
+
+        from palaia.doctor import _check_plugin_defaults_upgrade, apply_fixes
+
+        results = [_check_plugin_defaults_upgrade(palaia_root)]
+        actions = apply_fixes(palaia_root, results)
+
+        assert any("v2.0" in a for a in actions)
+
+        updated = json.loads((palaia_root / "config.json").read_text())
+        pc = updated["plugin_config"]
+        assert pc["autoCapture"] is True
+        assert pc["memoryInject"] is True
+        assert pc["maxInjectedChars"] == 8000
+        assert pc["recallMode"] == "query"
+
+    def test_fix_preserves_custom_maxInjectedChars(self, palaia_root):
+        """--fix should NOT touch custom maxInjectedChars=6000."""
+        config = json.loads((palaia_root / "config.json").read_text())
+        config["plugin_config"] = {
+            "autoCapture": False,
+            "maxInjectedChars": 6000,  # custom → should NOT touch
+        }
+        (palaia_root / "config.json").write_text(json.dumps(config))
+
+        from palaia.doctor import _check_plugin_defaults_upgrade, apply_fixes
+
+        results = [_check_plugin_defaults_upgrade(palaia_root)]
+        actions = apply_fixes(palaia_root, results)
+
+        updated = json.loads((palaia_root / "config.json").read_text())
+        pc = updated["plugin_config"]
+        assert pc["autoCapture"] is True  # upgraded
+        assert pc["maxInjectedChars"] == 6000  # preserved (custom)


### PR DESCRIPTION
Fixes all critical and high audit findings before v2.0 release.

## Changes

### Issue #81: Auto-Capture Missing Metadata (CRITICAL)
- Agent attribution via `PALAIA_AGENT` env var
- LLM project/scope detection with cached project list
- `<palaia-hint />` tag parsing for capture overrides
- `message_sending` hook to strip hints from outgoing messages
- Config: `captureScope`, `captureProject` static overrides
- Rule-based fallback gets agent attribution

### Issue #82: memory_write/memory_search Tool Extensions
- `memory_write`: added `type`, `project`, `title` params
- `memory_search`: added `type` filter param

### Issue #83: SKILL.md v2.0
- Version bumped 1.9.0 → 2.0.0
- New sections: Auto-Capture & Hints, Knowledge Packages, Process Runner, Temporal Queries, Cross-Project Search, Bounded Memory & GC, Significance Tagging, Adaptive Nudging

### Issue #84: Doctor Upgrade Check
- Now checks: `memoryInject` (false→true), `maxInjectedChars` (4000→8000), `recallMode` (list→query)
- Only upgrades values matching OLD defaults (custom values preserved)

### Issue #85: Package Import Agent Attribution
- `import_package()` accepts `agent` parameter
- CLI: `palaia package import <file> --agent <name>`

## Tests
- 782 Python tests pass (was 773, +9 new)
- 71 TS tests pass (was 59, +12 new), 5 pre-existing failures unchanged
- ruff check + format clean