### PR TITLE
fix: palaia skill strips install section to save context window

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -36,6 +36,7 @@ metadata:
 
 Palaia is the memory system for OpenClaw agents. It gives you persistent, searchable, crash-safe memory across sessions. You don't need to understand how it works — just use the commands below.
 
+<!-- begin:install -->
 ## First-Time Setup
 
 When a user asks you to "set up palaia", "enable memory", or "remember things across sessions", run these steps:
@@ -136,6 +137,7 @@ npm install -g @byte5ai/palaia@latest
 ```
 
 After the manual update, `palaia upgrade` will be available for future updates.
+<!-- end:install -->
 
 ## Auto-Check (run every time this skill is loaded)
 

--- a/palaia/SKILL.md
+++ b/palaia/SKILL.md
@@ -36,6 +36,7 @@ metadata:
 
 Palaia is the memory system for OpenClaw agents. It gives you persistent, searchable, crash-safe memory across sessions. You don't need to understand how it works — just use the commands below.
 
+<!-- begin:install -->
 ## First-Time Setup
 
 When a user asks you to "set up palaia", "enable memory", or "remember things across sessions", run these steps:
@@ -136,6 +137,7 @@ npm install -g @byte5ai/palaia@latest
 ```
 
 After the manual update, `palaia upgrade` will be available for future updates.
+<!-- end:install -->
 
 ## Auto-Check (run every time this skill is loaded)
 

--- a/palaia/services/misc.py
+++ b/palaia/services/misc.py
@@ -78,7 +78,17 @@ def unlock_project(root: Path, *, project: str) -> dict:
 
 
 def get_skill_content() -> dict:
-    """Read and return SKILL.md content. Returns dict with 'skill' or 'error'."""
+    """Read and return SKILL.md content.
+
+    Strips the install/update section (between ``<!-- begin:install -->``
+    and ``<!-- end:install -->``) because ``palaia skill`` is only called
+    when palaia is already installed — the install block wastes context window.
+    ClawHub and GitHub still see the full file.
+
+    Returns dict with 'skill' or 'error'.
+    """
+    import re
+
     skill_path = Path(__file__).parent.parent / "SKILL.md"
     if not skill_path.exists():
         return {
@@ -88,6 +98,13 @@ def get_skill_content() -> dict:
             )
         }
     content = skill_path.read_text(encoding="utf-8")
+    # Strip install section — agent already has palaia installed
+    content = re.sub(
+        r"<!-- begin:install -->.*?<!-- end:install -->\n*",
+        "",
+        content,
+        flags=re.DOTALL,
+    )
     return {"skill": content}
 
 

--- a/skills/palaia/SKILL.md
+++ b/skills/palaia/SKILL.md
@@ -36,6 +36,7 @@ metadata:
 
 Palaia is the memory system for OpenClaw agents. It gives you persistent, searchable, crash-safe memory across sessions. You don't need to understand how it works — just use the commands below.
 
+<!-- begin:install -->
 ## First-Time Setup
 
 When a user asks you to "set up palaia", "enable memory", or "remember things across sessions", run these steps:
@@ -136,6 +137,7 @@ npm install -g @byte5ai/palaia@latest
 ```
 
 After the manual update, `palaia upgrade` will be available for future updates.
+<!-- end:install -->
 
 ## Auto-Check (run every time this skill is loaded)
 


### PR DESCRIPTION
`palaia skill` now strips the install/update section (~100 lines) since the agent already has palaia installed. ClawHub and GitHub still serve the full SKILL.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)