### PR TITLE
fix(plugin): prevent auto-capture feedback loop — strip injected recall context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.0.13] — 2026-03-22
+
+### Fixed
+- **Auto-capture feedback loop**: `stripPalaiaInjectedContext()` strips the Palaia recall block from user messages before capture extraction, preventing re-captured memories from accumulating. Applied in `agent_end`, `extractWithLLM()`, and `buildRecallQuery()`.
+- **Doctor: feedback-loop artifact detection**: `palaia doctor` now detects entries that are re-captured recall context (feedback-loop artifacts). `palaia doctor --fix` marks them as done.
+
 ## [2.0.12] — 2026-03-22
 
 ### Version alignment

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byte5ai/palaia",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "Palaia memory backend for OpenClaw",
   "main": "index.ts",
   "openclaw": {

--- a/packages/openclaw-plugin/src/hooks.ts
+++ b/packages/openclaw-plugin/src/hooks.ts
@@ -892,9 +892,15 @@ export async function extractWithLLM(
   }
 
   const allTexts = extractMessageTexts(messages);
+  // Strip Palaia-injected recall context from user messages to prevent feedback loop
+  const cleanedTexts = allTexts.map(t =>
+    t.role === "user"
+      ? { ...t, text: stripPalaiaInjectedContext(t.text) }
+      : t
+  );
   // Only extract from recent exchanges — full history causes LLM timeouts
   // and dilutes extraction quality
-  const recentTexts = trimToRecentExchanges(allTexts);
+  const recentTexts = trimToRecentExchanges(cleanedTexts);
   const exchangeText = recentTexts
     .map((t) => `[${t.role}]: ${t.text}`)
     .join("\n");
@@ -1103,6 +1109,24 @@ export function extractSignificance(
   return { tags, type: primaryType, summary };
 }
 
+/**
+ * Strip Palaia-injected recall context from message text.
+ * The recall block is prepended to user messages by before_prompt_build via prependContext.
+ * OpenClaw merges it into the user message, so agent_end sees it as user content.
+ * Without stripping, auto-capture re-captures the injected memories → feedback loop.
+ *
+ * The block has a stable structure:
+ * - Starts with "## Active Memory (Palaia)"
+ * - Contains [t/m], [t/pr], [t/tk] prefixed entries
+ * - Ends with "[palaia] auto-capture=on..." nudge line
+ */
+export function stripPalaiaInjectedContext(text: string): string {
+  // Pattern: "## Active Memory (Palaia)" ... "[palaia] auto-capture=on..." + optional trailing newlines
+  // The nudge line is always present and marks the end of the injected block
+  const PALAIA_BLOCK_RE = /## Active Memory \(Palaia\)[\s\S]*?\[palaia\][^\n]*\n*/;
+  return text.replace(PALAIA_BLOCK_RE, '').trim();
+}
+
 export function extractMessageTexts(messages: unknown[]): Array<{ role: string; text: string; provenance?: string }> {
   const result: Array<{ role: string; text: string; provenance?: string }> = [];
 
@@ -1232,7 +1256,11 @@ function isSystemOnlyContent(text: string): boolean {
  * - Hard-caps at 500 characters.
  */
 export function buildRecallQuery(messages: unknown[]): string {
-  const texts = extractMessageTexts(messages);
+  const texts = extractMessageTexts(messages).map(t =>
+    t.role === "user"
+      ? { ...t, text: stripPalaiaInjectedContext(t.text) }
+      : t
+  );
 
   // Step 1: Filter out inter_session messages (sub-agent results, sessions_send)
   const candidates = texts.filter(
@@ -1709,9 +1737,18 @@ export function registerHooks(api: any, config: PalaiaPluginConfig): void {
           collectedHints.push(...hints);
         }
 
+        // Strip Palaia-injected recall context from user messages to prevent feedback loop.
+        // The recall block is prepended to user messages by before_prompt_build.
+        // Without stripping, auto-capture would re-capture previously recalled memories.
+        const cleanedTexts = allTexts.map(t =>
+          t.role === "user"
+            ? { ...t, text: stripPalaiaInjectedContext(t.text) }
+            : t
+        );
+
         // Only extract from recent exchanges — full history causes LLM timeouts
         // and dilutes extraction quality
-        const recentTexts = trimToRecentExchanges(allTexts);
+        const recentTexts = trimToRecentExchanges(cleanedTexts);
 
         // Build exchange text from recent window only
         const exchangeParts: string[] = [];

--- a/packages/openclaw-plugin/tests/hooks.test.ts
+++ b/packages/openclaw-plugin/tests/hooks.test.ts
@@ -32,6 +32,7 @@ import {
   registerHooks,
   setEmbeddedPiAgentLoader,
   trimToRecentExchanges,
+  stripPalaiaInjectedContext,
   type ExtractionResult,
   type PalaiaHint,
 } from "../src/hooks.js";
@@ -1260,5 +1261,88 @@ describe("agent_end reaction cleanup", () => {
     // State should be fresh
     const fresh = getOrCreateTurnState(sessionKey);
     expect(fresh.recallOccurred).toBe(false);
+  });
+});
+
+// ============================================================================
+// stripPalaiaInjectedContext — feedback loop prevention
+// ============================================================================
+
+describe("stripPalaiaInjectedContext", () => {
+  const MEMORY_BLOCK = `## Active Memory (Palaia)
+
+[t/m] User prefers dark mode
+[t/pr] Project palaia uses TypeScript
+[t/tk] Task: fix feedback loop
+
+[palaia] auto-capture=on | recall=semantic | /palaia help`;
+
+  it("strips injected memory block, preserves user text", () => {
+    const input = `${MEMORY_BLOCK}\n\nHey, can you fix the bug?`;
+    const result = stripPalaiaInjectedContext(input);
+    expect(result).toBe("Hey, can you fix the bug?");
+  });
+
+  it("returns text unchanged when no block present", () => {
+    const input = "Just a normal user message";
+    expect(stripPalaiaInjectedContext(input)).toBe(input);
+  });
+
+  it("does not strip partial block without nudge line (no false positive)", () => {
+    const input = "## Active Memory (Palaia)\n\nSome text without nudge ending";
+    expect(stripPalaiaInjectedContext(input)).toBe(input);
+  });
+
+  it("strips block with accumulated bold markdown artifacts", () => {
+    const input = `## Active Memory (Palaia)
+
+****[t/m] Some duplicated memory
+[t/pr] Project info
+
+[palaia] auto-capture=on | recall=semantic
+
+What should I work on next?`;
+    const result = stripPalaiaInjectedContext(input);
+    expect(result).toBe("What should I work on next?");
+  });
+
+  it("strips block when it appears mid-message", () => {
+    const input = `Previous context\n\n${MEMORY_BLOCK}\n\nActual question here`;
+    const result = stripPalaiaInjectedContext(input);
+    expect(result).toBe("Previous context\n\nActual question here");
+  });
+
+  it("handles empty string", () => {
+    expect(stripPalaiaInjectedContext("")).toBe("");
+  });
+
+  it("agent_end: extractMessageTexts + strip prevents feedback loop", () => {
+    // Simulate what OpenClaw does: prepend memory block to user message
+    const messages = [
+      {
+        role: "user",
+        content: `${MEMORY_BLOCK}\n\nPlease summarize the project status`,
+      },
+      {
+        role: "assistant",
+        content: "Here is the project status summary...",
+      },
+    ];
+
+    const texts = extractMessageTexts(messages);
+    // Before stripping: user message contains the memory block
+    expect(texts[0].text).toContain("Active Memory (Palaia)");
+
+    // After stripping (as agent_end now does):
+    const cleaned = texts.map(t =>
+      t.role === "user"
+        ? { ...t, text: stripPalaiaInjectedContext(t.text) }
+        : t
+    );
+    expect(cleaned[0].text).toBe("Please summarize the project status");
+    expect(cleaned[0].text).not.toContain("Active Memory");
+    expect(cleaned[0].text).not.toContain("[palaia]");
+    // Assistant message unchanged
+    expect(cleaned[1].text).toBe("Here is the project status summary...");
   });
 });

--- a/palaia/__init__.py
+++ b/palaia/__init__.py
@@ -4,5 +4,5 @@ Palaia — Local, cloud-free memory for OpenClaw agents.
 
 from __future__ import annotations
 
-__version__ = "2.0.12"
+__version__ = "2.0.13"
 __author__ = "byte5 GmbH"

--- a/palaia/doctor.py
+++ b/palaia/doctor.py
@@ -445,6 +445,69 @@ def _check_heartbeat_legacy(workspace: Path | None = None) -> dict[str, Any]:
     }
 
 
+LOOP_ARTIFACT_PATTERNS = [
+    re.compile(r"## Active Memory \(Palaia\)"),
+    re.compile(r"\[t/(m|pr|tk)\]"),
+    re.compile(r"\[palaia\] auto-capture=on"),
+    re.compile(r"\*{4,}"),  # accumulated markdown (****)
+]
+
+
+def _is_loop_artifact(meta: dict, body: str) -> bool:
+    """Check if an entry is a feedback-loop artifact (re-captured recall context)."""
+    text = f"{meta.get('title', '')}\n{body}"
+    return any(p.search(text) for p in LOOP_ARTIFACT_PATTERNS)
+
+
+def _check_loop_artifacts(palaia_root: Path | None) -> dict[str, Any]:
+    """Check for feedback-loop artifacts (re-captured recall context)."""
+    if palaia_root is None:
+        return {
+            "name": "loop_artifacts",
+            "label": "Feedback-loop artifacts",
+            "status": "error",
+            "message": "Not initialized",
+        }
+
+    from palaia.entry import parse_entry
+
+    artifact_ids: list[str] = []
+
+    for tier in ("hot", "warm", "cold"):
+        tier_dir = palaia_root / tier
+        if not tier_dir.exists():
+            continue
+        for p in tier_dir.glob("*.md"):
+            try:
+                text = p.read_text(encoding="utf-8")
+                meta, body = parse_entry(text)
+                # Skip already-cleaned entries (idempotent)
+                if meta.get("status") == "done":
+                    continue
+                if _is_loop_artifact(meta, body):
+                    artifact_ids.append(p.stem)
+            except Exception:
+                continue
+
+    if not artifact_ids:
+        return {
+            "name": "loop_artifacts",
+            "label": "Feedback-loop artifacts",
+            "status": "ok",
+            "message": "No feedback-loop artifacts detected",
+        }
+
+    return {
+        "name": "loop_artifacts",
+        "label": "Feedback-loop artifacts",
+        "status": "warn",
+        "fixable": True,
+        "message": f"{len(artifact_ids)} entries contain re-captured recall context",
+        "fix": "Run: palaia doctor --fix  to clean up feedback-loop artifacts",
+        "details": {"artifact_ids": artifact_ids},
+    }
+
+
 def _check_wal_health(palaia_root: Path | None) -> dict[str, Any]:
     """Check for unflushed WAL entries."""
     if palaia_root is None:
@@ -1333,6 +1396,7 @@ def run_doctor(palaia_root: Path | None = None) -> list[dict[str, Any]]:
         _check_legacy_memory_files(),
         _check_heartbeat_legacy(),
         _check_wal_health(palaia_root),
+        _check_loop_artifacts(palaia_root),
     ]
     return results
 
@@ -1554,6 +1618,36 @@ def apply_fixes(palaia_root: Path | None, results: list[dict[str, Any]]) -> list
                 actions.append(f"Reindex failed: {e}")
         except Exception as e:
             actions.append(f"Warmup failed: {e}")
+
+    # Fix: feedback-loop artifacts
+    for r in results:
+        if r.get("name") == "loop_artifacts" and r.get("fixable") and r.get("status") == "warn":
+            artifact_ids = r.get("details", {}).get("artifact_ids", [])
+            if not artifact_ids:
+                continue
+
+            from palaia.entry import parse_entry, serialize_entry
+
+            cleaned = 0
+            for entry_id in artifact_ids:
+                # Find the entry file across tiers
+                for tier in ("hot", "warm", "cold"):
+                    entry_path = palaia_root / tier / f"{entry_id}.md"
+                    if entry_path.exists():
+                        try:
+                            text = entry_path.read_text(encoding="utf-8")
+                            meta, body = parse_entry(text)
+                            meta["status"] = "done"
+                            if meta.get("type") != "memory":
+                                meta["type"] = "memory"
+                            entry_path.write_text(serialize_entry(meta, body), encoding="utf-8")
+                            cleaned += 1
+                        except Exception as e:
+                            actions.append(f"Failed to clean {entry_id}: {e}")
+                        break
+
+            if cleaned > 0:
+                actions.append(f"Cleaned {cleaned} feedback-loop artifact(s)")
 
     return actions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "palaia"
-version = "2.0.12"
+version = "2.0.13"
 description = "Local, cloud-free memory for OpenClaw agents."
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -328,7 +328,7 @@ class TestRunDoctor:
     def test_run_all_checks(self, palaia_root, tmp_path, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))
         results = run_doctor(palaia_root)
-        assert len(results) == 21
+        assert len(results) == 22
         assert all("status" in r for r in results)
         assert all("name" in r for r in results)
 

--- a/tests/test_doctor_version.py
+++ b/tests/test_doctor_version.py
@@ -102,4 +102,4 @@ def test_version_check_count(palaia_root):
         mock_urlopen.return_value = _mock_pypi_response(__version__)
         results = run_doctor(palaia_root)
 
-    assert len(results) == 21
+    assert len(results) == 22


### PR DESCRIPTION
## Problem

Auto-capture was re-capturing Palaia-injected recall context from user messages, creating exponentially growing duplicate entries (feedback loop).

### Root Cause

1. `before_prompt_build`: Palaia injects memory block as `prependContext`
2. OpenClaw merges `prependContext` into the user message
3. `agent_end`: `extractMessageTexts()` extracts the combined message as `role="user"`
4. LLM extraction sees the injected memory block as significant user content
5. Saves it as new entry → next recall finds original + copy → loop

## Fix

### Part 1: `stripPalaiaInjectedContext()` function

New exported function in `hooks.ts` that strips the Palaia recall block from message text. The block has a stable structure:
- Starts with `## Active Memory (Palaia)`
- Contains `[t/m]`, `[t/pr]`, `[t/tk]` prefixed entries
- Ends with `[palaia] auto-capture=on...` nudge line

Uses a single regex that matches from header to nudge line (non-greedy).

### Part 2: Integration points

Strip applied in three locations:
- **`agent_end`**: Before `trimToRecentExchanges()` — prevents re-capture
- **`extractWithLLM()`**: Before trimming — prevents extraction of injected context
- **`buildRecallQuery()`**: After `extractMessageTexts()` — prevents polluted recall queries

### Part 3: `palaia doctor` cleanup

- New check: `_check_loop_artifacts()` detects entries containing re-captured recall context
- `palaia doctor --fix` marks artifacts as `status: done` (soft-delete)
- Idempotent: already-cleaned entries are skipped

## Tests

7 new tests in `hooks.test.ts`:
- Basic strip, no-block passthrough, partial block (no false positive)
- Accumulated markdown artifacts (`****`)
- Mid-message block, empty string
- Integration: extractMessageTexts + strip prevents feedback loop

## Store Cleanup

Ran `palaia doctor --fix` across all agent stores — cleaned 12 feedback-loop artifacts from Elliot's store. All other stores were clean.

## Version

2.0.12 → 2.0.13