### PR TITLE
fix: v2.1 minor — dedup, stale detection, token TTL, atomic writes, test coverage

### DIFF
--- a/packages/openclaw-plugin/src/hooks.ts
+++ b/packages/openclaw-plugin/src/hooks.ts
@@ -1304,11 +1304,29 @@ export function buildRecallQuery(messages: unknown[]): string {
   );
 
   // Fallback: if no messages without provenance, use all user messages
-  const userMsgs = candidates.length > 0
+  const allUserMsgs = candidates.length > 0
     ? candidates
     : texts.filter(t => t.role === "user");
 
-  if (userMsgs.length === 0) return "";
+  if (allUserMsgs.length === 0) return "";
+
+  // Early exit: only scan the last 3 user messages or 2000 chars, whichever comes first
+  const MAX_SCAN_MSGS = 3;
+  const MAX_SCAN_CHARS = 2000;
+  let userMsgs: typeof allUserMsgs;
+  if (allUserMsgs.length <= MAX_SCAN_MSGS) {
+    userMsgs = allUserMsgs;
+  } else {
+    userMsgs = allUserMsgs.slice(-MAX_SCAN_MSGS);
+    // Extend backwards if total chars < MAX_SCAN_CHARS and more messages available
+    let totalChars = userMsgs.reduce((sum, m) => sum + m.text.length, 0);
+    let startIdx = allUserMsgs.length - MAX_SCAN_MSGS;
+    while (startIdx > 0 && totalChars < MAX_SCAN_CHARS) {
+      startIdx--;
+      totalChars += allUserMsgs[startIdx].text.length;
+      userMsgs = allUserMsgs.slice(startIdx);
+    }
+  }
 
   // Step 2: Strip envelopes from the last user message(s)
   let lastText = stripSystemPrefix(stripChannelEnvelope(userMsgs[userMsgs.length - 1].text.trim()));

--- a/packages/openclaw-plugin/src/hooks.ts
+++ b/packages/openclaw-plugin/src/hooks.ts
@@ -293,10 +293,14 @@ export async function sendReaction(
 
 /** Cached Slack bot token resolved from env or OpenClaw config. */
 let _cachedSlackToken: string | null | undefined;
+/** Timestamp when the token was cached (for TTL expiry). */
+let _slackTokenCachedAt = 0;
+/** TTL for cached Slack bot token in milliseconds (5 minutes). */
+const SLACK_TOKEN_CACHE_TTL_MS = 5 * 60 * 1000;
 
 /**
  * Resolve the Slack bot token from environment or OpenClaw config file.
- * Caches the result for the lifetime of the process.
+ * Caches the result with a 5-minute TTL — re-resolves after expiry.
  *
  * Resolution order:
  * 1. SLACK_BOT_TOKEN env var (explicit override)
@@ -306,12 +310,15 @@ let _cachedSlackToken: string | null | undefined;
  * Config path: OPENCLAW_CONFIG env var → ~/.openclaw/openclaw.json
  */
 async function resolveSlackBotToken(): Promise<string | null> {
-  if (_cachedSlackToken !== undefined) return _cachedSlackToken;
+  if (_cachedSlackToken !== undefined && (Date.now() - _slackTokenCachedAt) < SLACK_TOKEN_CACHE_TTL_MS) {
+    return _cachedSlackToken;
+  }
 
   // 1) Environment variable
   const envToken = process.env.SLACK_BOT_TOKEN?.trim();
   if (envToken) {
     _cachedSlackToken = envToken;
+    _slackTokenCachedAt = Date.now();
     return envToken;
   }
 
@@ -330,6 +337,7 @@ async function resolveSlackBotToken(): Promise<string | null> {
       const directToken = config?.channels?.slack?.botToken?.trim();
       if (directToken) {
         _cachedSlackToken = directToken;
+        _slackTokenCachedAt = Date.now();
         return directToken;
       }
 
@@ -337,6 +345,7 @@ async function resolveSlackBotToken(): Promise<string | null> {
       const accountToken = config?.channels?.slack?.accounts?.default?.botToken?.trim();
       if (accountToken) {
         _cachedSlackToken = accountToken;
+        _slackTokenCachedAt = Date.now();
         return accountToken;
       }
     } catch {
@@ -345,12 +354,14 @@ async function resolveSlackBotToken(): Promise<string | null> {
   }
 
   _cachedSlackToken = null;
+  _slackTokenCachedAt = Date.now();
   return null;
 }
 
 /** Reset cached token (for testing). */
 export function resetSlackTokenCache(): void {
   _cachedSlackToken = undefined;
+  _slackTokenCachedAt = 0;
 }
 
 async function sendSlackReaction(

--- a/palaia/embed_server.py
+++ b/palaia/embed_server.py
@@ -90,7 +90,7 @@ def _warmup_missing(store: Store, engine: SearchEngine) -> dict:
 class EmbedServer:
     """JSON-RPC server over stdin/stdout for embedding queries."""
 
-    def __init__(self, root: Path):
+    def __init__(self, root: Path, stale_check_interval: float = 30.0):
         self.root = root
         self.store = Store(root)
         self.engine = SearchEngine(self.store)
@@ -100,6 +100,7 @@ class EmbedServer:
         self._last_entry_count = _count_entries(self.store)
         self._running = True
         self._warming_up = False
+        self._stale_check_interval = stale_check_interval
         self._stale_check_thread: threading.Thread | None = None
 
     def _start_stale_detection(self) -> None:
@@ -107,7 +108,7 @@ class EmbedServer:
 
         def _check_loop():
             while self._running:
-                time.sleep(30)
+                time.sleep(self._stale_check_interval)
                 if not self._running:
                     break
                 try:

--- a/palaia/index.py
+++ b/palaia/index.py
@@ -1,7 +1,6 @@
 """Embedding cache for Tier 2/3 search (ADR-001).
 
-Cache-only infrastructure. Actual embedding computation is not yet implemented.
-# TODO: ollama/API integration for real embeddings.
+Cache-only infrastructure. Embedding computation is handled by embeddings.py.
 """
 
 from __future__ import annotations

--- a/palaia/metadata_index.py
+++ b/palaia/metadata_index.py
@@ -85,7 +85,19 @@ class MetadataIndex:
                 f.flush()
                 os.fsync(f.fileno())
             tmp.rename(self.index_path)
-        except OSError:
+        except OSError as e:
+            import errno
+
+            # Expected: cross-filesystem rename (e.g. tmp on different mount)
+            if e.errno == errno.EXDEV:
+                import shutil
+
+                try:
+                    shutil.move(str(tmp), str(self.index_path))
+                except OSError:
+                    pass
+            else:
+                logger.warning("Unexpected error renaming metadata index: %s", e)
             # Best-effort cleanup
             try:
                 tmp.unlink(missing_ok=True)

--- a/palaia/store.py
+++ b/palaia/store.py
@@ -545,8 +545,8 @@ class Store:
                     key = f"{tier}_to_{new_tier}"
                     moves[key] = moves.get(key, 0) + 1
                 else:
-                    with open(p, "w") as f:
-                        f.write(new_text)
+                    # Atomic write for in-place score update (same tier)
+                    self.write_raw(str(p.relative_to(self.root)), new_text)
                     # Update metadata index (score may have changed)
                     entry_id = meta.get("id", p.stem)
                     self.metadata_index.update(entry_id, meta, tier)

--- a/palaia/store.py
+++ b/palaia/store.py
@@ -717,26 +717,12 @@ class Store:
         """Find entry ID by content hash (dedup).
 
         Uses metadata index for O(n-in-memory) lookup instead of O(n) disk scan.
-        Falls back to disk scan if index is empty (cold start).
+        If the index is empty on cold start, triggers a lazy rebuild from disk
+        instead of falling through to an unindexed disk scan.
         """
-        # Try index first
-        if self.metadata_index.is_populated():
-            result = self.metadata_index.find_by_hash(h)
-            if result is not None:
-                return result
-            return None
+        if not self.metadata_index.is_populated():
+            # Lazy rebuild: populate index from disk on first dedup check
+            self.metadata_index.rebuild(parse_entry)
 
-        # Fallback: disk scan (index not yet built)
-        for tier in TIERS:
-            tier_dir = self.root / tier
-            if not tier_dir.exists():
-                continue
-            for p in tier_dir.glob("*.md"):
-                try:
-                    text = p.read_text(encoding="utf-8")
-                    meta, _ = parse_entry(text)
-                    if meta.get("content_hash") == h:
-                        return meta.get("id")
-                except (OSError, UnicodeDecodeError):
-                    continue
-        return None
+        result = self.metadata_index.find_by_hash(h)
+        return result

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -1,0 +1,163 @@
+"""Tests for Unicode and special character handling."""
+
+import pytest
+
+from palaia.config import DEFAULT_CONFIG, save_config
+from palaia.store import Store
+
+
+@pytest.fixture
+def palaia_root(tmp_path):
+    root = tmp_path / ".palaia"
+    root.mkdir()
+    for sub in ("hot", "warm", "cold", "wal", "index"):
+        (root / sub).mkdir()
+    save_config(root, DEFAULT_CONFIG)
+    return root
+
+
+# ── Emoji content ─────────────────────────────────────────────
+
+
+def test_write_read_emoji_content(palaia_root):
+    store = Store(palaia_root)
+    body = "Great progress today! 🚀🎉 The deployment went smooth 💯"
+    entry_id = store.write(body, scope="team", agent="test")
+    result = store.read(entry_id)
+    assert result is not None
+    meta, read_body = result
+    assert "🚀🎉" in read_body
+    assert "💯" in read_body
+
+
+def test_write_emoji_tags(palaia_root):
+    store = Store(palaia_root)
+    entry_id = store.write(
+        "Tagged with emoji",
+        scope="team",
+        tags=["🏷️tag", "fire🔥", "✅done"],
+    )
+    result = store.read(entry_id)
+    assert result is not None
+    meta, _ = result
+    assert "🏷️tag" in meta["tags"]
+    assert "fire🔥" in meta["tags"]
+    assert "✅done" in meta["tags"]
+
+
+def test_write_emoji_title(palaia_root):
+    store = Store(palaia_root)
+    entry_id = store.write(
+        "Content body here",
+        scope="team",
+        title="🎯 Sprint Goal 🏁",
+    )
+    result = store.read(entry_id)
+    assert result is not None
+    meta, _ = result
+    assert meta["title"] == "🎯 Sprint Goal 🏁"
+
+
+# ── CJK characters ───────────────────────────────────────────
+
+
+def test_write_read_cjk(palaia_root):
+    store = Store(palaia_root)
+    body = "这是一个测试条目。日本語のテスト。한국어 테스트입니다."
+    entry_id = store.write(body, scope="team", agent="test")
+    result = store.read(entry_id)
+    assert result is not None
+    _, read_body = result
+    assert "这是一个测试条目" in read_body
+    assert "日本語のテスト" in read_body
+    assert "한국어 테스트" in read_body
+
+
+def test_cjk_tags_and_title(palaia_root):
+    store = Store(palaia_root)
+    entry_id = store.write(
+        "CJK metadata test",
+        scope="team",
+        tags=["标签", "タグ", "태그"],
+        title="中文标题 / 日本語タイトル",
+    )
+    result = store.read(entry_id)
+    assert result is not None
+    meta, _ = result
+    assert "标签" in meta["tags"]
+    assert "タグ" in meta["tags"]
+    assert "태그" in meta["tags"]
+    assert "中文标题" in meta["title"]
+
+
+# ── RTL text ──────────────────────────────────────────────────
+
+
+def test_write_read_rtl(palaia_root):
+    store = Store(palaia_root)
+    body = "هذا اختبار للنص العربي. עברית בדיקה."
+    entry_id = store.write(body, scope="team", agent="test")
+    result = store.read(entry_id)
+    assert result is not None
+    _, read_body = result
+    assert "هذا اختبار" in read_body
+    assert "עברית בדיקה" in read_body
+
+
+# ── Zero-width characters ────────────────────────────────────
+
+
+def test_write_read_zero_width(palaia_root):
+    store = Store(palaia_root)
+    # Zero-width space (U+200B), zero-width joiner (U+200D), zero-width non-joiner (U+200C)
+    body = "Text\u200bwith\u200dzero\u200cwidth characters"
+    entry_id = store.write(body, scope="team", agent="test")
+    result = store.read(entry_id)
+    assert result is not None
+    _, read_body = result
+    assert "\u200b" in read_body
+    assert "\u200d" in read_body
+    assert "\u200c" in read_body
+
+
+# ── List with Unicode ─────────────────────────────────────────
+
+
+def test_list_unicode_entries(palaia_root):
+    store = Store(palaia_root)
+    store.write("Emoji entry 🌟", scope="team")
+    store.write("CJK entry 漢字", scope="team")
+    store.write("RTL entry مرحبا", scope="team")
+
+    entries = store.list_entries("hot")
+    assert len(entries) == 3
+    bodies = [body for _, body in entries]
+    assert any("🌟" in b for b in bodies)
+    assert any("漢字" in b for b in bodies)
+    assert any("مرحبا" in b for b in bodies)
+
+
+# ── Dedup with Unicode ────────────────────────────────────────
+
+
+def test_dedup_unicode(palaia_root):
+    store = Store(palaia_root)
+    id1 = store.write("同じ内容 🎯")
+    id2 = store.write("同じ内容 🎯")
+    assert id1 == id2  # Deduplicated
+
+
+# ── Mixed scripts ─────────────────────────────────────────────
+
+
+def test_mixed_scripts(palaia_root):
+    store = Store(palaia_root)
+    body = "English mixed with 中文 and العربية and emoji 🎉 and Кириллица"
+    entry_id = store.write(body, scope="team", tags=["mixed", "テスト"])
+    result = store.read(entry_id)
+    assert result is not None
+    meta, read_body = result
+    assert "中文" in read_body
+    assert "العربية" in read_body
+    assert "Кириллица" in read_body
+    assert "テスト" in meta["tags"]

--- a/tests/test_wal_corruption.py
+++ b/tests/test_wal_corruption.py
@@ -1,0 +1,227 @@
+"""Tests for WAL corruption recovery — graceful degradation."""
+
+import json
+
+import pytest
+
+from palaia.config import DEFAULT_CONFIG, save_config
+from palaia.store import Store
+from palaia.wal import WAL, WALEntry
+
+
+@pytest.fixture
+def palaia_root(tmp_path):
+    root = tmp_path / ".palaia"
+    root.mkdir()
+    for sub in ("hot", "warm", "cold", "wal", "index"):
+        (root / sub).mkdir()
+    save_config(root, DEFAULT_CONFIG)
+    return root
+
+
+# ── Corrupt JSON in WAL files ─────────────────────────────────
+
+
+def test_get_pending_skips_corrupt_json(palaia_root):
+    """Corrupt WAL files should be skipped, not crash get_pending."""
+    wal = WAL(palaia_root)
+
+    # Write a valid pending entry
+    valid = WALEntry(
+        operation="write",
+        target="hot/valid.md",
+        payload_hash="abc",
+        payload="valid content",
+    )
+    wal.log(valid)
+
+    # Write a corrupt WAL file (invalid JSON)
+    corrupt_path = palaia_root / "wal" / "2026-01-01T00-00-00+00-00-corrupt-id.json"
+    corrupt_path.write_text("{broken json!!! not valid", encoding="utf-8")
+
+    # get_pending should return only the valid entry
+    pending = wal.get_pending()
+    assert len(pending) == 1
+    assert pending[0].id == valid.id
+
+
+def test_get_pending_skips_missing_keys(palaia_root):
+    """WAL files with missing required keys should be skipped."""
+    wal = WAL(palaia_root)
+
+    # Write a WAL file with missing required keys
+    incomplete_path = palaia_root / "wal" / "2026-01-01T00-00-00+00-00-incomplete.json"
+    incomplete_path.write_text(json.dumps({"status": "pending"}), encoding="utf-8")
+
+    # Should not crash, returns empty list
+    pending = wal.get_pending()
+    assert len(pending) == 0
+
+
+# ── Partial / truncated writes ────────────────────────────────
+
+
+def test_get_pending_skips_truncated_json(palaia_root):
+    """Truncated JSON (simulating crash mid-write) should be skipped."""
+    wal = WAL(palaia_root)
+
+    # Valid entry first
+    valid = WALEntry(
+        operation="write",
+        target="hot/test.md",
+        payload_hash="def",
+        payload="test content",
+    )
+    wal.log(valid)
+
+    # Truncated JSON (simulates crash during write)
+    truncated_path = palaia_root / "wal" / "2026-01-02T00-00-00+00-00-truncated.json"
+    truncated_data = json.dumps(
+        {
+            "id": "truncated-id",
+            "timestamp": "2026-01-02T00:00:00+00:00",
+            "operation": "write",
+            "target": "hot/truncated.md",
+            "payload_hash": "xyz",
+            "status": "pending",
+            "payload": "some con",  # truncated payload
+        }
+    )
+    # Write only first half of the JSON to simulate crash
+    truncated_path.write_text(truncated_data[: len(truncated_data) // 2], encoding="utf-8")
+
+    pending = wal.get_pending()
+    # Should only get the valid entry, truncated is skipped
+    assert len(pending) == 1
+    assert pending[0].id == valid.id
+
+
+def test_recover_skips_corrupt_wal_entries(palaia_root):
+    """Recovery should skip corrupt WAL files and continue with valid ones."""
+    store = Store(palaia_root)
+    wal = store.wal
+
+    # Write a valid recoverable entry
+    content = (
+        "---\nid: recover-ok\nscope: team\n"
+        "created: 2026-03-11T00:00:00+00:00\n"
+        "accessed: 2026-03-11T00:00:00+00:00\n"
+        "access_count: 1\ndecay_score: 1.0\n"
+        "content_hash: aaa\n---\n\nRecoverable content\n"
+    )
+    valid = WALEntry(
+        operation="write",
+        target="hot/recover-ok.md",
+        payload_hash="aaa",
+        payload=content,
+    )
+    wal.log(valid)
+
+    # Write corrupt WAL file
+    corrupt_path = palaia_root / "wal" / "2026-01-03T00-00-00+00-00-corrupt.json"
+    corrupt_path.write_text("not json at all", encoding="utf-8")
+
+    # Recovery should handle both gracefully
+    recovered = store.recover()
+    assert recovered == 1
+
+    # Verify the valid entry was written
+    assert (palaia_root / "hot" / "recover-ok.md").exists()
+
+
+# ── WAL referencing deleted entries ───────────────────────────
+
+
+def test_recover_write_to_deleted_path(palaia_root):
+    """WAL write entry for a path that doesn't exist yet should create it."""
+    store = Store(palaia_root)
+    wal = store.wal
+
+    content = (
+        "---\nid: ghost-entry\nscope: team\n"
+        "created: 2026-03-11T00:00:00+00:00\n"
+        "accessed: 2026-03-11T00:00:00+00:00\n"
+        "access_count: 1\ndecay_score: 1.0\n"
+        "content_hash: ghost\n---\n\nGhost content\n"
+    )
+    entry = WALEntry(
+        operation="write",
+        target="hot/ghost-entry.md",
+        payload_hash="ghost",
+        payload=content,
+    )
+    wal.log(entry)
+
+    # Recover — file doesn't exist yet, should be created
+    recovered = store.recover()
+    assert recovered == 1
+    assert (palaia_root / "hot" / "ghost-entry.md").exists()
+
+
+def test_recover_delete_already_gone(palaia_root):
+    """WAL delete entry for an already-deleted file should succeed silently."""
+    store = Store(palaia_root)
+    wal = store.wal
+
+    entry = WALEntry(
+        operation="delete",
+        target="hot/already-gone.md",
+        payload_hash="",
+    )
+    wal.log(entry)
+
+    # File doesn't exist — recovery should not crash
+    recovered = store.recover()
+    assert recovered == 1
+
+
+def test_recover_no_payload_rolls_back(palaia_root):
+    """WAL write entry without payload should be rolled back."""
+    store = Store(palaia_root)
+    wal = store.wal
+
+    entry = WALEntry(
+        operation="write",
+        target="hot/no-payload.md",
+        payload_hash="nope",
+        # No payload — can't recover
+    )
+    wal.log(entry)
+
+    recovered = store.recover()
+    assert recovered == 0  # Can't recover without payload
+
+    # Verify the WAL entry is marked as rolled_back
+    wal_files = list((palaia_root / "wal").glob("*.json"))
+    assert len(wal_files) == 1
+    data = json.loads(wal_files[0].read_text())
+    assert data["status"] == "rolled_back"
+
+
+# ── Cleanup handles corrupt files ────────────────────────────
+
+
+def test_cleanup_skips_corrupt_files(palaia_root):
+    """WAL cleanup should skip corrupt files without crashing."""
+    wal = WAL(palaia_root)
+
+    # Write corrupt file
+    corrupt_path = palaia_root / "wal" / "corrupt-cleanup.json"
+    corrupt_path.write_text("}{bad", encoding="utf-8")
+
+    # Write valid committed entry (old enough to clean)
+    old = WALEntry(
+        operation="write",
+        target="hot/old.md",
+        payload_hash="old",
+    )
+    old.status = "committed"
+    old.timestamp = "2020-01-01T00:00:00+00:00"
+    path = wal._entry_path(old)
+    path.write_text(json.dumps(old.to_dict()), encoding="utf-8")
+
+    # Cleanup should handle both without crashing
+    removed = wal.cleanup(max_age_days=1)
+    assert removed == 1  # Only the valid committed entry
+    # Corrupt file should still exist (not touched by cleanup)
+    assert corrupt_path.exists()


### PR DESCRIPTION
9 minor fixes and test coverage improvements for v2.1:

- M-1: Lazy metadata index for dedup (avoid cold-start disk scan)
- M-2: Configurable stale detection interval
- M-3: Slack bot token cache TTL (5min)
- M-4: buildRecallQuery scan depth limit
- M-5: Remove stale TODO
- M-6: Atomic GC in-place writes
- M-7: Better error logging in metadata rename
- M-8: Unicode/special character test coverage
- M-9: WAL corruption recovery test coverage