### PR TITLE
fix: v2.5.1 — doctor alignment, postUpdateMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v2.5.1 — 2026-04-02
+
+### Fixed
+- **Doctor report alignment** — Long check labels ("Embedding model integrity", "HEARTBEAT.md legacy patterns") no longer overlap with values. Column width increased from 24 to 30 characters.
+- **SKILL.md postUpdateMessage** — Updated from v2.4 to v2.5 feature summary.
+
+---
+
 ## v2.5 — 2026-04-02
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## v2.5 — 2026-04-02
+
+### New Features
+- **Agent Isolation Mode** — `--isolated` flag on `palaia init` enables scope-based memory filtering between agents. Agents can operate with isolated memory scopes via `scopeVisibility` and `captureScope` in `priorities.json`. Pre-configured profiles: Isolated Worker, Orchestrator, Lean Worker.
+- **Modern CLI Design System** — Borderless column-aligned tables replace box-drawing. ANSI colors with full TTY detection. Respects `NO_COLOR` and `FORCE_COLOR` env vars. Unicode symbols (✓ ✗ ⚠ ℹ → ▸). Zero new dependencies.
+- **Backup-Restore Fix** — Auto-detect orphaned entries on disk (e.g. after restoring a backup). `palaia doctor --fix` rebuilds metadata index from flat files. Migration auto-triggers on `Store()` init when entries are orphaned but database is empty.
+
+### Infrastructure
+- CI stabilization: flaky concurrent write tests marked `xfail(strict=False)`.
+- Matrix `fail-fast: false` for complete test coverage across Python 3.9–3.12.
+- AGENTS.md and pre-push hook for branch protection.
+
+### Migration from v2.4
+- `pip install --upgrade palaia` — no manual steps required.
+- Existing stores work as-is. New CLI output is purely cosmetic.
+
+---
+
+## v2.4 — 2026-03-28
+
+### New Features
+- **Session Continuity** — Automatic briefings and summaries across agent sessions. Agents resume where they left off.
+- **Privacy Markers** — Fine-grained control over which parts of conversations get captured.
+- **Recency Boost** — Recent entries rank higher in recall queries.
+- **Progressive Disclosure** — CLI nudges adapt based on agent experience level.
+- **`palaia skill` strips install section** — Saves context window tokens when agents read SKILL.md.
+
+### Improvements
+- OpenClaw v2026.3.28 compatibility (updated plugin SDK types).
+- Codex review fixes: 8 findings addressed, 20 new tests.
+- README restructured for better first impression.
+
+### Migration from v2.2
+- `pip install --upgrade palaia && palaia doctor --fix` — handles everything automatically.
+
+---
+
 ## v2.2.0 — 2026-03-26
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Palaia gives your agents a persistent, searchable knowledge store. They save wha
 | **Zero-config local setup** | SQLite with native SIMD vector search — no separate database process |
 | **Works everywhere via MCP** | One memory store for OpenClaw, Claude Desktop, Cursor, and more |
 | **Multi-agent ready** | Private, team, and public scopes — agents see what they should |
+| **Agent isolation** | `--isolated` mode for strict per-agent memory boundaries |
 | **Crash-safe by default** | SQLite WAL mode survives power loss, kills, OOM |
 | **Fast** | Embed server keeps model in RAM — CLI queries ~1.5s, MCP/Plugin <500ms |
 | **Scales when needed** | Swap to PostgreSQL + pgvector for distributed teams, no code changes |

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: palaia
-version: "2.5"
+version: "2.5.1"
 description: >
   Local, crash-safe persistent memory for OpenClaw agents.
   SQLite-backed by default. Semantic search, projects, scopes, auto-capture.
@@ -25,8 +25,8 @@ metadata:
       - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && (npm install -g @byte5ai/palaia@latest 2>/dev/null || true) && palaia doctor --fix && palaia warmup"
         label: "Upgrade Palaia with semantic search (pip + npm plugin) and run health checks"
     postUpdateMessage: >
-      Palaia has been updated to v2.4. New: session continuity (automatic briefings and
-      summaries), privacy markers, recency boost, progressive disclosure. Run `palaia doctor --fix` to upgrade.
+      Palaia has been updated to v2.5. New: agent isolation mode (--isolated), modern CLI
+      design, backup-restore auto-fix. Run `palaia doctor --fix` to upgrade.
     plugin:
       slot: memory
       package: "@byte5ai/palaia"

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -151,7 +151,14 @@ Show system health, entry counts, backend type, vector search method, embed-serv
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--fix` | — | Show guided fix instructions |
+| `--fix` | — | Auto-fix detected issues |
+
+Detects and fixes:
+- Missing or broken embedding chains
+- Orphaned entries on disk with empty database (e.g. after backup restore)
+- Stale embedding indexes
+- Version mismatches
+- Unread memos
 
 ### `palaia upgrade`
 

--- a/docs/multi-agent.md
+++ b/docs/multi-agent.md
@@ -103,6 +103,44 @@ When a new agent joins an existing workspace:
 
 Agents without palaia will not auto-capture conversations, not benefit from shared knowledge, and may duplicate work.
 
+## Agent Isolation Mode
+
+For strict memory separation between agents, use isolation mode:
+
+```bash
+palaia init --agent alice --isolated
+```
+
+This configures the agent with:
+- **`captureScope: private`** — all captured entries are private by default
+- **`scopeVisibility: own`** — agent only sees its own entries in recall
+
+### Pre-configured Profiles
+
+Configure via `priorities.json`:
+
+| Profile | `captureScope` | `scopeVisibility` | Use case |
+|---------|---------------|-------------------|----------|
+| **Isolated Worker** | `private` | `own` | Default for `--isolated`. Agent works alone. |
+| **Orchestrator** | `team` | `all` | Coordinator that reads all, writes team-visible. |
+| **Lean Worker** | `private` | `team` | Reads team knowledge, captures privately. |
+
+### Example: Mixed team
+
+```bash
+# Worker agents — isolated
+palaia init --agent coder --isolated
+palaia init --agent reviewer --isolated
+
+# Orchestrator — sees everything
+palaia init --agent lead
+# Then in priorities.json: set scopeVisibility: "all" for lead
+```
+
+Isolation mode is purely additive — it doesn't affect existing entries or other agents.
+
+---
+
 ## Project-Level Isolation
 
 Entries can be scoped to projects:

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byte5ai/palaia",
-  "version": "2.5",
+  "version": "2.5.1",
   "description": "Palaia memory backend for OpenClaw",
   "main": "index.ts",
   "openclaw": {

--- a/packages/openclaw-plugin/skill/SKILL.md
+++ b/packages/openclaw-plugin/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: palaia
-version: "2.5"
+version: "2.5.1"
 description: >
   Local, crash-safe persistent memory for OpenClaw agents.
   SQLite-backed by default. Semantic search, projects, scopes, auto-capture.
@@ -25,8 +25,8 @@ metadata:
       - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && (npm install -g @byte5ai/palaia@latest 2>/dev/null || true) && palaia doctor --fix && palaia warmup"
         label: "Upgrade Palaia with semantic search (pip + npm plugin) and run health checks"
     postUpdateMessage: >
-      Palaia has been updated to v2.4. New: session continuity (automatic briefings and
-      summaries), privacy markers, recency boost, progressive disclosure. Run `palaia doctor --fix` to upgrade.
+      Palaia has been updated to v2.5. New: agent isolation mode (--isolated), modern CLI
+      design, backup-restore auto-fix. Run `palaia doctor --fix` to upgrade.
     plugin:
       slot: memory
       package: "@byte5ai/palaia"

--- a/palaia/SKILL.md
+++ b/palaia/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: palaia
-version: "2.5"
+version: "2.5.1"
 description: >
   Local, crash-safe persistent memory for OpenClaw agents.
   SQLite-backed by default. Semantic search, projects, scopes, auto-capture.
@@ -25,8 +25,8 @@ metadata:
       - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && (npm install -g @byte5ai/palaia@latest 2>/dev/null || true) && palaia doctor --fix && palaia warmup"
         label: "Upgrade Palaia with semantic search (pip + npm plugin) and run health checks"
     postUpdateMessage: >
-      Palaia has been updated to v2.4. New: session continuity (automatic briefings and
-      summaries), privacy markers, recency boost, progressive disclosure. Run `palaia doctor --fix` to upgrade.
+      Palaia has been updated to v2.5. New: agent isolation mode (--isolated), modern CLI
+      design, backup-restore auto-fix. Run `palaia doctor --fix` to upgrade.
     plugin:
       slot: memory
       package: "@byte5ai/palaia"

--- a/palaia/__init__.py
+++ b/palaia/__init__.py
@@ -4,5 +4,5 @@ Palaia — Local, cloud-free memory for OpenClaw agents.
 
 from __future__ import annotations
 
-__version__ = "2.5"
+__version__ = "2.5.1"
 __author__ = "byte5 GmbH"

--- a/palaia/doctor/report.py
+++ b/palaia/doctor/report.py
@@ -27,7 +27,7 @@ def format_doctor_report(results: list[dict[str, Any]], show_fix: bool = False) 
 
         sym = status_label(status)
         # Pad label for alignment
-        label_str = label.ljust(24)
+        label_str = label.ljust(30)
         lines.append(f"  {sym}  {label_str}{dim(message)}")
 
         if status == "warn":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "palaia"
-version = "2.5"
+version = "2.5.1"
 description = "Local, cloud-free memory for OpenClaw agents."
 readme = "README.md"
 license = {text = "MIT"}

--- a/skills/palaia/SKILL.md
+++ b/skills/palaia/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: palaia
-version: "2.5"
+version: "2.5.1"
 description: >
   Local, crash-safe persistent memory for OpenClaw agents.
   SQLite-backed by default. Semantic search, projects, scopes, auto-capture.
@@ -25,8 +25,8 @@ metadata:
       - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && (npm install -g @byte5ai/palaia@latest 2>/dev/null || true) && palaia doctor --fix && palaia warmup"
         label: "Upgrade Palaia with semantic search (pip + npm plugin) and run health checks"
     postUpdateMessage: >
-      Palaia has been updated to v2.4. New: session continuity (automatic briefings and
-      summaries), privacy markers, recency boost, progressive disclosure. Run `palaia doctor --fix` to upgrade.
+      Palaia has been updated to v2.5. New: agent isolation mode (--isolated), modern CLI
+      design, backup-restore auto-fix. Run `palaia doctor --fix` to upgrade.
     plugin:
       slot: memory
       package: "@byte5ai/palaia"


### PR DESCRIPTION
## Summary
- Fix doctor report label/value overlap for long check names (ljust 24→30)
- Update SKILL.md postUpdateMessage from v2.4 to v2.5
- Version bump to 2.5.1
- CHANGELOG entry for v2.5.1

## Test plan
- [ ] `palaia doctor` shows aligned columns for all checks
- [ ] SKILL.md postUpdateMessage mentions v2.5 features

🤖 Generated with [Claude Code](https://claude.com/claude-code)