### PR TITLE
fix: session continuity audit — 5 critical/moderate fixes

### DIFF
--- a/packages/openclaw-plugin/src/context-engine.ts
+++ b/packages/openclaw-plugin/src/context-engine.ts
@@ -16,6 +16,8 @@ import type {
 } from "./types.js";
 import type { PalaiaPluginConfig } from "./config.js";
 import { run, recover, type RunnerOpts, getEmbedServerManager } from "./runner.js";
+import { getOrCreateSessionState } from "./hooks/state.js";
+import { formatBriefing } from "./hooks/session.js";
 
 import {
   extractMessageTexts,
@@ -421,7 +423,34 @@ export function createPalaiaContextEngine(
 
         _lastRecallOccurred = recallOccurred;
 
-        if (!text) {
+        // Inject session briefing if pending (session_start or model switch)
+        let briefingText = "";
+        if (config.sessionBriefing && params.sessionKey) {
+          const sessionState = getOrCreateSessionState(params.sessionKey);
+          if (sessionState.pendingBriefing && !sessionState.briefingDelivered) {
+            // Wait for briefing to be ready (with timeout)
+            if (sessionState.briefingReady) {
+              await Promise.race([
+                sessionState.briefingReady,
+                new Promise<void>(r => setTimeout(r, 3000)),
+              ]);
+            }
+            if (sessionState.pendingBriefing) {
+              const remainingChars = maxChars - (text?.length || 0);
+              briefingText = formatBriefing(
+                sessionState.pendingBriefing,
+                Math.min(config.sessionBriefingMaxChars || 1500, remainingChars),
+              );
+              if (briefingText) {
+                sessionState.briefingDelivered = true;
+              }
+            }
+          }
+        }
+
+        const combined = [briefingText, text].filter(Boolean).join("\n\n");
+
+        if (!combined) {
           return {
             messages: params.messages || [],
             estimatedTokens: 0,
@@ -430,8 +459,8 @@ export function createPalaiaContextEngine(
 
         return {
           messages: params.messages || [],
-          estimatedTokens: estimateTokens(text),
-          systemPromptAddition: text,
+          estimatedTokens: estimateTokens(combined),
+          systemPromptAddition: combined,
         };
       } catch (error) {
         logger.warn(`[palaia] ContextEngine assemble failed: ${error}`);

--- a/packages/openclaw-plugin/src/hooks/index.ts
+++ b/packages/openclaw-plugin/src/hooks/index.ts
@@ -606,14 +606,17 @@ export function registerHooks(api: OpenClawPluginApi, config: PalaiaPluginConfig
           collectedHints.push(...hints);
         }
 
-        // Strip Palaia-injected recall context from user messages to prevent feedback loop.
+        // Strip Palaia-injected recall context and private blocks from messages.
         // The recall block is prepended to user messages by before_prompt_build.
         // Without stripping, auto-capture would re-capture previously recalled memories.
-        const cleanedTexts = allTexts.map(t =>
-          t.role === "user"
-            ? { ...t, text: stripPalaiaInjectedContext(t.text) }
-            : t
-        );
+        // Private blocks (<private>...</private>) must be excluded from capture.
+        const { stripPrivateBlocks } = await import("./capture.js");
+        const cleanedTexts = allTexts.map(t => ({
+          ...t,
+          text: stripPrivateBlocks(
+            t.role === "user" ? stripPalaiaInjectedContext(t.text) : t.text
+          ),
+        }));
 
         // Only extract from recent exchanges — full history causes LLM timeouts
         // and dilutes extraction quality

--- a/packages/openclaw-plugin/src/hooks/session.ts
+++ b/packages/openclaw-plugin/src/hooks/session.ts
@@ -21,6 +21,7 @@ import {
 } from "./state.js";
 import {
   stripPalaiaInjectedContext,
+  stripPrivateBlocks,
   trimToRecentExchanges,
   extractWithLLM,
 } from "./capture.js";
@@ -151,11 +152,12 @@ export async function captureSessionSummary(
     // Rule-based fallback: last 3 user+assistant pairs
     if (!summaryText) {
       const allTexts = extractMessageTexts(messages);
-      const cleaned = allTexts.map((t: { role: string; text: string }) =>
-        t.role === "user"
-          ? { ...t, text: stripPalaiaInjectedContext(t.text) }
-          : t
-      );
+      const cleaned = allTexts.map((t: { role: string; text: string }) => ({
+        ...t,
+        text: stripPrivateBlocks(
+          t.role === "user" ? stripPalaiaInjectedContext(t.text) : t.text
+        ),
+      }));
       const recent = trimToRecentExchanges(cleaned, 3);
       if (recent.length > 0) {
         summaryText = recent
@@ -305,9 +307,14 @@ export function registerSessionHooks(
       if (!sessionKey) return;
 
       try {
-        // Only save summary if session had meaningful interaction
-        const messageCount = (event as any)?.messageCount ?? 0;
-        if (messageCount >= 4) { // At least 2 user + 2 assistant messages
+        // Only save summary if session had meaningful interaction.
+        // Guard: if OpenClaw omits messageCount, fall back to tool observations
+        // as evidence of interaction rather than silently skipping.
+        const messageCount = (event as any)?.messageCount;
+        const state = getOrCreateSessionState(sessionKey);
+        const hasInteraction = (typeof messageCount === "number" && messageCount >= 4)
+          || (messageCount === undefined && state.toolObservations.length > 0);
+        if (hasInteraction) {
           await captureSessionSummary(undefined, sessionKey, api, config, logger);
         }
       } catch (error) {
@@ -357,19 +364,6 @@ export function registerSessionHooks(
       }
     }
     state.lastModel = model;
-  });
-
-  // ── llm_output: Token usage tracking ──────────────────────────────
-  api.on("llm_output", (event: any, ctx: any) => {
-    const sessionKey = ctx?.sessionKey || ctx?.sessionId;
-    if (!sessionKey) return;
-    const state = getOrCreateSessionState(sessionKey);
-
-    const usage = (event as any)?.usage;
-    if (usage) {
-      state.tokenUsage.input += usage.input || 0;
-      state.tokenUsage.output += usage.output || 0;
-    }
   });
 
   // ── after_tool_call: Tool observation tracking ────────────────��───

--- a/packages/openclaw-plugin/src/hooks/state.ts
+++ b/packages/openclaw-plugin/src/hooks/state.ts
@@ -127,6 +127,8 @@ export function pruneStaleEntries(): void {
       lastInboundMessageByChannel.delete(key);
     }
   }
+  // Also prune stale session state (orphaned sessions)
+  pruneStaleSessionState();
 }
 
 /**
@@ -186,8 +188,6 @@ export interface SessionState {
   pendingBriefing: PendingBriefing | null;
   /** Accumulated tool observations for the session (used in session summary). */
   toolObservations: ToolObservation[];
-  /** Accumulated token usage for the session. */
-  tokenUsage: { input: number; output: number };
   /** Timestamp of session start. */
   startedAt: number;
   /** Whether the first turn briefing has been delivered. */
@@ -202,6 +202,23 @@ export interface SessionState {
 
 /** Session state map. Keyed by sessionKey. */
 export const sessionStateByKey = new Map<string, SessionState>();
+
+/** Maximum age for session state entries before pruning (1 hour). */
+const SESSION_STATE_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * Remove stale entries from sessionStateByKey.
+ * Called alongside pruneStaleEntries() to prevent memory leaks from
+ * sessions that ended without firing session_end (crash/kill).
+ */
+export function pruneStaleSessionState(): void {
+  const now = Date.now();
+  for (const [key, state] of sessionStateByKey) {
+    if (now - state.startedAt > SESSION_STATE_TTL_MS) {
+      sessionStateByKey.delete(key);
+    }
+  }
+}
 
 /** Generate an auto session ID. */
 export function generateAutoSessionId(): string {
@@ -223,7 +240,6 @@ export function getOrCreateSessionState(sessionKey: string): SessionState {
       modelSwitchDetected: false,
       pendingBriefing: null,
       toolObservations: [],
-      tokenUsage: { input: 0, output: 0 },
       startedAt: Date.now(),
       briefingDelivered: false,
       summarySaved: false,


### PR DESCRIPTION
## Summary
Fixes all critical and moderate issues found in the Session Continuity v3 audit.

### Critical
- **ContextEngine briefing broken**: `assemble()` now injects session briefing (was silently dropped on modern OpenClaw)
- **Privacy markers leaking**: `<private>` blocks now stripped in session summaries AND legacy rule-based capture

### Moderate
- **Dead code removed**: Token usage tracking (accumulated but never read)
- **messageCount guard**: Falls back to tool observations when `event.messageCount` is undefined
- **Memory leak fix**: TTL pruning (1h) for `sessionStateByKey` — orphaned sessions no longer persist forever

🤖 Generated with [Claude Code](https://claude.com/claude-code)