### PR TITLE
docs: add Claude Code MCP setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,17 @@ Note: `palaia[fastembed]` already includes sqlite-vec for native vector search a
 
 **Upgrading?** `palaia upgrade` — auto-detects install method, preserves extras, runs doctor.
 
-### MCP Setup (Claude Desktop, Cursor — no OpenClaw needed)
+### MCP Setup (Claude Desktop, Cursor, Claude Code — no OpenClaw needed)
 
 ```bash
 pip install "palaia[mcp,fastembed]"
 palaia init
 ```
 
-Add to `~/.config/claude/claude_desktop_config.json` (Claude Desktop) or `.cursor/mcp.json` (Cursor):
+Add to your MCP config:
+- Claude Desktop: `~/.config/claude/claude_desktop_config.json`
+- Cursor: `.cursor/mcp.json`
+- Claude Code: `~/.claude/settings.json`
 ```json
 {
   "mcpServers": {

--- a/SKILL.md
+++ b/SKILL.md
@@ -234,9 +234,14 @@ palaia-mcp --read-only                  # No writes (untrusted hosts)
 }
 ```
 
-**Cursor** (Settings → MCP Servers → Add):
+**Cursor** (Settings → MCP Servers → Add, or `.cursor/mcp.json`):
 - Command: `palaia-mcp`
 - Arguments: (none, or `--root /path/to/.palaia`)
+
+**Claude Code** (`~/.claude/settings.json`):
+```json
+{"mcpServers": {"palaia": {"command": "palaia-mcp"}}}
+```
 
 **MCP Tools:**
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -54,6 +54,32 @@ Or add to `.cursor/mcp.json`:
 }
 ```
 
+### Claude Code
+
+Add to `~/.claude/settings.json`:
+```json
+{
+  "mcpServers": {
+    "palaia": {
+      "command": "palaia-mcp"
+    }
+  }
+}
+```
+
+If palaia is installed in a virtualenv, use the full path:
+```json
+{
+  "mcpServers": {
+    "palaia": {
+      "command": "/path/to/.venv/bin/palaia-mcp"
+    }
+  }
+}
+```
+
+Restart Claude Code after adding the config. palaia tools (`palaia_search`, `palaia_store`, etc.) will be available automatically.
+
 ### Other MCP Hosts
 
 Any MCP-compatible host that supports stdio transport can use palaia:

--- a/palaia/SKILL.md
+++ b/palaia/SKILL.md
@@ -234,9 +234,14 @@ palaia-mcp --read-only                  # No writes (untrusted hosts)
 }
 ```
 
-**Cursor** (Settings → MCP Servers → Add):
+**Cursor** (Settings → MCP Servers → Add, or `.cursor/mcp.json`):
 - Command: `palaia-mcp`
 - Arguments: (none, or `--root /path/to/.palaia`)
+
+**Claude Code** (`~/.claude/settings.json`):
+```json
+{"mcpServers": {"palaia": {"command": "palaia-mcp"}}}
+```
 
 **MCP Tools:**
 

--- a/skills/palaia/SKILL.md
+++ b/skills/palaia/SKILL.md
@@ -234,9 +234,14 @@ palaia-mcp --read-only                  # No writes (untrusted hosts)
 }
 ```
 
-**Cursor** (Settings → MCP Servers → Add):
+**Cursor** (Settings → MCP Servers → Add, or `.cursor/mcp.json`):
 - Command: `palaia-mcp`
 - Arguments: (none, or `--root /path/to/.palaia`)
+
+**Claude Code** (`~/.claude/settings.json`):
+```json
+{"mcpServers": {"palaia": {"command": "palaia-mcp"}}}
+```
 
 **MCP Tools:**
 


### PR DESCRIPTION
Claude Code was missing from all MCP setup docs. Added settings.json config to docs/mcp.md, SKILL.md, and README.