### PR TITLE
dev: v2.4.dev1 — session continuity + OpenClaw v2026.3.28

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: palaia
-version: "2.3.6"
+version: "2.4.dev1"
 description: >
   Local, crash-safe persistent memory for OpenClaw agents.
   SQLite-backed by default. Semantic search, projects, scopes, auto-capture.

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byte5ai/palaia",
-  "version": "2.3.6",
+  "version": "2.4.dev1",
   "description": "Palaia memory backend for OpenClaw",
   "main": "index.ts",
   "openclaw": {

--- a/palaia/SKILL.md
+++ b/palaia/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: palaia
-version: "2.3.6"
+version: "2.4.dev1"
 description: >
   Local, crash-safe persistent memory for OpenClaw agents.
   SQLite-backed by default. Semantic search, projects, scopes, auto-capture.

--- a/palaia/__init__.py
+++ b/palaia/__init__.py
@@ -4,5 +4,5 @@ Palaia — Local, cloud-free memory for OpenClaw agents.
 
 from __future__ import annotations
 
-__version__ = "2.3.6"
+__version__ = "2.4.dev1"
 __author__ = "byte5 GmbH"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "palaia"
-version = "2.3.6"
+version = "2.4.dev1"
 description = "Local, cloud-free memory for OpenClaw agents."
 readme = "README.md"
 license = {text = "MIT"}

--- a/skills/palaia/SKILL.md
+++ b/skills/palaia/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: palaia
-version: "2.3.6"
+version: "2.4.dev1"
 description: >
   Local, crash-safe persistent memory for OpenClaw agents.
   SQLite-backed by default. Semantic search, projects, scopes, auto-capture.


### PR DESCRIPTION
## Summary
Dev release v2.4.dev1 for testing before stable v2.4.

### What is new in v2.4
- Session Continuity v3 (auto-briefings, auto-summaries, tool observations)
- OpenClaw v2026.3.28 plugin SDK compatibility
- Progressive disclosure, privacy markers, recency boost
- GitHub org: byte5ai/palaia
- Audit fixes: ContextEngine briefing, privacy markers, memory leak prevention

### Install for testing
```bash
pip install palaia==2.4.dev1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)