### PR TITLE
feat: UX Transparency — Footnotes, Capture Confirms, Satisfaction Nudge (#87)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -386,6 +386,8 @@ Find your npm global path with: `npm root -g`
 | `captureFrequency` | `"every"` or `"significant"` (default: `"significant"`) |
 | `captureMinTurns` | Minimum exchange turns before capture (default: 2) |
 | `captureModel` | Model override for LLM extraction (e.g. `"anthropic/claude-haiku-3"`, `"cheap"`) |
+| `showMemorySources` | Show memory source footnotes in responses (default: `true`) |
+| `showCaptureConfirm` | Show capture confirmations in responses (default: `true`) |
 | `recallMode` | `"list"` or `"query"` — how memories are retrieved (default: `"query"`) |
 
 > **Note (Issue #66):** Plugin config is currently **global** — all agents on the same OpenClaw
@@ -570,6 +572,43 @@ Palaia includes a graduation system that adapts to agent behavior:
 - New processes always trigger nudges until a pattern is established
 
 **Important:** SKILL.md documentation is the primary source for agent behavior. Nudging is the safety net for when agents don't read the docs — not a replacement for good documentation.
+
+## Transparency Features
+
+Palaia makes its memory operations visible to the user by default. Both features are enabled out of the box and can be toggled independently.
+
+### Memory Source Footnotes
+
+When Palaia injects memories into the agent context and the agent uses them in a response, a footnote is appended:
+
+```
+📎 Palaia: "PostgreSQL migration plan" (Mar 16), "Deploy process" (Mar 10)
+```
+
+This shows the user which memories influenced the response. Max 3 sources are shown, selected by keyword relevance between the memory title and the response text.
+
+**Disable:** `palaia config set showMemorySources false`
+**Re-enable:** `palaia config set showMemorySources true`
+
+### Capture Confirmations
+
+When Palaia auto-captures a significant exchange, a confirmation is shown:
+
+```
+💾 Saved: "Team decided to use PostgreSQL for the project due to JSON support"
+```
+
+This confirms that knowledge was stored and gives the user a preview of what was captured.
+
+**Disable:** `palaia config set showCaptureConfirm false`
+**Re-enable:** `palaia config set showCaptureConfirm true`
+
+### Satisfaction and Preference Nudges
+
+After sustained usage, Palaia nudges agents to check in with the user:
+
+1. **Satisfaction check** (after ~10 successful recalls): Ask the user if the memory system is working well. Suggest `palaia doctor` if there are issues.
+2. **Transparency preference** (after ~50 recalls or ~7 days): Ask the user whether they want to keep seeing footnotes and capture confirmations, or hide them. Both are one-shot nudges that won't repeat.
 
 ## Commands Reference
 

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -52,6 +52,16 @@
         "default": 2,
         "description": "Minimum exchange turns before capture is attempted"
       },
+      "showMemorySources": {
+        "type": "boolean",
+        "default": true,
+        "description": "Show memory source footnotes in agent responses"
+      },
+      "showCaptureConfirm": {
+        "type": "boolean",
+        "default": true,
+        "description": "Show capture confirmations in agent responses"
+      },
       "recallMode": {
         "type": "string",
         "enum": ["list", "query"],
@@ -90,6 +100,14 @@
     "autoCapture": {
       "label": "Auto-Capture",
       "description": "Automatically capture significant exchanges as memories (recommended: on)"
+    },
+    "showMemorySources": {
+      "label": "Memory Source Footnotes",
+      "description": "Show which memories were used in agent responses (recommended: on)"
+    },
+    "showCaptureConfirm": {
+      "label": "Capture Confirmations",
+      "description": "Show confirmation when exchanges are saved to memory (recommended: on)"
     },
     "recallMode": {
       "label": "Recall Mode",

--- a/packages/openclaw-plugin/src/config.ts
+++ b/packages/openclaw-plugin/src/config.ts
@@ -43,6 +43,12 @@ export interface PalaiaPluginConfig {
   /** Static project override for auto-capture (default: undefined → LLM detection) */
   captureProject?: string;
 
+  // ── Transparency Features (Issue #87) ────────────────────────
+  /** Show memory source footnotes in agent responses (default: true) */
+  showMemorySources: boolean;
+  /** Show capture confirmation in agent responses (default: true) */
+  showCaptureConfirm: boolean;
+
   // ── Query-based Recall (Issue #65) ───────────────────────────
   /** Recall mode: "list" (context-independent) or "query" (context-relevant) */
   recallMode: "list" | "query";
@@ -66,6 +72,8 @@ export const DEFAULT_CONFIG: PalaiaPluginConfig = {
   captureFrequency: "significant",
   captureMinTurns: 2,
   captureMinSignificance: 0.3,
+  showMemorySources: true,
+  showCaptureConfirm: true,
   recallMode: "query",
   recallTypeWeight: { ...DEFAULT_RECALL_TYPE_WEIGHTS },
 };

--- a/packages/openclaw-plugin/src/hooks.ts
+++ b/packages/openclaw-plugin/src/hooks.ts
@@ -15,6 +15,173 @@ import { run, runJson, recover, type RunnerOpts } from "./runner.js";
 import type { PalaiaPluginConfig, RecallTypeWeights } from "./config.js";
 
 // ============================================================================
+// Turn-level State (Issue #87: Transparency Features)
+// ============================================================================
+// Shared between hooks within one turn. Reset after use in message_sending.
+
+/** Entries injected by before_prompt_build for footnote attribution. */
+let _lastInjectedEntries: Array<{ title: string; date: string }> = [];
+
+/** Summaries of auto-captured content from agent_end for confirmation display. */
+let _lastCapturedSummaries: string[] = [];
+
+/** Reset turn state (for testing). */
+export function resetTurnState(): void {
+  _lastInjectedEntries = [];
+  _lastCapturedSummaries = [];
+}
+
+// ============================================================================
+// Plugin State Persistence (Issue #87: Recall counter for nudges)
+// ============================================================================
+
+interface PluginState {
+  successfulRecalls: number;
+  satisfactionNudged: boolean;
+  transparencyNudged: boolean;
+  firstRecallTimestamp: string | null;
+}
+
+const DEFAULT_PLUGIN_STATE: PluginState = {
+  successfulRecalls: 0,
+  satisfactionNudged: false,
+  transparencyNudged: false,
+  firstRecallTimestamp: null,
+};
+
+async function loadPluginState(workspace?: string): Promise<PluginState> {
+  const dir = workspace || process.cwd();
+  const statePath = path.join(dir, ".palaia", "plugin-state.json");
+  try {
+    const raw = await fs.readFile(statePath, "utf-8");
+    return { ...DEFAULT_PLUGIN_STATE, ...JSON.parse(raw) };
+  } catch {
+    return { ...DEFAULT_PLUGIN_STATE };
+  }
+}
+
+async function savePluginState(state: PluginState, workspace?: string): Promise<void> {
+  const dir = workspace || process.cwd();
+  const statePath = path.join(dir, ".palaia", "plugin-state.json");
+  try {
+    await fs.writeFile(statePath, JSON.stringify(state, null, 2));
+  } catch {
+    // Non-fatal
+  }
+}
+
+// ============================================================================
+// Footnote Helpers (Issue #87)
+// ============================================================================
+
+/**
+ * Format an ISO date string as a short date: "Mar 16", "Feb 10".
+ */
+export function formatShortDate(isoDate: string): string {
+  const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  try {
+    const d = new Date(isoDate);
+    if (isNaN(d.getTime())) return "";
+    return `${months[d.getMonth()]} ${d.getDate()}`;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Check if an injected entry is relevant to the response text.
+ * Simple keyword overlap: split title into words, check if >=2 words appear
+ * in the response (case-insensitive). Words shorter than 3 chars are skipped.
+ */
+export function isEntryRelevant(title: string, responseText: string): boolean {
+  const responseLower = responseText.toLowerCase();
+  const titleWords = title
+    .toLowerCase()
+    .split(/[\s\-_/]+/)
+    .filter((w) => w.length >= 3);
+  if (titleWords.length === 0) return false;
+  // For single-word titles, require that one word to match
+  const threshold = titleWords.length === 1 ? 1 : 2;
+  let matches = 0;
+  for (const word of titleWords) {
+    if (responseLower.includes(word)) {
+      matches++;
+      if (matches >= threshold) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Build a memory source footnote string from injected entries and response text.
+ * Returns null if no relevant entries found.
+ */
+export function buildFootnote(
+  entries: Array<{ title: string; date: string }>,
+  responseText: string,
+  maxEntries = 3,
+): string | null {
+  const relevant = entries.filter((e) => isEntryRelevant(e.title, responseText));
+  if (relevant.length === 0) return null;
+
+  const display = relevant.slice(0, maxEntries);
+  const parts = display.map((e) => {
+    const dateStr = formatShortDate(e.date);
+    return dateStr ? `"${e.title}" (${dateStr})` : `"${e.title}"`;
+  });
+  return `\n\n📎 Palaia: ${parts.join(", ")}`;
+}
+
+// ============================================================================
+// Satisfaction / Transparency Nudge Helpers (Issue #87)
+// ============================================================================
+
+const SATISFACTION_THRESHOLD = 10;
+const TRANSPARENCY_RECALL_THRESHOLD = 50;
+const TRANSPARENCY_DAYS_THRESHOLD = 7;
+
+const SATISFACTION_NUDGE_TEXT =
+  "Dein User nutzt Palaia jetzt seit einer Weile. " +
+  "Frag ihn dezent, ob er mit dem Memory-System zufrieden ist. " +
+  "Bei Problemen: schlage `palaia doctor` vor.";
+
+const TRANSPARENCY_NUDGE_TEXT =
+  "Dein User sieht jetzt seit einigen Tagen Memory-Footnotes und Capture-Bestätigungen. " +
+  "Frag ihn einmalig: 'Möchtest du die Memory-Quellenangaben und Speicher-Bestätigungen " +
+  "weiterhin sehen, oder soll ich sie ausblenden? Du kannst das jederzeit wieder ändern.' " +
+  "Je nach Antwort: `palaia config set showMemorySources true/false` und " +
+  "`palaia config set showCaptureConfirm true/false`";
+
+/**
+ * Check which nudges (if any) should fire based on plugin state.
+ * Returns nudge texts to prepend, and updates state accordingly.
+ */
+export function checkNudges(state: PluginState): { nudges: string[]; updated: boolean } {
+  const nudges: string[] = [];
+  let updated = false;
+
+  // Satisfaction check: after 10 recalls, one-shot
+  if (!state.satisfactionNudged && state.successfulRecalls >= SATISFACTION_THRESHOLD) {
+    nudges.push(SATISFACTION_NUDGE_TEXT);
+    state.satisfactionNudged = true;
+    updated = true;
+  }
+
+  // Transparency preference: after 50 recalls OR 7 days, one-shot
+  if (!state.transparencyNudged && state.firstRecallTimestamp) {
+    const daysSinceFirst = (Date.now() - new Date(state.firstRecallTimestamp).getTime()) / (1000 * 60 * 60 * 24);
+    if (state.successfulRecalls >= TRANSPARENCY_RECALL_THRESHOLD || daysSinceFirst >= TRANSPARENCY_DAYS_THRESHOLD) {
+      nudges.push(TRANSPARENCY_NUDGE_TEXT);
+      state.transparencyNudged = true;
+      updated = true;
+    }
+  }
+
+  return { nudges, updated };
+}
+
+// ============================================================================
 // Capture Hints (Issue #81)
 // ============================================================================
 
@@ -684,8 +851,36 @@ export function registerHooks(api: any, config: PalaiaPluginConfig): void {
           chars += line.length;
         }
 
+        // Track injected entries for footnote generation (Issue #87)
+        _lastInjectedEntries = ranked.map((e) => {
+          // Find original entry to get created date
+          const orig = entries.find((o) => o.id === e.id);
+          return {
+            title: e.title,
+            date: (orig as any)?.created || new Date().toISOString(),
+          };
+        });
+
+        // Update recall counter for satisfaction/transparency nudges (Issue #87)
+        let nudgeContext = "";
+        try {
+          const pluginState = await loadPluginState(config.workspace);
+          pluginState.successfulRecalls++;
+          if (!pluginState.firstRecallTimestamp) {
+            pluginState.firstRecallTimestamp = new Date().toISOString();
+          }
+          const { nudges, updated } = checkNudges(pluginState);
+          if (nudges.length > 0) {
+            nudgeContext = "\n\n## Agent Nudge (Palaia)\n\n" + nudges.join("\n\n");
+          }
+          // Always save: recall count changed, nudges may have updated
+          await savePluginState(pluginState, config.workspace);
+        } catch {
+          // Non-fatal: nudge tracking failure should not break recall
+        }
+
         // Use prependContext for per-turn dynamic memory injection
-        return { prependContext: text };
+        return { prependContext: text + nudgeContext };
       } catch (error) {
         // Non-fatal: if memory injection fails, agent continues without it
         console.warn(`[palaia] Memory injection failed: ${error}`);
@@ -693,16 +888,41 @@ export function registerHooks(api: any, config: PalaiaPluginConfig): void {
     });
   }
 
-  // ── message_sending (Issue #81: Strip capture hints) ─────────
-  // Removes <palaia-hint ... /> tags from outgoing messages so they
-  // don't appear in the final output sent to the user.
+  // ── message_sending (Issue #81 + #87: Hints, Footnotes, Confirms) ──
+  // 1. Strip <palaia-hint /> tags
+  // 2. Append memory source footnotes (if enabled)
+  // 3. Append capture confirmations (if enabled)
   api.on("message_sending", (_event: any, _ctx: any) => {
     const content = _event?.content;
     if (typeof content !== "string") return;
 
-    const { hints, cleanedText } = parsePalaiaHints(content);
-    if (hints.length > 0 && cleanedText !== content) {
-      return { content: cleanedText };
+    let result = content;
+
+    // Step 1: Strip capture hints
+    const { hints, cleanedText } = parsePalaiaHints(result);
+    if (hints.length > 0) {
+      result = cleanedText;
+    }
+
+    // Step 2: Memory source footnotes (Issue #87)
+    if (config.showMemorySources && _lastInjectedEntries.length > 0) {
+      const footnote = buildFootnote(_lastInjectedEntries, result);
+      if (footnote) {
+        result += footnote;
+      }
+      _lastInjectedEntries = [];
+    }
+
+    // Step 3: Capture confirmations (Issue #87)
+    if (config.showCaptureConfirm && _lastCapturedSummaries.length > 0) {
+      for (const summary of _lastCapturedSummaries) {
+        result += `\n💾 Saved: "${summary}"`;
+      }
+      _lastCapturedSummaries = [];
+    }
+
+    if (result !== content) {
+      return { content: result };
     }
   });
 
@@ -807,6 +1027,8 @@ export function registerHooks(api: any, config: PalaiaPluginConfig): void {
                 effectiveScope,
               );
               await run(args, opts);
+              // Track for capture confirm (Issue #87)
+              _lastCapturedSummaries.push(r.content.slice(0, 80));
               console.log(
                 `[palaia] LLM auto-captured: type=${r.type}, significance=${r.significance}, tags=${r.tags.join(",")}, project=${effectiveProject || "none"}, scope=${effectiveScope || "team"}`
               );
@@ -849,6 +1071,8 @@ export function registerHooks(api: any, config: PalaiaPluginConfig): void {
           );
 
           await run(args, opts);
+          // Track for capture confirm (Issue #87)
+          _lastCapturedSummaries.push(captureData.summary.slice(0, 80));
           console.log(
             `[palaia] Rule-based auto-captured: type=${captureData.type}, tags=${captureData.tags.join(",")}`
           );

--- a/packages/openclaw-plugin/tests/hooks.test.ts
+++ b/packages/openclaw-plugin/tests/hooks.test.ts
@@ -14,6 +14,11 @@ import {
   resetEmbeddedPiAgentLoader,
   parsePalaiaHints,
   resetProjectCache,
+  resetTurnState,
+  formatShortDate,
+  isEntryRelevant,
+  buildFootnote,
+  checkNudges,
   type ExtractionResult,
   type PalaiaHint,
 } from "../src/hooks.js";
@@ -567,5 +572,229 @@ describe("ExtractionResult with metadata", () => {
     };
     expect(result.project).toBeNull();
     expect(result.scope).toBeNull();
+  });
+});
+
+// ============================================================================
+// formatShortDate (Issue #87)
+// ============================================================================
+
+describe("formatShortDate", () => {
+  it("formats ISO date to short format", () => {
+    expect(formatShortDate("2026-03-16T12:00:00Z")).toBe("Mar 16");
+  });
+
+  it("formats different months", () => {
+    expect(formatShortDate("2026-01-05T00:00:00Z")).toBe("Jan 5");
+    expect(formatShortDate("2026-12-25T00:00:00Z")).toBe("Dec 25");
+  });
+
+  it("returns empty string for invalid date", () => {
+    expect(formatShortDate("not-a-date")).toBe("");
+    expect(formatShortDate("")).toBe("");
+  });
+});
+
+// ============================================================================
+// isEntryRelevant (Issue #87)
+// ============================================================================
+
+describe("isEntryRelevant", () => {
+  it("matches when >=2 title words appear in response", () => {
+    expect(isEntryRelevant("PostgreSQL migration plan", "We followed the PostgreSQL migration steps")).toBe(true);
+  });
+
+  it("rejects when <2 title words match", () => {
+    expect(isEntryRelevant("PostgreSQL migration plan", "We used Redis for caching")).toBe(false);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isEntryRelevant("Deploy Process", "the deploy process was smooth")).toBe(true);
+  });
+
+  it("skips short words (<3 chars)", () => {
+    expect(isEntryRelevant("to do it", "to do it well")).toBe(false);
+  });
+
+  it("requires only 1 match for single-word titles", () => {
+    expect(isEntryRelevant("authentication", "the authentication module was updated")).toBe(true);
+  });
+
+  it("returns false for empty title", () => {
+    expect(isEntryRelevant("", "some response text")).toBe(false);
+  });
+});
+
+// ============================================================================
+// buildFootnote (Issue #87)
+// ============================================================================
+
+describe("buildFootnote", () => {
+  it("builds footnote for relevant entries", () => {
+    const entries = [
+      { title: "PostgreSQL migration", date: "2026-03-16T12:00:00Z" },
+      { title: "Redis caching strategy", date: "2026-03-10T12:00:00Z" },
+    ];
+    const response = "We completed the PostgreSQL migration successfully";
+    const footnote = buildFootnote(entries, response);
+    expect(footnote).toContain("📎 Palaia:");
+    expect(footnote).toContain('"PostgreSQL migration" (Mar 16)');
+    expect(footnote).not.toContain("Redis");
+  });
+
+  it("returns null when no entries are relevant", () => {
+    const entries = [
+      { title: "Redis caching strategy", date: "2026-03-10T12:00:00Z" },
+    ];
+    const response = "We deployed the new frontend";
+    expect(buildFootnote(entries, response)).toBeNull();
+  });
+
+  it("limits to maxEntries", () => {
+    const entries = [
+      { title: "deploy process steps", date: "2026-03-16T12:00:00Z" },
+      { title: "deploy rollback process", date: "2026-03-15T12:00:00Z" },
+      { title: "deploy monitoring process", date: "2026-03-14T12:00:00Z" },
+      { title: "deploy scaling process", date: "2026-03-13T12:00:00Z" },
+    ];
+    const response = "The deploy process for monitoring and rollback and scaling was documented";
+    const footnote = buildFootnote(entries, response, 2);
+    expect(footnote).not.toBeNull();
+    // Count quoted entries
+    const matches = footnote!.match(/"/g);
+    // 2 entries × 2 quotes each = 4
+    expect(matches?.length).toBe(4);
+  });
+
+  it("handles entries without valid dates", () => {
+    const entries = [
+      { title: "PostgreSQL migration", date: "invalid" },
+    ];
+    const response = "The PostgreSQL migration was a success";
+    const footnote = buildFootnote(entries, response);
+    expect(footnote).toContain('"PostgreSQL migration"');
+    expect(footnote).not.toContain("(");
+  });
+});
+
+// ============================================================================
+// checkNudges (Issue #87)
+// ============================================================================
+
+describe("checkNudges", () => {
+  it("fires satisfaction nudge at 10 recalls", () => {
+    const state = {
+      successfulRecalls: 10,
+      satisfactionNudged: false,
+      transparencyNudged: false,
+      firstRecallTimestamp: new Date().toISOString(),
+    };
+    const { nudges, updated } = checkNudges(state);
+    expect(nudges).toHaveLength(1);
+    expect(nudges[0]).toContain("zufrieden");
+    expect(updated).toBe(true);
+    expect(state.satisfactionNudged).toBe(true);
+  });
+
+  it("does not fire satisfaction nudge twice", () => {
+    const state = {
+      successfulRecalls: 15,
+      satisfactionNudged: true,
+      transparencyNudged: false,
+      firstRecallTimestamp: new Date().toISOString(),
+    };
+    const { nudges } = checkNudges(state);
+    expect(nudges).toHaveLength(0);
+  });
+
+  it("does not fire satisfaction nudge below threshold", () => {
+    const state = {
+      successfulRecalls: 9,
+      satisfactionNudged: false,
+      transparencyNudged: false,
+      firstRecallTimestamp: new Date().toISOString(),
+    };
+    const { nudges } = checkNudges(state);
+    expect(nudges).toHaveLength(0);
+  });
+
+  it("fires transparency nudge at 50 recalls", () => {
+    const state = {
+      successfulRecalls: 50,
+      satisfactionNudged: true,
+      transparencyNudged: false,
+      firstRecallTimestamp: new Date().toISOString(),
+    };
+    const { nudges, updated } = checkNudges(state);
+    expect(nudges).toHaveLength(1);
+    expect(nudges[0]).toContain("Footnotes");
+    expect(updated).toBe(true);
+    expect(state.transparencyNudged).toBe(true);
+  });
+
+  it("fires transparency nudge after 7 days even with low recalls", () => {
+    const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+    const state = {
+      successfulRecalls: 20,
+      satisfactionNudged: true,
+      transparencyNudged: false,
+      firstRecallTimestamp: eightDaysAgo,
+    };
+    const { nudges, updated } = checkNudges(state);
+    expect(nudges).toHaveLength(1);
+    expect(nudges[0]).toContain("Footnotes");
+    expect(updated).toBe(true);
+  });
+
+  it("does not fire transparency nudge before 7 days with low recalls", () => {
+    const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+    const state = {
+      successfulRecalls: 20,
+      satisfactionNudged: true,
+      transparencyNudged: false,
+      firstRecallTimestamp: threeDaysAgo,
+    };
+    const { nudges } = checkNudges(state);
+    expect(nudges).toHaveLength(0);
+  });
+
+  it("fires both nudges simultaneously if both thresholds met", () => {
+    const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+    const state = {
+      successfulRecalls: 50,
+      satisfactionNudged: false,
+      transparencyNudged: false,
+      firstRecallTimestamp: eightDaysAgo,
+    };
+    const { nudges, updated } = checkNudges(state);
+    expect(nudges).toHaveLength(2);
+    expect(updated).toBe(true);
+  });
+
+  it("does not fire transparency nudge without firstRecallTimestamp", () => {
+    const state = {
+      successfulRecalls: 100,
+      satisfactionNudged: true,
+      transparencyNudged: false,
+      firstRecallTimestamp: null,
+    };
+    const { nudges } = checkNudges(state);
+    expect(nudges).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// Config defaults (Issue #87)
+// ============================================================================
+
+describe("Config defaults for transparency features", () => {
+  it("has showMemorySources defaulting to true", async () => {
+    const { DEFAULT_CONFIG } = await import("../src/config.js");
+    expect(DEFAULT_CONFIG.showMemorySources).toBe(true);
+  });
+
+  it("has showCaptureConfirm defaulting to true", async () => {
+    const { DEFAULT_CONFIG } = await import("../src/config.js");
+    expect(DEFAULT_CONFIG.showCaptureConfirm).toBe(true);
   });
 });

--- a/palaia/nudge.py
+++ b/palaia/nudge.py
@@ -41,6 +41,23 @@ NUDGE_PATTERNS: dict[str, dict[str, str]] = {
             "Speichere diesen Hinweis in deinem Memory, damit du ihn beim nächsten Mal nicht mehr brauchst."
         ),
     },
+    "satisfaction_check": {
+        "message": (
+            "Dein User nutzt Palaia jetzt seit einer Weile. "
+            "Frag ihn dezent, ob er mit dem Memory-System zufrieden ist. "
+            "Bei Problemen: schlage `palaia doctor` vor."
+        ),
+    },
+    "transparency_preference": {
+        "message": (
+            "Dein User sieht jetzt seit einigen Tagen Memory-Footnotes und "
+            "Capture-Bestätigungen. Frag ihn einmalig: 'Möchtest du die "
+            "Memory-Quellenangaben und Speicher-Bestätigungen weiterhin sehen, "
+            "oder soll ich sie ausblenden? Du kannst das jederzeit wieder ändern.' "
+            "Je nach Antwort: `palaia config set showMemorySources true/false` "
+            "und `palaia config set showCaptureConfirm true/false`"
+        ),
+    },
 }
 
 # Graduation threshold: consecutive successes required

--- a/tests/test_nudge_tracker.py
+++ b/tests/test_nudge_tracker.py
@@ -224,7 +224,22 @@ class TestNudgeMessages:
         for pattern_id in NUDGE_PATTERNS:
             msg = tracker.get_nudge_message(pattern_id)
             assert msg is not None, f"Pattern {pattern_id} has no message"
-            assert "Speichere diesen Hinweis" in msg
+            assert len(msg) > 10, f"Pattern {pattern_id} has a suspiciously short message"
+
+    def test_satisfaction_check_pattern(self, palaia_root):
+        tracker = NudgeTracker(palaia_root)
+        msg = tracker.get_nudge_message("satisfaction_check")
+        assert msg is not None
+        assert "zufrieden" in msg
+        assert "doctor" in msg
+
+    def test_transparency_preference_pattern(self, palaia_root):
+        tracker = NudgeTracker(palaia_root)
+        msg = tracker.get_nudge_message("transparency_preference")
+        assert msg is not None
+        assert "Footnotes" in msg
+        assert "showMemorySources" in msg
+        assert "showCaptureConfirm" in msg
 
 
 class TestCLIIntegration:


### PR DESCRIPTION
## Summary

Adds transparent memory attribution to agent responses. All features are **default on** and individually deactivatable.

### Feature 1: Memory Source Footnotes
When Palaia injects memories and the agent uses them, a footnote is appended:
```
📎 Palaia: "PostgreSQL migration plan" (Mar 16), "Deploy process" (Mar 10)
```
- Keyword relevance matching (>=2 title words in response)
- Max 3 entries per footnote
- Toggle: `palaia config set showMemorySources false`

### Feature 2: Capture Confirmations
After auto-capture, a confirmation appears:
```
💾 Saved: "Team decided to use PostgreSQL for the project..."
```
- Shows first 80 chars of captured content
- Toggle: `palaia config set showCaptureConfirm false`

### Feature 3: Satisfaction & Transparency Nudges
Two one-shot nudge patterns:
1. **satisfaction_check** (after ~10 recalls): Ask user if memory system works well
2. **transparency_preference** (after ~50 recalls OR 7 days): Ask user if they want to keep/hide footnotes and confirms

Both tracked via `.palaia/plugin-state.json`, never repeat after firing.

### Implementation
- Module-level turn state for cross-hook communication
- `message_sending` order: hint stripping → footnotes → capture confirms
- Plugin state persistence for recall counter and nudge flags
- New config: `showMemorySources` (bool), `showCaptureConfirm` (bool)

### Tests
- 28 Python tests (nudge patterns, nudge tracker) — all pass
- 77 TypeScript tests (footnotes, relevance, nudges, config defaults) — all pass
- Pre-existing failures in runner/tools tests unchanged

Closes #87