### PR TITLE
fix: use openclaw plugins install for plugin setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,21 @@ The agent handles everything: ClawHub skill install, pip setup, plugin config, a
 ```bash
 pip install "palaia[fastembed]"
 palaia init
+openclaw plugins install @byte5ai/palaia
 palaia doctor --fix
 ```
+
+Then activate the memory slot in your OpenClaw config:
+```json5
+// openclaw.json
+{
+  plugins: {
+    slots: { memory: "palaia" }
+  }
+}
+```
+
+Restart the gateway: `openclaw gateway restart`
 
 Optional extras:
 ```bash

--- a/SKILL.md
+++ b/SKILL.md
@@ -19,11 +19,11 @@ metadata:
     postInstall:
       - command: "palaia init"
         label: "Initialize palaia store"
-      - command: "npm install -g @byte5ai/palaia@latest"
-        label: "Install OpenClaw plugin (npm)"
+      - command: "openclaw plugins install @byte5ai/palaia"
+        label: "Install OpenClaw plugin"
     postUpdate:
-      - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && (npm install -g @byte5ai/palaia@latest 2>/dev/null || true) && palaia doctor --fix && palaia warmup"
-        label: "Upgrade palaia with semantic search (pip + npm plugin) and run health checks"
+      - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && (openclaw plugins install @byte5ai/palaia 2>/dev/null || true) && palaia doctor --fix && palaia warmup"
+        label: "Upgrade palaia with semantic search + plugin and run health checks"
     postUpdateMessage: >
       palaia has been updated to v2.6. New: usage-data-driven optimization (task-as-post-it,
       manual entry boost), auto-capture workspace fix for sub-agents, capture health check,
@@ -75,22 +75,15 @@ Note: `palaia[fastembed]` already includes sqlite-vec for native SIMD vector sea
 After the CLI is installed, wire it into OpenClaw:
 
 ```bash
-npm install -g @byte5ai/palaia@latest
+openclaw plugins install @byte5ai/palaia
 ```
 
-Then activate in OpenClaw config (read existing values first, never overwrite arrays):
-```bash
-PALAIA_PATH="$(npm root -g)/@byte5ai/palaia"
-```
-
-Add to `openclaw.json`:
-```json
+Then activate the memory slot in OpenClaw config:
+```json5
+// openclaw.json
 {
-  "plugins": {
-    "load": { "paths": ["<PALAIA_PATH>"] },
-    "allow": ["..existing..", "palaia"],
-    "slots": { "memory": "palaia" },
-    "entries": { "palaia": { "enabled": true } }
+  plugins: {
+    slots: { memory: "palaia" }
   }
 }
 ```
@@ -135,7 +128,7 @@ pipx install "palaia[fastembed]" --force
 palaia doctor --fix
 
 # Step 4: Update OpenClaw plugin (if installed)
-npm install -g @byte5ai/palaia@latest
+openclaw plugins install @byte5ai/palaia
 ```
 
 After the manual update, `palaia upgrade` will be available for future updates.

--- a/packages/openclaw-plugin/skill/SKILL.md
+++ b/packages/openclaw-plugin/skill/SKILL.md
@@ -19,11 +19,11 @@ metadata:
     postInstall:
       - command: "palaia init"
         label: "Initialize palaia store"
-      - command: "npm install -g @byte5ai/palaia@latest"
-        label: "Install OpenClaw plugin (npm)"
+      - command: "openclaw plugins install @byte5ai/palaia"
+        label: "Install OpenClaw plugin"
     postUpdate:
-      - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && (npm install -g @byte5ai/palaia@latest 2>/dev/null || true) && palaia doctor --fix && palaia warmup"
-        label: "Upgrade palaia with semantic search (pip + npm plugin) and run health checks"
+      - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && (openclaw plugins install @byte5ai/palaia 2>/dev/null || true) && palaia doctor --fix && palaia warmup"
+        label: "Upgrade palaia with semantic search + plugin and run health checks"
     postUpdateMessage: >
       palaia has been updated to v2.6. New: usage-data-driven optimization (task-as-post-it,
       manual entry boost), auto-capture workspace fix for sub-agents, capture health check,
@@ -75,22 +75,15 @@ Note: `palaia[fastembed]` already includes sqlite-vec for native SIMD vector sea
 After the CLI is installed, wire it into OpenClaw:
 
 ```bash
-npm install -g @byte5ai/palaia@latest
+openclaw plugins install @byte5ai/palaia
 ```
 
-Then activate in OpenClaw config (read existing values first, never overwrite arrays):
-```bash
-PALAIA_PATH="$(npm root -g)/@byte5ai/palaia"
-```
-
-Add to `openclaw.json`:
-```json
+Then activate the memory slot in OpenClaw config:
+```json5
+// openclaw.json
 {
-  "plugins": {
-    "load": { "paths": ["<PALAIA_PATH>"] },
-    "allow": ["..existing..", "palaia"],
-    "slots": { "memory": "palaia" },
-    "entries": { "palaia": { "enabled": true } }
+  plugins: {
+    slots: { memory: "palaia" }
   }
 }
 ```
@@ -135,7 +128,7 @@ pipx install "palaia[fastembed]" --force
 palaia doctor --fix
 
 # Step 4: Update OpenClaw plugin (if installed)
-npm install -g @byte5ai/palaia@latest
+openclaw plugins install @byte5ai/palaia
 ```
 
 After the manual update, `palaia upgrade` will be available for future updates.

--- a/palaia/SKILL.md
+++ b/palaia/SKILL.md
@@ -19,11 +19,11 @@ metadata:
     postInstall:
       - command: "palaia init"
         label: "Initialize palaia store"
-      - command: "npm install -g @byte5ai/palaia@latest"
-        label: "Install OpenClaw plugin (npm)"
+      - command: "openclaw plugins install @byte5ai/palaia"
+        label: "Install OpenClaw plugin"
     postUpdate:
-      - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && (npm install -g @byte5ai/palaia@latest 2>/dev/null || true) && palaia doctor --fix && palaia warmup"
-        label: "Upgrade palaia with semantic search (pip + npm plugin) and run health checks"
+      - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && (openclaw plugins install @byte5ai/palaia 2>/dev/null || true) && palaia doctor --fix && palaia warmup"
+        label: "Upgrade palaia with semantic search + plugin and run health checks"
     postUpdateMessage: >
       palaia has been updated to v2.6. New: usage-data-driven optimization (task-as-post-it,
       manual entry boost), auto-capture workspace fix for sub-agents, capture health check,
@@ -75,22 +75,15 @@ Note: `palaia[fastembed]` already includes sqlite-vec for native SIMD vector sea
 After the CLI is installed, wire it into OpenClaw:
 
 ```bash
-npm install -g @byte5ai/palaia@latest
+openclaw plugins install @byte5ai/palaia
 ```
 
-Then activate in OpenClaw config (read existing values first, never overwrite arrays):
-```bash
-PALAIA_PATH="$(npm root -g)/@byte5ai/palaia"
-```
-
-Add to `openclaw.json`:
-```json
+Then activate the memory slot in OpenClaw config:
+```json5
+// openclaw.json
 {
-  "plugins": {
-    "load": { "paths": ["<PALAIA_PATH>"] },
-    "allow": ["..existing..", "palaia"],
-    "slots": { "memory": "palaia" },
-    "entries": { "palaia": { "enabled": true } }
+  plugins: {
+    slots: { memory: "palaia" }
   }
 }
 ```
@@ -135,7 +128,7 @@ pipx install "palaia[fastembed]" --force
 palaia doctor --fix
 
 # Step 4: Update OpenClaw plugin (if installed)
-npm install -g @byte5ai/palaia@latest
+openclaw plugins install @byte5ai/palaia
 ```
 
 After the manual update, `palaia upgrade` will be available for future updates.

--- a/palaia/cli.py
+++ b/palaia/cli.py
@@ -1376,17 +1376,17 @@ def cmd_upgrade(args):
     print("\nRunning health checks...")
     subprocess.run([sys.executable, "-m", "palaia", "doctor", "--fix"])
 
-    # Check for OpenClaw plugin
-    npm_bin = shutil.which("npm")
-    if npm_bin:
+    # Check for OpenClaw plugin and upgrade via openclaw plugins install
+    openclaw_bin = shutil.which("openclaw")
+    if openclaw_bin:
         try:
-            npm_check = subprocess.run(
-                ["npm", "list", "-g", "@byte5ai/palaia"],
+            oc_check = subprocess.run(
+                ["openclaw", "plugins", "info", "palaia"],
                 capture_output=True, text=True,
             )
-            if "@byte5ai/palaia" in npm_check.stdout:
+            if oc_check.returncode == 0 and "palaia" in oc_check.stdout:
                 print("\nUpgrading OpenClaw plugin...")
-                subprocess.run(["npm", "install", "-g", "@byte5ai/palaia@latest"])
+                subprocess.run(["openclaw", "plugins", "install", "@byte5ai/palaia"])
         except Exception:
             pass
 

--- a/skills/palaia/SKILL.md
+++ b/skills/palaia/SKILL.md
@@ -19,11 +19,11 @@ metadata:
     postInstall:
       - command: "palaia init"
         label: "Initialize palaia store"
-      - command: "npm install -g @byte5ai/palaia@latest"
-        label: "Install OpenClaw plugin (npm)"
+      - command: "openclaw plugins install @byte5ai/palaia"
+        label: "Install OpenClaw plugin"
     postUpdate:
-      - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && (npm install -g @byte5ai/palaia@latest 2>/dev/null || true) && palaia doctor --fix && palaia warmup"
-        label: "Upgrade palaia with semantic search (pip + npm plugin) and run health checks"
+      - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && (openclaw plugins install @byte5ai/palaia 2>/dev/null || true) && palaia doctor --fix && palaia warmup"
+        label: "Upgrade palaia with semantic search + plugin and run health checks"
     postUpdateMessage: >
       palaia has been updated to v2.6. New: usage-data-driven optimization (task-as-post-it,
       manual entry boost), auto-capture workspace fix for sub-agents, capture health check,
@@ -75,22 +75,15 @@ Note: `palaia[fastembed]` already includes sqlite-vec for native SIMD vector sea
 After the CLI is installed, wire it into OpenClaw:
 
 ```bash
-npm install -g @byte5ai/palaia@latest
+openclaw plugins install @byte5ai/palaia
 ```
 
-Then activate in OpenClaw config (read existing values first, never overwrite arrays):
-```bash
-PALAIA_PATH="$(npm root -g)/@byte5ai/palaia"
-```
-
-Add to `openclaw.json`:
-```json
+Then activate the memory slot in OpenClaw config:
+```json5
+// openclaw.json
 {
-  "plugins": {
-    "load": { "paths": ["<PALAIA_PATH>"] },
-    "allow": ["..existing..", "palaia"],
-    "slots": { "memory": "palaia" },
-    "entries": { "palaia": { "enabled": true } }
+  plugins: {
+    slots: { memory: "palaia" }
   }
 }
 ```
@@ -135,7 +128,7 @@ pipx install "palaia[fastembed]" --force
 palaia doctor --fix
 
 # Step 4: Update OpenClaw plugin (if installed)
-npm install -g @byte5ai/palaia@latest
+openclaw plugins install @byte5ai/palaia
 ```
 
 After the manual update, `palaia upgrade` will be available for future updates.


### PR DESCRIPTION
## Summary

- SKILL.md install instructions used `npm install -g` + manual `load.paths` config, causing the plugin to register as `origin:"config"` instead of `origin:"installed"`
- This made `openclaw doctor` unable to detect palaia as the active memory plugin ("No active memory plugin is registered")
- Switched all install/update paths (SKILL.md frontmatter, manual instructions, `palaia upgrade` CLI) to `openclaw plugins install @byte5ai/palaia`

## Context

Discovered during OpenClaw v2026.4.2 compatibility check. The root README already recommended `openclaw plugins install`, but the SKILL.md (which agents actually read during setup) used the legacy `npm install -g` + `load.paths` approach.

## Test plan

- [ ] Fresh install via ClawHub skill: verify `openclaw plugins info palaia` shows `origin: "installed"`
- [ ] `openclaw doctor` no longer reports "No active memory plugin is registered"
- [ ] `palaia upgrade` updates plugin via `openclaw plugins install`
- [ ] Manual install path in SKILL.md works as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)