### PR TITLE
feat: session continuity v3 + OpenClaw v2026.3.28 compat

### DIFF
--- a/packages/openclaw-plugin/index.ts
+++ b/packages/openclaw-plugin/index.ts
@@ -4,16 +4,20 @@
  * Plugin entry point. Loaded by OpenClaw via jiti (no build step needed).
  *
  * Registers:
- * - memory_search: Semantic search over Palaia memory
- * - memory_get: Read a specific memory entry
- * - memory_write: Write new entries (optional, opt-in)
- * - before_prompt_build: Query-based contextual recall (opt-in, Issue #65)
- * - agent_end: Auto-capture of significant exchanges (opt-in, Issue #64)
- * - palaia-recovery: WAL replay on startup
+ * - Tools: memory_search, memory_get, memory_write
+ * - MemoryPromptSection: Guided tool usage hints
+ * - Session hooks (always): session_start, session_end, before_reset,
+ *   llm_input, llm_output, after_tool_call, subagent_spawning, subagent_ended
+ * - ContextEngine (modern) OR legacy hooks (before_prompt_build, agent_end,
+ *   message_received, message_sending)
  *
- * Phase 1.5: ContextEngine adapter support. When the host provides
- * api.registerContextEngine, palaia registers as a ContextEngine.
- * Otherwise, falls back to legacy hook-based integration.
+ * v3.0 Features:
+ * - Session continuity: Auto-briefing on session start / LLM switch
+ * - Session summaries: Auto-saved on session end / reset
+ * - Tool observations: Tracked via after_tool_call
+ * - Progressive disclosure: Compact mode for large memory stores
+ * - Privacy markers: <private> blocks excluded from capture
+ * - Recency boost: Fresh memories ranked higher
  *
  * Activation:
  *   plugins: { slots: { memory: "palaia" } }
@@ -22,6 +26,7 @@
 import { resolveConfig, type PalaiaPluginConfig } from "./src/config.js";
 import { registerTools } from "./src/tools.js";
 import { registerHooks } from "./src/hooks/index.js";
+import { registerSessionHooks } from "./src/hooks/session.js";
 import { createPalaiaContextEngine } from "./src/context-engine.js";
 import type { OpenClawPluginApi, OpenClawPluginEntry } from "./src/types.js";
 
@@ -51,9 +56,31 @@ const palaiaPlugin: OpenClawPluginEntry = {
     // Register agent tools (memory_search, memory_get, memory_write)
     registerTools(api, config);
 
+    // Register MemoryPromptSection for guided memory tool usage (v3.0)
+    if (api.registerMemoryPromptSection) {
+      api.registerMemoryPromptSection(({ availableTools }) => {
+        const lines: string[] = [];
+        if (availableTools.has("memory_search")) {
+          lines.push("Use `memory_search` to find relevant memories by semantic query.");
+        }
+        if (availableTools.has("memory_get")) {
+          lines.push("Use `memory_get <id>` to retrieve full memory details by ID.");
+        }
+        if (availableTools.has("memory_write")) {
+          lines.push("Use `memory_write` for processes/SOPs and tasks only — conversation knowledge is auto-captured.");
+        }
+        return lines;
+      });
+    }
+
+    // Session lifecycle hooks are always registered (session_start, session_end,
+    // before_reset, llm_input, llm_output, after_tool_call).
+    // These work independently of the ContextEngine vs legacy hooks choice.
+    registerSessionHooks(api, config);
+
     // Register ContextEngine when available, otherwise use legacy hooks
     if (api.registerContextEngine) {
-      api.registerContextEngine("palaia", createPalaiaContextEngine(api, config));
+      api.registerContextEngine("palaia", () => createPalaiaContextEngine(api, config));
     } else {
       registerHooks(api, config);  // Legacy fallback
     }

--- a/packages/openclaw-plugin/index.ts
+++ b/packages/openclaw-plugin/index.ts
@@ -35,13 +35,11 @@ const palaiaPlugin: OpenClawPluginEntry = {
   id: "palaia",
   name: "Palaia Memory",
   async register(api: OpenClawPluginApi) {
-    // Issue #66: Plugin config is currently resolved GLOBALLY via api.getConfig("palaia").
+    // Issue #66: Plugin config is resolved GLOBALLY via api.pluginConfig.
     // OpenClaw does NOT provide per-agent config resolution — all agents share the same
-    // plugin config from openclaw.json → plugins.config.palaia.
-    // A per-agent resolver would require an OpenClaw upstream change where api.getConfig()
-    // accepts an agentId parameter or automatically scopes to the current agent context.
+    // plugin config from openclaw.json → plugins.entries.palaia.config.
     // See: https://github.com/byte5ai/palaia/issues/66
-    const rawConfig = api.getConfig?.("palaia") as
+    const rawConfig = api.pluginConfig as
       | Partial<PalaiaPluginConfig>
       | undefined;
     const config = resolveConfig(rawConfig);

--- a/packages/openclaw-plugin/src/config.ts
+++ b/packages/openclaw-plugin/src/config.ts
@@ -62,6 +62,18 @@ export interface PalaiaPluginConfig {
   // ── Embedding Server (v2.0.8) ──────────────────────────────
   /** Enable long-lived embedding server subprocess for fast queries (default: true) */
   embeddingServer: boolean;
+
+  // ── Session Continuity (v3.0) ─────────────────────────────
+  /** Enable automatic session summaries on session end/reset (default: true) */
+  sessionSummary: boolean;
+  /** Enable session briefing injection on session start (default: true) */
+  sessionBriefing: boolean;
+  /** Max characters for session briefing (default: 1500) */
+  sessionBriefingMaxChars: number;
+  /** Enable tool observation tracking via after_tool_call hook (default: true) */
+  captureToolObservations: boolean;
+  /** Recency boost factor for recall (0 = off, 0.3 = 30% boost for <24h entries) */
+  recallRecencyBoost: number;
 }
 
 export const DEFAULT_RECALL_TYPE_WEIGHTS: RecallTypeWeights = {
@@ -86,6 +98,11 @@ export const DEFAULT_CONFIG: PalaiaPluginConfig = {
   recallTypeWeight: { ...DEFAULT_RECALL_TYPE_WEIGHTS },
   recallMinScore: 0.7,
   embeddingServer: true,
+  sessionSummary: true,
+  sessionBriefing: true,
+  sessionBriefingMaxChars: 1500,
+  captureToolObservations: true,
+  recallRecencyBoost: 0.3,
 };
 
 /**

--- a/packages/openclaw-plugin/src/context-engine.ts
+++ b/packages/openclaw-plugin/src/context-engine.ts
@@ -1,13 +1,26 @@
 /**
- * ContextEngine adapter for deeper OpenClaw integration.
+ * ContextEngine adapter for OpenClaw integration.
  *
- * Maps the 7 ContextEngine lifecycle hooks to palaia functionality,
- * using the decomposed hooks modules as the implementation layer.
+ * Implements the OpenClaw v2026.3.24 ContextEngine interface,
+ * mapping lifecycle hooks to palaia functionality via the
+ * decomposed hooks modules.
  *
- * Phase 1.5: Created as a thin adapter over existing recall/capture logic.
+ * Supports both the modern ContextEngine interface (v2026.3.24+)
+ * and the legacy interface for backward compatibility.
  */
 
-import type { OpenClawPluginApi } from "./types.js";
+import type {
+  OpenClawPluginApi,
+  ContextEngine,
+  ContextEngineInfo,
+  AgentMessage,
+  AssembleResult,
+  BootstrapResult,
+  CompactResult,
+  IngestResult,
+  SubagentSpawnPreparation,
+  SubagentEndReason,
+} from "./types.js";
 import type { PalaiaPluginConfig } from "./config.js";
 import { run, recover, type RunnerOpts, getEmbedServerManager } from "./runner.js";
 
@@ -16,6 +29,8 @@ import {
   buildRecallQuery,
   rerankByTypeWeight,
   checkNudges,
+  formatEntryLine,
+  shouldUseCompactMode,
   type QueryResult,
 } from "./hooks/recall.js";
 
@@ -45,20 +60,6 @@ import {
   filterBlocked,
 } from "./priorities.js";
 
-/**
- * ContextEngine adapter for deeper OpenClaw integration.
- * Maps the 7 ContextEngine lifecycle hooks to palaia functionality.
- */
-export interface PalaiaContextEngine {
-  bootstrap(): Promise<void>;
-  ingest(messages: unknown[]): Promise<void>;
-  assemble(budget: { maxTokens: number }): Promise<{ content: string; tokenEstimate: number }>;
-  compact(): Promise<void>;
-  afterTurn(turn: unknown): Promise<void>;
-  prepareSubagentSpawn(parentContext: unknown): Promise<unknown>;
-  onSubagentEnded(result: unknown): Promise<void>;
-}
-
 function buildRunnerOpts(config: PalaiaPluginConfig, overrides?: { workspace?: string }): RunnerOpts {
   return {
     binaryPath: config.binaryPath,
@@ -72,28 +73,288 @@ function estimateTokens(text: string): number {
   return Math.ceil(text.length / 4);
 }
 
+/**
+ * Build the memory context string from recall results.
+ *
+ * Shared between assemble() and the legacy hooks path,
+ * so the logic lives here as a pure function.
+ */
+export async function buildMemoryContext(
+  config: PalaiaPluginConfig,
+  opts: RunnerOpts,
+  messages: unknown[],
+  maxChars: number,
+): Promise<{ text: string; recallOccurred: boolean; recallMinScore: number }> {
+  // Load and resolve priorities (Issue #121)
+  const prio = await loadPriorities(config.workspace || "");
+  const agentId = process.env.PALAIA_AGENT || undefined;
+  const project = config.captureProject || undefined;
+  const resolvedPrio = resolvePriorities(prio, {
+    recallTypeWeight: config.recallTypeWeight,
+    recallMinScore: config.recallMinScore,
+    maxInjectedChars: config.maxInjectedChars,
+    tier: config.tier,
+  }, agentId, project);
+
+  const effectiveMaxChars = Math.min(resolvedPrio.maxInjectedChars || 4000, maxChars);
+  const limit = Math.min(config.maxResults || 10, 20);
+  let entries: QueryResult["results"] = [];
+
+  if (config.recallMode === "query" && messages.length > 0) {
+    const userMessage = buildRecallQuery(messages);
+    if (userMessage && userMessage.length >= 5) {
+      // Try embed server first
+      let serverQueried = false;
+      if (config.embeddingServer) {
+        try {
+          const mgr = getEmbedServerManager(opts);
+          const resp = await mgr.query({
+            text: userMessage,
+            top_k: limit,
+            include_cold: resolvedPrio.tier === "all",
+          }, config.timeoutMs || 3000);
+          if (resp?.result?.results && Array.isArray(resp.result.results)) {
+            entries = resp.result.results;
+            serverQueried = true;
+          }
+        } catch {
+          // Fall through to CLI
+        }
+      }
+
+      if (!serverQueried) {
+        try {
+          const { runJson } = await import("./runner.js");
+          const queryArgs: string[] = ["query", userMessage, "--limit", String(limit)];
+          if (resolvedPrio.tier === "all") queryArgs.push("--all");
+          const result = await runJson<QueryResult>(queryArgs, { ...opts, timeoutMs: 15000 });
+          if (result && Array.isArray(result.results)) {
+            entries = result.results;
+          }
+        } catch {
+          // Fall through to list
+        }
+      }
+    }
+  }
+
+  // List fallback
+  if (entries.length === 0) {
+    try {
+      const { runJson } = await import("./runner.js");
+      const listArgs: string[] = ["list"];
+      if (resolvedPrio.tier === "all") {
+        listArgs.push("--all");
+      } else {
+        listArgs.push("--tier", resolvedPrio.tier || "hot");
+      }
+      const result = await runJson<QueryResult>(listArgs, opts);
+      if (result && Array.isArray(result.results)) {
+        entries = result.results;
+      }
+    } catch {
+      return { text: "", recallOccurred: false, recallMinScore: resolvedPrio.recallMinScore };
+    }
+  }
+
+  if (entries.length === 0) {
+    return { text: "", recallOccurred: false, recallMinScore: resolvedPrio.recallMinScore };
+  }
+
+  // Apply type-weighted reranking and blocked filtering (Issue #121)
+  const rankedRaw = rerankByTypeWeight(entries, resolvedPrio.recallTypeWeight, config.recallRecencyBoost);
+  const ranked = filterBlocked(rankedRaw, resolvedPrio.blocked);
+
+  // Build context string — progressive disclosure for large stores
+  const compact = shouldUseCompactMode(ranked.length);
+  let text = "## Active Memory (Palaia)\n\n";
+  if (compact) {
+    text += "_Compact mode — use `memory_get <id>` for full details._\n\n";
+  }
+  let chars = text.length;
+
+  for (const entry of ranked) {
+    const line = formatEntryLine(entry, compact);
+    if (chars + line.length > effectiveMaxChars) break;
+    text += line;
+    chars += line.length;
+  }
+
+  // Build nudge text and check remaining budget before appending
+  const USAGE_NUDGE = "[palaia] auto-capture=on. Manual write: --type process (SOPs/checklists) or --type task (todos with assignee/deadline) only. Conversation knowledge is auto-captured — do not duplicate with manual writes.";
+  let agentNudges = "";
+  try {
+    const pluginState = await loadPluginState(config.workspace);
+    pluginState.successfulRecalls++;
+    if (!pluginState.firstRecallTimestamp) {
+      pluginState.firstRecallTimestamp = new Date().toISOString();
+    }
+    const { nudges } = checkNudges(pluginState);
+    if (nudges.length > 0) {
+      agentNudges = "\n\n## Agent Nudge (Palaia)\n\n" + nudges.join("\n\n");
+    }
+    await savePluginState(pluginState, config.workspace);
+  } catch {
+    // Non-fatal
+  }
+
+  const nudgeText = USAGE_NUDGE + "\n\n" + agentNudges;
+  if (chars + nudgeText.length <= effectiveMaxChars) {
+    text += nudgeText;
+  }
+
+  const recallOccurred = entries.some(
+    (e) => typeof e.score === "number" && e.score >= resolvedPrio.recallMinScore,
+  );
+
+  return { text, recallOccurred, recallMinScore: resolvedPrio.recallMinScore };
+}
+
+/**
+ * Run auto-capture logic on a set of messages.
+ *
+ * Shared between ingest() and the legacy agent_end hook.
+ */
+export async function runAutoCapture(
+  messages: unknown[],
+  api: OpenClawPluginApi,
+  config: PalaiaPluginConfig,
+  logger: { info(...a: unknown[]): void; warn(...a: unknown[]): void },
+): Promise<boolean> {
+  if (!config.autoCapture) return false;
+  if (!messages || messages.length === 0) return false;
+
+  const allTexts = extractMessageTexts(messages);
+  const userTurns = allTexts.filter((t) => t.role === "user").length;
+  if (userTurns < config.captureMinTurns) return false;
+
+  // Parse capture hints
+  const collectedHints: { project?: string; scope?: string }[] = [];
+  for (const t of allTexts) {
+    const { hints } = parsePalaiaHints(t.text);
+    collectedHints.push(...hints);
+  }
+
+  // Strip injected context and trim to recent
+  const cleanedTexts = allTexts.map(t =>
+    t.role === "user"
+      ? { ...t, text: stripPalaiaInjectedContext(t.text) }
+      : t
+  );
+  const recentTexts = trimToRecentExchanges(cleanedTexts);
+  const exchangeParts: string[] = [];
+  for (const t of recentTexts) {
+    const { cleanedText } = parsePalaiaHints(t.text);
+    exchangeParts.push(`[${t.role}]: ${cleanedText}`);
+  }
+  const exchangeText = exchangeParts.join("\n");
+
+  if (!shouldAttemptCapture(exchangeText)) return false;
+
+  const hookOpts = buildRunnerOpts(config);
+  const knownProjects = await loadProjects(hookOpts);
+  const agentName = process.env.PALAIA_AGENT || undefined;
+
+  // LLM-based extraction (primary)
+  let llmHandled = false;
+  try {
+    const results = await extractWithLLM(messages, api.config, {
+      captureModel: config.captureModel,
+    }, knownProjects);
+
+    for (const r of results) {
+      if (r.significance >= config.captureMinSignificance) {
+        const hintProject = collectedHints.find((h) => h.project)?.project;
+        const hintScope = collectedHints.find((h) => h.scope)?.scope;
+        const effectiveProject = hintProject || r.project;
+        const scope = config.captureScope
+          ? sanitizeScope(config.captureScope, "team", true)
+          : sanitizeScope(hintScope || r.scope, "team", false);
+        const tags = [...r.tags];
+        if (!tags.includes("auto-capture")) tags.push("auto-capture");
+
+        const args: string[] = [
+          "write", r.content,
+          "--type", r.type,
+          "--tags", tags.join(",") || "auto-capture",
+          "--scope", scope,
+        ];
+        const project = config.captureProject || effectiveProject;
+        if (project) args.push("--project", project);
+        if (agentName) args.push("--agent", agentName);
+
+        await run(args, { ...hookOpts, timeoutMs: 10_000 });
+      }
+    }
+    llmHandled = true;
+  } catch {
+    // Fall through to rule-based
+  }
+
+  // Rule-based fallback
+  if (!llmHandled) {
+    if (config.captureFrequency === "significant") {
+      const significance = extractSignificance(exchangeText);
+      if (!significance) return false;
+      const tags = [...significance.tags];
+      if (!tags.includes("auto-capture")) tags.push("auto-capture");
+      const scope = config.captureScope
+        ? sanitizeScope(config.captureScope, "team", true)
+        : "team";
+      const args: string[] = [
+        "write", significance.summary,
+        "--type", significance.type,
+        "--tags", tags.join(","),
+        "--scope", scope,
+      ];
+      if (agentName) args.push("--agent", agentName);
+      await run(args, { ...hookOpts, timeoutMs: 10_000 });
+    } else {
+      const summary = exchangeParts.slice(-4).map(p => p.slice(0, 200)).join(" | ").slice(0, 500);
+      const args: string[] = [
+        "write", summary,
+        "--type", "memory",
+        "--tags", "auto-capture",
+        "--scope", config.captureScope || "team",
+      ];
+      if (agentName) args.push("--agent", agentName);
+      await run(args, { ...hookOpts, timeoutMs: 10_000 });
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Create a palaia ContextEngine implementing OpenClaw v2026.3.24 interface.
+ */
 export function createPalaiaContextEngine(
   api: OpenClawPluginApi,
   config: PalaiaPluginConfig,
-): PalaiaContextEngine {
+): ContextEngine {
   const logger = api.logger;
   const opts = buildRunnerOpts(config);
 
   /** Last messages seen via ingest(), used by assemble() for query building. */
-  let _lastMessages: unknown[] = [];
+  let _lastMessages: AgentMessage[] = [];
 
-  /** State from the last assemble() call, used by afterTurn(). */
-  let _lastAssembleState: {
-    recallOccurred: boolean;
-    capturedInThisTurn: boolean;
-  } = { recallOccurred: false, capturedInThisTurn: false };
+  /** State from the last assemble() call. */
+  let _lastAssembleState = {
+    recallOccurred: false,
+    capturedInThisTurn: false,
+  };
 
-  return {
+  const engine: ContextEngine = {
+    info: {
+      id: "palaia",
+      name: "Palaia Memory",
+      version: "2.3",
+    },
+
     /**
      * Bootstrap: WAL recovery + embed-server start.
-     * Maps to the palaia-recovery service from runner.ts.
      */
-    async bootstrap(): Promise<void> {
+    async bootstrap(_params) {
       try {
         const result = await recover(opts);
         if (result.replayed > 0) {
@@ -116,326 +377,164 @@ export function createPalaiaContextEngine(
           logger.info(`[palaia] Embed server pre-start skipped: ${err}`);
         }
       }
+
+      return { bootstrapped: true };
     },
 
     /**
-     * Ingest: auto-capture logic from hooks/capture.ts.
-     * Called with the turn's messages after the agent responds.
+     * Ingest: process a single message for auto-capture.
+     * Called per-message by the ContextEngine lifecycle.
+     * Accumulates messages; capture runs in afterTurn().
      */
-    async ingest(messages: unknown[]): Promise<void> {
-      _lastMessages = messages;
+    async ingest(params) {
+      if (params.message) {
+        _lastMessages.push(params.message);
+      }
+      return { ingested: true };
+    },
 
-      if (!config.autoCapture) return;
-      if (!messages || messages.length === 0) return;
+    /**
+     * AfterTurn: run auto-capture on accumulated messages.
+     */
+    async afterTurn(params) {
+      // Use params.messages if available (richer), else fall back to accumulated
+      const messages = params?.messages?.length ? params.messages : _lastMessages;
 
       try {
-        const allTexts = extractMessageTexts(messages);
-        const userTurns = allTexts.filter((t) => t.role === "user").length;
-        if (userTurns < config.captureMinTurns) return;
-
-        // Parse capture hints
-        const collectedHints: { project?: string; scope?: string }[] = [];
-        for (const t of allTexts) {
-          const { hints } = parsePalaiaHints(t.text);
-          collectedHints.push(...hints);
-        }
-
-        // Strip injected context and trim to recent
-        const cleanedTexts = allTexts.map(t =>
-          t.role === "user"
-            ? { ...t, text: stripPalaiaInjectedContext(t.text) }
-            : t
-        );
-        const recentTexts = trimToRecentExchanges(cleanedTexts);
-        const exchangeParts: string[] = [];
-        for (const t of recentTexts) {
-          const { cleanedText } = parsePalaiaHints(t.text);
-          exchangeParts.push(`[${t.role}]: ${cleanedText}`);
-        }
-        const exchangeText = exchangeParts.join("\n");
-
-        if (!shouldAttemptCapture(exchangeText)) return;
-
-        const hookOpts = buildRunnerOpts(config);
-        const knownProjects = await loadProjects(hookOpts);
-        const agentName = process.env.PALAIA_AGENT || undefined;
-
-        // LLM-based extraction (primary)
-        let llmHandled = false;
-        try {
-          const results = await extractWithLLM(messages, api.config, {
-            captureModel: config.captureModel,
-          }, knownProjects);
-
-          for (const r of results) {
-            if (r.significance >= config.captureMinSignificance) {
-              const hintProject = collectedHints.find((h) => h.project)?.project;
-              const hintScope = collectedHints.find((h) => h.scope)?.scope;
-              const effectiveProject = hintProject || r.project;
-              const scope = config.captureScope
-                ? sanitizeScope(config.captureScope, "team", true)
-                : sanitizeScope(hintScope || r.scope, "team", false);
-              const tags = [...r.tags];
-              if (!tags.includes("auto-capture")) tags.push("auto-capture");
-
-              const args: string[] = [
-                "write", r.content,
-                "--type", r.type,
-                "--tags", tags.join(",") || "auto-capture",
-                "--scope", scope,
-              ];
-              const project = config.captureProject || effectiveProject;
-              if (project) args.push("--project", project);
-              if (agentName) args.push("--agent", agentName);
-
-              await run(args, { ...hookOpts, timeoutMs: 10_000 });
-            }
-          }
-          llmHandled = true;
-        } catch {
-          // Fall through to rule-based
-        }
-
-        // Rule-based fallback
-        if (!llmHandled) {
-          if (config.captureFrequency === "significant") {
-            const significance = extractSignificance(exchangeText);
-            if (!significance) return;
-            const tags = [...significance.tags];
-            if (!tags.includes("auto-capture")) tags.push("auto-capture");
-            const scope = config.captureScope
-              ? sanitizeScope(config.captureScope, "team", true)
-              : "team";
-            const args: string[] = [
-              "write", significance.summary,
-              "--type", significance.type,
-              "--tags", tags.join(","),
-              "--scope", scope,
-            ];
-            if (agentName) args.push("--agent", agentName);
-            await run(args, { ...hookOpts, timeoutMs: 10_000 });
-          } else {
-            const summary = exchangeParts.slice(-4).map(p => p.slice(0, 200)).join(" | ").slice(0, 500);
-            const args: string[] = [
-              "write", summary,
-              "--type", "memory",
-              "--tags", "auto-capture",
-              "--scope", config.captureScope || "team",
-            ];
-            if (agentName) args.push("--agent", agentName);
-            await run(args, { ...hookOpts, timeoutMs: 10_000 });
-          }
-        }
-
-        _lastAssembleState.capturedInThisTurn = true;
+        const captured = await runAutoCapture(messages, api, config, logger);
+        _lastAssembleState.capturedInThisTurn = captured;
       } catch (error) {
-        logger.warn(`[palaia] ContextEngine ingest failed: ${error}`);
+        logger.warn(`[palaia] ContextEngine afterTurn capture failed: ${error}`);
       }
+
+      // Reset for next turn
+      _lastAssembleState = { recallOccurred: false, capturedInThisTurn: false };
+      _lastMessages = [];
     },
 
     /**
-     * Assemble: recall logic with token budget awareness from hooks/recall.ts.
-     * Returns memory context string and token estimate, respecting the budget.
+     * Assemble: recall logic with token budget awareness.
+     * Returns memory context via systemPromptAddition.
      */
-    async assemble(budget: { maxTokens: number }): Promise<{ content: string; tokenEstimate: number }> {
-      _lastAssembleState = { recallOccurred: false, capturedInThisTurn: _lastAssembleState.capturedInThisTurn };
+    async assemble(params) {
+      _lastAssembleState = {
+        recallOccurred: false,
+        capturedInThisTurn: _lastAssembleState.capturedInThisTurn,
+      };
 
       if (!config.memoryInject) {
-        return { content: "", tokenEstimate: 0 };
+        return {
+          messages: params.messages || [],
+          estimatedTokens: 0,
+        };
       }
 
       try {
-        // Load and resolve priorities (Issue #121)
-        const prio = await loadPriorities(config.workspace || "");
-        const agentId = process.env.PALAIA_AGENT || undefined;
-        const project = config.captureProject || undefined;
-        const resolvedPrio = resolvePriorities(prio, {
-          recallTypeWeight: config.recallTypeWeight,
-          recallMinScore: config.recallMinScore,
-          maxInjectedChars: config.maxInjectedChars,
-          tier: config.tier,
-        }, agentId, project);
+        const tokenBudget = params.tokenBudget || 4000;
+        const maxChars = tokenBudget * 4;
 
-        // Convert token budget to char budget (~4 chars per token)
-        const maxChars = Math.min(resolvedPrio.maxInjectedChars || 4000, budget.maxTokens * 4);
-        const limit = Math.min(config.maxResults || 10, 20);
-        let entries: QueryResult["results"] = [];
+        // Use params.messages for query building (richer than accumulated)
+        const queryMessages = params.messages?.length ? params.messages : _lastMessages;
 
-        if (config.recallMode === "query" && _lastMessages.length > 0) {
-          const userMessage = buildRecallQuery(_lastMessages);
-          if (userMessage && userMessage.length >= 5) {
-            // Try embed server first
-            let serverQueried = false;
-            if (config.embeddingServer) {
-              try {
-                const mgr = getEmbedServerManager(opts);
-                const resp = await mgr.query({
-                  text: userMessage,
-                  top_k: limit,
-                  include_cold: resolvedPrio.tier === "all",
-                }, config.timeoutMs || 3000);
-                if (resp?.result?.results && Array.isArray(resp.result.results)) {
-                  entries = resp.result.results;
-                  serverQueried = true;
-                }
-              } catch {
-                // Fall through to CLI
-              }
-            }
-
-            if (!serverQueried) {
-              try {
-                const { runJson } = await import("./runner.js");
-                const queryArgs: string[] = ["query", userMessage, "--limit", String(limit)];
-                if (resolvedPrio.tier === "all") queryArgs.push("--all");
-                const result = await runJson<QueryResult>(queryArgs, { ...opts, timeoutMs: 15000 });
-                if (result && Array.isArray(result.results)) {
-                  entries = result.results;
-                }
-              } catch {
-                // Fall through to list
-              }
-            }
-          }
-        }
-
-        // List fallback
-        if (entries.length === 0) {
-          try {
-            const { runJson } = await import("./runner.js");
-            const listArgs: string[] = ["list"];
-            if (resolvedPrio.tier === "all") {
-              listArgs.push("--all");
-            } else {
-              listArgs.push("--tier", resolvedPrio.tier || "hot");
-            }
-            const result = await runJson<QueryResult>(listArgs, opts);
-            if (result && Array.isArray(result.results)) {
-              entries = result.results;
-            }
-          } catch {
-            return { content: "", tokenEstimate: 0 };
-          }
-        }
-
-        if (entries.length === 0) {
-          return { content: "", tokenEstimate: 0 };
-        }
-
-        // Apply type-weighted reranking and blocked filtering (Issue #121)
-        const rankedRaw = rerankByTypeWeight(entries, resolvedPrio.recallTypeWeight);
-        const ranked = filterBlocked(rankedRaw, resolvedPrio.blocked);
-
-        // Build context string
-        const SCOPE_SHORT: Record<string, string> = { team: "t", private: "p", public: "pub" };
-        const TYPE_SHORT: Record<string, string> = { memory: "m", process: "pr", task: "tk" };
-
-        let text = "## Active Memory (Palaia)\n\n";
-        let chars = text.length;
-
-        for (const entry of ranked) {
-          const scopeKey = SCOPE_SHORT[entry.scope] || entry.scope;
-          const typeKey = TYPE_SHORT[entry.type] || entry.type;
-          const prefix = `[${scopeKey}/${typeKey}]`;
-
-          let line: string;
-          if (entry.body.toLowerCase().startsWith(entry.title.toLowerCase())) {
-            line = `${prefix} ${entry.body}\n\n`;
-          } else {
-            line = `${prefix} ${entry.title}\n${entry.body}\n\n`;
-          }
-
-          if (chars + line.length > maxChars) break;
-          text += line;
-          chars += line.length;
-        }
-
-        // Build nudge text and check remaining budget before appending
-        const USAGE_NUDGE = "[palaia] auto-capture=on. Manual write: --type process (SOPs/checklists) or --type task (todos with assignee/deadline) only. Conversation knowledge is auto-captured — do not duplicate with manual writes.";
-        let agentNudges = "";
-        try {
-          const pluginState = await loadPluginState(config.workspace);
-          pluginState.successfulRecalls++;
-          if (!pluginState.firstRecallTimestamp) {
-            pluginState.firstRecallTimestamp = new Date().toISOString();
-          }
-          const { nudges } = checkNudges(pluginState);
-          if (nudges.length > 0) {
-            agentNudges = "\n\n## Agent Nudge (Palaia)\n\n" + nudges.join("\n\n");
-          }
-          await savePluginState(pluginState, config.workspace);
-        } catch {
-          // Non-fatal
-        }
-
-        // Before adding nudges, check remaining budget
-        const nudgeText = USAGE_NUDGE + "\n\n" + agentNudges;
-        if (chars + nudgeText.length <= maxChars) {
-          text += nudgeText;
-        }
-        // If nudges don't fit, skip them — the recall content is more important
-
-        _lastAssembleState.recallOccurred = entries.some(
-          (e) => typeof e.score === "number" && e.score >= resolvedPrio.recallMinScore,
+        const { text, recallOccurred } = await buildMemoryContext(
+          config, opts, queryMessages, maxChars,
         );
 
+        _lastAssembleState.recallOccurred = recallOccurred;
+
+        if (!text) {
+          return {
+            messages: params.messages || [],
+            estimatedTokens: 0,
+          };
+        }
+
         return {
-          content: text,
-          tokenEstimate: estimateTokens(text),
+          messages: params.messages || [],
+          estimatedTokens: estimateTokens(text),
+          systemPromptAddition: text,
         };
       } catch (error) {
         logger.warn(`[palaia] ContextEngine assemble failed: ${error}`);
-        return { content: "", tokenEstimate: 0 };
+        return {
+          messages: params.messages || [],
+          estimatedTokens: 0,
+        };
       }
     },
 
     /**
      * Compact: trigger `palaia gc` via runner.
      */
-    async compact(): Promise<void> {
+    async compact(_params) {
       try {
         await run(["gc"], { ...opts, timeoutMs: 30_000 });
         logger.info("[palaia] GC compaction completed");
       } catch (error) {
         logger.warn(`[palaia] GC compaction failed: ${error}`);
       }
+      return { ok: true, compacted: true };
     },
 
     /**
-     * AfterTurn: state save + emoji reactions.
-     * Called after each agent turn completes.
+     * PrepareSubagentSpawn: load session summary for sub-agent context.
      */
-    async afterTurn(turn: unknown): Promise<void> {
-      // State save is handled implicitly by assemble() nudge logic.
-      // Reset for next turn.
-      _lastAssembleState = { recallOccurred: false, capturedInThisTurn: false };
-      _lastMessages = [];
+    async prepareSubagentSpawn(params) {
+      try {
+        // Load latest session summary for sub-agent context injection
+        const { runJson } = await import("./runner.js");
+        const result = await runJson<{ results: Array<{ body: string }> }>(
+          ["query", "session-summary", "--limit", "1", "--tags", "session-summary"],
+          { ...opts, timeoutMs: 5000 },
+        );
+        const summary = result?.results?.[0]?.body;
+        if (summary) {
+          // Set PALAIA_INSTANCE env so sub-agent writes to same session scope
+          const { getOrCreateSessionState } = await import("./hooks/state.js");
+          const parentState = getOrCreateSessionState(params?.parentSessionKey || "unknown");
+          process.env.PALAIA_INSTANCE = parentState.autoSessionId;
+          logger.info(`[palaia] Sub-agent context prepared (${summary.length} chars summary)`);
+        }
+      } catch {
+        // Non-fatal — sub-agent will still work, just without parent context
+      }
+      return undefined;
     },
 
     /**
-     * PrepareSubagentSpawn: pass workspace + agent identity.
-     * Returns context for the sub-agent to inherit.
+     * OnSubagentEnded: capture sub-agent result as memory.
      */
-    async prepareSubagentSpawn(parentContext: unknown): Promise<unknown> {
-      const workspace = typeof api.workspace === "string"
-        ? api.workspace
-        : api.workspace?.dir;
-      const agentId = process.env.PALAIA_AGENT || undefined;
-
-      return {
-        palaiaWorkspace: workspace || config.workspace,
-        palaiaAgentId: agentId,
-        parentContext,
-      };
-    },
-
-    /**
-     * OnSubagentEnded: placeholder for future sub-agent memory merge.
-     * Will eventually merge sub-agent captures into parent context.
-     */
-    async onSubagentEnded(_result: unknown): Promise<void> {
-      // Future: merge sub-agent memory captures into parent agent's context.
-      // For now, sub-agents write to the same palaia store, so no merge needed.
+    async onSubagentEnded(params) {
+      if (!config.autoCapture) return;
+      try {
+        // Try to get sub-agent's last messages for summary
+        if (api.runtime?.subagent?.getSessionMessages && params?.childSessionKey) {
+          const result = await api.runtime.subagent.getSessionMessages({
+            sessionKey: params.childSessionKey,
+            limit: 10,
+          });
+          if (result?.messages?.length) {
+            const texts = extractMessageTexts(result.messages);
+            const summaryParts = texts.slice(-4).map(
+              (t: { role: string; text: string }) => `[${t.role}]: ${t.text.slice(0, 200)}`
+            );
+            if (summaryParts.length > 0) {
+              const summaryText = `Sub-agent result:\n${summaryParts.join("\n")}`.slice(0, 500);
+              await run([
+                "write", summaryText,
+                "--type", "memory",
+                "--tags", "subagent-result,auto-capture",
+                "--scope", config.captureScope || "team",
+              ], { ...opts, timeoutMs: 10_000 });
+              logger.info(`[palaia] Sub-agent result captured (${summaryText.length} chars)`);
+            }
+          }
+        }
+      } catch (error) {
+        logger.warn(`[palaia] Sub-agent result capture failed: ${error}`);
+      }
     },
   };
+
+  return engine;
 }

--- a/packages/openclaw-plugin/src/context-engine.ts
+++ b/packages/openclaw-plugin/src/context-engine.ts
@@ -42,16 +42,13 @@ import {
   trimToRecentExchanges,
   parsePalaiaHints,
   loadProjects,
-  resolveCaptureModel,
   type ExtractionResult,
 } from "./hooks/capture.js";
 
 import {
   loadPluginState,
   savePluginState,
-  resolvePerAgentContext,
   sanitizeScope,
-  isValidScope,
 } from "./hooks/state.js";
 
 import {
@@ -75,9 +72,7 @@ function estimateTokens(text: string): number {
 
 /**
  * Build the memory context string from recall results.
- *
- * Shared between assemble() and the legacy hooks path,
- * so the logic lives here as a pure function.
+ * Used by the ContextEngine assemble() method.
  */
 export async function buildMemoryContext(
   config: PalaiaPluginConfig,
@@ -212,8 +207,7 @@ export async function buildMemoryContext(
 
 /**
  * Run auto-capture logic on a set of messages.
- *
- * Shared between ingest() and the legacy agent_end hook.
+ * Used by the ContextEngine afterTurn() method.
  */
 export async function runAutoCapture(
   messages: unknown[],
@@ -470,34 +464,20 @@ export function createPalaiaContextEngine(
       try {
         await run(["gc"], { ...opts, timeoutMs: 30_000 });
         logger.info("[palaia] GC compaction completed");
+        return { ok: true, compacted: true };
       } catch (error) {
         logger.warn(`[palaia] GC compaction failed: ${error}`);
+        return { ok: false, compacted: false, reason: String(error) };
       }
-      return { ok: true, compacted: true };
     },
 
     /**
      * PrepareSubagentSpawn: load session summary for sub-agent context.
      */
-    async prepareSubagentSpawn(params) {
-      try {
-        // Load latest session summary for sub-agent context injection
-        const { runJson } = await import("./runner.js");
-        const result = await runJson<{ results: Array<{ body: string }> }>(
-          ["query", "session-summary", "--limit", "1", "--tags", "session-summary"],
-          { ...opts, timeoutMs: 5000 },
-        );
-        const summary = result?.results?.[0]?.body;
-        if (summary) {
-          // Set PALAIA_INSTANCE env so sub-agent writes to same session scope
-          const { getOrCreateSessionState } = await import("./hooks/state.js");
-          const parentState = getOrCreateSessionState(params?.parentSessionKey || "unknown");
-          process.env.PALAIA_INSTANCE = parentState.autoSessionId;
-          logger.info(`[palaia] Sub-agent context prepared (${summary.length} chars summary)`);
-        }
-      } catch {
-        // Non-fatal — sub-agent will still work, just without parent context
-      }
+    async prepareSubagentSpawn(_params) {
+      // Sub-agents share the same palaia store via workspace,
+      // so no explicit context passing is needed.
+      // Future: use OpenClaw's extraSystemPrompt to pass session summary.
       return undefined;
     },
 
@@ -506,6 +486,8 @@ export function createPalaiaContextEngine(
      */
     async onSubagentEnded(params) {
       if (!config.autoCapture) return;
+      // Only capture results for successfully completed sub-agents
+      if (params?.reason !== "completed") return;
       try {
         // Try to get sub-agent's last messages for summary
         if (api.runtime?.subagent?.getSessionMessages && params?.childSessionKey) {

--- a/packages/openclaw-plugin/src/context-engine.ts
+++ b/packages/openclaw-plugin/src/context-engine.ts
@@ -12,14 +12,7 @@
 import type {
   OpenClawPluginApi,
   ContextEngine,
-  ContextEngineInfo,
   AgentMessage,
-  AssembleResult,
-  BootstrapResult,
-  CompactResult,
-  IngestResult,
-  SubagentSpawnPreparation,
-  SubagentEndReason,
 } from "./types.js";
 import type { PalaiaPluginConfig } from "./config.js";
 import { run, recover, type RunnerOpts, getEmbedServerManager } from "./runner.js";
@@ -42,7 +35,6 @@ import {
   trimToRecentExchanges,
   parsePalaiaHints,
   loadProjects,
-  type ExtractionResult,
 } from "./hooks/capture.js";
 
 import {
@@ -74,7 +66,7 @@ function estimateTokens(text: string): number {
  * Build the memory context string from recall results.
  * Used by the ContextEngine assemble() method.
  */
-export async function buildMemoryContext(
+async function buildMemoryContext(
   config: PalaiaPluginConfig,
   opts: RunnerOpts,
   messages: unknown[],
@@ -209,7 +201,7 @@ export async function buildMemoryContext(
  * Run auto-capture logic on a set of messages.
  * Used by the ContextEngine afterTurn() method.
  */
-export async function runAutoCapture(
+async function runAutoCapture(
   messages: unknown[],
   api: OpenClawPluginApi,
   config: PalaiaPluginConfig,
@@ -332,11 +324,8 @@ export function createPalaiaContextEngine(
   /** Last messages seen via ingest(), used by assemble() for query building. */
   let _lastMessages: AgentMessage[] = [];
 
-  /** State from the last assemble() call. */
-  let _lastAssembleState = {
-    recallOccurred: false,
-    capturedInThisTurn: false,
-  };
+  /** Whether the last assemble() call found relevant memories. */
+  let _lastRecallOccurred = false;
 
   const engine: ContextEngine = {
     info: {
@@ -395,14 +384,13 @@ export function createPalaiaContextEngine(
       const messages = params?.messages?.length ? params.messages : _lastMessages;
 
       try {
-        const captured = await runAutoCapture(messages, api, config, logger);
-        _lastAssembleState.capturedInThisTurn = captured;
+        await runAutoCapture(messages, api, config, logger);
       } catch (error) {
         logger.warn(`[palaia] ContextEngine afterTurn capture failed: ${error}`);
       }
 
       // Reset for next turn
-      _lastAssembleState = { recallOccurred: false, capturedInThisTurn: false };
+      _lastRecallOccurred = false;
       _lastMessages = [];
     },
 
@@ -411,10 +399,7 @@ export function createPalaiaContextEngine(
      * Returns memory context via systemPromptAddition.
      */
     async assemble(params) {
-      _lastAssembleState = {
-        recallOccurred: false,
-        capturedInThisTurn: _lastAssembleState.capturedInThisTurn,
-      };
+      _lastRecallOccurred = false;
 
       if (!config.memoryInject) {
         return {
@@ -434,7 +419,7 @@ export function createPalaiaContextEngine(
           config, opts, queryMessages, maxChars,
         );
 
-        _lastAssembleState.recallOccurred = recallOccurred;
+        _lastRecallOccurred = recallOccurred;
 
         if (!text) {
           return {

--- a/packages/openclaw-plugin/src/hooks/capture.ts
+++ b/packages/openclaw-plugin/src/hooks/capture.ts
@@ -469,11 +469,11 @@ export async function extractWithLLM(
   }
 
   const allTexts = extractMessageTexts(messages);
-  // Strip Palaia-injected recall context from user messages to prevent feedback loop
+  // Strip Palaia-injected recall context and private blocks from user messages
   const cleanedTexts = allTexts.map(t =>
     t.role === "user"
-      ? { ...t, text: stripPalaiaInjectedContext(t.text) }
-      : t
+      ? { ...t, text: stripPrivateBlocks(stripPalaiaInjectedContext(t.text)) }
+      : { ...t, text: stripPrivateBlocks(t.text) }
   );
   // Only extract from recent exchanges — full history causes LLM timeouts
   // and dilutes extraction quality
@@ -736,5 +736,19 @@ export function stripPalaiaInjectedContext(text: string): string {
   // Pattern: "## Active Memory (Palaia)" ... "[palaia] auto-capture=on..." + optional trailing newlines
   // The nudge line is always present and marks the end of the injected block
   const PALAIA_BLOCK_RE = /## Active Memory \(Palaia\)[\s\S]*?\[palaia\][^\n]*\n*/;
-  return text.replace(PALAIA_BLOCK_RE, '').trim();
+  // Also strip Session Briefing blocks
+  const BRIEFING_BLOCK_RE = /## Session Briefing \(Palaia\)[\s\S]*?(?=\n##|\n\n\n|$)/;
+  return text
+    .replace(PALAIA_BLOCK_RE, '')
+    .replace(BRIEFING_BLOCK_RE, '')
+    .trim();
+}
+
+/**
+ * Strip <private>...</private> blocks from text.
+ * Content inside private tags is excluded from memory capture.
+ * Inspired by claude-mem's privacy marker system.
+ */
+export function stripPrivateBlocks(text: string): string {
+  return text.replace(/<private>[\s\S]*?<\/private>/gi, '').trim();
 }

--- a/packages/openclaw-plugin/src/hooks/index.ts
+++ b/packages/openclaw-plugin/src/hooks/index.ts
@@ -350,9 +350,19 @@ export function registerHooks(api: OpenClawPluginApi, config: PalaiaPluginConfig
         // If a session briefing is pending (from session_start or model switch),
         // prepend it to the recall context for seamless session continuity.
         let briefingText = "";
+        let briefingSummary: string | null = null; // Kept for smart query fallback
         const sessionKey = resolveSessionKeyFromCtx(ctx);
         if (sessionKey) {
           const sessState = getOrCreateSessionState(sessionKey);
+          // Wait for session_start briefing load (max 3s to avoid blocking)
+          if (sessState.briefingReady) {
+            await Promise.race([
+              sessState.briefingReady,
+              new Promise<void>(r => setTimeout(r, 3000)),
+            ]);
+          }
+          // Capture summary BEFORE clearing, for smart query fallback below
+          briefingSummary = sessState.pendingBriefing?.summary ?? null;
           if (sessState.pendingBriefing && !sessState.briefingDelivered) {
             briefingText = formatBriefing(sessState.pendingBriefing, config.sessionBriefingMaxChars);
             sessState.briefingDelivered = true;
@@ -388,13 +398,9 @@ export function registerHooks(api: OpenClawPluginApi, config: PalaiaPluginConfig
           // If query is too short or matches a continuation pattern,
           // use the session summary as query for better recall results.
           const CONTINUATION_PATTERN = /^(ja|ok|weiter|mach|genau|do it|yes|continue|go|proceed|sure|klar|passt|yep|yup|exactly|right)\b/i;
-          if (sessionKey) {
-            const sessState = getOrCreateSessionState(sessionKey);
-            const summaryText = sessState.pendingBriefing?.summary;
-            if (summaryText && userMessage && (userMessage.length < 10 || CONTINUATION_PATTERN.test(userMessage.trim()))) {
-              userMessage = summaryText.slice(0, 500);
-              logger.info("[palaia] Smart query fallback: using session summary as recall query");
-            }
+          if (briefingSummary && userMessage && (userMessage.length < 10 || CONTINUATION_PATTERN.test(userMessage.trim()))) {
+            userMessage = briefingSummary.slice(0, 500);
+            logger.info("[palaia] Smart query fallback: using session summary as recall query");
           }
 
           if (userMessage && userMessage.length >= 5) {
@@ -458,11 +464,21 @@ export function registerHooks(api: OpenClawPluginApi, config: PalaiaPluginConfig
               entries = result.results;
             }
           } catch {
+            // Still deliver briefing even if recall fails completely
+            if (briefingText) {
+              return { prependContext: briefingText };
+            }
             return;
           }
         }
 
-        if (entries.length === 0) return;
+        // If no recall entries but briefing exists, deliver briefing alone
+        if (entries.length === 0) {
+          if (briefingText) {
+            return { prependContext: briefingText };
+          }
+          return;
+        }
 
         // Apply type-weighted reranking and blocked filtering (Issue #121)
         const rankedRaw = rerankByTypeWeight(entries, resolvedPrio.recallTypeWeight, config.recallRecencyBoost);
@@ -537,7 +553,7 @@ export function registerHooks(api: OpenClawPluginApi, config: PalaiaPluginConfig
 
         // Return prependContext + appendSystemContext for recall emoji
         return {
-          prependContext: briefingText + text + nudgeContext,
+          prependContext: briefingText + text,
           appendSystemContext: config.showMemorySources
             ? "You used Palaia memory in this turn. Add \u{1f9e0} at the very end of your response (after everything else, on its own line)."
             : undefined,

--- a/packages/openclaw-plugin/src/hooks/index.ts
+++ b/packages/openclaw-plugin/src/hooks/index.ts
@@ -119,6 +119,8 @@ import {
   extractMessageTexts,
   buildRecallQuery,
   rerankByTypeWeight,
+  formatEntryLine,
+  shouldUseCompactMode,
 } from "./recall.js";
 
 import {
@@ -150,6 +152,9 @@ import {
   resolvePriorities,
   filterBlocked,
 } from "../priorities.js";
+
+import { formatBriefing } from "./session.js";
+import { getOrCreateSessionState } from "./state.js";
 
 // ============================================================================
 // Logger (Issue: api.logger integration)
@@ -189,6 +194,10 @@ export function registerHooks(api: OpenClawPluginApi, config: PalaiaPluginConfig
   }
 
   const opts = buildRunnerOpts(config);
+
+  // Note: Session lifecycle hooks (session_start, session_end, before_reset,
+  // llm_input, llm_output, after_tool_call) are registered in index.ts entry
+  // point BEFORE this function, so they work for both ContextEngine and legacy paths.
 
   // ── Startup checks (H-2, H-3, captureModel validation) ────────
   (async () => {
@@ -326,7 +335,7 @@ export function registerHooks(api: OpenClawPluginApi, config: PalaiaPluginConfig
     }
   });
 
-  // ── before_prompt_build (Issue #65: Query-based Recall) ────────
+  // ── before_prompt_build (Issue #65: Query-based Recall + v3.0 Session Briefing) ──
   if (config.memoryInject) {
     api.on("before_prompt_build", async (event: any, ctx: any) => {
       // Prune stale entries to prevent memory leaks from crashed sessions (C-2)
@@ -337,6 +346,24 @@ export function registerHooks(api: OpenClawPluginApi, config: PalaiaPluginConfig
       const hookOpts = buildRunnerOpts(config, { workspace: resolved.workspace });
 
       try {
+        // ── Session Briefing Injection (v3.0) ─────────────────────
+        // If a session briefing is pending (from session_start or model switch),
+        // prepend it to the recall context for seamless session continuity.
+        let briefingText = "";
+        const sessionKey = resolveSessionKeyFromCtx(ctx);
+        if (sessionKey) {
+          const sessState = getOrCreateSessionState(sessionKey);
+          if (sessState.pendingBriefing && !sessState.briefingDelivered) {
+            briefingText = formatBriefing(sessState.pendingBriefing, config.sessionBriefingMaxChars);
+            sessState.briefingDelivered = true;
+            // Clear pending briefing after delivery (unless model switch re-triggers)
+            if (!sessState.modelSwitchDetected) {
+              sessState.pendingBriefing = null;
+            }
+            sessState.modelSwitchDetected = false;
+          }
+        }
+
         // Load and resolve priorities (Issue #121)
         const prio = await loadPriorities(resolved.workspace);
         const project = config.captureProject || undefined;
@@ -347,14 +374,28 @@ export function registerHooks(api: OpenClawPluginApi, config: PalaiaPluginConfig
           tier: config.tier,
         }, resolved.agentId, project);
 
-        const maxChars = resolvedPrio.maxInjectedChars || 4000;
+        // Reduce recall budget by briefing size
+        const maxChars = Math.max((resolvedPrio.maxInjectedChars || 4000) - briefingText.length, 500);
         const limit = Math.min(config.maxResults || 10, 20);
         let entries: QueryResult["results"] = [];
 
         if (config.recallMode === "query") {
-          const userMessage = event.messages
+          let userMessage = event.messages
             ? buildRecallQuery(event.messages)
             : (event.prompt || null);
+
+          // ── Smart Query Fallback (v3.0) ───────────────────────
+          // If query is too short or matches a continuation pattern,
+          // use the session summary as query for better recall results.
+          const CONTINUATION_PATTERN = /^(ja|ok|weiter|mach|genau|do it|yes|continue|go|proceed|sure|klar|passt|yep|yup|exactly|right)\b/i;
+          if (sessionKey) {
+            const sessState = getOrCreateSessionState(sessionKey);
+            const summaryText = sessState.pendingBriefing?.summary;
+            if (summaryText && userMessage && (userMessage.length < 10 || CONTINUATION_PATTERN.test(userMessage.trim()))) {
+              userMessage = summaryText.slice(0, 500);
+              logger.info("[palaia] Smart query fallback: using session summary as recall query");
+            }
+          }
 
           if (userMessage && userMessage.length >= 5) {
             // Try embed server first (fast path: ~0.5s), then CLI fallback (~3-14s)
@@ -424,29 +465,20 @@ export function registerHooks(api: OpenClawPluginApi, config: PalaiaPluginConfig
         if (entries.length === 0) return;
 
         // Apply type-weighted reranking and blocked filtering (Issue #121)
-        const rankedRaw = rerankByTypeWeight(entries, resolvedPrio.recallTypeWeight);
+        const rankedRaw = rerankByTypeWeight(entries, resolvedPrio.recallTypeWeight, config.recallRecencyBoost);
         const ranked = filterBlocked(rankedRaw, resolvedPrio.blocked);
 
-        // Build context string with char budget (compact format for token efficiency)
-        const SCOPE_SHORT: Record<string, string> = { team: "t", private: "p", public: "pub" };
-        const TYPE_SHORT: Record<string, string> = { memory: "m", process: "pr", task: "tk" };
-
+        // Build context string with char budget
+        // Progressive disclosure: compact mode for large stores (title + first line + ID)
+        const compact = shouldUseCompactMode(ranked.length);
         let text = "## Active Memory (Palaia)\n\n";
+        if (compact) {
+          text += "_Compact mode — use `memory_get <id>` for full details._\n\n";
+        }
         let chars = text.length;
 
         for (const entry of ranked) {
-          const scopeKey = SCOPE_SHORT[entry.scope] || entry.scope;
-          const typeKey = TYPE_SHORT[entry.type] || entry.type;
-          const prefix = `[${scopeKey}/${typeKey}]`;
-
-          // If body starts with title (common), skip title to save tokens
-          let line: string;
-          if (entry.body.toLowerCase().startsWith(entry.title.toLowerCase())) {
-            line = `${prefix} ${entry.body}\n\n`;
-          } else {
-            line = `${prefix} ${entry.title}\n${entry.body}\n\n`;
-          }
-
+          const line = formatEntryLine(entry, compact);
           if (chars + line.length > maxChars) break;
           text += line;
           chars += line.length;
@@ -483,7 +515,6 @@ export function registerHooks(api: OpenClawPluginApi, config: PalaiaPluginConfig
         const hasRelevantRecall = !isListFallback && entries.some(
           (e) => typeof e.score === "number" && e.score >= resolvedPrio.recallMinScore,
         );
-        const sessionKey = resolveSessionKeyFromCtx(ctx);
         if (sessionKey && hasRelevantRecall) {
           const turnState = getOrCreateTurnState(sessionKey);
           turnState.recallOccurred = true;
@@ -506,7 +537,7 @@ export function registerHooks(api: OpenClawPluginApi, config: PalaiaPluginConfig
 
         // Return prependContext + appendSystemContext for recall emoji
         return {
-          prependContext: text + nudgeContext,
+          prependContext: briefingText + text + nudgeContext,
           appendSystemContext: config.showMemorySources
             ? "You used Palaia memory in this turn. Add \u{1f9e0} at the very end of your response (after everything else, on its own line)."
             : undefined,

--- a/packages/openclaw-plugin/src/hooks/index.ts
+++ b/packages/openclaw-plugin/src/hooks/index.ts
@@ -868,7 +868,7 @@ export function registerHooks(api: OpenClawPluginApi, config: PalaiaPluginConfig
   // ── Startup Recovery Service ───────────────────────────────────
   api.registerService({
     id: "palaia-recovery",
-    start: async () => {
+    start: async (_ctx) => {
       const result = await recover(opts);
       if (result.replayed > 0) {
         logger.info(`[palaia] WAL recovery: replayed ${result.replayed} entries`);

--- a/packages/openclaw-plugin/src/hooks/recall.ts
+++ b/packages/openclaw-plugin/src/hooks/recall.ts
@@ -26,6 +26,7 @@ export interface QueryResult {
     title?: string;
     type?: string;
     tags?: string[];
+    created?: string;
   }>;
 }
 
@@ -342,16 +343,35 @@ export interface RankedEntry {
   bm25Score?: number;
   embedScore?: number;
   weightedScore: number;
+  created?: string;
+}
+
+/**
+ * Calculate recency boost factor.
+ * Returns a multiplier: 1.0 (no boost) to 1.0 + boostFactor (max boost for very recent).
+ * Formula: 1 + boostFactor * exp(-hoursAgo / 24)
+ */
+function calcRecencyBoost(created: string | undefined, boostFactor: number): number {
+  if (!boostFactor || !created) return 1.0;
+  try {
+    const hoursAgo = (Date.now() - new Date(created).getTime()) / (1000 * 60 * 60);
+    if (hoursAgo < 0 || isNaN(hoursAgo)) return 1.0;
+    return 1.0 + boostFactor * Math.exp(-hoursAgo / 24);
+  } catch {
+    return 1.0;
+  }
 }
 
 export function rerankByTypeWeight(
   results: QueryResult["results"],
   weights: RecallTypeWeights,
+  recencyBoost = 0,
 ): RankedEntry[] {
   return results
     .map((r) => {
       const type = r.type || "memory";
       const weight = weights[type] ?? 1.0;
+      const recency = calcRecencyBoost(r.created, recencyBoost);
       return {
         id: r.id,
         body: r.content || r.body || "",
@@ -362,8 +382,49 @@ export function rerankByTypeWeight(
         score: r.score,
         bm25Score: r.bm25_score,
         embedScore: r.embed_score,
-        weightedScore: r.score * weight,
+        weightedScore: r.score * weight * recency,
+        created: r.created,
       };
     })
     .sort((a, b) => b.weightedScore - a.weightedScore);
+}
+
+// ── Context Formatting ──────────────────────────────────────────────────
+
+const SCOPE_SHORT: Record<string, string> = { team: "t", private: "p", public: "pub" };
+const TYPE_SHORT: Record<string, string> = { memory: "m", process: "pr", task: "tk" };
+
+/**
+ * Format a ranked entry as an injectable context line.
+ *
+ * In compact mode (progressive disclosure), only title + first line + ID are shown.
+ * The agent can use `memory_get <id>` for the full entry.
+ */
+export function formatEntryLine(entry: RankedEntry, compact: boolean): string {
+  const scopeKey = SCOPE_SHORT[entry.scope] || entry.scope;
+  const typeKey = TYPE_SHORT[entry.type] || entry.type;
+  const prefix = `[${scopeKey}/${typeKey}]`;
+
+  if (compact) {
+    // Compact: title + first line of body + ID reference
+    const firstLine = entry.body.split("\n")[0]?.slice(0, 120) || "";
+    const titlePart = entry.body.toLowerCase().startsWith(entry.title.toLowerCase())
+      ? firstLine
+      : `${entry.title} — ${firstLine}`;
+    return `${prefix} ${titlePart} [id:${entry.id}]\n`;
+  }
+
+  // Full: title + complete body
+  if (entry.body.toLowerCase().startsWith(entry.title.toLowerCase())) {
+    return `${prefix} ${entry.body}\n\n`;
+  }
+  return `${prefix} ${entry.title}\n${entry.body}\n\n`;
+}
+
+/**
+ * Determine if compact mode should be used based on result count.
+ * Above threshold, use compact mode to fit more entries in budget.
+ */
+export function shouldUseCompactMode(totalResults: number, threshold = 100): boolean {
+  return totalResults > threshold;
 }

--- a/packages/openclaw-plugin/src/hooks/session.ts
+++ b/packages/openclaw-plugin/src/hooks/session.ts
@@ -423,7 +423,6 @@ export function registerSessionHooks(
         });
         if (!result?.messages?.length) return;
 
-        const { extractMessageTexts } = await import("./recall.js");
         const texts = extractMessageTexts(result.messages);
         const summaryParts = texts.slice(-4).map(
           (t: { role: string; text: string }) => `[${t.role}]: ${t.text.slice(0, 200)}`

--- a/packages/openclaw-plugin/src/hooks/session.ts
+++ b/packages/openclaw-plugin/src/hooks/session.ts
@@ -12,11 +12,10 @@
 
 import type { OpenClawPluginApi } from "../types.js";
 import type { PalaiaPluginConfig } from "../config.js";
-import { run, type RunnerOpts, getEmbedServerManager } from "../runner.js";
+import { run, type RunnerOpts } from "../runner.js";
 import {
   getOrCreateSessionState,
   deleteSessionState,
-  resolveSessionKeyFromCtx,
   type PendingBriefing,
   type ToolObservation,
 } from "./state.js";
@@ -24,7 +23,6 @@ import {
   stripPalaiaInjectedContext,
   trimToRecentExchanges,
   extractWithLLM,
-  extractSignificance,
 } from "./capture.js";
 import { extractMessageTexts } from "./recall.js";
 
@@ -48,46 +46,46 @@ export async function loadSessionBriefing(
 ): Promise<PendingBriefing> {
   const opts = buildRunnerOpts(config);
   let summary: string | null = null;
+  let summaryCreated: number = Date.now();
   const openTasks: string[] = [];
 
-  // Load last session summary
-  try {
-    const { runJson } = await import("../runner.js");
-    const result = await runJson<{ results: Array<{ title: string; body: string; created: string }> }>(
+  // Load last session summary and open tasks in parallel
+  const { runJson } = await import("../runner.js");
+  const [summaryResult, tasksResult] = await Promise.allSettled([
+    runJson<{ results: Array<{ title: string; body: string; created?: string }> }>(
       ["query", "session-summary", "--limit", "1", "--tags", "session-summary"],
       { ...opts, timeoutMs: 5000 },
-    );
-    if (result?.results?.[0]) {
-      summary = result.results[0].body;
-    }
-  } catch {
-    // Non-fatal — no summary available
-  }
-
-  // Load open tasks
-  try {
-    const { runJson } = await import("../runner.js");
-    const result = await runJson<{ results: Array<{ title: string; body: string; priority?: string }> }>(
+    ),
+    runJson<{ results: Array<{ title: string; body: string; priority?: string }> }>(
       ["list", "--type", "task", "--status", "open", "--limit", "5"],
       { ...opts, timeoutMs: 5000 },
-    );
-    if (result?.results) {
-      for (const task of result.results) {
-        const prio = task.priority ? ` (${task.priority})` : "";
-        openTasks.push(`${task.title}${prio}`);
-      }
+    ),
+  ]);
+
+  if (summaryResult.status === "fulfilled" && summaryResult.value?.results?.[0]) {
+    summary = summaryResult.value.results[0].body;
+    const created = summaryResult.value.results[0].created;
+    if (created) {
+      const parsed = new Date(created).getTime();
+      if (!isNaN(parsed)) summaryCreated = parsed;
     }
-  } catch {
-    // Non-fatal
   }
 
-  return { summary, openTasks, timestamp: Date.now() };
+  if (tasksResult.status === "fulfilled" && tasksResult.value?.results) {
+    for (const task of tasksResult.value.results) {
+      const prio = task.priority ? ` (${task.priority})` : "";
+      openTasks.push(`${task.title}${prio}`);
+    }
+  }
+
+  return { summary, openTasks, timestamp: summaryCreated };
 }
 
 /**
  * Format a pending briefing into injectable text.
  */
 export function formatBriefing(briefing: PendingBriefing, maxChars: number): string {
+  if (maxChars <= 0) return "";
   if (!briefing.summary && briefing.openTasks.length === 0) return "";
 
   const parts: string[] = ["## Session Briefing (Palaia)\n"];
@@ -95,16 +93,16 @@ export function formatBriefing(briefing: PendingBriefing, maxChars: number): str
   if (briefing.summary) {
     const agoMs = Date.now() - briefing.timestamp;
     const agoMin = Math.round(agoMs / 60_000);
-    const agoStr = agoMin < 1 ? "gerade eben" :
-      agoMin < 60 ? `vor ${agoMin} Min.` :
-      `vor ${Math.round(agoMin / 60)} Std.`;
-    parts.push(`Letzte Session (${agoStr}):`);
+    const agoStr = agoMin < 1 ? "just now" :
+      agoMin < 60 ? `${agoMin}m ago` :
+      `${Math.round(agoMin / 60)}h ago`;
+    parts.push(`Last session (${agoStr}):`);
     parts.push(briefing.summary);
     parts.push("");
   }
 
   if (briefing.openTasks.length > 0) {
-    parts.push("Offene Aufgaben:");
+    parts.push("Open tasks:");
     for (const task of briefing.openTasks) {
       parts.push(`- ${task}`);
     }
@@ -130,6 +128,10 @@ export async function captureSessionSummary(
 ): Promise<void> {
   const opts = buildRunnerOpts(config);
   const state = getOrCreateSessionState(sessionKey);
+
+  // Guard: prevent double-save (before_reset + session_end race)
+  if (state.summarySaved) return;
+  state.summarySaved = true;
   let summaryText: string | null = null;
 
   if (messages && messages.length > 0) {
@@ -223,16 +225,20 @@ export function processToolCall(
     return null;
   }
 
-  // Skip errored tool calls
-  if (!result) return null;
+  // Skip errored tool calls (only null/undefined, not falsy 0/"")
+  if (result === undefined || result === null) return null;
 
   // Summarize params (keep it short)
   const paramKeys = Object.keys(params).slice(0, 3);
   const paramsSummary = paramKeys
     .map(k => {
       const v = params[k];
-      const s = typeof v === "string" ? v.slice(0, 80) : JSON.stringify(v)?.slice(0, 80);
-      return `${k}=${s}`;
+      try {
+        const s = typeof v === "string" ? v.slice(0, 80) : JSON.stringify(v)?.slice(0, 80) ?? "";
+        return `${k}=${s}`;
+      } catch {
+        return `${k}=[object]`;
+      }
     })
     .join(", ");
 
@@ -270,8 +276,14 @@ export function registerSessionHooks(
   // ── session_start: Load briefing for context restoration ──────────
   if (config.sessionBriefing) {
     api.on("session_start", async (event: any, ctx: any) => {
-      const sessionKey = ctx?.sessionKey || ctx?.sessionId || "unknown";
+      const sessionKey = ctx?.sessionKey || ctx?.sessionId;
+      if (!sessionKey) return;
       const state = getOrCreateSessionState(sessionKey);
+
+      // Create a promise that before_prompt_build can await
+      let resolve: () => void;
+      state.briefingReady = new Promise<void>(r => { resolve = r; });
+      state.briefingReadyResolve = resolve!;
 
       try {
         state.pendingBriefing = await loadSessionBriefing(config, logger);
@@ -280,6 +292,8 @@ export function registerSessionHooks(
         }
       } catch (error) {
         logger.warn(`[palaia] Failed to load session briefing: ${error}`);
+      } finally {
+        state.briefingReadyResolve?.();
       }
     });
   }
@@ -287,8 +301,8 @@ export function registerSessionHooks(
   // ── session_end: Save session summary ─────────────────────────────
   if (config.sessionSummary) {
     api.on("session_end", async (event: any, ctx: any) => {
-      const sessionKey = ctx?.sessionKey || ctx?.sessionId || "unknown";
-      const state = getOrCreateSessionState(sessionKey);
+      const sessionKey = ctx?.sessionKey || ctx?.sessionId;
+      if (!sessionKey) return;
 
       try {
         // Only save summary if session had meaningful interaction
@@ -307,7 +321,8 @@ export function registerSessionHooks(
   // ── before_reset: Save session summary with messages (priority) ───
   if (config.sessionSummary) {
     api.on("before_reset", async (event: any, ctx: any) => {
-      const sessionKey = ctx?.sessionKey || ctx?.sessionId || "unknown";
+      const sessionKey = ctx?.sessionKey || ctx?.sessionId;
+      if (!sessionKey) return;
 
       try {
         const messages = (event as any)?.messages;
@@ -381,18 +396,12 @@ export function registerSessionHooks(
     });
   }
 
-  // ── subagent_spawning: Pass session context to sub-agent ──────
+  // ── subagent_spawning: Log sub-agent spawn for context tracking ─
   api.on("subagent_spawning", async (event: any, _ctx: any) => {
     try {
       const childKey = (event as any)?.childSessionKey;
       if (!childKey) return;
-
-      // Set PALAIA_INSTANCE so sub-agent shares the session scope
-      const parentKey = _ctx?.requesterSessionKey;
-      if (parentKey) {
-        const parentState = getOrCreateSessionState(parentKey);
-        process.env.PALAIA_INSTANCE = parentState.autoSessionId;
-      }
+      logger.info(`[palaia] Sub-agent spawning: ${childKey}`);
     } catch {
       // Non-fatal
     }

--- a/packages/openclaw-plugin/src/hooks/session.ts
+++ b/packages/openclaw-plugin/src/hooks/session.ts
@@ -1,0 +1,437 @@
+/**
+ * Session lifecycle hooks for palaia v3.
+ *
+ * Handles session_start, session_end, before_reset, llm_input, llm_output,
+ * and after_tool_call hooks to provide:
+ * - Session briefing on session start (context restoration)
+ * - Automatic session summaries on session end/reset
+ * - LLM model switch detection
+ * - Tool observation tracking
+ * - Token usage tracking
+ */
+
+import type { OpenClawPluginApi } from "../types.js";
+import type { PalaiaPluginConfig } from "../config.js";
+import { run, type RunnerOpts, getEmbedServerManager } from "../runner.js";
+import {
+  getOrCreateSessionState,
+  deleteSessionState,
+  resolveSessionKeyFromCtx,
+  type PendingBriefing,
+  type ToolObservation,
+} from "./state.js";
+import {
+  stripPalaiaInjectedContext,
+  trimToRecentExchanges,
+  extractWithLLM,
+  extractSignificance,
+} from "./capture.js";
+import { extractMessageTexts } from "./recall.js";
+
+function buildRunnerOpts(config: PalaiaPluginConfig): RunnerOpts {
+  return {
+    binaryPath: config.binaryPath,
+    workspace: config.workspace,
+    timeoutMs: config.timeoutMs,
+  };
+}
+
+// ── Session Briefing ────────────────────────────────────────���───────────
+
+/**
+ * Load session briefing data (last session summary + open tasks).
+ * Called during session_start to prepare context for the first turn.
+ */
+export async function loadSessionBriefing(
+  config: PalaiaPluginConfig,
+  logger: { info(...a: unknown[]): void; warn(...a: unknown[]): void },
+): Promise<PendingBriefing> {
+  const opts = buildRunnerOpts(config);
+  let summary: string | null = null;
+  const openTasks: string[] = [];
+
+  // Load last session summary
+  try {
+    const { runJson } = await import("../runner.js");
+    const result = await runJson<{ results: Array<{ title: string; body: string; created: string }> }>(
+      ["query", "session-summary", "--limit", "1", "--tags", "session-summary"],
+      { ...opts, timeoutMs: 5000 },
+    );
+    if (result?.results?.[0]) {
+      summary = result.results[0].body;
+    }
+  } catch {
+    // Non-fatal — no summary available
+  }
+
+  // Load open tasks
+  try {
+    const { runJson } = await import("../runner.js");
+    const result = await runJson<{ results: Array<{ title: string; body: string; priority?: string }> }>(
+      ["list", "--type", "task", "--status", "open", "--limit", "5"],
+      { ...opts, timeoutMs: 5000 },
+    );
+    if (result?.results) {
+      for (const task of result.results) {
+        const prio = task.priority ? ` (${task.priority})` : "";
+        openTasks.push(`${task.title}${prio}`);
+      }
+    }
+  } catch {
+    // Non-fatal
+  }
+
+  return { summary, openTasks, timestamp: Date.now() };
+}
+
+/**
+ * Format a pending briefing into injectable text.
+ */
+export function formatBriefing(briefing: PendingBriefing, maxChars: number): string {
+  if (!briefing.summary && briefing.openTasks.length === 0) return "";
+
+  const parts: string[] = ["## Session Briefing (Palaia)\n"];
+
+  if (briefing.summary) {
+    const agoMs = Date.now() - briefing.timestamp;
+    const agoMin = Math.round(agoMs / 60_000);
+    const agoStr = agoMin < 1 ? "gerade eben" :
+      agoMin < 60 ? `vor ${agoMin} Min.` :
+      `vor ${Math.round(agoMin / 60)} Std.`;
+    parts.push(`Letzte Session (${agoStr}):`);
+    parts.push(briefing.summary);
+    parts.push("");
+  }
+
+  if (briefing.openTasks.length > 0) {
+    parts.push("Offene Aufgaben:");
+    for (const task of briefing.openTasks) {
+      parts.push(`- ${task}`);
+    }
+    parts.push("");
+  }
+
+  const text = parts.join("\n");
+  return text.length <= maxChars ? text : text.slice(0, maxChars - 3) + "...";
+}
+
+// ── Session Summary Capture ─────────────────────────────────────────────
+
+/**
+ * Extract and save a session summary from conversation messages.
+ * Called during before_reset (with messages) or session_end (without).
+ */
+export async function captureSessionSummary(
+  messages: unknown[] | undefined,
+  sessionKey: string,
+  api: OpenClawPluginApi,
+  config: PalaiaPluginConfig,
+  logger: { info(...a: unknown[]): void; warn(...a: unknown[]): void },
+): Promise<void> {
+  const opts = buildRunnerOpts(config);
+  const state = getOrCreateSessionState(sessionKey);
+  let summaryText: string | null = null;
+
+  if (messages && messages.length > 0) {
+    // Try LLM-based summary extraction
+    try {
+      const results = await extractWithLLM(messages, api.config, {
+        captureModel: config.captureModel,
+      }, []);
+
+      if (results.length > 0) {
+        summaryText = results[0].content;
+      }
+    } catch {
+      // Fall through to rule-based
+    }
+
+    // Rule-based fallback: last 3 user+assistant pairs
+    if (!summaryText) {
+      const allTexts = extractMessageTexts(messages);
+      const cleaned = allTexts.map((t: { role: string; text: string }) =>
+        t.role === "user"
+          ? { ...t, text: stripPalaiaInjectedContext(t.text) }
+          : t
+      );
+      const recent = trimToRecentExchanges(cleaned, 3);
+      if (recent.length > 0) {
+        summaryText = recent
+          .map(t => `[${t.role}]: ${t.text.slice(0, 200)}`)
+          .join("\n")
+          .slice(0, 500);
+      }
+    }
+  } else {
+    // No messages available (session_end without before_reset).
+    // Use accumulated tool observations as summary.
+    if (state.toolObservations.length > 0) {
+      summaryText = state.toolObservations
+        .map(o => `${o.toolName}: ${o.resultSummary}`)
+        .join("\n")
+        .slice(0, 500);
+    }
+  }
+
+  if (!summaryText) return;
+
+  // Save session summary
+  try {
+    const args: string[] = [
+      "write", summaryText,
+      "--type", "memory",
+      "--tags", "session-summary,auto-capture",
+      "--scope", config.captureScope || "team",
+    ];
+    if (state.autoSessionId) args.push("--instance", state.autoSessionId);
+    const agentName = process.env.PALAIA_AGENT || undefined;
+    if (agentName) args.push("--agent", agentName);
+
+    await run(args, { ...opts, timeoutMs: 10_000 });
+    logger.info(`[palaia] Session summary saved (${summaryText.length} chars)`);
+  } catch (error) {
+    logger.warn(`[palaia] Failed to save session summary: ${error}`);
+  }
+}
+
+// ── Tool Observations ─────────────────────────────────────────────────���─
+
+/** Tools worth tracking for observations. */
+const TRACKED_TOOLS = new Set([
+  // File operations
+  "memory_search", "memory_get", "memory_write",
+  "read_file", "write_file", "edit_file",
+  "search_files", "list_files",
+  // Shell
+  "bash", "shell", "terminal",
+  // Web
+  "web_search", "fetch_url",
+]);
+
+/**
+ * Process an after_tool_call event into a tool observation.
+ * Returns null if the tool isn't worth tracking.
+ */
+export function processToolCall(
+  toolName: string,
+  params: Record<string, unknown>,
+  result: unknown,
+  durationMs: number,
+): ToolObservation | null {
+  // Only track relevant tools (skip internal/framework tools)
+  if (!TRACKED_TOOLS.has(toolName) && !toolName.startsWith("palaia_")) {
+    return null;
+  }
+
+  // Skip errored tool calls
+  if (!result) return null;
+
+  // Summarize params (keep it short)
+  const paramKeys = Object.keys(params).slice(0, 3);
+  const paramsSummary = paramKeys
+    .map(k => {
+      const v = params[k];
+      const s = typeof v === "string" ? v.slice(0, 80) : JSON.stringify(v)?.slice(0, 80);
+      return `${k}=${s}`;
+    })
+    .join(", ");
+
+  // Summarize result
+  let resultSummary: string;
+  if (typeof result === "string") {
+    resultSummary = result.slice(0, 200);
+  } else if (typeof result === "object" && result !== null) {
+    resultSummary = JSON.stringify(result).slice(0, 200);
+  } else {
+    resultSummary = String(result).slice(0, 200);
+  }
+
+  return {
+    toolName,
+    paramsSummary,
+    resultSummary,
+    durationMs,
+    timestamp: Date.now(),
+  };
+}
+
+// ── Hook Registration ───────────────────────────────────────────────────
+
+/**
+ * Register all session lifecycle hooks.
+ * Called from hooks/index.ts during plugin registration.
+ */
+export function registerSessionHooks(
+  api: OpenClawPluginApi,
+  config: PalaiaPluginConfig,
+): void {
+  const logger = api.logger;
+
+  // ── session_start: Load briefing for context restoration ──────────
+  if (config.sessionBriefing) {
+    api.on("session_start", async (event: any, ctx: any) => {
+      const sessionKey = ctx?.sessionKey || ctx?.sessionId || "unknown";
+      const state = getOrCreateSessionState(sessionKey);
+
+      try {
+        state.pendingBriefing = await loadSessionBriefing(config, logger);
+        if (state.pendingBriefing.summary || state.pendingBriefing.openTasks.length > 0) {
+          logger.info(`[palaia] Session briefing loaded for ${sessionKey}`);
+        }
+      } catch (error) {
+        logger.warn(`[palaia] Failed to load session briefing: ${error}`);
+      }
+    });
+  }
+
+  // ── session_end: Save session summary ─────────────────────────────
+  if (config.sessionSummary) {
+    api.on("session_end", async (event: any, ctx: any) => {
+      const sessionKey = ctx?.sessionKey || ctx?.sessionId || "unknown";
+      const state = getOrCreateSessionState(sessionKey);
+
+      try {
+        // Only save summary if session had meaningful interaction
+        const messageCount = (event as any)?.messageCount ?? 0;
+        if (messageCount >= 4) { // At least 2 user + 2 assistant messages
+          await captureSessionSummary(undefined, sessionKey, api, config, logger);
+        }
+      } catch (error) {
+        logger.warn(`[palaia] session_end summary failed: ${error}`);
+      } finally {
+        deleteSessionState(sessionKey);
+      }
+    });
+  }
+
+  // ── before_reset: Save session summary with messages (priority) ───
+  if (config.sessionSummary) {
+    api.on("before_reset", async (event: any, ctx: any) => {
+      const sessionKey = ctx?.sessionKey || ctx?.sessionId || "unknown";
+
+      try {
+        const messages = (event as any)?.messages;
+        if (messages && Array.isArray(messages) && messages.length >= 4) {
+          await captureSessionSummary(messages, sessionKey, api, config, logger);
+        }
+      } catch (error) {
+        logger.warn(`[palaia] before_reset summary failed: ${error}`);
+      }
+    });
+  }
+
+  // ── llm_input: Model switch detection ─────────────────────────────
+  api.on("llm_input", (event: any, ctx: any) => {
+    const sessionKey = ctx?.sessionKey || ctx?.sessionId;
+    if (!sessionKey) return;
+    const state = getOrCreateSessionState(sessionKey);
+
+    const model = (event as any)?.model;
+    if (!model) return;
+
+    if (state.lastModel && model !== state.lastModel) {
+      state.modelSwitchDetected = true;
+      logger.info(`[palaia] Model switch detected: ${state.lastModel} → ${model}`);
+
+      // Re-load briefing for next assemble
+      if (config.sessionBriefing && !state.pendingBriefing) {
+        loadSessionBriefing(config, logger).then(briefing => {
+          state.pendingBriefing = briefing;
+          state.briefingDelivered = false;
+        }).catch(() => {});
+      }
+    }
+    state.lastModel = model;
+  });
+
+  // ── llm_output: Token usage tracking ──────────────────────────────
+  api.on("llm_output", (event: any, ctx: any) => {
+    const sessionKey = ctx?.sessionKey || ctx?.sessionId;
+    if (!sessionKey) return;
+    const state = getOrCreateSessionState(sessionKey);
+
+    const usage = (event as any)?.usage;
+    if (usage) {
+      state.tokenUsage.input += usage.input || 0;
+      state.tokenUsage.output += usage.output || 0;
+    }
+  });
+
+  // ── after_tool_call: Tool observation tracking ────────────────��───
+  if (config.captureToolObservations) {
+    api.on("after_tool_call", (event: any, ctx: any) => {
+      const sessionKey = ctx?.sessionKey || ctx?.sessionId;
+      if (!sessionKey) return;
+      const state = getOrCreateSessionState(sessionKey);
+
+      const obs = processToolCall(
+        (event as any)?.toolName || "",
+        (event as any)?.params || {},
+        (event as any)?.result,
+        (event as any)?.durationMs || 0,
+      );
+
+      if (obs) {
+        state.toolObservations.push(obs);
+        // Keep max 50 observations per session to prevent memory bloat
+        if (state.toolObservations.length > 50) {
+          state.toolObservations.shift();
+        }
+      }
+    });
+  }
+
+  // ── subagent_spawning: Pass session context to sub-agent ──────
+  api.on("subagent_spawning", async (event: any, _ctx: any) => {
+    try {
+      const childKey = (event as any)?.childSessionKey;
+      if (!childKey) return;
+
+      // Set PALAIA_INSTANCE so sub-agent shares the session scope
+      const parentKey = _ctx?.requesterSessionKey;
+      if (parentKey) {
+        const parentState = getOrCreateSessionState(parentKey);
+        process.env.PALAIA_INSTANCE = parentState.autoSessionId;
+      }
+    } catch {
+      // Non-fatal
+    }
+  });
+
+  // ── subagent_ended: Capture sub-agent results ─────────────────
+  if (config.autoCapture) {
+    api.on("subagent_ended", async (event: any, _ctx: any) => {
+      try {
+        const outcome = (event as any)?.outcome;
+        if (outcome !== "ok") return;
+
+        const childKey = (event as any)?.targetSessionKey;
+        if (!childKey || !api.runtime?.subagent?.getSessionMessages) return;
+
+        const result = await api.runtime.subagent.getSessionMessages({
+          sessionKey: childKey,
+          limit: 10,
+        });
+        if (!result?.messages?.length) return;
+
+        const { extractMessageTexts } = await import("./recall.js");
+        const texts = extractMessageTexts(result.messages);
+        const summaryParts = texts.slice(-4).map(
+          (t: { role: string; text: string }) => `[${t.role}]: ${t.text.slice(0, 200)}`
+        );
+        if (summaryParts.length === 0) return;
+
+        const summaryText = `Sub-agent result:\n${summaryParts.join("\n")}`.slice(0, 500);
+        await run([
+          "write", summaryText,
+          "--type", "memory",
+          "--tags", "subagent-result,auto-capture",
+          "--scope", config.captureScope || "team",
+        ], { ...buildRunnerOpts(config), timeoutMs: 10_000 });
+        logger.info(`[palaia] Sub-agent result captured (${summaryText.length} chars)`);
+      } catch (error) {
+        logger.warn(`[palaia] Sub-agent result capture failed: ${error}`);
+      }
+    });
+  }
+}

--- a/packages/openclaw-plugin/src/hooks/state.ts
+++ b/packages/openclaw-plugin/src/hooks/state.ts
@@ -184,7 +184,7 @@ export interface SessionState {
   modelSwitchDetected: boolean;
   /** Pending briefing to inject on next before_prompt_build. */
   pendingBriefing: PendingBriefing | null;
-  /** Accumulated tool observations for the current turn. */
+  /** Accumulated tool observations for the session (used in session summary). */
   toolObservations: ToolObservation[];
   /** Accumulated token usage for the session. */
   tokenUsage: { input: number; output: number };
@@ -192,6 +192,12 @@ export interface SessionState {
   startedAt: number;
   /** Whether the first turn briefing has been delivered. */
   briefingDelivered: boolean;
+  /** Whether a session summary has already been saved (prevents double-save). */
+  summarySaved: boolean;
+  /** Promise that resolves when session_start briefing load is complete. */
+  briefingReady: Promise<void> | null;
+  /** Resolver for briefingReady promise. */
+  briefingReadyResolve: (() => void) | null;
 }
 
 /** Session state map. Keyed by sessionKey. */
@@ -220,6 +226,9 @@ export function getOrCreateSessionState(sessionKey: string): SessionState {
       tokenUsage: { input: 0, output: 0 },
       startedAt: Date.now(),
       briefingDelivered: false,
+      summarySaved: false,
+      briefingReady: null,
+      briefingReadyResolve: null,
     };
     sessionStateByKey.set(sessionKey, state);
   }

--- a/packages/openclaw-plugin/src/hooks/state.ts
+++ b/packages/openclaw-plugin/src/hooks/state.ts
@@ -155,6 +155,83 @@ export function resetTurnState(): void {
 }
 
 // ============================================================================
+// Session Continuity State (v3.0)
+// ============================================================================
+
+/** Accumulated tool observation from after_tool_call hooks. */
+export interface ToolObservation {
+  toolName: string;
+  paramsSummary: string;
+  resultSummary: string;
+  durationMs: number;
+  timestamp: number;
+}
+
+/** Pending session briefing, cached between session_start and first before_prompt_build. */
+export interface PendingBriefing {
+  summary: string | null;
+  openTasks: string[];
+  timestamp: number;
+}
+
+/** Session-level state that persists across turns within a session. */
+export interface SessionState {
+  /** Auto-generated session ID for instance tracking. */
+  autoSessionId: string;
+  /** Last known LLM model (for switch detection). */
+  lastModel: string | null;
+  /** True when model switch detected, cleared after briefing re-injection. */
+  modelSwitchDetected: boolean;
+  /** Pending briefing to inject on next before_prompt_build. */
+  pendingBriefing: PendingBriefing | null;
+  /** Accumulated tool observations for the current turn. */
+  toolObservations: ToolObservation[];
+  /** Accumulated token usage for the session. */
+  tokenUsage: { input: number; output: number };
+  /** Timestamp of session start. */
+  startedAt: number;
+  /** Whether the first turn briefing has been delivered. */
+  briefingDelivered: boolean;
+}
+
+/** Session state map. Keyed by sessionKey. */
+export const sessionStateByKey = new Map<string, SessionState>();
+
+/** Generate an auto session ID. */
+export function generateAutoSessionId(): string {
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const date = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}`;
+  const time = `${pad(now.getHours())}${pad(now.getMinutes())}`;
+  const hex = Math.floor(Math.random() * 0xffff).toString(16).padStart(4, "0");
+  return `auto-${date}-${time}-${hex}`;
+}
+
+/** Get or create session state for a session key. */
+export function getOrCreateSessionState(sessionKey: string): SessionState {
+  let state = sessionStateByKey.get(sessionKey);
+  if (!state) {
+    state = {
+      autoSessionId: generateAutoSessionId(),
+      lastModel: null,
+      modelSwitchDetected: false,
+      pendingBriefing: null,
+      toolObservations: [],
+      tokenUsage: { input: 0, output: 0 },
+      startedAt: Date.now(),
+      briefingDelivered: false,
+    };
+    sessionStateByKey.set(sessionKey, state);
+  }
+  return state;
+}
+
+/** Delete session state (cleanup). */
+export function deleteSessionState(sessionKey: string): void {
+  sessionStateByKey.delete(sessionKey);
+}
+
+// ============================================================================
 // Session Key Helpers
 // ============================================================================
 

--- a/packages/openclaw-plugin/src/types.ts
+++ b/packages/openclaw-plugin/src/types.ts
@@ -5,7 +5,7 @@
  * They are maintained locally to avoid a build-time dependency on the
  * openclaw package (which is a peerDependency loaded at runtime).
  *
- * Based on OpenClaw v2026.3.22 plugin-sdk.
+ * Based on OpenClaw v2026.3.24 plugin-sdk.
  */
 
 import type { TObject } from "@sinclair/typebox";
@@ -30,21 +30,228 @@ export interface ToolOptions {
 
 export type ToolFactory = ToolDefinition;
 
-// ── Hook Types ──────────────────────────────────────────────────────────
+// ── Hook Types ─────────────��────────────────────────────────────────────
 
+/**
+ * All hook names supported by OpenClaw v2026.3.24.
+ * palaia registers handlers for a subset of these.
+ */
 export type HookName =
+  // Session lifecycle
+  | "session_start"
+  | "session_end"
+  // Agent & LLM
+  | "before_model_resolve"
   | "before_prompt_build"
+  | "before_agent_start"
+  | "llm_input"
+  | "llm_output"
   | "agent_end"
+  // Context management
+  | "before_compaction"
+  | "after_compaction"
+  | "before_reset"
+  // Messages
+  | "inbound_claim"
+  | "before_dispatch"
   | "message_received"
-  | "message_sending";
+  | "message_sending"
+  | "message_sent"
+  // Tool execution
+  | "before_tool_call"
+  | "after_tool_call"
+  | "tool_result_persist"
+  | "before_message_write"
+  // Subagents
+  | "subagent_spawning"
+  | "subagent_delivery_target"
+  | "subagent_spawned"
+  | "subagent_ended"
+  // Gateway
+  | "gateway_start"
+  | "gateway_stop";
 
-export type HookHandler = (event: unknown, ctx: unknown) => void | Promise<unknown>;
+export type HookHandler = (event: unknown, ctx: unknown) => unknown | Promise<unknown>;
 
 export interface HookOptions {
   priority?: number;
 }
 
-// ── Command Types ───────────────────────────────────────────────────────
+// ── Hook Event Types ────────────────────────────────────────────────────
+
+/** session_start event. */
+export type SessionStartEvent = {
+  sessionId: string;
+  sessionKey?: string;
+  resumedFrom?: string;
+};
+
+/** session_end event. */
+export type SessionEndEvent = {
+  sessionId: string;
+  sessionKey?: string;
+  messageCount: number;
+  durationMs?: number;
+};
+
+/** before_prompt_build event. */
+export type BeforePromptBuildEvent = {
+  prompt: string;
+  messages: unknown[];
+};
+
+/** before_prompt_build result. */
+export type BeforePromptBuildResult = {
+  systemPrompt?: string;
+  prependContext?: string;
+  prependSystemContext?: string;
+  appendSystemContext?: string;
+};
+
+/** before_reset event. */
+export type BeforeResetEvent = {
+  sessionFile?: string;
+  messages?: unknown[];
+  reason?: string;
+};
+
+/** agent_end event. */
+export type AgentEndEvent = {
+  messages: unknown[];
+  success: boolean;
+  error?: string;
+  durationMs?: number;
+};
+
+/** llm_input event — fired before each LLM call. */
+export type LlmInputEvent = {
+  runId: string;
+  sessionId: string;
+  provider: string;
+  model: string;
+  systemPrompt?: string;
+  prompt: string;
+  historyMessages: unknown[];
+  imagesCount: number;
+};
+
+/** llm_output event — fired after each LLM response. */
+export type LlmOutputEvent = {
+  runId: string;
+  sessionId: string;
+  provider: string;
+  model: string;
+  assistantTexts: string[];
+  lastAssistant?: unknown;
+  usage?: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+    total?: number;
+  };
+};
+
+/** after_tool_call event. */
+export type AfterToolCallEvent = {
+  toolName: string;
+  params: Record<string, unknown>;
+  runId?: string;
+  toolCallId?: string;
+  result?: unknown;
+  error?: string;
+  durationMs?: number;
+};
+
+/** message_received event. */
+export type MessageReceivedEvent = {
+  from: string;
+  content: string;
+  timestamp?: number;
+  metadata?: Record<string, unknown>;
+};
+
+/** message_sending event. */
+export type MessageSendingEvent = {
+  to: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+};
+
+/** message_sending result. */
+export type MessageSendingResult = {
+  content?: string;
+  cancel?: boolean;
+};
+
+/** subagent_spawning event. */
+export type SubagentSpawningEvent = {
+  childSessionKey: string;
+  agentId: string;
+  label?: string;
+  mode: "run" | "session";
+  requester?: {
+    channel?: string;
+    accountId?: string;
+    to?: string;
+    threadId?: string | number;
+  };
+  threadRequested: boolean;
+};
+
+/** subagent_ended event. */
+export type SubagentEndedEvent = {
+  targetSessionKey: string;
+  targetKind: "subagent" | "acp";
+  reason: string;
+  sendFarewell?: boolean;
+  accountId?: string;
+  runId?: string;
+  endedAt?: number;
+  outcome?: "ok" | "error" | "timeout" | "killed" | "reset" | "deleted";
+  error?: string;
+};
+
+// ── Hook Context Types ──────────────��───────────────────────────────────
+
+export type AgentContext = {
+  agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  workspaceDir?: string;
+  messageProvider?: string;
+  trigger?: string;
+  channelId?: string;
+};
+
+export type MessageContext = {
+  channelId: string;
+  accountId?: string;
+  conversationId?: string;
+};
+
+export type SessionContext = {
+  agentId?: string;
+  sessionId: string;
+  sessionKey?: string;
+};
+
+export type ToolContext = {
+  agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  runId?: string;
+  toolName: string;
+  toolCallId?: string;
+};
+
+export type SubagentContext = {
+  runId?: string;
+  childSessionKey?: string;
+  requesterSessionKey?: string;
+};
+
+// ── Command Types ───���───────────────────────────────────────────────────
 
 export interface CommandDefinition {
   name: string;
@@ -52,7 +259,7 @@ export interface CommandDefinition {
   handler(args: string): Promise<{ text: string }> | { text: string };
 }
 
-// ── Service Types ───────────────────────────────────────────────────────
+// ── Service Types ─────────────────────────────────────���─────────────────
 
 export interface ServiceDefinition {
   id: string;
@@ -60,9 +267,141 @@ export interface ServiceDefinition {
   stop?(): Promise<void>;
 }
 
-// ── Context Engine Types ────────────────────────────────────────────────
+// ���─ Context Engine Types ────────────���───────────────────────────────────
 
+/** Opaque message type from OpenClaw's agent runtime. */
+export type AgentMessage = unknown;
+
+export interface ContextEngineInfo {
+  id: string;
+  name: string;
+  version?: string;
+  ownsCompaction?: boolean;
+}
+
+export type BootstrapResult = {
+  bootstrapped: boolean;
+  importedMessages?: number;
+  reason?: string;
+};
+
+export type IngestResult = {
+  ingested: boolean;
+};
+
+export type AssembleResult = {
+  messages: AgentMessage[];
+  estimatedTokens: number;
+  systemPromptAddition?: string;
+};
+
+export type CompactResult = {
+  ok: boolean;
+  compacted: boolean;
+  reason?: string;
+  result?: {
+    summary?: string;
+    firstKeptEntryId?: string;
+    tokensBefore: number;
+    tokensAfter?: number;
+    details?: unknown;
+  };
+};
+
+export type SubagentSpawnPreparation = {
+  rollback: () => void | Promise<void>;
+};
+
+export type SubagentEndReason = "deleted" | "completed" | "swept" | "released";
+
+/**
+ * ContextEngine interface — matches OpenClaw v2026.3.24.
+ *
+ * This is the full interface. Palaia implements a subset;
+ * optional methods are marked with `?`.
+ */
 export interface ContextEngine {
+  readonly info: ContextEngineInfo;
+
+  bootstrap?(params: {
+    sessionId: string;
+    sessionKey?: string;
+    sessionFile: string;
+  }): Promise<BootstrapResult>;
+
+  maintain?(params: {
+    sessionId: string;
+    sessionKey?: string;
+    sessionFile: string;
+    runtimeContext?: Record<string, unknown>;
+  }): Promise<unknown>;
+
+  ingest(params: {
+    sessionId: string;
+    sessionKey?: string;
+    message: AgentMessage;
+    isHeartbeat?: boolean;
+  }): Promise<IngestResult>;
+
+  ingestBatch?(params: {
+    sessionId: string;
+    sessionKey?: string;
+    messages: AgentMessage[];
+    isHeartbeat?: boolean;
+  }): Promise<{ ingestedCount: number }>;
+
+  afterTurn?(params: {
+    sessionId: string;
+    sessionKey?: string;
+    sessionFile: string;
+    messages: AgentMessage[];
+    prePromptMessageCount: number;
+    autoCompactionSummary?: string;
+    isHeartbeat?: boolean;
+    tokenBudget?: number;
+    runtimeContext?: Record<string, unknown>;
+  }): Promise<void>;
+
+  assemble(params: {
+    sessionId: string;
+    sessionKey?: string;
+    messages: AgentMessage[];
+    tokenBudget?: number;
+    model?: string;
+    prompt?: string;
+  }): Promise<AssembleResult>;
+
+  compact(params: {
+    sessionId: string;
+    sessionKey?: string;
+    sessionFile: string;
+    tokenBudget?: number;
+    force?: boolean;
+    currentTokenCount?: number;
+    compactionTarget?: "budget" | "threshold";
+    customInstructions?: string;
+    runtimeContext?: Record<string, unknown>;
+  }): Promise<CompactResult>;
+
+  prepareSubagentSpawn?(params: {
+    parentSessionKey: string;
+    childSessionKey: string;
+    ttlMs?: number;
+  }): Promise<SubagentSpawnPreparation | undefined>;
+
+  onSubagentEnded?(params: {
+    childSessionKey: string;
+    reason: SubagentEndReason;
+  }): Promise<void>;
+
+  dispose?(): Promise<void>;
+}
+
+/**
+ * Legacy ContextEngine interface for backward compatibility.
+ * Used when OpenClaw < 2026.3.24 registers via the old signature.
+ */
+export interface LegacyContextEngine {
   bootstrap?(): Promise<void>;
   ingest?(messages: unknown[]): Promise<void>;
   assemble(budget: { maxTokens: number }): Promise<{ content: string; tokenEstimate: number }>;
@@ -72,7 +411,16 @@ export interface ContextEngine {
   onSubagentEnded?(result: unknown): Promise<void>;
 }
 
-// ── Logger ──────────────────────────────────────────────────────────────
+export type ContextEngineFactory = () => ContextEngine | Promise<ContextEngine>;
+
+// ── Memory Prompt Section ───────────────────────────────────────────────
+
+export type MemoryPromptSectionBuilder = (params: {
+  availableTools: Set<string>;
+  citationsMode?: string;
+}) => string[];
+
+// ── Logger ──────────────���───────────────────────────────────────────────
 
 export interface PluginLogger {
   info(...args: unknown[]): void;
@@ -81,36 +429,70 @@ export interface PluginLogger {
   debug?(...args: unknown[]): void;
 }
 
-// ── Runtime ─────────────────────────────────────────────────────────────
+// ���─ Runtime ───────────────��─────────────────────────────���───────────────
 
 export interface PluginRuntime {
+  version?: string;
   agent?: {
     runEmbeddedPiAgent?(params: Record<string, unknown>): Promise<unknown>;
+    session?: {
+      resolveStorePath?(...args: unknown[]): string;
+      loadSessionStore?(...args: unknown[]): Promise<unknown>;
+    };
+  };
+  subagent?: {
+    run?(params: {
+      sessionKey: string;
+      message: string;
+      provider?: string;
+      model?: string;
+      extraSystemPrompt?: string;
+    }): Promise<{ runId: string }>;
+    getSessionMessages?(params: {
+      sessionKey: string;
+      limit?: number;
+    }): Promise<{ messages: unknown[] }>;
   };
   modelAuth?: {
     resolveApiKeyForProvider(params: {
       provider: string;
-      cfg: Record<string, unknown>;
+      cfg?: Record<string, unknown>;
     }): Promise<string | null>;
+  };
+  system?: {
+    requestHeartbeatNow?(): void;
+  };
+  events?: {
+    onSessionTranscriptUpdate?(handler: (event: unknown) => void): void;
   };
 }
 
 // ── Main Plugin API ─────────────────────────────────────────────────────
 
 export interface OpenClawPluginApi {
+  id: string;
+  name: string;
+  version?: string;
+  source?: string;
+  registrationMode?: string;
+
   registerTool(definition: ToolDefinition, options?: ToolOptions): void;
   registerCommand(command: CommandDefinition): void;
   registerService(service: ServiceDefinition): void;
-  registerContextEngine?(id: string, engine: ContextEngine): void;
-  on(hook: HookName | string, handler: HookHandler): void;
-  getConfig(pluginId: string): Record<string, unknown> | undefined;
+  registerContextEngine?(id: string, factory: ContextEngineFactory): void;
+  registerMemoryPromptSection?(builder: MemoryPromptSectionBuilder): void;
+  registerHook?(events: string | string[], handler: HookHandler, opts?: HookOptions): void;
+  on(hook: HookName | string, handler: HookHandler, opts?: HookOptions): void;
+  getConfig?(pluginId: string): Record<string, unknown> | undefined;
+
   logger: PluginLogger;
   runtime: PluginRuntime;
   config: Record<string, unknown>;
+  pluginConfig?: Record<string, unknown>;
   workspace?: { dir: string; agentId?: string } | string;
 }
 
-// ── Plugin Entry ────────────────────────────────────────────────────────
+// ── Plugin Entry ────────���───────────────────────────────────────────────
 
 export interface OpenClawPluginEntry {
   id: string;

--- a/packages/openclaw-plugin/src/types.ts
+++ b/packages/openclaw-plugin/src/types.ts
@@ -5,7 +5,7 @@
  * They are maintained locally to avoid a build-time dependency on the
  * openclaw package (which is a peerDependency loaded at runtime).
  *
- * Based on OpenClaw v2026.3.24 plugin-sdk.
+ * Based on OpenClaw v2026.3.28 plugin-sdk.
  */
 
 import type { TObject } from "@sinclair/typebox";
@@ -28,12 +28,12 @@ export interface ToolOptions {
   optional?: boolean;
 }
 
-export type ToolFactory = ToolDefinition;
+export type ToolFactory = ToolDefinition | ((ctx: Record<string, unknown>) => ToolDefinition | ToolDefinition[] | null);
 
 // ── Hook Types ─────────────��────────────────────────────────────────────
 
 /**
- * All hook names supported by OpenClaw v2026.3.24.
+ * All hook names supported by OpenClaw v2026.3.28.
  * palaia registers handlers for a subset of these.
  */
 export type HookName =
@@ -261,10 +261,17 @@ export interface CommandDefinition {
 
 // ── Service Types ─────────────────────────────────────���─────────────────
 
+export interface ServiceContext {
+  config: Record<string, unknown>;
+  workspaceDir?: string;
+  stateDir: string;
+  logger: PluginLogger;
+}
+
 export interface ServiceDefinition {
   id: string;
-  start(): Promise<void>;
-  stop?(): Promise<void>;
+  start(ctx: ServiceContext): Promise<void>;
+  stop?(ctx: ServiceContext): Promise<void>;
 }
 
 // ���─ Context Engine Types ────────────���───────────────────────────────────
@@ -315,7 +322,7 @@ export type SubagentSpawnPreparation = {
 export type SubagentEndReason = "deleted" | "completed" | "swept" | "released";
 
 /**
- * ContextEngine interface — matches OpenClaw v2026.3.24.
+ * ContextEngine interface — matches OpenClaw v2026.3.28.
  *
  * This is the full interface. Palaia implements a subset;
  * optional methods are marked with `?`.
@@ -423,10 +430,10 @@ export type MemoryPromptSectionBuilder = (params: {
 // ── Logger ──────────────���───────────────────────────────────────────────
 
 export interface PluginLogger {
-  info(...args: unknown[]): void;
-  warn(...args: unknown[]): void;
-  error?(...args: unknown[]): void;
-  debug?(...args: unknown[]): void;
+  info(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+  debug?(message: string): void;
 }
 
 // ���─ Runtime ───────────────��─────────────────────────────���───────────────
@@ -476,15 +483,13 @@ export interface OpenClawPluginApi {
   source?: string;
   registrationMode?: string;
 
-  registerTool(definition: ToolDefinition, options?: ToolOptions): void;
+  registerTool(definition: ToolDefinition | ToolFactory, options?: ToolOptions): void;
   registerCommand(command: CommandDefinition): void;
   registerService(service: ServiceDefinition): void;
   registerContextEngine?(id: string, factory: ContextEngineFactory): void;
   registerMemoryPromptSection?(builder: MemoryPromptSectionBuilder): void;
   registerHook?(events: string | string[], handler: HookHandler, opts?: HookOptions): void;
   on(hook: HookName | string, handler: HookHandler, opts?: HookOptions): void;
-  getConfig?(pluginId: string): Record<string, unknown> | undefined;
-
   logger: PluginLogger;
   runtime: PluginRuntime;
   config: Record<string, unknown>;


### PR DESCRIPTION
## Summary
- Session continuity: auto-briefing on session start, auto-summaries on session end
- ContextEngine rewrite matching OpenClaw v2026.3.28 spec
- 25+ hook types (session lifecycle, tool observation, subagent tracking)
- Progressive disclosure, privacy markers, recency boost

## OpenClaw v2026.3.28 Fixes (vs original PR #127)
- `api.getConfig()` removed → `api.pluginConfig`
- `Service.start()` now accepts `ctx: ServiceContext`
- `PluginLogger.error` now required, signature uses `string`
- `registerTool` accepts `ToolFactory` (factory pattern)
- Version refs updated from v2026.3.24 → v2026.3.28

Supersedes #127 and #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)