### PR TITLE
chore: update GitHub org from iret77 to byte5ai

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for your interest in contributing to Palaia!
 ## Development Setup
 
 ```bash
-git clone https://github.com/iret77/palaia.git
+git clone https://github.com/byte5ai/palaia.git
 cd palaia
 pip install -e ".[dev,fastembed]"
 pytest tests/ -v
@@ -34,7 +34,7 @@ Intentional patterns in the codebase:
 
 ## Reporting Bugs
 
-Open a [GitHub Issue](https://github.com/iret77/palaia/issues). Include:
+Open a [GitHub Issue](https://github.com/byte5ai/palaia/issues). Include:
 
 - Python version (`python --version`)
 - Palaia version (`palaia --version`)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Crash-safe. Local-first. Zero-cloud. The memory system that makes your agents smarter over time.**
 
-[![CI](https://github.com/iret77/palaia/actions/workflows/ci.yml/badge.svg)](https://github.com/iret77/palaia/actions/workflows/ci.yml)
+[![CI](https://github.com/byte5ai/palaia/actions/workflows/ci.yml/badge.svg)](https://github.com/byte5ai/palaia/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/palaia)](https://pypi.org/project/palaia/)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -127,7 +127,7 @@ palaia status                                        # Check health
 ## Development
 
 ```bash
-git clone https://github.com/iret77/palaia.git
+git clone https://github.com/byte5ai/palaia.git
 cd palaia
 pip install -e ".[dev]"
 pytest

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Palaia
 site_description: Local, cloud-free memory for OpenClaw agents.
-site_url: https://github.com/iret77/palaia
-repo_url: https://github.com/iret77/palaia
+site_url: https://github.com/byte5ai/palaia
+repo_url: https://github.com/byte5ai/palaia
 
 theme:
   name: readthedocs

--- a/packages/openclaw-plugin/README.md
+++ b/packages/openclaw-plugin/README.md
@@ -122,7 +122,7 @@ OpenClaw Agent
 
 ```bash
 # Clone the repo
-git clone https://github.com/iret77/palaia.git
+git clone https://github.com/byte5ai/palaia.git
 cd palaia/packages/openclaw-plugin
 
 # Install deps

--- a/packages/openclaw-plugin/index.ts
+++ b/packages/openclaw-plugin/index.ts
@@ -35,7 +35,7 @@ const palaiaPlugin: OpenClawPluginEntry = {
     // plugin config from openclaw.json → plugins.config.palaia.
     // A per-agent resolver would require an OpenClaw upstream change where api.getConfig()
     // accepts an agentId parameter or automatically scopes to the current agent context.
-    // See: https://github.com/iret77/palaia/issues/66
+    // See: https://github.com/byte5ai/palaia/issues/66
     const rawConfig = api.getConfig?.("palaia") as
       | Partial<PalaiaPluginConfig>
       | undefined;

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iret77/palaia.git",
+    "url": "https://github.com/byte5ai/palaia.git",
     "directory": "packages/openclaw-plugin"
   },
   "peerDependencies": {

--- a/palaia/migrate.py
+++ b/palaia/migrate.py
@@ -500,6 +500,6 @@ def format_result(result: dict) -> str:
             lines.append("    This file is used at runtime by agents. It was copied to Palaia but NOT deleted.")
             lines.append("    Do not remove it manually.")
         lines.append("")
-        lines.append("See: https://github.com/iret77/palaia/blob/main/docs/migration-guide.md")
+        lines.append("See: https://github.com/byte5ai/palaia/blob/main/docs/migration-guide.md")
 
     return "\n".join(lines)

--- a/palaia/services/misc.py
+++ b/palaia/services/misc.py
@@ -84,7 +84,7 @@ def get_skill_content() -> dict:
         return {
             "error": (
                 "SKILL.md not found in this installation. "
-                "View it online: https://github.com/iret77/palaia/blob/main/SKILL.md"
+                "View it online: https://github.com/byte5ai/palaia/blob/main/SKILL.md"
             )
         }
     content = skill_path.read_text(encoding="utf-8")

--- a/palaia/ui.py
+++ b/palaia/ui.py
@@ -22,7 +22,7 @@ from palaia import __version__
 # ── Constants ────────────────────────────────────────────────────────────────
 
 HEADER_LINE = f"Palaia v{__version__} — Local memory for AI agents"
-HEADER_URL = "(c) 2026 byte5 GmbH — https://github.com/iret77/palaia"
+HEADER_URL = "(c) 2026 byte5 GmbH — https://github.com/byte5ai/palaia"
 
 # Box-drawing chars
 B_TL = "\u250c"  # ┌

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,9 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://palaia.ai"
-Repository = "https://github.com/iret77/palaia"
-Issues = "https://github.com/iret77/palaia/issues"
-Documentation = "https://github.com/iret77/palaia/tree/main/docs"
+Repository = "https://github.com/byte5ai/palaia"
+Issues = "https://github.com/byte5ai/palaia/issues"
+Documentation = "https://github.com/byte5ai/palaia/tree/main/docs"
 
 [project.scripts]
 palaia = "palaia.cli:main"


### PR DESCRIPTION
## Summary
- Update all GitHub URLs from `iret77/palaia` to `byte5ai/palaia`
- Affects: pyproject.toml, README, CONTRIBUTING, mkdocs.yml, palaia source, openclaw-plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)