### PR TITLE
fix: use openclaw plugins install for plugin setup

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -22,7 +22,7 @@ metadata:
       - command: "openclaw plugins install @byte5ai/palaia"
         label: "Install OpenClaw plugin"
     postUpdate:
-      - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && (openclaw plugins install @byte5ai/palaia 2>/dev/null || true) && palaia doctor --fix && palaia warmup"
+      - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && openclaw plugins install @byte5ai/palaia && palaia doctor --fix && palaia warmup"
         label: "Upgrade palaia with semantic search + plugin and run health checks"
     postUpdateMessage: >
       palaia has been updated to v2.6. New: usage-data-driven optimization (task-as-post-it,

--- a/packages/openclaw-plugin/skill/SKILL.md
+++ b/packages/openclaw-plugin/skill/SKILL.md
@@ -22,7 +22,7 @@ metadata:
       - command: "openclaw plugins install @byte5ai/palaia"
         label: "Install OpenClaw plugin"
     postUpdate:
-      - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && (openclaw plugins install @byte5ai/palaia 2>/dev/null || true) && palaia doctor --fix && palaia warmup"
+      - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && openclaw plugins install @byte5ai/palaia && palaia doctor --fix && palaia warmup"
         label: "Upgrade palaia with semantic search + plugin and run health checks"
     postUpdateMessage: >
       palaia has been updated to v2.6. New: usage-data-driven optimization (task-as-post-it,

--- a/palaia/SKILL.md
+++ b/palaia/SKILL.md
@@ -22,7 +22,7 @@ metadata:
       - command: "openclaw plugins install @byte5ai/palaia"
         label: "Install OpenClaw plugin"
     postUpdate:
-      - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && (openclaw plugins install @byte5ai/palaia 2>/dev/null || true) && palaia doctor --fix && palaia warmup"
+      - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && openclaw plugins install @byte5ai/palaia && palaia doctor --fix && palaia warmup"
         label: "Upgrade palaia with semantic search + plugin and run health checks"
     postUpdateMessage: >
       palaia has been updated to v2.6. New: usage-data-driven optimization (task-as-post-it,

--- a/palaia/doctor/checks.py
+++ b/palaia/doctor/checks.py
@@ -290,15 +290,16 @@ def _check_openclaw_plugin() -> dict[str, Any]:
                     "label": "OpenClaw plugin",
                     "status": "warn",
                     "message": f"{memory_plugin} is active (not palaia)",
-                    "fix": ('Set plugins.slots.memory = "palaia" in OpenClaw config\nThen restart OpenClaw.'),
+                    "fix": "openclaw plugins install @byte5ai/palaia",
                     "details": {"plugin": memory_plugin, "config_path": str(config_path)},
                 }
             else:
                 return {
                     "name": "openclaw_plugin",
                     "label": "OpenClaw plugin",
-                    "status": "info",
-                    "message": "No memory plugin configured",
+                    "status": "warn",
+                    "message": "No memory plugin registered (palaia not active)",
+                    "fix": "openclaw plugins install @byte5ai/palaia",
                     "details": {"config_path": str(config_path)},
                 }
         except (json.JSONDecodeError, OSError, KeyError):

--- a/skills/palaia/SKILL.md
+++ b/skills/palaia/SKILL.md
@@ -22,7 +22,7 @@ metadata:
       - command: "openclaw plugins install @byte5ai/palaia"
         label: "Install OpenClaw plugin"
     postUpdate:
-      - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && (openclaw plugins install @byte5ai/palaia 2>/dev/null || true) && palaia doctor --fix && palaia warmup"
+      - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && openclaw plugins install @byte5ai/palaia && palaia doctor --fix && palaia warmup"
         label: "Upgrade palaia with semantic search + plugin and run health checks"
     postUpdateMessage: >
       palaia has been updated to v2.6. New: usage-data-driven optimization (task-as-post-it,


### PR DESCRIPTION
Fixes the silent postUpdate failure that left palaia un-registered as OpenClaw memory plugin after upgrade from pre-2.5 installs. Also upgrades the doctor check severity from info to warn so the auto-check catches it.