### PR TITLE
feat: usage-data-driven optimization

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -147,8 +147,13 @@ Before doing anything else with Palaia, run `palaia doctor` silently. If it repo
 
 ## Core Concepts
 
-### Auto-Capture
-Conversations are automatically captured when the OpenClaw plugin is active. You do NOT need to manually write things from conversations — Palaia handles it. Manual `palaia write` is only for structured knowledge: processes, tasks, and knowledge from external sources.
+### Auto-Capture vs. Manual Write
+Conversations are automatically captured when the OpenClaw plugin is active. Auto-capture handles routine knowledge extraction from conversations.
+
+**Manual writes (`palaia write`) are higher value.** When you or the user identify something as especially important — a key decision, a reusable workflow, a critical fact from an external source — write it manually. Manually written entries are ranked higher than auto-captured ones in recall results, so they surface more prominently in future sessions. Use manual writes for:
+- Important facts, decisions, or context from external sources
+- Reusable processes and workflows (team runbooks)
+- Sticky notes / reminders for future sessions (tasks)
 
 ### Three Tiers
 - **HOT** — Active memories (< 7 days or frequently accessed). Always searched.
@@ -162,8 +167,8 @@ Conversations are automatically captured when the OpenClaw plugin is active. You
 
 ### Entry Types
 - **memory** — Facts, decisions, learnings (default)
-- **process** — Workflows, checklists, SOPs
-- **task** — Action items with status, priority, assignee, due date
+- **process** — Workflows, checklists, SOPs (team runbooks)
+- **task** — Sticky notes / reminders for future sessions. Tasks are ephemeral: when marked done, they are automatically deleted. Never auto-captured — only created by explicit `palaia write --type task`.
 
 ---
 
@@ -265,21 +270,27 @@ palaia-mcp --read-only                  # No writes (untrusted hosts)
 
 ### `palaia write` — Save structured knowledge
 
-Only use for explicit process/task entries, or knowledge from external sources. Conversation knowledge is auto-captured.
+Use for important facts, reusable processes, sticky-note tasks, and knowledge from external sources. Manually written entries rank higher than auto-captured ones in recall.
 
 ```bash
-# Save a fact from outside the conversation
+# Save an important fact (ranks higher than auto-capture)
 palaia write "API rate limit is 100 req/min" --type memory --tags api,limits
 
-# Record a step-by-step process
-palaia write "1. Build 2. Test 3. Deploy" --type process --project myapp
+# Record a reusable team workflow (use specific, unique titles!)
+palaia write "Backend: Deploy to staging via Docker" --type process --project myapp --scope team
 
-# Create a task with structured fields
-palaia write "fix login bug" --type task --priority high --assignee Elliot --due-date 2026-04-01
+# Create a sticky note for a future session (deleted when done)
+palaia write "verify backup works after schema migration" --type task
 
 # Save to a specific project with scope
 palaia write "Use JWT for auth" --project backend --scope team --tags decision
 ```
+
+**Process naming convention:** Use the format `[Domain]: [What it does]` for process titles. Specific titles prevent duplicates and make processes findable.
+- Good: `"Release: PyPI publish + ClawHub sync"`, `"Backend: Deploy to staging via Docker"`
+- Bad: `"Deploy steps"`, `"Release process"` (too generic, will collide with other similar processes)
+
+Before writing a new process, search for existing ones: `palaia query "deploy" --type process`. If a similar process exists, update it with `palaia edit <id>` instead of creating a new one.
 
 ### `palaia query` — Semantic search
 
@@ -486,9 +497,12 @@ palaia project locks                      # List all active locks
 ### `palaia edit` — Modify existing entries
 
 ```bash
-palaia edit <id> --status done
+palaia edit <id> --status done         # For tasks: this DELETES the entry (sticky note completed)
+palaia edit <id> --status wontfix      # For tasks: also deletes (cancelled reminder)
 palaia edit <id> "updated content" --tags new,tags --priority high
 ```
+
+**Task lifecycle:** Tasks are sticky notes. When you mark a task as `done` or `wontfix`, it is automatically deleted — not archived. This is intentional: completed reminders have no long-term value. If the outcome of the task should be remembered, write a separate memory entry before marking the task done.
 
 ### Other commands
 
@@ -649,12 +663,12 @@ palaia write "## Dev-Agent Lifecycle
 
 | Situation | Command |
 |-----------|---------|
-| Remember a fact (not from conversation) | `palaia write "..." --type memory` |
-| Record a process/SOP | `palaia write "steps..." --type process` |
-| Create a task | `palaia write "fix bug" --type task --priority high` |
-| Mark task done | `palaia edit <id> --status done` |
+| Save an important fact or decision | `palaia write "..." --type memory` (ranks higher than auto-capture) |
+| Document a reusable workflow | `palaia write "Domain: Steps..." --type process --scope team` |
+| Leave a reminder for future sessions | `palaia write "check X after Y" --type task` (auto-deleted when done) |
+| Mark a reminder as done | `palaia edit <id> --status done` (deletes the task) |
 | Find something | `palaia query "..."` |
-| Find open tasks | `palaia list --type task --status open` |
+| Find open reminders | `palaia list --type task --status open` |
 | Check system health | `palaia status` |
 | Something is wrong | `palaia doctor --fix` |
 | Clean up old entries | `palaia gc` |
@@ -662,11 +676,11 @@ palaia write "## Dev-Agent Lifecycle
 | Review accumulated knowledge | `palaia curate analyze` |
 | Share knowledge | `palaia sync export` or `palaia package export` |
 | Check for messages | `palaia memo inbox` |
-| Start of session | Session briefing is now automatic. Just run `palaia doctor` and check `palaia memo inbox`. |
+| Start of session | Session briefing is automatic. Just run `palaia doctor` and check `palaia memo inbox`. |
 
-**Do NOT manually write:** facts, decisions, or preferences that came up in the current conversation. Auto-Capture handles these.
+**Auto-capture** handles routine conversation knowledge. **Manual writes rank higher** in recall — use them when something is especially important, reusable, or comes from an external source.
 
-**DO manually write:** processes, tasks with structured fields, knowledge from external sources, project setup.
+**DO manually write:** key decisions, reusable processes (team runbooks), sticky-note reminders (tasks), important facts from external sources.
 
 ---
 
@@ -706,7 +720,7 @@ palaia init --capture-level <off|minimal|normal|aggressive>
 Session continuity gives agents automatic context restoration across sessions. These features work out of the box with the OpenClaw plugin -- no manual setup needed.
 
 ### Session Briefings
-On session start, Palaia automatically injects a briefing with the last session summary and any open tasks. This means agents resume work without needing to manually search for context.
+Session briefings are injected automatically at session start. They contain your last session summary and any open tasks (sticky notes). Read the briefing carefully — it is your primary context for continuing previous work. Do not ask the user "where did we leave off?" when a briefing is present. Instead, acknowledge the context and continue seamlessly.
 
 ### Session Summaries
 When a session ends or resets, Palaia auto-saves a summary of what happened. These are stored as entries with the `session-summary` tag and can be queried:
@@ -750,6 +764,7 @@ Set in `openclaw.json` under `plugins.entries.palaia.config`:
 | `sessionBriefingMaxChars` | `1500` | Max chars for session briefing injection |
 | `captureToolObservations` | `true` | Track tool usage as session context |
 | `recallRecencyBoost` | `0.3` | Boost factor for fresh memories (0=off) |
+| `manualEntryBoost` | `1.3` | Boost factor for manually written entries vs auto-captured (1.0=off) |
 
 ---
 

--- a/packages/openclaw-plugin/skill/SKILL.md
+++ b/packages/openclaw-plugin/skill/SKILL.md
@@ -147,8 +147,13 @@ Before doing anything else with Palaia, run `palaia doctor` silently. If it repo
 
 ## Core Concepts
 
-### Auto-Capture
-Conversations are automatically captured when the OpenClaw plugin is active. You do NOT need to manually write things from conversations — Palaia handles it. Manual `palaia write` is only for structured knowledge: processes, tasks, and knowledge from external sources.
+### Auto-Capture vs. Manual Write
+Conversations are automatically captured when the OpenClaw plugin is active. Auto-capture handles routine knowledge extraction from conversations.
+
+**Manual writes (`palaia write`) are higher value.** When you or the user identify something as especially important — a key decision, a reusable workflow, a critical fact from an external source — write it manually. Manually written entries are ranked higher than auto-captured ones in recall results, so they surface more prominently in future sessions. Use manual writes for:
+- Important facts, decisions, or context from external sources
+- Reusable processes and workflows (team runbooks)
+- Sticky notes / reminders for future sessions (tasks)
 
 ### Three Tiers
 - **HOT** — Active memories (< 7 days or frequently accessed). Always searched.
@@ -162,8 +167,8 @@ Conversations are automatically captured when the OpenClaw plugin is active. You
 
 ### Entry Types
 - **memory** — Facts, decisions, learnings (default)
-- **process** — Workflows, checklists, SOPs
-- **task** — Action items with status, priority, assignee, due date
+- **process** — Workflows, checklists, SOPs (team runbooks)
+- **task** — Sticky notes / reminders for future sessions. Tasks are ephemeral: when marked done, they are automatically deleted. Never auto-captured — only created by explicit `palaia write --type task`.
 
 ---
 
@@ -265,21 +270,27 @@ palaia-mcp --read-only                  # No writes (untrusted hosts)
 
 ### `palaia write` — Save structured knowledge
 
-Only use for explicit process/task entries, or knowledge from external sources. Conversation knowledge is auto-captured.
+Use for important facts, reusable processes, sticky-note tasks, and knowledge from external sources. Manually written entries rank higher than auto-captured ones in recall.
 
 ```bash
-# Save a fact from outside the conversation
+# Save an important fact (ranks higher than auto-capture)
 palaia write "API rate limit is 100 req/min" --type memory --tags api,limits
 
-# Record a step-by-step process
-palaia write "1. Build 2. Test 3. Deploy" --type process --project myapp
+# Record a reusable team workflow (use specific, unique titles!)
+palaia write "Backend: Deploy to staging via Docker" --type process --project myapp --scope team
 
-# Create a task with structured fields
-palaia write "fix login bug" --type task --priority high --assignee Elliot --due-date 2026-04-01
+# Create a sticky note for a future session (deleted when done)
+palaia write "verify backup works after schema migration" --type task
 
 # Save to a specific project with scope
 palaia write "Use JWT for auth" --project backend --scope team --tags decision
 ```
+
+**Process naming convention:** Use the format `[Domain]: [What it does]` for process titles. Specific titles prevent duplicates and make processes findable.
+- Good: `"Release: PyPI publish + ClawHub sync"`, `"Backend: Deploy to staging via Docker"`
+- Bad: `"Deploy steps"`, `"Release process"` (too generic, will collide with other similar processes)
+
+Before writing a new process, search for existing ones: `palaia query "deploy" --type process`. If a similar process exists, update it with `palaia edit <id>` instead of creating a new one.
 
 ### `palaia query` — Semantic search
 
@@ -486,9 +497,12 @@ palaia project locks                      # List all active locks
 ### `palaia edit` — Modify existing entries
 
 ```bash
-palaia edit <id> --status done
+palaia edit <id> --status done         # For tasks: this DELETES the entry (sticky note completed)
+palaia edit <id> --status wontfix      # For tasks: also deletes (cancelled reminder)
 palaia edit <id> "updated content" --tags new,tags --priority high
 ```
+
+**Task lifecycle:** Tasks are sticky notes. When you mark a task as `done` or `wontfix`, it is automatically deleted — not archived. This is intentional: completed reminders have no long-term value. If the outcome of the task should be remembered, write a separate memory entry before marking the task done.
 
 ### Other commands
 
@@ -649,12 +663,12 @@ palaia write "## Dev-Agent Lifecycle
 
 | Situation | Command |
 |-----------|---------|
-| Remember a fact (not from conversation) | `palaia write "..." --type memory` |
-| Record a process/SOP | `palaia write "steps..." --type process` |
-| Create a task | `palaia write "fix bug" --type task --priority high` |
-| Mark task done | `palaia edit <id> --status done` |
+| Save an important fact or decision | `palaia write "..." --type memory` (ranks higher than auto-capture) |
+| Document a reusable workflow | `palaia write "Domain: Steps..." --type process --scope team` |
+| Leave a reminder for future sessions | `palaia write "check X after Y" --type task` (auto-deleted when done) |
+| Mark a reminder as done | `palaia edit <id> --status done` (deletes the task) |
 | Find something | `palaia query "..."` |
-| Find open tasks | `palaia list --type task --status open` |
+| Find open reminders | `palaia list --type task --status open` |
 | Check system health | `palaia status` |
 | Something is wrong | `palaia doctor --fix` |
 | Clean up old entries | `palaia gc` |
@@ -662,11 +676,11 @@ palaia write "## Dev-Agent Lifecycle
 | Review accumulated knowledge | `palaia curate analyze` |
 | Share knowledge | `palaia sync export` or `palaia package export` |
 | Check for messages | `palaia memo inbox` |
-| Start of session | Session briefing is now automatic. Just run `palaia doctor` and check `palaia memo inbox`. |
+| Start of session | Session briefing is automatic. Just run `palaia doctor` and check `palaia memo inbox`. |
 
-**Do NOT manually write:** facts, decisions, or preferences that came up in the current conversation. Auto-Capture handles these.
+**Auto-capture** handles routine conversation knowledge. **Manual writes rank higher** in recall — use them when something is especially important, reusable, or comes from an external source.
 
-**DO manually write:** processes, tasks with structured fields, knowledge from external sources, project setup.
+**DO manually write:** key decisions, reusable processes (team runbooks), sticky-note reminders (tasks), important facts from external sources.
 
 ---
 
@@ -706,7 +720,7 @@ palaia init --capture-level <off|minimal|normal|aggressive>
 Session continuity gives agents automatic context restoration across sessions. These features work out of the box with the OpenClaw plugin -- no manual setup needed.
 
 ### Session Briefings
-On session start, Palaia automatically injects a briefing with the last session summary and any open tasks. This means agents resume work without needing to manually search for context.
+Session briefings are injected automatically at session start. They contain your last session summary and any open tasks (sticky notes). Read the briefing carefully — it is your primary context for continuing previous work. Do not ask the user "where did we leave off?" when a briefing is present. Instead, acknowledge the context and continue seamlessly.
 
 ### Session Summaries
 When a session ends or resets, Palaia auto-saves a summary of what happened. These are stored as entries with the `session-summary` tag and can be queried:
@@ -750,6 +764,7 @@ Set in `openclaw.json` under `plugins.entries.palaia.config`:
 | `sessionBriefingMaxChars` | `1500` | Max chars for session briefing injection |
 | `captureToolObservations` | `true` | Track tool usage as session context |
 | `recallRecencyBoost` | `0.3` | Boost factor for fresh memories (0=off) |
+| `manualEntryBoost` | `1.3` | Boost factor for manually written entries vs auto-captured (1.0=off) |
 
 ---
 

--- a/packages/openclaw-plugin/src/config.ts
+++ b/packages/openclaw-plugin/src/config.ts
@@ -74,6 +74,8 @@ export interface PalaiaPluginConfig {
   captureToolObservations: boolean;
   /** Recency boost factor for recall (0 = off, 0.3 = 30% boost for <24h entries) */
   recallRecencyBoost: number;
+  /** Boost factor for manually written entries vs auto-captured (default: 1.3 = 30% boost) */
+  manualEntryBoost: number;
 }
 
 export const DEFAULT_RECALL_TYPE_WEIGHTS: RecallTypeWeights = {
@@ -103,6 +105,7 @@ export const DEFAULT_CONFIG: PalaiaPluginConfig = {
   sessionBriefingMaxChars: 1500,
   captureToolObservations: true,
   recallRecencyBoost: 0.3,
+  manualEntryBoost: 1.3,
 };
 
 /**

--- a/packages/openclaw-plugin/src/context-engine.ts
+++ b/packages/openclaw-plugin/src/context-engine.ts
@@ -174,7 +174,7 @@ async function buildMemoryContext(
   }
 
   // Apply type-weighted reranking and blocked filtering (Issue #121)
-  const rankedRaw = rerankByTypeWeight(entries, resolvedPrio.recallTypeWeight, config.recallRecencyBoost);
+  const rankedRaw = rerankByTypeWeight(entries, resolvedPrio.recallTypeWeight, config.recallRecencyBoost, config.manualEntryBoost);
   const ranked = filterBlocked(rankedRaw, resolvedPrio.blocked);
 
   // Build context string — progressive disclosure for large stores
@@ -193,7 +193,7 @@ async function buildMemoryContext(
   }
 
   // Build nudge text and check remaining budget before appending
-  const USAGE_NUDGE = "[palaia] auto-capture=on. Manual write: --type process (SOPs/checklists) or --type task (todos with assignee/deadline) only. Conversation knowledge is auto-captured — do not duplicate with manual writes.";
+  const USAGE_NUDGE = "[palaia] auto-capture=on. Manual writes rank higher in recall. Use --type process for reusable workflows, --type task for sticky-note reminders (auto-deleted when done), --type memory for important facts.";
   let agentNudges = "";
   try {
     const pluginState = await loadPluginState(config.workspace);
@@ -255,11 +255,17 @@ async function runAutoCapture(
   logger: { info(...a: unknown[]): void; warn(...a: unknown[]): void },
 ): Promise<boolean> {
   if (!config.autoCapture) return false;
-  if (!messages || messages.length === 0) return false;
+  if (!messages || messages.length === 0) {
+    logger.info("[palaia] Auto-capture skipped: no messages");
+    return false;
+  }
 
   const allTexts = extractMessageTexts(messages);
   const userTurns = allTexts.filter((t) => t.role === "user").length;
-  if (userTurns < config.captureMinTurns) return false;
+  if (userTurns < config.captureMinTurns) {
+    logger.info(`[palaia] Auto-capture skipped: ${userTurns} user turns < captureMinTurns=${config.captureMinTurns}`);
+    return false;
+  }
 
   // Parse capture hints
   const collectedHints: { project?: string; scope?: string }[] = [];
@@ -283,7 +289,10 @@ async function runAutoCapture(
   }
   const exchangeText = exchangeParts.join("\n");
 
-  if (!shouldAttemptCapture(exchangeText)) return false;
+  if (!shouldAttemptCapture(exchangeText)) {
+    logger.info(`[palaia] Auto-capture skipped: content did not pass significance filter (${exchangeText.length} chars)`);
+    return false;
+  }
 
   const hookOpts = buildRunnerOpts(config);
   const knownProjects = await loadProjects(hookOpts);
@@ -295,6 +304,7 @@ async function runAutoCapture(
   try {
     const results = await extractWithLLM(messages, api.config, {
       captureModel: config.captureModel,
+      workspace: config.workspace,
     }, knownProjects);
 
     for (const r of results) {
@@ -330,7 +340,10 @@ async function runAutoCapture(
   if (!llmHandled) {
     if (config.captureFrequency === "significant") {
       const significance = extractSignificance(exchangeText);
-      if (!significance) return false;
+      if (!significance) {
+        logger.info("[palaia] Auto-capture skipped: rule-based extraction found no significance (need ≥2 distinct tags)");
+        return false;
+      }
       const tags = [...significance.tags];
       if (!tags.includes("auto-capture")) tags.push("auto-capture");
       const scope = effectiveCaptureScope !== "team"

--- a/packages/openclaw-plugin/src/hooks/capture.ts
+++ b/packages/openclaw-plugin/src/hooks/capture.ts
@@ -237,12 +237,8 @@ WHAT TO CAPTURE (be thorough — capture anything worth remembering):
 - Project context changes: scope changes, timeline shifts, requirement updates, priority changes
 - Workflow patterns the user established ("my process is...", "I always do X before Y")
 
-STRICT TASK CLASSIFICATION RULES — a "task" MUST have ALL three of:
-1. A clear, completable action (not just an observation or idea)
-2. An identifiable responsible party (explicitly named or unambiguously inferable from context)
-3. A concrete deliverable or measurable end state
-If ANY of these is missing, classify as "memory" instead of "task". When in doubt, use "memory".
-Observations, learnings, insights, opinions, and general knowledge are ALWAYS "memory", never "task".
+IMPORTANT: Never classify as "task". Tasks are manually created sticky notes (post-its) — they must only come from explicit user/agent intent via palaia write --type task. Auto-capture must use "memory" or "process" only.
+Observations, learnings, insights, opinions, action items, and general knowledge are ALWAYS "memory" or "process", never "task".
 
 Only extract genuinely significant knowledge. Skip small talk, acknowledgments, routine exchanges.
 Do NOT extract if similar knowledge was likely captured in a recent exchange. Prefer quality over quantity. Skip routine status updates and acknowledgments.
@@ -461,7 +457,7 @@ export function trimToRecentExchanges(
 export async function extractWithLLM(
   messages: unknown[],
   config: any,
-  pluginConfig?: { captureModel?: string },
+  pluginConfig?: { captureModel?: string; workspace?: string },
   knownProjects?: CachedProject[],
 ): Promise<ExtractionResult[]> {
   const runEmbeddedPiAgent = await getEmbeddedPiAgent();
@@ -519,7 +515,7 @@ export async function extractWithLLM(
     const result = await runEmbeddedPiAgent({
       sessionId,
       sessionFile,
-      workspaceDir: config?.agents?.defaults?.workspace ?? process.cwd(),
+      workspaceDir: pluginConfig?.workspace || config?.agents?.defaults?.workspace || process.cwd(),
       config,
       prompt,
       timeoutMs: 15_000,
@@ -551,7 +547,8 @@ export async function extractWithLLM(
       const content = typeof item.content === "string" ? item.content.trim() : "";
       if (!content) continue;
 
-      const validTypes = new Set(["memory", "process", "task"]);
+      const validTypes = new Set(["memory", "process"]);
+      // Tasks are manual-only (post-its) — auto-capture never creates tasks
       const type = validTypes.has(item.type) ? item.type : "memory";
 
       const validTags = new Set([
@@ -614,9 +611,9 @@ const SIGNIFICANCE_RULES: Array<{
   { pattern: /(?:mistake was|fehler war|should have|hätten sollen|next time)/i, tag: "lesson", type: "memory" },
   // Surprises
   { pattern: /(?:surprising|überraschend|unexpected|unerwartet|didn'?t expect|nicht erwartet|plot twist)/i, tag: "surprise", type: "memory" },
-  // Commitments and tasks
-  { pattern: /(?:i will|ich werde|todo:|action item|must do|muss noch|need to|commit to|verspreche)/i, tag: "commitment", type: "task" },
-  { pattern: /(?:deadline|frist|due date|bis zum|by end of|spätestens)/i, tag: "commitment", type: "task" },
+  // Commitments (captured as memory — tasks are manual-only post-its)
+  { pattern: /(?:i will|ich werde|todo:|action item|must do|muss noch|need to|commit to|verspreche)/i, tag: "commitment", type: "memory" },
+  { pattern: /(?:deadline|frist|due date|bis zum|by end of|spätestens)/i, tag: "commitment", type: "memory" },
   // Processes and workflows
   { pattern: /(?:the process is|der prozess|steps?:|workflow:|how to|anleitung|recipe:|checklist)/i, tag: "process", type: "process" },
   { pattern: /(?:first,?\s.*then|schritt \d|step \d|1\.\s.*2\.\s)/i, tag: "process", type: "process" },

--- a/packages/openclaw-plugin/src/hooks/index.ts
+++ b/packages/openclaw-plugin/src/hooks/index.ts
@@ -482,7 +482,7 @@ export function registerHooks(api: OpenClawPluginApi, config: PalaiaPluginConfig
         }
 
         // Apply type-weighted reranking and blocked filtering (Issue #121)
-        const rankedRaw = rerankByTypeWeight(entries, resolvedPrio.recallTypeWeight, config.recallRecencyBoost);
+        const rankedRaw = rerankByTypeWeight(entries, resolvedPrio.recallTypeWeight, config.recallRecencyBoost, config.manualEntryBoost);
         const ranked = filterBlocked(rankedRaw, resolvedPrio.blocked);
 
         // Build context string with char budget
@@ -587,6 +587,7 @@ export function registerHooks(api: OpenClawPluginApi, config: PalaiaPluginConfig
       const hookOpts = buildRunnerOpts(config, { workspace: resolved.workspace });
 
       if (!event.success || !event.messages || event.messages.length === 0) {
+        logger.info(`[palaia] Auto-capture skipped: success=${event.success}, messages=${event.messages?.length ?? 0}`);
         return;
       }
 
@@ -597,6 +598,7 @@ export function registerHooks(api: OpenClawPluginApi, config: PalaiaPluginConfig
 
         const userTurns = allTexts.filter((t) => t.role === "user").length;
         if (userTurns < config.captureMinTurns) {
+          logger.info(`[palaia] Auto-capture skipped: ${userTurns} user turns < captureMinTurns=${config.captureMinTurns}`);
           return;
         }
 
@@ -632,6 +634,7 @@ export function registerHooks(api: OpenClawPluginApi, config: PalaiaPluginConfig
         const exchangeText = exchangeParts.join("\n");
 
         if (!shouldAttemptCapture(exchangeText)) {
+          logger.info(`[palaia] Auto-capture skipped: content did not pass significance filter (${exchangeText.length} chars)`);
           return;
         }
 
@@ -733,6 +736,7 @@ export function registerHooks(api: OpenClawPluginApi, config: PalaiaPluginConfig
         try {
           const results = await extractWithLLM(event.messages, api.config, {
             captureModel: config.captureModel,
+            workspace: resolved.workspace,
           }, knownProjects);
 
           await storeLLMResults(results);
@@ -752,6 +756,7 @@ export function registerHooks(api: OpenClawPluginApi, config: PalaiaPluginConfig
               // Retry without captureModel -> resolveCaptureModel will use primary model
               const fallbackResults = await extractWithLLM(event.messages, api.config, {
                 captureModel: undefined,
+                workspace: resolved.workspace,
               }, knownProjects);
               await storeLLMResults(fallbackResults);
               llmHandled = true;
@@ -776,6 +781,7 @@ export function registerHooks(api: OpenClawPluginApi, config: PalaiaPluginConfig
           if (config.captureFrequency === "significant") {
             const significance = extractSignificance(exchangeText);
             if (!significance) {
+              logger.info("[palaia] Auto-capture skipped: rule-based extraction found no significance (need ≥2 distinct tags)");
               return;
             }
             captureData = significance;

--- a/packages/openclaw-plugin/src/hooks/recall.ts
+++ b/packages/openclaw-plugin/src/hooks/recall.ts
@@ -367,12 +367,17 @@ export function rerankByTypeWeight(
   results: QueryResult["results"],
   weights: Record<string, number>,
   recencyBoost = 0,
+  manualEntryBoost = 1.3,
 ): RankedEntry[] {
   return results
     .map((r) => {
       const type = r.type || "memory";
       const weight = weights[type] ?? 1.0;
       const recency = calcRecencyBoost(r.created, recencyBoost);
+      // Manual entries (no auto-capture tag) get a boost over auto-captured ones.
+      // This ensures intentionally stored knowledge ranks higher than conversation noise.
+      const isAutoCapture = r.tags?.includes("auto-capture") ?? false;
+      const sourceBoost = isAutoCapture ? 1.0 : manualEntryBoost;
       return {
         id: r.id,
         body: r.content || r.body || "",
@@ -383,7 +388,7 @@ export function rerankByTypeWeight(
         score: r.score,
         bm25Score: r.bm25_score,
         embedScore: r.embed_score,
-        weightedScore: r.score * weight * recency,
+        weightedScore: r.score * weight * recency * sourceBoost,
         created: r.created,
         tags: r.tags,
       };

--- a/packages/openclaw-plugin/src/hooks/session.ts
+++ b/packages/openclaw-plugin/src/hooks/session.ts
@@ -161,6 +161,7 @@ export async function captureSessionSummary(
     try {
       const results = await extractWithLLM(messages, api.config, {
         captureModel: config.captureModel,
+        workspace: config.workspace,
       }, []);
 
       if (results.length > 0) {

--- a/packages/openclaw-plugin/src/hooks/state.ts
+++ b/packages/openclaw-plugin/src/hooks/state.ts
@@ -338,10 +338,11 @@ const VALID_SCOPES = ["private", "team", "public"];
 
 /**
  * Check if a scope string is valid for palaia write.
- * Valid: "private", "team", "public", or any "shared:*" prefix.
+ * Valid: "private", "team", "public".
+ * Legacy shared:X is accepted but normalized to "team" by the CLI.
  */
 export function isValidScope(s: string): boolean {
-  return VALID_SCOPES.includes(s) || s.startsWith("shared:");
+  return VALID_SCOPES.includes(s);
 }
 
 /**

--- a/packages/openclaw-plugin/src/tools.ts
+++ b/packages/openclaw-plugin/src/tools.ts
@@ -133,11 +133,9 @@ export function registerTools(api: OpenClawPluginApi, config: PalaiaPluginConfig
       if (scopeVisibility) {
         filteredResults = filteredResults.filter((r) => {
           const scope = r.scope || "team";
-          return scopeVisibility!.some((allowed) => {
-            if (scope === allowed) return true;
-            if (allowed === "shared" && scope.startsWith("shared:")) return true;
-            return false;
-          });
+          // Legacy shared:X entries are treated as team
+          const effectiveScope = scope.startsWith("shared:") ? "team" : scope;
+          return scopeVisibility!.includes(effectiveScope);
         });
       }
 
@@ -218,7 +216,7 @@ export function registerTools(api: OpenClawPluginApi, config: PalaiaPluginConfig
         content: Type.String({ description: "Memory content to write" }),
         scope: Type.Optional(
           Type.String({
-            description: "Scope: private|team|shared:X|public (default: team)",
+            description: "Scope: private|team|public (default: team)",
             default: "team",
           })
         ),
@@ -306,7 +304,7 @@ export function registerTools(api: OpenClawPluginApi, config: PalaiaPluginConfig
               content: [
                 {
                   type: "text" as const,
-                  text: `Invalid scope "${params.scope}". Valid scopes: private, team, public, shared:<name>`,
+                  text: `Invalid scope "${params.scope}". Valid scopes: private, team, public`,
                 },
               ],
             };

--- a/packages/openclaw-plugin/tests/hooks.test.ts
+++ b/packages/openclaw-plugin/tests/hooks.test.ts
@@ -175,12 +175,12 @@ describe("extractSignificance", () => {
     expect(result!.tags).toContain("lesson");
   });
 
-  it("detects commitments as task type (requires 2+ tags)", () => {
+  it("detects commitments as memory type (tasks are manual-only post-its)", () => {
     const text = "We decided on a new approach. I will refactor the authentication module by end of week. The deadline is Friday.";
     const result = extractSignificance(text);
     expect(result).not.toBeNull();
     expect(result!.tags).toContain("commitment");
-    expect(result!.type).toBe("task");
+    expect(result!.type).toBe("memory");
   });
 
   it("detects process documentation (requires 2+ tags)", () => {
@@ -217,11 +217,11 @@ describe("extractSignificance", () => {
     expect(result!.tags.length).toBeGreaterThanOrEqual(2);
   });
 
-  it("prioritizes task type over memory", () => {
+  it("commitments with decisions stay memory (tasks are manual-only)", () => {
     const text = "We decided to use Redis. I will deploy it by the deadline Friday.";
     const result = extractSignificance(text);
     expect(result).not.toBeNull();
-    expect(result!.type).toBe("task");
+    expect(result!.type).toBe("memory");
   });
 
   it("truncates summary to 500 chars", () => {
@@ -353,7 +353,7 @@ describe("rerankByTypeWeight", () => {
       { id: "1", content: "Unknown type", score: 0.8, tier: "hot", scope: "team", type: "custom" },
     ];
 
-    const ranked = rerankByTypeWeight(results, weights);
+    const ranked = rerankByTypeWeight(results, weights, 0, 1.0);
     expect(ranked[0].weightedScore).toBe(0.8);
   });
 
@@ -362,7 +362,7 @@ describe("rerankByTypeWeight", () => {
       { id: "1", content: "No type", score: 0.8, tier: "hot", scope: "team" },
     ];
 
-    const ranked = rerankByTypeWeight(results, weights);
+    const ranked = rerankByTypeWeight(results, weights, 0, 1.0);
     expect(ranked[0].type).toBe("memory");
     expect(ranked[0].weightedScore).toBe(0.8);
   });
@@ -643,12 +643,12 @@ describe("Task classification strictness", () => {
     }
   });
 
-  it("rule-based extraction classifies clear commitment with deadline as task", () => {
+  it("rule-based extraction classifies commitments as memory (tasks are manual-only post-its)", () => {
     const text = "We decided to migrate the database. I will complete the schema migration by Friday. " +
       "The deadline is strict because the release depends on it.";
     const result = extractSignificance(text);
     expect(result).not.toBeNull();
-    expect(result!.type).toBe("task");
+    expect(result!.type).toBe("memory");
   });
 
   it("vague actionable statements without assignee stay as memory", () => {
@@ -1017,7 +1017,7 @@ describe("isValidScope", () => {
   it("accepts private", () => expect(isValidScope("private")).toBe(true));
   it("accepts team", () => expect(isValidScope("team")).toBe(true));
   it("accepts public", () => expect(isValidScope("public")).toBe(true));
-  it("accepts shared: prefix", () => expect(isValidScope("shared:org")).toBe(true));
+  it("rejects shared: prefix (shared scopes removed)", () => expect(isValidScope("shared:org")).toBe(false));
   it("rejects garbage", () => expect(isValidScope("y")).toBe(false));
   it("rejects empty string", () => expect(isValidScope("")).toBe(false));
   it("rejects partial match", () => expect(isValidScope("teams")).toBe(false));
@@ -1030,7 +1030,7 @@ describe("sanitizeScope", () => {
   it("returns fallback for null", () => expect(sanitizeScope(null)).toBe("team"));
   it("returns fallback for undefined", () => expect(sanitizeScope(undefined)).toBe("team"));
   it("uses custom fallback", () => expect(sanitizeScope("garbage", "private")).toBe("private"));
-  it("accepts shared: scope", () => expect(sanitizeScope("shared:org")).toBe("shared:org"));
+  it("normalizes shared: scope to team", () => expect(sanitizeScope("shared:org")).toBe("team"));
 });
 
 // ============================================================================

--- a/palaia/SKILL.md
+++ b/palaia/SKILL.md
@@ -147,8 +147,13 @@ Before doing anything else with Palaia, run `palaia doctor` silently. If it repo
 
 ## Core Concepts
 
-### Auto-Capture
-Conversations are automatically captured when the OpenClaw plugin is active. You do NOT need to manually write things from conversations — Palaia handles it. Manual `palaia write` is only for structured knowledge: processes, tasks, and knowledge from external sources.
+### Auto-Capture vs. Manual Write
+Conversations are automatically captured when the OpenClaw plugin is active. Auto-capture handles routine knowledge extraction from conversations.
+
+**Manual writes (`palaia write`) are higher value.** When you or the user identify something as especially important — a key decision, a reusable workflow, a critical fact from an external source — write it manually. Manually written entries are ranked higher than auto-captured ones in recall results, so they surface more prominently in future sessions. Use manual writes for:
+- Important facts, decisions, or context from external sources
+- Reusable processes and workflows (team runbooks)
+- Sticky notes / reminders for future sessions (tasks)
 
 ### Three Tiers
 - **HOT** — Active memories (< 7 days or frequently accessed). Always searched.
@@ -162,8 +167,8 @@ Conversations are automatically captured when the OpenClaw plugin is active. You
 
 ### Entry Types
 - **memory** — Facts, decisions, learnings (default)
-- **process** — Workflows, checklists, SOPs
-- **task** — Action items with status, priority, assignee, due date
+- **process** — Workflows, checklists, SOPs (team runbooks)
+- **task** — Sticky notes / reminders for future sessions. Tasks are ephemeral: when marked done, they are automatically deleted. Never auto-captured — only created by explicit `palaia write --type task`.
 
 ---
 
@@ -265,21 +270,27 @@ palaia-mcp --read-only                  # No writes (untrusted hosts)
 
 ### `palaia write` — Save structured knowledge
 
-Only use for explicit process/task entries, or knowledge from external sources. Conversation knowledge is auto-captured.
+Use for important facts, reusable processes, sticky-note tasks, and knowledge from external sources. Manually written entries rank higher than auto-captured ones in recall.
 
 ```bash
-# Save a fact from outside the conversation
+# Save an important fact (ranks higher than auto-capture)
 palaia write "API rate limit is 100 req/min" --type memory --tags api,limits
 
-# Record a step-by-step process
-palaia write "1. Build 2. Test 3. Deploy" --type process --project myapp
+# Record a reusable team workflow (use specific, unique titles!)
+palaia write "Backend: Deploy to staging via Docker" --type process --project myapp --scope team
 
-# Create a task with structured fields
-palaia write "fix login bug" --type task --priority high --assignee Elliot --due-date 2026-04-01
+# Create a sticky note for a future session (deleted when done)
+palaia write "verify backup works after schema migration" --type task
 
 # Save to a specific project with scope
 palaia write "Use JWT for auth" --project backend --scope team --tags decision
 ```
+
+**Process naming convention:** Use the format `[Domain]: [What it does]` for process titles. Specific titles prevent duplicates and make processes findable.
+- Good: `"Release: PyPI publish + ClawHub sync"`, `"Backend: Deploy to staging via Docker"`
+- Bad: `"Deploy steps"`, `"Release process"` (too generic, will collide with other similar processes)
+
+Before writing a new process, search for existing ones: `palaia query "deploy" --type process`. If a similar process exists, update it with `palaia edit <id>` instead of creating a new one.
 
 ### `palaia query` — Semantic search
 
@@ -486,9 +497,12 @@ palaia project locks                      # List all active locks
 ### `palaia edit` — Modify existing entries
 
 ```bash
-palaia edit <id> --status done
+palaia edit <id> --status done         # For tasks: this DELETES the entry (sticky note completed)
+palaia edit <id> --status wontfix      # For tasks: also deletes (cancelled reminder)
 palaia edit <id> "updated content" --tags new,tags --priority high
 ```
+
+**Task lifecycle:** Tasks are sticky notes. When you mark a task as `done` or `wontfix`, it is automatically deleted — not archived. This is intentional: completed reminders have no long-term value. If the outcome of the task should be remembered, write a separate memory entry before marking the task done.
 
 ### Other commands
 
@@ -649,12 +663,12 @@ palaia write "## Dev-Agent Lifecycle
 
 | Situation | Command |
 |-----------|---------|
-| Remember a fact (not from conversation) | `palaia write "..." --type memory` |
-| Record a process/SOP | `palaia write "steps..." --type process` |
-| Create a task | `palaia write "fix bug" --type task --priority high` |
-| Mark task done | `palaia edit <id> --status done` |
+| Save an important fact or decision | `palaia write "..." --type memory` (ranks higher than auto-capture) |
+| Document a reusable workflow | `palaia write "Domain: Steps..." --type process --scope team` |
+| Leave a reminder for future sessions | `palaia write "check X after Y" --type task` (auto-deleted when done) |
+| Mark a reminder as done | `palaia edit <id> --status done` (deletes the task) |
 | Find something | `palaia query "..."` |
-| Find open tasks | `palaia list --type task --status open` |
+| Find open reminders | `palaia list --type task --status open` |
 | Check system health | `palaia status` |
 | Something is wrong | `palaia doctor --fix` |
 | Clean up old entries | `palaia gc` |
@@ -662,11 +676,11 @@ palaia write "## Dev-Agent Lifecycle
 | Review accumulated knowledge | `palaia curate analyze` |
 | Share knowledge | `palaia sync export` or `palaia package export` |
 | Check for messages | `palaia memo inbox` |
-| Start of session | Session briefing is now automatic. Just run `palaia doctor` and check `palaia memo inbox`. |
+| Start of session | Session briefing is automatic. Just run `palaia doctor` and check `palaia memo inbox`. |
 
-**Do NOT manually write:** facts, decisions, or preferences that came up in the current conversation. Auto-Capture handles these.
+**Auto-capture** handles routine conversation knowledge. **Manual writes rank higher** in recall — use them when something is especially important, reusable, or comes from an external source.
 
-**DO manually write:** processes, tasks with structured fields, knowledge from external sources, project setup.
+**DO manually write:** key decisions, reusable processes (team runbooks), sticky-note reminders (tasks), important facts from external sources.
 
 ---
 
@@ -706,7 +720,7 @@ palaia init --capture-level <off|minimal|normal|aggressive>
 Session continuity gives agents automatic context restoration across sessions. These features work out of the box with the OpenClaw plugin -- no manual setup needed.
 
 ### Session Briefings
-On session start, Palaia automatically injects a briefing with the last session summary and any open tasks. This means agents resume work without needing to manually search for context.
+Session briefings are injected automatically at session start. They contain your last session summary and any open tasks (sticky notes). Read the briefing carefully — it is your primary context for continuing previous work. Do not ask the user "where did we leave off?" when a briefing is present. Instead, acknowledge the context and continue seamlessly.
 
 ### Session Summaries
 When a session ends or resets, Palaia auto-saves a summary of what happened. These are stored as entries with the `session-summary` tag and can be queried:
@@ -750,6 +764,7 @@ Set in `openclaw.json` under `plugins.entries.palaia.config`:
 | `sessionBriefingMaxChars` | `1500` | Max chars for session briefing injection |
 | `captureToolObservations` | `true` | Track tool usage as session context |
 | `recallRecencyBoost` | `0.3` | Boost factor for fresh memories (0=off) |
+| `manualEntryBoost` | `1.3` | Boost factor for manually written entries vs auto-captured (1.0=off) |
 
 ---
 

--- a/palaia/doctor/__init__.py
+++ b/palaia/doctor/__init__.py
@@ -9,6 +9,7 @@ from palaia.doctor.checks import (
     LOOP_ARTIFACT_PATTERNS,
     _check_agent_identity,
     _check_binary_path,
+    _check_capture_health,
     _check_capture_level,
     _check_capture_model,
     _check_default_agent_alias,
@@ -64,6 +65,7 @@ def run_doctor(palaia_root: Path | None = None) -> list[dict[str, Any]]:
         _check_unread_memos(palaia_root),
         _check_capture_level(palaia_root),
         _check_capture_model(),
+        _check_capture_health(palaia_root),
         _check_plugin_defaults_upgrade(palaia_root),
         _check_openclaw_plugin(),
         _check_smart_memory_skill(),
@@ -86,6 +88,7 @@ __all__ = [
     "format_doctor_report",
     # Check functions (used by tests)
     "_check_agent_identity",
+    "_check_capture_health",
     "_check_capture_level",
     "_check_capture_model",
     "_check_default_agent_alias",

--- a/palaia/doctor/checks.py
+++ b/palaia/doctor/checks.py
@@ -1315,6 +1315,85 @@ def _check_capture_model() -> dict[str, Any]:
     }
 
 
+def _check_capture_health(palaia_root: Path | None) -> dict[str, Any]:
+    """Detect silent auto-capture failure: autoCapture=true but no captured entries."""
+    if palaia_root is None:
+        return {
+            "name": "capture_health",
+            "label": "Capture health",
+            "status": "ok",
+            "message": "Not initialized (skipped)",
+        }
+
+    from palaia.config import load_config
+
+    config = load_config(palaia_root)
+    plugin_config = config.get("plugin_config")
+
+    # Only relevant when autoCapture is enabled
+    auto_capture = False
+    if plugin_config and isinstance(plugin_config, dict):
+        auto_capture = plugin_config.get("autoCapture", False)
+
+    if not auto_capture:
+        return {
+            "name": "capture_health",
+            "label": "Capture health",
+            "status": "ok",
+            "message": "autoCapture is off (skipped)",
+        }
+
+    # Count auto-captured entries
+    import sqlite3
+
+    db_path = palaia_root / "palaia.db"
+    capture_count = 0
+    if db_path.exists():
+        try:
+            conn = sqlite3.connect(str(db_path))
+            row = conn.execute(
+                "SELECT COUNT(*) FROM entries WHERE tags LIKE '%auto-capture%'"
+            ).fetchone()
+            capture_count = row[0] if row else 0
+            conn.close()
+        except Exception:
+            pass
+    else:
+        # Legacy flat-file: check for auto-capture tag in .md files
+        for tier in ("hot", "warm", "cold"):
+            tier_dir = palaia_root / tier
+            if tier_dir.exists():
+                for md_file in tier_dir.glob("*.md"):
+                    try:
+                        content = md_file.read_text(encoding="utf-8", errors="ignore")
+                        if "auto-capture" in content:
+                            capture_count += 1
+                            break  # One is enough to confirm it works
+                    except (PermissionError, OSError):
+                        pass
+                if capture_count > 0:
+                    break
+
+    if capture_count == 0:
+        return {
+            "name": "capture_health",
+            "label": "Capture health",
+            "status": "warn",
+            "message": (
+                "autoCapture=true but no auto-captured entries found. "
+                "Auto-capture may not be firing. "
+                "Check plugin config and agent workspace setup."
+            ),
+        }
+
+    return {
+        "name": "capture_health",
+        "label": "Capture health",
+        "status": "ok",
+        "message": f"autoCapture=true, {capture_count} auto-captured entries",
+    }
+
+
 def _check_embedding_model_integrity(palaia_root: Path | None) -> dict[str, Any]:
     """Check fastembed model cache integrity (corrupted symlinks cause ONNX errors)."""
     if palaia_root is None:

--- a/palaia/migrate.py
+++ b/palaia/migrate.py
@@ -125,9 +125,10 @@ class SmartMemoryAdapter(BaseAdapter):
                             entries.append(
                                 MigrationEntry(
                                     body=body,
-                                    scope=f"shared:{proj_name}",
+                                    scope="team",
                                     tier="hot",
                                     title=f"Project: {proj_name}",
+                                    tags=["migrated", f"project:{proj_name}"],
                                     source_file=str(ctx.relative_to(source)),
                                 )
                             )

--- a/palaia/priorities.py
+++ b/palaia/priorities.py
@@ -191,18 +191,17 @@ def set_priority_value(
         from palaia.scope import validate_scope
         value = str(value).strip().lower()
         if not validate_scope(value):
-            raise ValueError(f"Invalid captureScope: {value}. Valid: private, team, public, shared:<name>")
+            raise ValueError(f"Invalid captureScope: {value}. Valid: private, team, public")
         target["captureScope"] = value
     elif key == "scopeVisibility":
         if isinstance(value, str):
             value = [s.strip() for s in value.split(",")]
         if not isinstance(value, list):
             raise ValueError("scopeVisibility must be a list of scopes or comma-separated string")
-        valid = {"private", "team", "public", "shared"}
+        valid = {"private", "team", "public"}
         for s in value:
-            base = s.split(":")[0] if ":" in s else s
-            if base not in valid:
-                raise ValueError(f"Invalid scope in scopeVisibility: {s}. Valid: private, team, public, shared:<name>")
+            if s not in valid:
+                raise ValueError(f"Invalid scope in scopeVisibility: {s}. Valid: private, team, public")
         target["scopeVisibility"] = value
     else:
         raise ValueError(f"Unknown priority key: {key}")

--- a/palaia/scope.py
+++ b/palaia/scope.py
@@ -1,4 +1,8 @@
-"""Scope-Tag parsing and enforcement (ADR-002)."""
+"""Scope-Tag parsing and enforcement (ADR-002).
+
+Scopes: private, team, public.
+Legacy shared:X scopes are treated as team for backward compatibility.
+"""
 
 from __future__ import annotations
 
@@ -7,25 +11,34 @@ import logging
 logger = logging.getLogger(__name__)
 
 VALID_SCOPES = {"private", "team", "public"}
-SHARED_PREFIX = "shared:"
+# Legacy prefix — accepted but normalized to "team" on write.
+_LEGACY_SHARED_PREFIX = "shared:"
 
 
 def validate_scope(scope: str) -> bool:
     """Check if a scope string is valid."""
     if scope in VALID_SCOPES:
         return True
-    if scope.startswith(SHARED_PREFIX) and len(scope) > len(SHARED_PREFIX):
+    # Accept legacy shared:X for backward compat (migration, old entries)
+    if scope.startswith(_LEGACY_SHARED_PREFIX) and len(scope) > len(_LEGACY_SHARED_PREFIX):
         return True
     return False
 
 
 def normalize_scope(scope: str | None, default: str = "team") -> str:
-    """Normalize and validate a scope, returning default if None."""
+    """Normalize and validate a scope, returning default if None.
+
+    Legacy shared:X scopes are silently normalized to 'team'.
+    """
     if scope is None:
         return default
     scope = scope.strip().lower()
     if not validate_scope(scope):
-        raise ValueError(f"Invalid scope: '{scope}'. Valid: private, team, shared:<name>, public")
+        raise ValueError(f"Invalid scope: '{scope}'. Valid: private, team, public")
+    # Normalize legacy shared:X → team
+    if scope.startswith(_LEGACY_SHARED_PREFIX):
+        logger.info("Normalizing legacy scope '%s' to 'team'", scope)
+        return "team"
     return scope
 
 
@@ -48,20 +61,18 @@ def can_access(
                           (Issue #145). When None, default visibility rules apply.
     """
     # Scope visibility filter: if set, entry scope must be in the allowed list.
-    # For shared:X scopes, check if "shared:X" is in the list literally,
-    # or if the base scope "shared" is allowed.
     if scope_visibility is not None:
         scope_allowed = False
         for allowed in scope_visibility:
             if entry_scope == allowed:
                 scope_allowed = True
                 break
-            # Allow "shared" to match any "shared:X"
-            if allowed == "shared" and entry_scope.startswith(SHARED_PREFIX):
-                scope_allowed = True
-                break
         if not scope_allowed:
-            return False
+            # Legacy: treat shared:X as team for visibility purposes
+            if entry_scope.startswith(_LEGACY_SHARED_PREFIX) and "team" in scope_visibility:
+                pass  # Allow access via team visibility
+            else:
+                return False
 
     if entry_scope == "team":
         return True
@@ -73,9 +84,9 @@ def can_access(
         if agent_names:
             return entry_agent in agent_names
         return agent_name == entry_agent
-    if entry_scope.startswith(SHARED_PREFIX):
-        project = entry_scope[len(SHARED_PREFIX) :]
-        return projects is not None and project in projects
+    # Legacy shared:X entries are accessible like team entries
+    if entry_scope.startswith(_LEGACY_SHARED_PREFIX):
+        return True
     return False
 
 

--- a/palaia/services/write.py
+++ b/palaia/services/write.py
@@ -47,6 +47,27 @@ def write_entry(
                 ),
             }
 
+    # Similarity check for processes: warn before creating near-duplicates
+    process_similarity_nudge: str | None = None
+    if entry_type == "process":
+        try:
+            from palaia.search import SearchEngine
+
+            engine = SearchEngine(store)
+            results = engine.search(body, top_k=3, entry_type="process")
+            for r in results:
+                if r.get("score", 0) > 0.8:
+                    similar_title = r.get("title", "(untitled)")
+                    similar_id = r.get("id", "???")[:8]
+                    process_similarity_nudge = (
+                        f"[palaia] Similar process found: '{similar_title}' "
+                        f"(id: {similar_id}, score: {r['score']:.2f}). "
+                        f"Consider updating it with `palaia edit {similar_id}` instead."
+                    )
+                    break
+        except Exception:
+            pass  # Never block writes with nudge errors
+
     entry_id = store.write(
         body=body,
         scope=scope,
@@ -160,10 +181,7 @@ def write_entry(
             if vis:
                 written_scope = scope or "team"
                 # Check if written scope is visible to this agent
-                scope_visible = any(
-                    written_scope == v or (v == "shared" and written_scope.startswith("shared:"))
-                    for v in vis
-                )
+                scope_visible = any(written_scope == v for v in vis)
                 if scope_visible:
                     tracker.record_success("isolation_scope_mismatch", agent_for_nudge)
                 else:
@@ -213,6 +231,8 @@ def write_entry(
         "deduplicated": deduplicated,
         "recovered": recovered,
     }
+    if process_similarity_nudge:
+        nudge_messages.append(process_similarity_nudge)
     if nudge_messages:
         result["nudge"] = nudge_messages
     if significance_detected:
@@ -266,5 +286,15 @@ def edit_entry(
         )
     except (ValueError, PermissionError) as e:
         return {"error": str(e)}
+
+    # Task-as-Post-It: completed/cancelled tasks are ephemeral — delete on close
+    effective_status = status or meta.get("status")
+    effective_type = entry_type or meta.get("type")
+    if effective_type == "task" and effective_status in ("done", "wontfix"):
+        try:
+            store.delete(entry_id)
+            return {"id": entry_id, "deleted": True, "reason": "task completed"}
+        except Exception:
+            pass  # Fall through to normal return if delete fails
 
     return {"id": entry_id, "updated": True, "meta": meta}

--- a/palaia/store.py
+++ b/palaia/store.py
@@ -392,6 +392,18 @@ class Store:
         if path.exists():
             path.unlink()
 
+    def delete(self, entry_id: str) -> bool:
+        """Delete an entry by ID, including metadata index and embedding cache."""
+        path = self._find_entry(entry_id)
+        if path is None:
+            return False
+        with self.lock:
+            rel_path = str(path.relative_to(self.root))
+            self.delete_raw(rel_path)
+            self.metadata_index.remove(entry_id)
+            self.embedding_cache.invalidate(entry_id)
+        return True
+
     def read(
         self, entry_id: str, agent: str | None = None, projects: list[str] | None = None,
         scope_visibility: list[str] | None = None,

--- a/skills/palaia/SKILL.md
+++ b/skills/palaia/SKILL.md
@@ -147,8 +147,13 @@ Before doing anything else with Palaia, run `palaia doctor` silently. If it repo
 
 ## Core Concepts
 
-### Auto-Capture
-Conversations are automatically captured when the OpenClaw plugin is active. You do NOT need to manually write things from conversations — Palaia handles it. Manual `palaia write` is only for structured knowledge: processes, tasks, and knowledge from external sources.
+### Auto-Capture vs. Manual Write
+Conversations are automatically captured when the OpenClaw plugin is active. Auto-capture handles routine knowledge extraction from conversations.
+
+**Manual writes (`palaia write`) are higher value.** When you or the user identify something as especially important — a key decision, a reusable workflow, a critical fact from an external source — write it manually. Manually written entries are ranked higher than auto-captured ones in recall results, so they surface more prominently in future sessions. Use manual writes for:
+- Important facts, decisions, or context from external sources
+- Reusable processes and workflows (team runbooks)
+- Sticky notes / reminders for future sessions (tasks)
 
 ### Three Tiers
 - **HOT** — Active memories (< 7 days or frequently accessed). Always searched.
@@ -162,8 +167,8 @@ Conversations are automatically captured when the OpenClaw plugin is active. You
 
 ### Entry Types
 - **memory** — Facts, decisions, learnings (default)
-- **process** — Workflows, checklists, SOPs
-- **task** — Action items with status, priority, assignee, due date
+- **process** — Workflows, checklists, SOPs (team runbooks)
+- **task** — Sticky notes / reminders for future sessions. Tasks are ephemeral: when marked done, they are automatically deleted. Never auto-captured — only created by explicit `palaia write --type task`.
 
 ---
 
@@ -265,21 +270,27 @@ palaia-mcp --read-only                  # No writes (untrusted hosts)
 
 ### `palaia write` — Save structured knowledge
 
-Only use for explicit process/task entries, or knowledge from external sources. Conversation knowledge is auto-captured.
+Use for important facts, reusable processes, sticky-note tasks, and knowledge from external sources. Manually written entries rank higher than auto-captured ones in recall.
 
 ```bash
-# Save a fact from outside the conversation
+# Save an important fact (ranks higher than auto-capture)
 palaia write "API rate limit is 100 req/min" --type memory --tags api,limits
 
-# Record a step-by-step process
-palaia write "1. Build 2. Test 3. Deploy" --type process --project myapp
+# Record a reusable team workflow (use specific, unique titles!)
+palaia write "Backend: Deploy to staging via Docker" --type process --project myapp --scope team
 
-# Create a task with structured fields
-palaia write "fix login bug" --type task --priority high --assignee Elliot --due-date 2026-04-01
+# Create a sticky note for a future session (deleted when done)
+palaia write "verify backup works after schema migration" --type task
 
 # Save to a specific project with scope
 palaia write "Use JWT for auth" --project backend --scope team --tags decision
 ```
+
+**Process naming convention:** Use the format `[Domain]: [What it does]` for process titles. Specific titles prevent duplicates and make processes findable.
+- Good: `"Release: PyPI publish + ClawHub sync"`, `"Backend: Deploy to staging via Docker"`
+- Bad: `"Deploy steps"`, `"Release process"` (too generic, will collide with other similar processes)
+
+Before writing a new process, search for existing ones: `palaia query "deploy" --type process`. If a similar process exists, update it with `palaia edit <id>` instead of creating a new one.
 
 ### `palaia query` — Semantic search
 
@@ -486,9 +497,12 @@ palaia project locks                      # List all active locks
 ### `palaia edit` — Modify existing entries
 
 ```bash
-palaia edit <id> --status done
+palaia edit <id> --status done         # For tasks: this DELETES the entry (sticky note completed)
+palaia edit <id> --status wontfix      # For tasks: also deletes (cancelled reminder)
 palaia edit <id> "updated content" --tags new,tags --priority high
 ```
+
+**Task lifecycle:** Tasks are sticky notes. When you mark a task as `done` or `wontfix`, it is automatically deleted — not archived. This is intentional: completed reminders have no long-term value. If the outcome of the task should be remembered, write a separate memory entry before marking the task done.
 
 ### Other commands
 
@@ -649,12 +663,12 @@ palaia write "## Dev-Agent Lifecycle
 
 | Situation | Command |
 |-----------|---------|
-| Remember a fact (not from conversation) | `palaia write "..." --type memory` |
-| Record a process/SOP | `palaia write "steps..." --type process` |
-| Create a task | `palaia write "fix bug" --type task --priority high` |
-| Mark task done | `palaia edit <id> --status done` |
+| Save an important fact or decision | `palaia write "..." --type memory` (ranks higher than auto-capture) |
+| Document a reusable workflow | `palaia write "Domain: Steps..." --type process --scope team` |
+| Leave a reminder for future sessions | `palaia write "check X after Y" --type task` (auto-deleted when done) |
+| Mark a reminder as done | `palaia edit <id> --status done` (deletes the task) |
 | Find something | `palaia query "..."` |
-| Find open tasks | `palaia list --type task --status open` |
+| Find open reminders | `palaia list --type task --status open` |
 | Check system health | `palaia status` |
 | Something is wrong | `palaia doctor --fix` |
 | Clean up old entries | `palaia gc` |
@@ -662,11 +676,11 @@ palaia write "## Dev-Agent Lifecycle
 | Review accumulated knowledge | `palaia curate analyze` |
 | Share knowledge | `palaia sync export` or `palaia package export` |
 | Check for messages | `palaia memo inbox` |
-| Start of session | Session briefing is now automatic. Just run `palaia doctor` and check `palaia memo inbox`. |
+| Start of session | Session briefing is automatic. Just run `palaia doctor` and check `palaia memo inbox`. |
 
-**Do NOT manually write:** facts, decisions, or preferences that came up in the current conversation. Auto-Capture handles these.
+**Auto-capture** handles routine conversation knowledge. **Manual writes rank higher** in recall — use them when something is especially important, reusable, or comes from an external source.
 
-**DO manually write:** processes, tasks with structured fields, knowledge from external sources, project setup.
+**DO manually write:** key decisions, reusable processes (team runbooks), sticky-note reminders (tasks), important facts from external sources.
 
 ---
 
@@ -706,7 +720,7 @@ palaia init --capture-level <off|minimal|normal|aggressive>
 Session continuity gives agents automatic context restoration across sessions. These features work out of the box with the OpenClaw plugin -- no manual setup needed.
 
 ### Session Briefings
-On session start, Palaia automatically injects a briefing with the last session summary and any open tasks. This means agents resume work without needing to manually search for context.
+Session briefings are injected automatically at session start. They contain your last session summary and any open tasks (sticky notes). Read the briefing carefully — it is your primary context for continuing previous work. Do not ask the user "where did we leave off?" when a briefing is present. Instead, acknowledge the context and continue seamlessly.
 
 ### Session Summaries
 When a session ends or resets, Palaia auto-saves a summary of what happened. These are stored as entries with the `session-summary` tag and can be queried:
@@ -750,6 +764,7 @@ Set in `openclaw.json` under `plugins.entries.palaia.config`:
 | `sessionBriefingMaxChars` | `1500` | Max chars for session briefing injection |
 | `captureToolObservations` | `true` | Track tool usage as session context |
 | `recallRecencyBoost` | `0.3` | Boost factor for fresh memories (0=off) |
+| `manualEntryBoost` | `1.3` | Boost factor for manually written entries vs auto-captured (1.0=off) |
 
 ---
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -328,7 +328,7 @@ class TestRunDoctor:
     def test_run_all_checks(self, palaia_root, tmp_path, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))
         results = run_doctor(palaia_root)
-        assert len(results) == 27  # +2: native_vector_search, mcp_server
+        assert len(results) == 28  # +3: native_vector_search, mcp_server, capture_health
         assert all("status" in r for r in results)
         assert all("name" in r for r in results)
 

--- a/tests/test_doctor_version.py
+++ b/tests/test_doctor_version.py
@@ -102,4 +102,4 @@ def test_version_check_count(palaia_root):
         mock_urlopen.return_value = _mock_pypi_response(__version__)
         results = run_doctor(palaia_root)
 
-    assert len(results) == 27  # +2: native_vector_search, mcp_server
+    assert len(results) == 28  # +3: native_vector_search, mcp_server, capture_health

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -80,7 +80,7 @@ def test_smart_memory_extract(smart_memory_source):
 
     # Check scopes
     by_title = {e.title: e for e in entries}
-    assert by_title["Project: clawsy"].scope == "shared:clawsy"
+    assert by_title["Project: clawsy"].scope == "team"  # Legacy shared:X normalized to team
     assert by_title["Agent: coding"].tier == "warm"
     assert by_title["Daily: 2026-03-10"].tier == "cold"
 
@@ -321,7 +321,7 @@ def test_format_result_shows_system_file_warnings():
         "total_entries": 6,
         "files_scanned": 5,
         "tiers": {"hot": 4, "warm": 1, "cold": 1},
-        "scopes": {"team": 5, "shared:clawsy": 1},
+        "scopes": {"team": 6},  # Legacy shared:X normalized to team
         "imported": 6,
         "skipped_dedup": 0,
         "dry_run": False,

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -37,10 +37,12 @@ def test_can_access_private():
     assert can_access("private", None, "agent1") is False
 
 
-def test_can_access_shared():
+def test_can_access_shared_legacy():
+    """Legacy shared:X entries are accessible like team entries."""
     assert can_access("shared:proj1", "agent1", "agent2", ["proj1"]) is True
-    assert can_access("shared:proj1", "agent1", "agent2", ["proj2"]) is False
-    assert can_access("shared:proj1", "agent1", "agent2", None) is False
+    # Legacy shared:X is treated as team — always accessible regardless of projects
+    assert can_access("shared:proj1", "agent1", "agent2", ["proj2"]) is True
+    assert can_access("shared:proj1", "agent1", "agent2", None) is True
 
 
 def test_can_access_private_with_agent_names():
@@ -84,15 +86,12 @@ class TestScopeVisibility:
         assert can_access("team", "a", "b", scope_visibility=["private", "team"]) is True
         assert can_access("public", "a", "b", scope_visibility=["private", "team"]) is False
 
-    def test_shared_exact(self):
-        """Exact shared:X match in scopeVisibility."""
-        assert can_access("shared:proj1", "a", "b", ["proj1"], scope_visibility=["private", "shared:proj1"]) is True
-        assert can_access("shared:proj2", "a", "b", ["proj2"], scope_visibility=["private", "shared:proj1"]) is False
-
-    def test_shared_wildcard(self):
-        """'shared' in scopeVisibility matches any shared:X."""
-        assert can_access("shared:proj1", "a", "b", ["proj1"], scope_visibility=["private", "shared"]) is True
-        assert can_access("shared:proj2", "a", "b", ["proj2"], scope_visibility=["private", "shared"]) is True
+    def test_shared_legacy_as_team(self):
+        """Legacy shared:X entries are accessible when 'team' is in scopeVisibility."""
+        assert can_access("shared:proj1", "a", "b", ["proj1"], scope_visibility=["private", "team"]) is True
+        assert can_access("shared:proj2", "a", "b", ["proj2"], scope_visibility=["private", "team"]) is True
+        # Without team in visibility, legacy shared:X entries are blocked
+        assert can_access("shared:proj1", "a", "b", ["proj1"], scope_visibility=["private"]) is False
 
     def test_private_scope_still_enforced(self):
         """scopeVisibility allows private, but agent ownership still checked."""

--- a/tests/test_scope_enforcement.py
+++ b/tests/test_scope_enforcement.py
@@ -202,16 +202,11 @@ def test_can_access_private_no_agent():
     assert can_access("private", None, "owner") is False
 
 
-def test_can_access_shared_project():
+def test_can_access_shared_legacy_as_team():
+    """Legacy shared:X entries are treated as team — always accessible."""
     assert can_access("shared:myproj", "anyone", "owner", projects=["myproj"]) is True
-
-
-def test_can_access_shared_wrong_project():
-    assert can_access("shared:myproj", "anyone", "owner", projects=["other"]) is False
-
-
-def test_can_access_shared_no_projects():
-    assert can_access("shared:myproj", "anyone", "owner", projects=None) is False
+    assert can_access("shared:myproj", "anyone", "owner", projects=["other"]) is True
+    assert can_access("shared:myproj", "anyone", "owner", projects=None) is True
 
 
 # --- Alias-aware scope enforcement ---


### PR DESCRIPTION
## Summary

Based on analysis of real-world usage data (1,903 entries from a production OpenClaw instance), this PR optimizes palaia for how it's actually used.

### Key findings from usage data
- 84% of all entries are auto-capture (1,595 of 1,903)
- Only 3 manual tasks ever created (feature was dead)
- Shared scopes: 5 entries, all migration artifacts
- Process used as team runbooks (59/64 manual processes are team-scoped)

### Changes

- **Remove shared scope** — Legacy `shared:X` normalized to `team`. Existing entries remain readable.
- **Task-as-Post-It** — Auto-capture never creates tasks (was 95% noise). Tasks are ephemeral sticky notes, deleted when marked done.
- **Manual entry boost** — Manual writes rank 30% higher in recall (`manualEntryBoost=1.3`).
- **Process similarity nudge** — Warns about near-duplicate processes before write (score > 0.8).
- **SKILL.md agent adoption** — Process naming convention, task lifecycle docs, session briefing guidance.

## Test plan
- [x] All 1,154 Python tests pass
- [ ] Verify `shared:X` entries accessible as team after deploy
- [ ] Verify `palaia edit <id> --status done` deletes task entries
- [ ] Verify auto-capture no longer creates task-type entries
- [ ] Verify manual entries rank higher in recall

🤖 Generated with [Claude Code](https://claude.com/claude-code)