### PR TITLE
release: palaia v2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## v2.6 — 2026-04-03
+
+### New Features
+- **Usage-Data-Driven Optimization** — Based on analysis of real-world usage data (1,903 entries). Shared scope removed (normalized to team), task-as-post-it model (auto-capture never creates tasks, `--status done` deletes), manual entry boost (1.3x ranking for intentionally stored knowledge).
+- **Capture Health Check** — `palaia doctor` now warns when `autoCapture=true` but zero entries have been captured. Detects silent auto-capture failures before they cause memory gaps.
+- **CLI/Plugin Version Mismatch Detection** — New doctor check detects when CLI and plugin versions diverge (e.g. plugin v2.6 but CLI v1.8). Nudges the correct upgrade command.
+- **Process Safety in Curate** — `merge_entries()` preserves full content for process entries (no truncation). `apply_report()` raises `ProcessSafetyError` on MERGE/DROP for processes unless `--force` is passed.
+
+### Fixed
+- **Auto-capture workspace bug** — `extractWithLLM` used global workspace instead of per-agent resolved workspace. Sub-agent auto-capture now works correctly (#157).
+- **memory_search timeout on parallel queries** — Uses embed server directly instead of spawning CLI processes. Fixes timeouts when agents fire multiple concurrent `memory_search` calls (#144).
+- **Auto-capture diagnostic logging** — Silent return paths now log the reason (min turns, significance filter, rule-based rejection). Previously invisible.
+- **Doctor severity bumps** — `captureModel` missing and legacy memory files promoted from `[info]` to `[warn]` so agent auto-check catches them after upgrades (#99, #101).
+
+### Chores
+- ASCII logo added to README.
+- Brand name lowercased ("Palaia" → "palaia") across 67 files.
+
+### Migration from v2.5.1
+- `pip install --upgrade palaia && palaia doctor --fix` — no manual steps required.
+- Existing `shared:X` scoped entries are automatically treated as `team`. No data loss.
+- Tasks created by auto-capture are now classified as `memory` type instead of `task`.
+
+---
+
 ## v2.5.1 — 2026-04-02
 
 ### Fixed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: palaia
-version: "2.5.1"
+version: "2.6"
 description: >
   Local, crash-safe persistent memory for OpenClaw agents.
   SQLite-backed by default. Semantic search, projects, scopes, auto-capture.
@@ -25,14 +25,16 @@ metadata:
       - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && (npm install -g @byte5ai/palaia@latest 2>/dev/null || true) && palaia doctor --fix && palaia warmup"
         label: "Upgrade palaia with semantic search (pip + npm plugin) and run health checks"
     postUpdateMessage: >
-      palaia has been updated to v2.5. New: agent isolation mode (--isolated), modern CLI
-      design, backup-restore auto-fix. Run `palaia doctor --fix` to upgrade.
+      palaia has been updated to v2.6. New: usage-data-driven optimization (task-as-post-it,
+      manual entry boost), auto-capture workspace fix for sub-agents, capture health check,
+      CLI/plugin version mismatch detection, process safety in curate.
+      Run `palaia doctor --fix` to upgrade.
     plugin:
       slot: memory
       package: "@byte5ai/palaia"
 ---
 
-# palaia v2.4 — Agent Memory Skill
+# palaia v2.6 — Agent Memory Skill
 
 palaia is the memory system for OpenClaw agents. It gives you persistent, searchable, crash-safe memory across sessions. You don't need to understand how it works — just use the commands below.
 

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byte5ai/palaia",
-  "version": "2.5.1",
+  "version": "2.6",
   "description": "palaia memory backend for OpenClaw",
   "main": "index.ts",
   "openclaw": {

--- a/packages/openclaw-plugin/skill/SKILL.md
+++ b/packages/openclaw-plugin/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: palaia
-version: "2.5.1"
+version: "2.6"
 description: >
   Local, crash-safe persistent memory for OpenClaw agents.
   SQLite-backed by default. Semantic search, projects, scopes, auto-capture.
@@ -25,14 +25,16 @@ metadata:
       - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && (npm install -g @byte5ai/palaia@latest 2>/dev/null || true) && palaia doctor --fix && palaia warmup"
         label: "Upgrade palaia with semantic search (pip + npm plugin) and run health checks"
     postUpdateMessage: >
-      palaia has been updated to v2.5. New: agent isolation mode (--isolated), modern CLI
-      design, backup-restore auto-fix. Run `palaia doctor --fix` to upgrade.
+      palaia has been updated to v2.6. New: usage-data-driven optimization (task-as-post-it,
+      manual entry boost), auto-capture workspace fix for sub-agents, capture health check,
+      CLI/plugin version mismatch detection, process safety in curate.
+      Run `palaia doctor --fix` to upgrade.
     plugin:
       slot: memory
       package: "@byte5ai/palaia"
 ---
 
-# palaia v2.4 — Agent Memory Skill
+# palaia v2.6 — Agent Memory Skill
 
 palaia is the memory system for OpenClaw agents. It gives you persistent, searchable, crash-safe memory across sessions. You don't need to understand how it works — just use the commands below.
 

--- a/palaia/SKILL.md
+++ b/palaia/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: palaia
-version: "2.5.1"
+version: "2.6"
 description: >
   Local, crash-safe persistent memory for OpenClaw agents.
   SQLite-backed by default. Semantic search, projects, scopes, auto-capture.
@@ -25,14 +25,16 @@ metadata:
       - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && (npm install -g @byte5ai/palaia@latest 2>/dev/null || true) && palaia doctor --fix && palaia warmup"
         label: "Upgrade palaia with semantic search (pip + npm plugin) and run health checks"
     postUpdateMessage: >
-      palaia has been updated to v2.5. New: agent isolation mode (--isolated), modern CLI
-      design, backup-restore auto-fix. Run `palaia doctor --fix` to upgrade.
+      palaia has been updated to v2.6. New: usage-data-driven optimization (task-as-post-it,
+      manual entry boost), auto-capture workspace fix for sub-agents, capture health check,
+      CLI/plugin version mismatch detection, process safety in curate.
+      Run `palaia doctor --fix` to upgrade.
     plugin:
       slot: memory
       package: "@byte5ai/palaia"
 ---
 
-# palaia v2.4 — Agent Memory Skill
+# palaia v2.6 — Agent Memory Skill
 
 palaia is the memory system for OpenClaw agents. It gives you persistent, searchable, crash-safe memory across sessions. You don't need to understand how it works — just use the commands below.
 

--- a/palaia/__init__.py
+++ b/palaia/__init__.py
@@ -4,5 +4,5 @@ palaia — Local, cloud-free memory for OpenClaw agents.
 
 from __future__ import annotations
 
-__version__ = "2.5.1"
+__version__ = "2.6"
 __author__ = "byte5 GmbH"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "palaia"
-version = "2.5.1"
+version = "2.6"
 description = "Local, cloud-free memory for OpenClaw agents."
 readme = "README.md"
 license = {text = "MIT"}

--- a/skills/palaia/SKILL.md
+++ b/skills/palaia/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: palaia
-version: "2.5.1"
+version: "2.6"
 description: >
   Local, crash-safe persistent memory for OpenClaw agents.
   SQLite-backed by default. Semantic search, projects, scopes, auto-capture.
@@ -25,14 +25,16 @@ metadata:
       - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && (npm install -g @byte5ai/palaia@latest 2>/dev/null || true) && palaia doctor --fix && palaia warmup"
         label: "Upgrade palaia with semantic search (pip + npm plugin) and run health checks"
     postUpdateMessage: >
-      palaia has been updated to v2.5. New: agent isolation mode (--isolated), modern CLI
-      design, backup-restore auto-fix. Run `palaia doctor --fix` to upgrade.
+      palaia has been updated to v2.6. New: usage-data-driven optimization (task-as-post-it,
+      manual entry boost), auto-capture workspace fix for sub-agents, capture health check,
+      CLI/plugin version mismatch detection, process safety in curate.
+      Run `palaia doctor --fix` to upgrade.
     plugin:
       slot: memory
       package: "@byte5ai/palaia"
 ---
 
-# palaia v2.4 — Agent Memory Skill
+# palaia v2.6 — Agent Memory Skill
 
 palaia is the memory system for OpenClaw agents. It gives you persistent, searchable, crash-safe memory across sessions. You don't need to understand how it works — just use the commands below.
 


### PR DESCRIPTION
## palaia v2.6

### Features
- Usage-data-driven optimization (task-as-post-it, manual entry boost, shared scope removal)
- Capture health check in `palaia doctor`
- CLI/plugin version mismatch detection
- Process safety in curate (`--force` override)

### Fixes
- Auto-capture workspace bug for sub-agents (#157)
- memory_search timeout on parallel queries (#144)
- Auto-capture diagnostic logging
- Doctor severity bumps (#99, #101)

### Risk Assessment
- shared:X → team normalization: 0 intentional users, backward-compatible
- Task-as-post-it: was 95% noise, manual tasks still work
- manualEntryBoost=1.3: relative ranking only, no data loss
- All risks mitigated, no blockers