### PR TITLE
chore: add AGENTS.md and pre-push hook

### DIFF
--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Pre-push hook: block direct pushes to main/master.
+# Override: ALLOW_PUSH_TO_MAIN=1 git push origin main
+
+if [ "$ALLOW_PUSH_TO_MAIN" = "1" ]; then
+  exit 0
+fi
+
+while read -r _local_ref _local_sha remote_ref _remote_sha; do
+  remote_branch="${remote_ref##refs/heads/}"
+  if [[ "$remote_branch" =~ ^(main|master)$ ]]; then
+    echo ""
+    echo "  BLOCKED: Direct push to '$remote_branch' is not allowed."
+    echo "  Create a feature branch and open a pull request instead."
+    echo ""
+    echo "  Override (emergencies only):"
+    echo "    ALLOW_PUSH_TO_MAIN=1 git push origin $remote_branch"
+    echo ""
+    exit 1
+  fi
+done
+
+exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Agent Instructions
+
+These rules apply to all AI agents working on this repository (Codex, Claude, Copilot, etc.).
+
+## Git Workflow
+
+- **Never push directly to `main`.** All changes go through feature branches and pull requests.
+- **Branch naming:** `feat/`, `fix/`, `refactor/`, `docs/`, `chore/` prefixes.
+- **Conventional commits:** `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`, `release:`, `dev:`.
+- **Never force-push** to any shared branch.
+- **Never commit secrets** (.env, API keys, tokens, credentials).
+- **Never skip hooks** (`--no-verify`).
+
+## Pull Requests
+
+- Keep PR titles short (<70 chars), use conventional prefix.
+- One logical change per PR.
+- Ensure tests pass before requesting merge.
+
+## Project
+
+- **Python + TypeScript** monorepo: `palaia/` (Python CLI/core) + `packages/openclaw-plugin/` (TS plugin).
+- Tests: `python3 -m pytest tests/ -q` and `cd packages/openclaw-plugin && npx vitest run`.
+- Dev server runs on **devhost** (Tailscale) — never use `localhost`.
+
+## Pre-push Hook
+
+A `.hooks/pre-push` hook blocks direct pushes to `main`/`master`. Override only when explicitly instructed:
+```bash
+ALLOW_PUSH_TO_MAIN=1 git push origin main
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,14 @@ Thanks for your interest in contributing to Palaia!
 ```bash
 git clone https://github.com/byte5ai/palaia.git
 cd palaia
-pip install -e ".[dev,fastembed]"
+./script/setup          # installs deps + configures git hooks
 pytest tests/ -v
+```
+
+Or manually:
+```bash
+pip install -e ".[dev,fastembed]"
+git config core.hooksPath .hooks
 ```
 
 For TypeScript plugin development:

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# One-time setup for palaia development.
+# Run after cloning: ./script/setup
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+echo "Installing Python dependencies..."
+pip install -e ".[dev,fastembed]"
+
+echo "Configuring git hooks..."
+git config core.hooksPath .hooks
+
+echo ""
+echo "Done. Run tests with:"
+echo "  pytest tests/ -v"
+echo "  cd packages/openclaw-plugin && npx vitest run"


### PR DESCRIPTION
## Summary
- `AGENTS.md`: Agent-agnostic git workflow rules (Codex, Copilot, etc.)
- `.hooks/pre-push`: Blocks direct pushes to main/master
- Override: `ALLOW_PUSH_TO_MAIN=1 git push origin main`

Ref: https://github.com/iret77/paperclip-lobster/pull/1

🤖 Generated with [Claude Code](https://claude.com/claude-code)