### PR TITLE
fix: memory_search timeout on parallel queries + process safety guardrails

### DIFF
--- a/packages/openclaw-plugin/src/tools.ts
+++ b/packages/openclaw-plugin/src/tools.ts
@@ -7,7 +7,7 @@
  */
 
 import { Type } from "@sinclair/typebox";
-import { run, runJson, type RunnerOpts } from "./runner.js";
+import { run, runJson, getEmbedServerManager, type RunnerOpts } from "./runner.js";
 import type { PalaiaPluginConfig } from "./config.js";
 import { sanitizeScope, isValidScope } from "./hooks/index.js";
 import { loadPriorities, resolvePriorities } from "./priorities.js";
@@ -114,19 +114,39 @@ export function registerTools(api: OpenClawPluginApi, config: PalaiaPluginConfig
       }
 
       const limit = params.maxResults || config.maxResults || 5;
-      const args: string[] = ["query", params.query, "--limit", String(limit)];
+      const includeCold = params.tier === "all" || config.tier === "all";
 
-      // --all flag includes cold tier
-      if (params.tier === "all" || config.tier === "all") {
-        args.push("--all");
+      // Try embed server first — its queue correctly handles concurrent requests
+      // without counting wait time against the timeout.
+      let result: QueryResult | null = null;
+      if (config.embeddingServer) {
+        try {
+          const mgr = getEmbedServerManager(opts);
+          const resp = await mgr.query({
+            text: params.query,
+            top_k: limit,
+            include_cold: includeCold,
+            ...(params.type ? { type: params.type } : {}),
+          }, config.timeoutMs || 3000);
+          if (resp?.result?.results && Array.isArray(resp.result.results)) {
+            result = { results: resp.result.results };
+          }
+        } catch {
+          // Fall through to CLI
+        }
       }
 
-      // Type filter (Issue #82)
-      if (params.type) {
-        args.push("--type", params.type);
+      // CLI fallback — longer timeout since it includes process spawn overhead
+      if (!result) {
+        const args: string[] = ["query", params.query, "--limit", String(limit)];
+        if (includeCold) {
+          args.push("--all");
+        }
+        if (params.type) {
+          args.push("--type", params.type);
+        }
+        result = await runJson<QueryResult>(args, { ...opts, timeoutMs: 15000 });
       }
-
-      const result = await runJson<QueryResult>(args, opts);
 
       // Apply scope visibility filter (Issue #145: agent isolation)
       let filteredResults = result.results || [];

--- a/packages/openclaw-plugin/tests/tools.test.ts
+++ b/packages/openclaw-plugin/tests/tools.test.ts
@@ -5,12 +5,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mock the runner module
+const mockQuery = vi.fn();
 vi.mock("../src/runner.js", () => ({
   runJson: vi.fn(),
   run: vi.fn(),
   detectBinary: vi.fn().mockResolvedValue("palaia"),
   recover: vi.fn().mockResolvedValue({ replayed: 0, errors: 0 }),
   resetCache: vi.fn(),
+  getEmbedServerManager: vi.fn(() => ({ query: mockQuery })),
 }));
 
 import { registerTools } from "../src/tools.js";
@@ -57,19 +59,21 @@ describe("tools", () => {
   });
 
   describe("memory_search", () => {
-    it("returns formatted results", async () => {
-      mockRunJson.mockResolvedValueOnce({
-        results: [
-          {
-            id: "abc-123",
-            body: "Test memory content",
-            score: 0.92,
-            tier: "hot",
-            scope: "team",
-            title: "Test Entry",
-            path: "hot/abc-123.md",
-          },
-        ],
+    it("returns formatted results via embed server", async () => {
+      mockQuery.mockResolvedValueOnce({
+        result: {
+          results: [
+            {
+              id: "abc-123",
+              body: "Test memory content",
+              score: 0.92,
+              tier: "hot",
+              scope: "team",
+              title: "Test Entry",
+              path: "hot/abc-123.md",
+            },
+          ],
+        },
       });
 
       const execute = api.tools["memory_search"].def.execute;
@@ -81,43 +85,70 @@ describe("tools", () => {
       expect(result.content[0].text).toContain("Source: hot/abc-123.md");
       expect(result.content[0].text).toContain("score: 0.92");
 
-      // Verify CLI args (default maxResults is 10)
+      // Should use embed server, not CLI
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ text: "test", top_k: 10 }),
+        expect.any(Number)
+      );
+      expect(mockRunJson).not.toHaveBeenCalled();
+    });
+
+    it("falls back to CLI when embed server fails", async () => {
+      mockQuery.mockRejectedValueOnce(new Error("server down"));
+      mockRunJson.mockResolvedValueOnce({
+        results: [
+          {
+            id: "abc-123",
+            body: "Fallback content",
+            score: 0.85,
+            tier: "hot",
+            scope: "team",
+            path: "hot/abc-123.md",
+          },
+        ],
+      });
+
+      const result = await api.tools["memory_search"].def.execute("call-fb", {
+        query: "test",
+      });
+
+      expect(result.content[0].text).toContain("Fallback content");
       expect(mockRunJson).toHaveBeenCalledWith(
         ["query", "test", "--limit", "10"],
-        expect.any(Object)
+        expect.objectContaining({ timeoutMs: 15000 })
       );
     });
 
     it("respects maxResults param", async () => {
-      mockRunJson.mockResolvedValueOnce({ results: [] });
+      mockQuery.mockResolvedValueOnce({ result: { results: [] } });
 
       await api.tools["memory_search"].def.execute("call-2", {
         query: "test",
         maxResults: 20,
       });
 
-      expect(mockRunJson).toHaveBeenCalledWith(
-        ["query", "test", "--limit", "20"],
-        expect.any(Object)
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ top_k: 20 }),
+        expect.any(Number)
       );
     });
 
-    it("passes --all for tier=all", async () => {
-      mockRunJson.mockResolvedValueOnce({ results: [] });
+    it("passes include_cold for tier=all", async () => {
+      mockQuery.mockResolvedValueOnce({ result: { results: [] } });
 
       await api.tools["memory_search"].def.execute("call-3", {
         query: "test",
         tier: "all",
       });
 
-      expect(mockRunJson).toHaveBeenCalledWith(
-        expect.arrayContaining(["--all"]),
-        expect.any(Object)
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ include_cold: true }),
+        expect.any(Number)
       );
     });
 
     it("returns 'No results found.' when empty", async () => {
-      mockRunJson.mockResolvedValueOnce({ results: [] });
+      mockQuery.mockResolvedValueOnce({ result: { results: [] } });
 
       const result = await api.tools["memory_search"].def.execute("call-4", {
         query: "nothing",
@@ -247,10 +278,36 @@ describe("tools", () => {
   });
 
   describe("memory_search type filter (Issue #82)", () => {
-    it("passes --type filter when set", async () => {
-      mockRunJson.mockResolvedValueOnce({ results: [] });
+    it("passes type filter to embed server", async () => {
+      mockQuery.mockResolvedValueOnce({ result: { results: [] } });
 
       await api.tools["memory_search"].def.execute("call-type-1", {
+        query: "tasks",
+        type: "task",
+      });
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "task" }),
+        expect.any(Number)
+      );
+    });
+
+    it("omits type when not set", async () => {
+      mockQuery.mockResolvedValueOnce({ result: { results: [] } });
+
+      await api.tools["memory_search"].def.execute("call-type-2", {
+        query: "anything",
+      });
+
+      const queryParams = mockQuery.mock.calls[0][0];
+      expect(queryParams).not.toHaveProperty("type");
+    });
+
+    it("passes --type to CLI fallback", async () => {
+      mockQuery.mockRejectedValueOnce(new Error("server down"));
+      mockRunJson.mockResolvedValueOnce({ results: [] });
+
+      await api.tools["memory_search"].def.execute("call-type-3", {
         query: "tasks",
         type: "task",
       });
@@ -259,17 +316,6 @@ describe("tools", () => {
         expect.arrayContaining(["--type", "task"]),
         expect.any(Object)
       );
-    });
-
-    it("omits --type when not set", async () => {
-      mockRunJson.mockResolvedValueOnce({ results: [] });
-
-      await api.tools["memory_search"].def.execute("call-type-2", {
-        query: "anything",
-      });
-
-      const callArgs = mockRunJson.mock.calls[0][0];
-      expect(callArgs).not.toContain("--type");
     });
   });
 });

--- a/palaia/cli.py
+++ b/palaia/cli.py
@@ -685,13 +685,19 @@ def cmd_curate(args):
         return 0
 
     elif action == "apply":
+        from palaia.curate import ProcessSafetyError
         from palaia.services.curate import apply_svc
 
-        result = apply_svc(
-            root,
-            report_path=args.report,
-            output=getattr(args, "output", None),
-        )
+        try:
+            result = apply_svc(
+                root,
+                report_path=args.report,
+                output=getattr(args, "output", None),
+                force=getattr(args, "force", False),
+            )
+        except ProcessSafetyError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
         if _json_out(result, args):
             return 0
         print(f"Curation applied: {result['output_path']}")

--- a/palaia/cli_args.py
+++ b/palaia/cli_args.py
@@ -325,6 +325,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_curate_apply = curate_sub.add_parser("apply", help="Apply edited curation report")
     p_curate_apply.add_argument("report", help="Path to edited curation report")
     p_curate_apply.add_argument("--output", default=None, help="Output package path")
+    p_curate_apply.add_argument("--force", action="store_true", help="Allow MERGE/DROP on process entries (dangerous)")
     p_curate_apply.add_argument("--json", action="store_true", help="Output as JSON")
 
     # sync

--- a/palaia/curate.py
+++ b/palaia/curate.py
@@ -668,13 +668,17 @@ def merge_entries(entries: list[ClusterEntry]) -> dict:
     base = sorted_entries[0]
     others = sorted_entries[1:]
 
-    # Combine content
+    # Combine content — process entries are never truncated
+    has_process = any(e.entry_type == "process" for e in entries)
     combined_content = base.content
     if others:
         bullets = []
         for o in others:
             title = o.title or "(untitled)"
-            bullets.append(f"- **{title}**: {o.content[:200]}")
+            if has_process:
+                bullets.append(f"- **{title}**:\n{o.content}")
+            else:
+                bullets.append(f"- **{title}**: {o.content[:200]}")
         combined_content = base.content + "\n\n---\n\n" + "\n".join(bullets)
 
     # Tags: union
@@ -705,10 +709,17 @@ def merge_entries(entries: list[ClusterEntry]) -> dict:
     }
 
 
-def apply_report(report: CurateReport, store) -> dict:
+class ProcessSafetyError(ValueError):
+    """Raised when a destructive action targets process-type entries without --force."""
+
+
+def apply_report(report: CurateReport, store, *, force: bool = False) -> dict:
     """Process an edited curation report and produce package-compatible entries.
 
     Returns dict with keys: kept, merged, dropped, total_output, entries.
+
+    Raises ProcessSafetyError if MERGE or DROP targets process-type entries
+    unless force=True.
     """
     kept = 0
     merged = 0
@@ -756,6 +767,21 @@ def apply_report(report: CurateReport, store) -> dict:
 
     for cluster in report.clusters:
         rec = cluster.recommendation.upper()
+        has_process = any(e.entry_type == "process" for e in cluster.entries)
+
+        # Guard: process entries must not be silently merged or dropped
+        if has_process and rec in ("DROP", "MERGE") and not force:
+            process_titles = [
+                e.title or e.full_id or "(untitled)"
+                for e in cluster.entries
+                if e.entry_type == "process"
+            ]
+            raise ProcessSafetyError(
+                f"Cannot {rec} cluster containing process entries: "
+                f"{', '.join(process_titles)}. "
+                f"Process entries contain critical operational knowledge. "
+                f"Use --force to override."
+            )
 
         if rec == "DROP":
             dropped += len(cluster.entries)

--- a/palaia/services/curate.py
+++ b/palaia/services/curate.py
@@ -31,12 +31,12 @@ def analyze_svc(root: Path, project: str | None = None, agent: str | None = None
     }
 
 
-def apply_svc(root: Path, report_path: str, output: str | None = None) -> dict:
+def apply_svc(root: Path, report_path: str, output: str | None = None, *, force: bool = False) -> dict:
     """Apply edited curation report. Returns {output_path, kept, merged, dropped}."""
     store = Store(root)
     markdown = Path(report_path).read_text(encoding="utf-8")
     report = parse_report(markdown)
-    result = apply_report(report, store)
+    result = apply_report(report, store, force=force)
 
     output_path = output or str(root / "curated.palaia-pkg.json")
     package = {

--- a/tests/test_curate.py
+++ b/tests/test_curate.py
@@ -12,6 +12,7 @@ from palaia.curate import (
     Cluster,
     ClusterEntry,
     CurateReport,
+    ProcessSafetyError,
     ScopeMapping,
     _cosine_similarity,
     _find_duplicates,
@@ -543,6 +544,138 @@ class TestMergeEntries:
         e = _make_entry(content="Only one", title="Solo")
         merged = merge_entries([e])
         assert merged["content"] == "Only one"
+
+    def test_merge_preserves_full_process_content(self):
+        """Process entries must never have their content truncated."""
+        long_content = "Step " + "x" * 500  # Well over 200 chars
+        e1 = _make_entry(
+            content="Main process", title="Main",
+            entry_type="process", decay_score=0.9,
+        )
+        e2 = _make_entry(
+            content=long_content, title="Extra steps",
+            entry_type="process", decay_score=0.3,
+        )
+        merged = merge_entries([e1, e2])
+        # Full content of secondary entry must be preserved
+        assert long_content in merged["content"]
+
+    def test_merge_truncates_non_process_content(self):
+        """Non-process entries still get truncated to 200 chars."""
+        long_content = "Note " + "x" * 500
+        e1 = _make_entry(
+            content="Main note", title="Main",
+            entry_type="memory", decay_score=0.9,
+        )
+        e2 = _make_entry(
+            content=long_content, title="Extra",
+            entry_type="memory", decay_score=0.3,
+        )
+        merged = merge_entries([e1, e2])
+        # Secondary content should be truncated
+        assert long_content not in merged["content"]
+        assert long_content[:200] in merged["content"]
+
+
+# ---------------------------------------------------------------------------
+# Test process safety guardrails
+# ---------------------------------------------------------------------------
+
+class TestProcessSafety:
+    def test_drop_process_raises(self, palaia_root):
+        """DROP on cluster with process entries raises ProcessSafetyError."""
+        store = Store(palaia_root)
+        e1 = _make_entry(content="Deploy SOP", title="Deploy", entry_type="process")
+        cluster = Cluster(
+            cluster_id=1, label="drop-proc", entries=[e1],
+            recommendation="DROP", reason="test",
+        )
+        report = CurateReport(
+            project=None, generated_at="", total_entries=1,
+            clusters=[cluster], scope_mappings=[], unclustered=[],
+        )
+        with pytest.raises(ProcessSafetyError, match="Cannot DROP"):
+            apply_report(report, store)
+
+    def test_merge_process_raises(self, palaia_root):
+        """MERGE on cluster with process entries raises ProcessSafetyError."""
+        store = Store(palaia_root)
+        e1 = _make_entry(content="Step 1", title="Process A", entry_type="process")
+        e2 = _make_entry(content="Step 2", title="Process B", entry_type="process")
+        cluster = Cluster(
+            cluster_id=1, label="merge-proc", entries=[e1, e2],
+            recommendation="MERGE", reason="test",
+        )
+        report = CurateReport(
+            project=None, generated_at="", total_entries=2,
+            clusters=[cluster], scope_mappings=[], unclustered=[],
+        )
+        with pytest.raises(ProcessSafetyError, match="Cannot MERGE"):
+            apply_report(report, store)
+
+    def test_force_allows_drop_process(self, palaia_root):
+        """DROP on process entries works with force=True."""
+        store = Store(palaia_root)
+        e1 = _make_entry(content="Old SOP", title="Old", entry_type="process")
+        cluster = Cluster(
+            cluster_id=1, label="force-drop", entries=[e1],
+            recommendation="DROP", reason="test",
+        )
+        report = CurateReport(
+            project=None, generated_at="", total_entries=1,
+            clusters=[cluster], scope_mappings=[], unclustered=[],
+        )
+        result = apply_report(report, store, force=True)
+        assert result["dropped"] == 1
+        assert len(result["entries"]) == 0
+
+    def test_force_allows_merge_process(self, palaia_root):
+        """MERGE on process entries works with force=True."""
+        store = Store(palaia_root)
+        e1 = _make_entry(content="Step 1", title="A", entry_type="process", decay_score=0.9)
+        e2 = _make_entry(content="Step 2", title="B", entry_type="process", decay_score=0.3)
+        cluster = Cluster(
+            cluster_id=1, label="force-merge", entries=[e1, e2],
+            recommendation="MERGE", reason="test",
+        )
+        report = CurateReport(
+            project=None, generated_at="", total_entries=2,
+            clusters=[cluster], scope_mappings=[], unclustered=[],
+        )
+        result = apply_report(report, store, force=True)
+        assert result["merged"] == 2
+        assert len(result["entries"]) == 1
+
+    def test_non_process_drop_unaffected(self, palaia_root):
+        """DROP on non-process entries works without force."""
+        store = Store(palaia_root)
+        e1 = _make_entry(content="Old note", entry_type="memory")
+        cluster = Cluster(
+            cluster_id=1, label="drop-mem", entries=[e1],
+            recommendation="DROP", reason="test",
+        )
+        report = CurateReport(
+            project=None, generated_at="", total_entries=1,
+            clusters=[cluster], scope_mappings=[], unclustered=[],
+        )
+        result = apply_report(report, store)
+        assert result["dropped"] == 1
+
+    def test_mixed_cluster_with_process_raises(self, palaia_root):
+        """A cluster mixing process and memory entries still triggers the guard."""
+        store = Store(palaia_root)
+        e1 = _make_entry(content="Note", entry_type="memory")
+        e2 = _make_entry(content="SOP", title="Deploy", entry_type="process")
+        cluster = Cluster(
+            cluster_id=1, label="mixed", entries=[e1, e2],
+            recommendation="DROP", reason="test",
+        )
+        report = CurateReport(
+            project=None, generated_at="", total_entries=2,
+            clusters=[cluster], scope_mappings=[], unclustered=[],
+        )
+        with pytest.raises(ProcessSafetyError):
+            apply_report(report, store)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **memory_search timeout fix**: Uses embed server directly instead of spawning CLI processes. The embed server's internal request queue correctly starts the timeout timer only when processing begins — not when enqueued. Fixes timeouts when agents fire multiple parallel `memory_search` calls (reported by CyberClaw via Saul's session transcript).
- **Process safety guardrails**: Process entries (`type: process`) are now protected from destructive curation actions. `merge_entries()` preserves full content (no 200-char truncation), `apply_report()` raises `ProcessSafetyError` on MERGE/DROP unless `--force` is passed.

## Changes

| File | What |
|------|------|
| `packages/openclaw-plugin/src/tools.ts` | Embed server first, CLI fallback (15s timeout) |
| `palaia/curate.py` | `ProcessSafetyError`, full-content merge for processes, guardrail in `apply_report()` |
| `palaia/cli.py` | Catch `ProcessSafetyError`, pass `--force` |
| `palaia/cli_args.py` | `--force` flag on `curate apply` |
| `palaia/services/curate.py` | `force` parameter passthrough |

## Test plan

- [x] 16/16 TS tests green (embed server path + CLI fallback + type filter)
- [x] 45/45 Python tests green (37 existing + 8 new: process safety, truncation, force override, mixed clusters)

🤖 Generated with [Claude Code](https://claude.com/claude-code)