### PR TITLE
feat: WebUI — local memory explorer aligned to v2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+- **WebUI — local memory explorer** (`palaia ui`) — Browser-based UI for browsing, searching, creating, and managing palaia entries. v2.6-aligned: manual entries visually highlighted (gold border + badge) to reflect the 1.3× recall boost; tasks are post-its (clicking ✓ deletes them); dedicated Active Tasks sidebar; health pill shows doctor status with actionable banner. Runs on 127.0.0.1 only, no auth, auto-opens the browser. Install with `pip install 'palaia[ui]'`, then `palaia ui`.
+- **New doctor route `/api/doctor`** — surfaces health checks directly in the WebUI banner, no context switch to the CLI.
+
+### Fixed
+- **Legacy memory files check** — now excludes OpenClaw system files (`agents/`, `systems/`, `projects/*/CONTEXT.md`, `active-context.md`) and downgrades from warn to info to avoid post-migration loops (#166).
+- **postUpdate plugin install** — removed `2>/dev/null || true` that silently swallowed plugin install failures when upgrading from pre-2.5 npm-based installs. Doctor now also warns (not info) when palaia is not registered as the OpenClaw memory slot (#170).
+
+---
+
 ## v2.6 — 2026-04-03
 
 ### New Features

--- a/palaia/cli.py
+++ b/palaia/cli.py
@@ -89,6 +89,7 @@ GATED_COMMANDS = frozenset(
         "priorities",
         "curate",
         "sync",
+        "ui",
     }
 )
 
@@ -1394,6 +1395,78 @@ def cmd_upgrade(args):
     return 0
 
 
+def cmd_ui(args):
+    """Launch the palaia WebUI (local memory explorer)."""
+    try:
+        import uvicorn  # noqa: F401
+        from fastapi import FastAPI  # noqa: F401
+    except ImportError:
+        print("WebUI requires fastapi + uvicorn.", file=sys.stderr)
+        print("Install with: pip install 'palaia[ui]'", file=sys.stderr)
+        return 1
+
+    import socket
+    import threading
+    import webbrowser
+
+    from palaia.web.app import create_app
+
+    root = find_palaia_root()
+    if not root:
+        print("palaia not initialized. Run: palaia init", file=sys.stderr)
+        return 1
+
+    host = getattr(args, "host", None) or "127.0.0.1"
+    requested_port = getattr(args, "port", None) or 8384
+    no_browser = getattr(args, "no_browser", False)
+
+    # Find a free port starting at the requested one (try up to +10)
+    def _port_free(p: int) -> bool:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind((host, p))
+                return True
+            except OSError:
+                return False
+
+    port = requested_port
+    for candidate in range(requested_port, requested_port + 11):
+        if _port_free(candidate):
+            port = candidate
+            break
+    else:
+        print(f"No free port in range {requested_port}-{requested_port + 10}", file=sys.stderr)
+        return 1
+
+    if port != requested_port:
+        print(f"Port {requested_port} busy, using {port} instead.")
+
+    try:
+        app = create_app(root)
+    except RuntimeError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    url = f"http://{host}:{port}"
+    print(f"palaia WebUI → {url}")
+    print("Press Ctrl+C to stop")
+
+    if not no_browser:
+        def _open():
+            try:
+                webbrowser.open(url)
+            except Exception:
+                pass
+        threading.Timer(0.5, _open).start()
+
+    import uvicorn as _uvicorn
+    try:
+        _uvicorn.run(app, host=host, port=port, log_level="warning")
+    except KeyboardInterrupt:
+        print("\nWebUI stopped.")
+    return 0
+
+
 def cmd_skill(args):
     """Print the embedded SKILL.md documentation."""
     from palaia.services.misc import get_skill_content
@@ -1467,6 +1540,7 @@ def main():
         "priorities": cmd_priorities,
         "curate": cmd_curate,
         "sync": cmd_sync,
+        "ui": cmd_ui,
     }
     try:
         return commands[args.command](args)

--- a/palaia/cli_args.py
+++ b/palaia/cli_args.py
@@ -279,6 +279,12 @@ def build_parser() -> argparse.ArgumentParser:
     # upgrade
     sub.add_parser("upgrade", help="Upgrade palaia to latest version (auto-detects install method and extras)")
 
+    # ui — local WebUI memory explorer
+    p_ui = sub.add_parser("ui", help="Launch the palaia WebUI in the browser")
+    p_ui.add_argument("--host", default="127.0.0.1", help="Host to bind (default: 127.0.0.1, localhost only)")
+    p_ui.add_argument("--port", type=int, default=8384, help="Port to bind (default: 8384, will fall back if busy)")
+    p_ui.add_argument("--no-browser", action="store_true", help="Do not auto-open the browser")
+
     # embed-server
     p_embed = sub.add_parser("embed-server", help="Start long-lived embedding server (JSON-RPC)")
     p_embed.add_argument("--socket", action="store_true", help="Use Unix socket transport instead of stdio")

--- a/palaia/web/__init__.py
+++ b/palaia/web/__init__.py
@@ -1,0 +1,1 @@
+"""palaia WebUI — local memory explorer (FastAPI)."""

--- a/palaia/web/app.py
+++ b/palaia/web/app.py
@@ -1,0 +1,53 @@
+"""FastAPI application factory for the palaia WebUI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+
+def create_app(palaia_root: Path | None = None) -> "FastAPI":
+    """Create and configure the FastAPI application.
+
+    Args:
+        palaia_root: Path to .palaia directory. Auto-detected if None.
+
+    Raises:
+        RuntimeError: if palaia is not initialized.
+    """
+    from fastapi import FastAPI
+    from fastapi.staticfiles import StaticFiles
+
+    from palaia import __version__
+    from palaia.config import find_palaia_root
+
+    root = palaia_root or find_palaia_root()
+    if root is None:
+        raise RuntimeError("palaia not initialized. Run: palaia init")
+
+    app = FastAPI(
+        title="palaia Memory Explorer",
+        description="Local memory browser for palaia",
+        version=__version__,
+        docs_url=None,  # no public docs page
+        redoc_url=None,
+    )
+    app.state.palaia_root = root
+
+    # Routes
+    from palaia.web.routes.entries import router as entries_router
+    from palaia.web.routes.search import router as search_router
+    from palaia.web.routes.status import router as status_router
+
+    app.include_router(status_router, prefix="/api")
+    app.include_router(entries_router, prefix="/api")
+    app.include_router(search_router, prefix="/api")
+
+    # Static assets
+    static_dir = Path(__file__).parent / "static"
+    app.mount("/", StaticFiles(directory=str(static_dir), html=True), name="static")
+
+    return app

--- a/palaia/web/routes/__init__.py
+++ b/palaia/web/routes/__init__.py
@@ -1,0 +1,1 @@
+"""WebUI API routes."""

--- a/palaia/web/routes/entries.py
+++ b/palaia/web/routes/entries.py
@@ -1,0 +1,314 @@
+"""Entry CRUD routes.
+
+v2.6 semantics:
+- Tasks are post-its: setting status=done/wontfix on a task deletes it.
+- Auto-capture entries carry the 'auto-capture' tag; manual entries do not.
+  Manual entries rank 30% higher in recall (visible via is_manual flag).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Query, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+router = APIRouter(tags=["entries"])
+
+
+# Valid values (match palaia core enums — no drift)
+VALID_TYPES = {"memory", "process", "task"}
+VALID_SCOPES = {"private", "team", "public"}
+VALID_STATUSES = {"open", "in-progress", "done", "wontfix"}
+VALID_PRIORITIES = {"low", "medium", "high", "critical"}
+
+# Task statuses that trigger deletion (post-it behavior)
+TASK_TERMINAL_STATUSES = {"done", "wontfix"}
+
+
+class EntryCreate(BaseModel):
+    body: str
+    title: str | None = None
+    type: str = "memory"
+    scope: str = "team"
+    tags: list[str] = []
+    project: str | None = None
+    status: str | None = None
+    priority: str | None = None
+    assignee: str | None = None
+    due_date: str | None = None
+
+
+class EntryPatch(BaseModel):
+    body: str | None = None
+    title: str | None = None
+    type: str | None = None
+    tags: list[str] | None = None
+    status: str | None = None
+    priority: str | None = None
+    assignee: str | None = None
+    due_date: str | None = None
+
+
+def _validate_enum(value: str | None, valid: set[str], field: str) -> str | None:
+    if value is None:
+        return None
+    if value not in valid:
+        raise ValueError(f"Invalid {field}: {value!r}. Allowed: {sorted(valid)}")
+    return value
+
+
+def _entry_to_dict(meta: dict, body: str, tier: str, *, preview: bool = True) -> dict:
+    """Convert store entry to JSON-serializable dict with v2.6 flags."""
+    tags = meta.get("tags", []) or []
+    is_auto = "auto-capture" in tags
+    return {
+        "id": meta.get("id", ""),
+        "title": meta.get("title", ""),
+        "type": meta.get("type", "memory"),
+        "scope": meta.get("scope", "team"),
+        "tier": tier,
+        "tags": tags,
+        "project": meta.get("project"),
+        "status": meta.get("status"),
+        "priority": meta.get("priority"),
+        "assignee": meta.get("assignee"),
+        "due_date": meta.get("due_date"),
+        "agent": meta.get("agent"),
+        "created": meta.get("created", ""),
+        "accessed": meta.get("accessed", ""),
+        "access_count": meta.get("access_count", 0),
+        "decay_score": meta.get("decay_score", 0),
+        "is_auto_capture": is_auto,
+        "is_manual": not is_auto,
+        "body_preview": (body[:200] + "…") if preview and len(body) > 200 else body,
+    }
+
+
+@router.get("/entries")
+def list_entries(
+    request: Request,
+    tier: str | None = Query(None, description="hot|warm|cold"),
+    type: str | None = Query(None, description="memory|process|task"),
+    scope: str | None = Query(None, description="private|team|public"),
+    project: str | None = Query(None),
+    status: str | None = Query(None),
+    priority: str | None = Query(None),
+    agent: str | None = Query(None, description="Filter by agent attribution"),
+    tag: str | None = Query(None),
+    source: str | None = Query(None, description="manual|auto"),
+    limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+) -> dict:
+    """List entries with filters. v2.6 adds scope, agent, and source (manual/auto) filters."""
+    from palaia.services.query import list_entries as svc_list
+
+    root = request.app.state.palaia_root
+    tag_filters = [tag] if tag else None
+
+    try:
+        _validate_enum(type, VALID_TYPES, "type")
+        _validate_enum(scope, VALID_SCOPES, "scope")
+        _validate_enum(status, VALID_STATUSES, "status")
+        _validate_enum(priority, VALID_PRIORITIES, "priority")
+    except ValueError as exc:
+        return JSONResponse(status_code=422, content={"error": str(exc)})
+
+    result = svc_list(
+        root,
+        tier=tier,
+        list_all=(tier is None),
+        entry_type=type,
+        project=project,
+        status=status,
+        priority=priority,
+        scope=scope,
+        tag_filters=tag_filters,
+        agent_filter=agent,
+        agent_names={agent} if agent else None,
+    )
+
+    entries = [_entry_to_dict(meta, body, t) for meta, body, t in result["entries_with_tier"]]
+
+    # Filter by source (manual|auto) — post-query because it's a computed flag
+    if source == "manual":
+        entries = [e for e in entries if e["is_manual"]]
+    elif source == "auto":
+        entries = [e for e in entries if e["is_auto_capture"]]
+
+    # Sort: manual entries get 1.3x boost to reflect recall ranking
+    def _rank(e: dict) -> float:
+        base = e.get("decay_score") or 0.0
+        return base * (1.3 if e["is_manual"] else 1.0)
+
+    entries.sort(key=_rank, reverse=True)
+
+    total = len(entries)
+    entries = entries[offset : offset + limit]
+
+    return {
+        "entries": entries,
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+    }
+
+
+@router.get("/entries/{entry_id}")
+def get_entry(request: Request, entry_id: str) -> dict:
+    """Get a single entry with full body."""
+    from palaia.services.query import get_entry as svc_get
+
+    root = request.app.state.palaia_root
+    result = svc_get(root, entry_id)
+
+    if "error" in result:
+        return JSONResponse(status_code=404, content=result)
+
+    # Augment with v2.6 flags
+    meta = result.get("meta", {}) or {}
+    tags = meta.get("tags", []) or []
+    result["is_auto_capture"] = "auto-capture" in tags
+    result["is_manual"] = not result["is_auto_capture"]
+    return result
+
+
+@router.post("/entries", status_code=201)
+def create_entry(request: Request, payload: EntryCreate) -> dict:
+    """Create a new entry. Scope and type are validated server-side."""
+    from palaia.store import Store
+
+    try:
+        _validate_enum(payload.type, VALID_TYPES, "type")
+        _validate_enum(payload.scope, VALID_SCOPES, "scope")
+        _validate_enum(payload.status, VALID_STATUSES, "status")
+        _validate_enum(payload.priority, VALID_PRIORITIES, "priority")
+    except ValueError as exc:
+        return JSONResponse(status_code=422, content={"error": str(exc)})
+
+    # v2.6: creating a task in terminal state makes no sense
+    if payload.type == "task" and payload.status in TASK_TERMINAL_STATUSES:
+        return JSONResponse(
+            status_code=422,
+            content={"error": f"Cannot create task with status={payload.status!r} — tasks are post-its, use status=open"},
+        )
+
+    root = request.app.state.palaia_root
+    store = Store(root)
+    store.recover()
+
+    try:
+        entry_id = store.write(
+            body=payload.body,
+            title=payload.title,
+            entry_type=payload.type,
+            scope=payload.scope,
+            tags=payload.tags or None,
+            project=payload.project,
+            status=payload.status,
+            priority=payload.priority,
+            assignee=payload.assignee,
+            due_date=payload.due_date,
+        )
+    except ValueError as exc:
+        return JSONResponse(status_code=422, content={"error": str(exc)})
+
+    return {"id": entry_id, "status": "created"}
+
+
+@router.patch("/entries/{entry_id}")
+def patch_entry(request: Request, entry_id: str, payload: EntryPatch) -> dict:
+    """Update fields on an entry (partial).
+
+    v2.6: if current type is 'task' and new status is done/wontfix, the entry
+    is deleted (post-it behavior). Response includes deleted=True.
+    """
+    from palaia.services.query import get_entry as svc_get
+    from palaia.store import Store
+
+    try:
+        _validate_enum(payload.type, VALID_TYPES, "type")
+        _validate_enum(payload.status, VALID_STATUSES, "status")
+        _validate_enum(payload.priority, VALID_PRIORITIES, "priority")
+    except ValueError as exc:
+        return JSONResponse(status_code=422, content={"error": str(exc)})
+
+    root = request.app.state.palaia_root
+
+    # Check if this patch triggers post-it deletion
+    existing = svc_get(root, entry_id)
+    if "error" in existing:
+        return JSONResponse(status_code=404, content=existing)
+
+    existing_meta = existing.get("meta", {}) or {}
+    existing_type = existing_meta.get("type", "memory")
+    new_type = payload.type or existing_type
+
+    if new_type == "task" and payload.status in TASK_TERMINAL_STATUSES:
+        # Post-it: delete instead of update
+        store = Store(root)
+        store.recover()
+        try:
+            store.delete(entry_id)
+        except ValueError as exc:
+            return JSONResponse(status_code=404, content={"error": str(exc)})
+        return {
+            "id": entry_id,
+            "status": "deleted",
+            "deleted": True,
+            "reason": f"task terminal status ({payload.status})",
+        }
+
+    # Normal update path
+    kwargs: dict = {}
+    if payload.body is not None:
+        kwargs["body"] = payload.body
+    if payload.title is not None:
+        kwargs["title"] = payload.title
+    if payload.type is not None:
+        kwargs["entry_type"] = payload.type
+    if payload.tags is not None:
+        kwargs["tags"] = payload.tags
+    if payload.status is not None:
+        kwargs["status"] = payload.status
+    if payload.priority is not None:
+        kwargs["priority"] = payload.priority
+    if payload.assignee is not None:
+        kwargs["assignee"] = payload.assignee
+    if payload.due_date is not None:
+        kwargs["due_date"] = payload.due_date
+
+    if not kwargs:
+        return JSONResponse(status_code=400, content={"error": "No fields to update"})
+
+    store = Store(root)
+    store.recover()
+
+    try:
+        meta = store.edit(entry_id, **kwargs)
+    except ValueError as exc:
+        return JSONResponse(status_code=404, content={"error": str(exc)})
+    except PermissionError as exc:
+        return JSONResponse(status_code=403, content={"error": str(exc)})
+
+    return {
+        "id": meta.get("id", entry_id),
+        "status": "updated",
+        "updated_fields": list(kwargs.keys()),
+    }
+
+
+@router.delete("/entries/{entry_id}")
+def delete_entry(request: Request, entry_id: str) -> dict:
+    """Delete an entry by ID."""
+    from palaia.store import Store
+
+    root = request.app.state.palaia_root
+    store = Store(root)
+    store.recover()
+
+    try:
+        store.delete(entry_id)
+    except ValueError as exc:
+        return JSONResponse(status_code=404, content={"error": str(exc)})
+
+    return {"id": entry_id, "status": "deleted"}

--- a/palaia/web/routes/search.py
+++ b/palaia/web/routes/search.py
@@ -1,0 +1,109 @@
+"""Search route with BM25 fallback on embedding timeout.
+
+Single-user local UI only. The BM25 fallback mutates engine.has_embeddings
+which would race under concurrent load, but uvicorn defaults to one worker
+and the UI is bound to 127.0.0.1.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import logging
+
+from fastapi import APIRouter, Query, Request
+
+logger = logging.getLogger(__name__)
+router = APIRouter(tags=["search"])
+
+SEARCH_TIMEOUT_SECONDS = 5.0
+
+
+@router.get("/search")
+def search(
+    request: Request,
+    q: str = Query(..., description="Search query"),
+    limit: int = Query(20, ge=1, le=100),
+    type: str | None = Query(None),
+    project: str | None = Query(None),
+    status: str | None = Query(None),
+    priority: str | None = Query(None),
+    include_cold: bool = Query(False),
+    timeout: float = Query(SEARCH_TIMEOUT_SECONDS, ge=0.5, le=30),
+) -> dict:
+    """Hybrid search (BM25 + embeddings) with graceful BM25 fallback."""
+    from palaia.services.query import search_entries
+
+    root = request.app.state.palaia_root
+
+    def _run():
+        return search_entries(
+            root,
+            q,
+            limit=limit,
+            entry_type=type,
+            project=project,
+            status=status,
+            priority=priority,
+            include_cold=include_cold,
+        )
+
+    timed_out = False
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+            result = ex.submit(_run).result(timeout=timeout)
+    except (concurrent.futures.TimeoutError, TimeoutError):
+        logger.warning("search exceeded %.1fs, falling back to BM25", timeout)
+        timed_out = True
+        try:
+            result = _bm25_only(
+                root, q,
+                limit=limit, entry_type=type, project=project,
+                status=status, priority=priority, include_cold=include_cold,
+            )
+        except Exception as exc:
+            logger.error("BM25 fallback failed: %s", exc)
+            result = {"results": [], "has_embeddings": False, "bm25_only": True}
+
+    # Augment results with manual/auto flags
+    for r in result.get("results", []):
+        tags = r.get("tags", []) or []
+        r["is_auto_capture"] = "auto-capture" in tags
+        r["is_manual"] = not r["is_auto_capture"]
+
+    return {
+        "query": q,
+        "results": result.get("results", []),
+        "has_embeddings": result.get("has_embeddings", False),
+        "bm25_only": result.get("bm25_only", True),
+        "timed_out": timed_out,
+        "count": len(result.get("results", [])),
+    }
+
+
+def _bm25_only(
+    root, query: str, *, limit: int, entry_type, project, status, priority, include_cold,
+) -> dict:
+    from palaia.search import SearchEngine
+    from palaia.store import Store
+
+    store = Store(root)
+    store.recover()
+    engine = SearchEngine(store)
+
+    # Mutate: safe because single-worker localhost.
+    original = engine.has_embeddings
+    engine.has_embeddings = False
+    try:
+        results = engine.search(
+            query,
+            top_k=limit,
+            include_cold=include_cold,
+            project=project,
+            entry_type=entry_type,
+            status=status,
+            priority=priority,
+        )
+    finally:
+        engine.has_embeddings = original
+
+    return {"results": results, "has_embeddings": False, "bm25_only": True}

--- a/palaia/web/routes/status.py
+++ b/palaia/web/routes/status.py
@@ -1,0 +1,119 @@
+"""Status, stats, projects, agents, and doctor routes."""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Request
+
+router = APIRouter(tags=["status"])
+
+
+@router.get("/status")
+def get_status(request: Request) -> dict:
+    """System overview: version, counts, tiers."""
+    from palaia.services.status import collect_status
+
+    root = request.app.state.palaia_root
+    info = collect_status(root)
+    return {
+        "version": info.get("version", "unknown"),
+        "entries": info.get("entries", {}),
+        "total": info.get("total", 0),
+        "total_chars": info.get("total_chars", 0),
+        "disk_bytes": info.get("disk_bytes", 0),
+        "project_count": info.get("project_count", 0),
+        "type_counts": info.get("type_counts", {}),
+        "task_status_counts": info.get("task_status_counts", {}),
+        "wal_pending": info.get("wal_pending", 0),
+        "last_write": info.get("last_write"),
+    }
+
+
+@router.get("/stats")
+def get_stats(request: Request) -> dict:
+    """Dashboard aggregates, including manual vs auto split."""
+    from palaia.services.status import collect_status
+    from palaia.store import Store
+
+    root = request.app.state.palaia_root
+    info = collect_status(root)
+
+    # Manual vs auto-capture split (reads tier files directly via Store)
+    store = Store(root)
+    store.recover()
+    manual = 0
+    auto = 0
+    for meta, _body, _tier in store.all_entries_unfiltered(include_cold=True):
+        if "auto-capture" in (meta.get("tags") or []):
+            auto += 1
+        else:
+            manual += 1
+
+    return {
+        "total_entries": info.get("total", 0),
+        "by_tier": info.get("entries", {}),
+        "by_type": info.get("type_counts", {}),
+        "task_statuses": info.get("task_status_counts", {}),
+        "total_chars": info.get("total_chars", 0),
+        "disk_bytes": info.get("disk_bytes", 0),
+        "projects": info.get("project_count", 0),
+        "by_source": {"manual": manual, "auto_capture": auto},
+    }
+
+
+@router.get("/projects")
+def list_projects(request: Request) -> dict:
+    """List projects from projects.json."""
+    root = request.app.state.palaia_root
+    projects_file = root / "projects.json"
+    projects: dict = {}
+    if projects_file.exists():
+        try:
+            projects = json.loads(projects_file.read_text())
+        except (OSError, json.JSONDecodeError):
+            pass
+    return {"projects": projects}
+
+
+@router.get("/agents")
+def list_agents(request: Request) -> dict:
+    """List distinct agent names found in entries."""
+    from palaia.store import Store
+
+    root = request.app.state.palaia_root
+    store = Store(root)
+    store.recover()
+    agents: set[str] = set()
+    for meta, _body, _tier in store.all_entries_unfiltered(include_cold=True):
+        agent = meta.get("agent")
+        if agent:
+            agents.add(agent)
+    return {"agents": sorted(agents)}
+
+
+@router.get("/doctor")
+def run_doctor(request: Request) -> dict:
+    """Run palaia doctor and return results for the UI banner.
+
+    Returns a summary (counts) and the full check list so the UI can show
+    an actionable banner on warnings/errors without crowding the main view.
+    """
+    from palaia.doctor import run_doctor as _run_doctor
+
+    root = request.app.state.palaia_root
+    results = _run_doctor(root)
+
+    counts = {"ok": 0, "info": 0, "warn": 0, "error": 0}
+    for r in results:
+        status = r.get("status", "ok")
+        # Normalize 'warning' → 'warn' (one check uses the long form)
+        if status == "warning":
+            status = "warn"
+        counts[status] = counts.get(status, 0) + 1
+
+    return {
+        "counts": counts,
+        "has_issues": counts.get("warn", 0) + counts.get("error", 0) > 0,
+        "checks": results,
+    }

--- a/palaia/web/static/app.js
+++ b/palaia/web/static/app.js
@@ -1,0 +1,605 @@
+// palaia WebUI — local memory explorer
+// Vanilla JS, no build step. Uses event delegation instead of inline onclick.
+//
+// v2.6 UX:
+// - Manual entries highlighted with a boost badge (1.3x recall weight)
+// - Tasks are post-its: completing deletes the entry
+// - Doctor health banner shows actionable issues
+
+(() => {
+  "use strict";
+
+  // ── State ────────────────────────────────────────────────────────────────
+  const state = {
+    entries: [],
+    searchMode: false,
+    currentEntryId: null,
+    currentEntryData: null,
+    filters: { type: "", source: "", scope: "", tier: "", project: "", agent: "", status: "" },
+  };
+
+  // ── DOM helpers ──────────────────────────────────────────────────────────
+  const $ = (id) => document.getElementById(id);
+  const $$ = (sel, ctx = document) => Array.from(ctx.querySelectorAll(sel));
+
+  function esc(s) {
+    if (s == null) return "";
+    const d = document.createElement("div");
+    d.textContent = String(s);
+    return d.innerHTML;
+  }
+
+  function el(tag, attrs = {}, ...children) {
+    const n = document.createElement(tag);
+    for (const [k, v] of Object.entries(attrs)) {
+      if (k === "class") n.className = v;
+      else if (k === "dataset") Object.assign(n.dataset, v);
+      else if (k.startsWith("on") && typeof v === "function") n.addEventListener(k.slice(2), v);
+      else if (v !== null && v !== undefined && v !== false) n.setAttribute(k, v);
+    }
+    for (const c of children) {
+      if (c == null || c === false) continue;
+      n.appendChild(typeof c === "string" ? document.createTextNode(c) : c);
+    }
+    return n;
+  }
+
+  // ── API client ───────────────────────────────────────────────────────────
+  async function api(path, opts) {
+    const resp = await fetch(path, opts);
+    if (!resp.ok) {
+      let detail = resp.statusText;
+      try {
+        const body = await resp.json();
+        detail = body.error || JSON.stringify(body);
+      } catch (_) { /* ignore */ }
+      throw new Error(`${resp.status}: ${detail}`);
+    }
+    if (resp.status === 204) return null;
+    return resp.json();
+  }
+  const apiGet = (p) => api(p);
+  const apiPost = (p, d) => api(p, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(d),
+  });
+  const apiPatch = (p, d) => api(p, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(d),
+  });
+  const apiDelete = (p) => api(p, { method: "DELETE" });
+
+  // ── Toast ────────────────────────────────────────────────────────────────
+  function toast(msg, kind = "info") {
+    const t = $("toast");
+    t.textContent = msg;
+    t.className = `toast toast-${kind} toast-visible`;
+    clearTimeout(toast._timer);
+    toast._timer = setTimeout(() => { t.className = "toast"; }, 3000);
+  }
+
+  // ── Date formatting ──────────────────────────────────────────────────────
+  function fmtDate(iso) {
+    if (!iso) return "—";
+    try {
+      const d = new Date(iso);
+      if (isNaN(d.getTime())) return iso;
+      return d.toLocaleDateString() + " " + d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+    } catch { return iso; }
+  }
+
+  // ── Initial loads ────────────────────────────────────────────────────────
+  async function loadStatus() {
+    try {
+      const d = await apiGet("/api/status");
+      $("stat-total").textContent = d.total + " entries";
+      $("stat-version").textContent = "v" + d.version;
+    } catch (e) { /* non-fatal */ }
+  }
+
+  async function loadProjects() {
+    try {
+      const d = await apiGet("/api/projects");
+      const sel = $("filter-project");
+      for (const name of Object.keys(d.projects || {})) {
+        sel.appendChild(el("option", { value: name }, name));
+      }
+    } catch (e) { /* non-fatal */ }
+  }
+
+  async function loadAgents() {
+    try {
+      const d = await apiGet("/api/agents");
+      const sel = $("filter-agent");
+      for (const name of d.agents || []) {
+        sel.appendChild(el("option", { value: name }, name));
+      }
+    } catch (e) { /* non-fatal */ }
+  }
+
+  async function loadDoctor() {
+    try {
+      const d = await apiGet("/api/doctor");
+      const pill = $("health-pill");
+      const label = $("health-label");
+      const counts = d.counts || {};
+      const warn = counts.warn || 0;
+      const err = counts.error || 0;
+
+      pill.hidden = false;
+      if (err > 0) {
+        pill.className = "health-pill health-error";
+        label.textContent = `${err + warn} issues`;
+      } else if (warn > 0) {
+        pill.className = "health-pill health-warn";
+        label.textContent = `${warn} warning${warn > 1 ? "s" : ""}`;
+      } else {
+        pill.className = "health-pill health-ok";
+        label.textContent = "healthy";
+      }
+
+      // Auto-show banner only when there are warn/error items
+      if (d.has_issues) {
+        renderDoctorList(d.checks);
+        $("doctor-banner").hidden = false;
+      } else {
+        $("doctor-banner").hidden = true;
+      }
+    } catch (e) { /* non-fatal */ }
+  }
+
+  function renderDoctorList(checks) {
+    const list = $("doctor-list");
+    list.innerHTML = "";
+    for (const c of checks || []) {
+      const status = c.status === "warning" ? "warn" : c.status;
+      if (status !== "warn" && status !== "error") continue;
+      const li = el("li", { class: `doctor-item doctor-${status}` },
+        el("span", { class: "doctor-label" }, c.label || c.name || ""),
+        el("span", { class: "doctor-msg" }, c.message || ""),
+      );
+      if (c.fix) li.appendChild(el("code", { class: "doctor-fix" }, c.fix));
+      list.appendChild(li);
+    }
+  }
+
+  // ── Entry list ───────────────────────────────────────────────────────────
+  async function loadEntries() {
+    const params = new URLSearchParams({ limit: "100" });
+    for (const [key, val] of Object.entries(state.filters)) {
+      if (val) params.set(key, val);
+    }
+    try {
+      const d = await apiGet("/api/entries?" + params);
+      state.entries = d.entries;
+      renderEntries(d.entries, d.total, false);
+    } catch (e) {
+      $("entry-list").innerHTML = '<div class="loading">Error: ' + esc(e.message) + "</div>";
+    }
+  }
+
+  async function doSearch() {
+    const q = $("search-input").value.trim();
+    if (!q) { clearSearch(); return; }
+    const params = new URLSearchParams({ q, limit: "30" });
+    if (state.filters.type) params.set("type", state.filters.type);
+    if (state.filters.project) params.set("project", state.filters.project);
+    if (state.filters.status) params.set("status", state.filters.status);
+
+    $("entry-list").innerHTML = '<div class="loading">Searching…</div>';
+    try {
+      const d = await apiGet("/api/search?" + params);
+      state.searchMode = true;
+      const entries = (d.results || []).map((r) => ({
+        id: r.id, title: r.title, type: r.type, scope: r.scope, tier: r.tier,
+        tags: r.tags || [], project: r.project, status: r.status, priority: r.priority,
+        decay_score: r.decay_score, body_preview: r.body || r.content,
+        score: r.score, is_manual: r.is_manual, is_auto_capture: r.is_auto_capture,
+        agent: r.agent,
+      }));
+      state.entries = entries;
+      const extra = d.timed_out ? " (BM25 only)" : (d.bm25_only ? " (BM25)" : "");
+      renderEntries(entries, d.count, true, extra);
+    } catch (e) {
+      $("entry-list").innerHTML = '<div class="loading">Search error: ' + esc(e.message) + "</div>";
+    }
+  }
+
+  function clearSearch() {
+    state.searchMode = false;
+    closeDetail();
+    loadEntries();
+  }
+
+  function applyFiltersThenReload() {
+    for (const sel of $$("[data-filter]")) {
+      state.filters[sel.dataset.filter] = sel.value;
+    }
+    if (state.searchMode) doSearch();
+    else loadEntries();
+  }
+
+  function renderEntries(entries, total, isSearch, extra = "") {
+    const list = $("entry-list");
+    const count = $("result-count");
+
+    if (!entries.length) {
+      list.innerHTML = '<div class="loading">No entries found.</div>';
+      count.textContent = "";
+      return;
+    }
+    count.textContent = isSearch
+      ? `${total} result${total !== 1 ? "s" : ""}${extra}`
+      : `Showing ${entries.length} of ${total} entries`;
+
+    list.innerHTML = "";
+    for (const e of entries) {
+      list.appendChild(renderEntryCard(e));
+    }
+  }
+
+  function renderEntryCard(e) {
+    const scoreText = e.score != null
+      ? "score: " + Number(e.score).toFixed(3)
+      : "decay: " + Number(e.decay_score || 0).toFixed(2);
+
+    const card = el("div", {
+      class: "entry-card" + (e.is_manual ? " is-manual" : " is-auto"),
+      dataset: { id: e.id, action: "show-detail" },
+    });
+
+    // Header
+    const header = el("div", { class: "entry-header" },
+      el("span", { class: "entry-title" }, e.title || "(untitled)"),
+      el("span", { class: "entry-score" }, scoreText),
+    );
+    card.appendChild(header);
+
+    // Meta line
+    const meta = el("div", { class: "entry-meta" });
+    meta.appendChild(el("span", { class: "badge badge-tier badge-" + (e.tier || "hot") }, e.tier || "hot"));
+    meta.appendChild(el("span", { class: "badge badge-type badge-" + (e.type || "memory") }, e.type || "memory"));
+    meta.appendChild(el("span", { class: "badge badge-source " + (e.is_manual ? "badge-manual" : "badge-auto") },
+      e.is_manual ? "manual ✦" : "auto"));
+    if (e.priority) meta.appendChild(el("span", { class: "badge badge-priority-" + e.priority }, e.priority));
+    if (e.status) meta.appendChild(el("span", { class: "badge badge-status" }, e.status));
+    if (e.scope && e.scope !== "team") meta.appendChild(el("span", { class: "badge badge-scope" }, e.scope));
+    if (e.project) meta.appendChild(el("span", { class: "badge badge-project" }, e.project));
+    if (e.agent) meta.appendChild(el("span", { class: "badge badge-agent" }, "@" + e.agent));
+    for (const tag of (e.tags || []).slice(0, 4)) {
+      if (tag === "auto-capture") continue; // already shown via source badge
+      meta.appendChild(el("span", { class: "tag" }, tag));
+    }
+    card.appendChild(meta);
+
+    // Preview
+    if (e.body_preview) {
+      card.appendChild(el("div", { class: "entry-preview" }, e.body_preview));
+    }
+    return card;
+  }
+
+  // ── Detail (inline expand) ───────────────────────────────────────────────
+  async function showDetail(id) {
+    const existing = $("inline-detail-" + id);
+    const card = document.querySelector(`.entry-card[data-id="${id}"]`);
+    if (existing) {
+      existing.remove();
+      if (card) card.classList.remove("active");
+      state.currentEntryId = null;
+      state.currentEntryData = null;
+      return;
+    }
+    // Close previously open detail
+    $$(".inline-detail").forEach(n => n.remove());
+    $$(".entry-card").forEach(c => c.classList.remove("active"));
+    if (card) card.classList.add("active");
+
+    try {
+      const d = await apiGet("/api/entries/" + encodeURIComponent(id));
+      state.currentEntryId = id;
+      state.currentEntryData = d;
+      const det = renderDetailPanel(id, d);
+      if (card) {
+        card.after(det);
+        det.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      }
+    } catch (e) {
+      toast("Load failed: " + e.message, "error");
+    }
+  }
+
+  function renderDetailPanel(id, d) {
+    const m = d.meta || {};
+    const isManual = d.is_manual ?? !(m.tags || []).includes("auto-capture");
+
+    const rows = [
+      ["Type", m.type || "memory"],
+      ["Scope", m.scope || "team"],
+      ["Tier", m.tier || "—"],
+      ["Source", isManual ? "manual (1.3× boost)" : "auto-capture"],
+      ["Created", fmtDate(m.created)],
+      ["Accessed", fmtDate(m.accessed)],
+      ["Decay", Number(m.decay_score || 0).toFixed(4)],
+      ["Tags", (m.tags || []).join(", ") || "—"],
+      ["Agent", m.agent || "—"],
+    ];
+    if (m.priority) rows.push(["Priority", m.priority]);
+    if (m.status) rows.push(["Status", m.status]);
+    if (m.assignee) rows.push(["Assignee", m.assignee]);
+    if (m.due_date) rows.push(["Due", m.due_date]);
+    if (m.project) rows.push(["Project", m.project]);
+
+    const dl = el("dl", { class: "detail-meta" });
+    for (const [k, v] of rows) {
+      dl.appendChild(el("dt", {}, k));
+      dl.appendChild(el("dd", {}, String(v)));
+    }
+
+    const toolbar = el("div", { class: "detail-toolbar" },
+      el("h2", {}, m.title || "(untitled)"),
+      el("div", { class: "detail-actions" },
+        el("button", { class: "btn-secondary btn-small", dataset: { action: "edit-current" } }, "Edit"),
+        el("button", { class: "btn-danger btn-small", dataset: { action: "delete-current" } }, "Delete"),
+        el("button", { class: "btn-icon", dataset: { action: "close-detail", id } }, "✕"),
+      ),
+    );
+
+    const body = el("pre", { class: "detail-body" }, d.content || "");
+
+    return el("div", { id: "inline-detail-" + id, class: "inline-detail" }, toolbar, dl, body);
+  }
+
+  function closeDetail() {
+    $$(".inline-detail").forEach(n => n.remove());
+    $$(".entry-card").forEach(c => c.classList.remove("active"));
+    state.currentEntryId = null;
+    state.currentEntryData = null;
+  }
+
+  // ── Tasks panel (post-it UX) ─────────────────────────────────────────────
+  async function loadTasks() {
+    try {
+      const d = await apiGet("/api/entries?type=task&status=open&limit=100");
+      // Also fetch in-progress
+      const d2 = await apiGet("/api/entries?type=task&status=in-progress&limit=100");
+      const tasks = [...d.entries, ...d2.entries];
+      renderTasks(tasks);
+    } catch (e) { /* non-fatal */ }
+  }
+
+  function renderTasks(tasks) {
+    const list = $("task-list");
+    list.innerHTML = "";
+    if (!tasks.length) {
+      list.appendChild(el("div", { class: "tasks-empty" }, "No active tasks."));
+      return;
+    }
+    for (const t of tasks) {
+      const item = el("div", { class: "task-item", dataset: { id: t.id } });
+      item.appendChild(el("button", {
+        class: "task-done",
+        dataset: { action: "task-done", id: t.id },
+        title: "Mark done (deletes post-it)",
+      }, "✓"));
+      const body = el("div", { class: "task-body" });
+      body.appendChild(el("div", { class: "task-title" }, t.title || t.body_preview || "(untitled)"));
+      const metaLine = el("div", { class: "task-meta" });
+      if (t.priority) metaLine.appendChild(el("span", { class: "badge badge-priority-" + t.priority }, t.priority));
+      if (t.status && t.status !== "open") metaLine.appendChild(el("span", { class: "badge badge-status" }, t.status));
+      if (t.due_date) metaLine.appendChild(el("span", { class: "task-due" }, "due " + t.due_date));
+      body.appendChild(metaLine);
+      item.appendChild(body);
+      list.appendChild(item);
+    }
+  }
+
+  async function completeTask(id) {
+    try {
+      const resp = await apiPatch("/api/entries/" + encodeURIComponent(id), { status: "done" });
+      if (resp && resp.deleted) {
+        toast("Task completed (deleted)", "success");
+      } else {
+        toast("Task marked done", "success");
+      }
+      loadTasks();
+      loadStatus();
+      if (!state.searchMode) loadEntries();
+    } catch (e) {
+      toast("Failed: " + e.message, "error");
+    }
+  }
+
+  // ── Create/Edit modal ────────────────────────────────────────────────────
+  function openCreateModal(prefill = {}) {
+    $("form-id").value = "";
+    $("form-body").value = prefill.body || "";
+    $("form-title").value = "";
+    $("form-type").value = prefill.type || "memory";
+    $("form-scope").value = "team";
+    $("form-project").value = "";
+    $("form-tags").value = "";
+    $("form-agent").value = "";
+    $("form-priority").value = "";
+    $("form-status").value = prefill.status || "";
+    $("form-assignee").value = "";
+    $("form-due").value = "";
+    $("modal-title").textContent = "New Entry";
+    $("form-submit-btn").textContent = "Create";
+    toggleTaskFields();
+    $("modal-overlay").hidden = false;
+    $("form-body").focus();
+  }
+
+  function openEditModal() {
+    if (!state.currentEntryData) return;
+    const d = state.currentEntryData;
+    const m = d.meta || {};
+    $("form-id").value = state.currentEntryId;
+    $("form-body").value = d.content || "";
+    $("form-title").value = m.title || "";
+    $("form-type").value = m.type || "memory";
+    $("form-scope").value = m.scope || "team";
+    $("form-project").value = m.project || "";
+    $("form-tags").value = (m.tags || []).filter(t => t !== "auto-capture").join(", ");
+    $("form-agent").value = m.agent || "";
+    $("form-priority").value = m.priority || "";
+    $("form-status").value = m.status || "";
+    $("form-assignee").value = m.assignee || "";
+    $("form-due").value = m.due_date || "";
+    $("modal-title").textContent = "Edit Entry";
+    $("form-submit-btn").textContent = "Save";
+    toggleTaskFields();
+    $("modal-overlay").hidden = false;
+    $("form-body").focus();
+  }
+
+  function closeModal() {
+    $("modal-overlay").hidden = true;
+  }
+
+  function toggleTaskFields() {
+    $("task-fields").hidden = $("form-type").value !== "task";
+  }
+
+  async function submitForm(ev) {
+    ev.preventDefault();
+    const id = $("form-id").value;
+    const isEdit = !!id;
+
+    const body = $("form-body").value.trim();
+    if (!body) { toast("Content required", "error"); return; }
+
+    const type = $("form-type").value;
+    const status = $("form-status").value || null;
+
+    // Warn before deleting a task via edit
+    if (isEdit && type === "task" && (status === "done" || status === "wontfix")) {
+      if (!confirm(`Setting status to '${status}' will delete this task (post-it behaviour). Continue?`)) return;
+    }
+
+    const payload = {
+      body,
+      title: $("form-title").value.trim() || null,
+      type,
+      scope: $("form-scope").value,
+      tags: $("form-tags").value.trim()
+        ? $("form-tags").value.split(",").map(t => t.trim()).filter(Boolean)
+        : [],
+      project: $("form-project").value.trim() || null,
+      priority: $("form-priority").value || null,
+      status,
+      assignee: $("form-assignee").value.trim() || null,
+      due_date: $("form-due").value || null,
+    };
+
+    try {
+      if (isEdit) {
+        // PATCH accepts the same field names except entry_type vs type handled server-side
+        const resp = await apiPatch("/api/entries/" + encodeURIComponent(id), payload);
+        closeModal();
+        if (resp && resp.deleted) {
+          toast("Entry deleted (task completed)", "success");
+          closeDetail();
+        } else {
+          toast("Updated", "success");
+          showDetail(id); // refresh detail
+        }
+      } else {
+        await apiPost("/api/entries", payload);
+        closeModal();
+        toast("Created", "success");
+      }
+      loadStatus();
+      loadTasks();
+      if (!state.searchMode) loadEntries();
+    } catch (e) {
+      toast("Error: " + e.message, "error");
+    }
+  }
+
+  async function deleteCurrent() {
+    if (!state.currentEntryId) return;
+    if (!confirm("Delete this entry? Cannot be undone.")) return;
+    try {
+      await apiDelete("/api/entries/" + encodeURIComponent(state.currentEntryId));
+      toast("Deleted", "success");
+      closeDetail();
+      loadStatus();
+      loadTasks();
+      if (!state.searchMode) loadEntries();
+    } catch (e) {
+      toast("Delete failed: " + e.message, "error");
+    }
+  }
+
+  // ── Event wiring (delegation) ────────────────────────────────────────────
+  function wireEvents() {
+    // Filter changes
+    for (const sel of $$("[data-filter]")) {
+      sel.addEventListener("change", applyFiltersThenReload);
+    }
+
+    // Type toggle in form
+    $("form-type").addEventListener("change", toggleTaskFields);
+
+    // Form submit
+    $("entry-form").addEventListener("submit", submitForm);
+
+    // Search input
+    $("search-input").addEventListener("keydown", (ev) => {
+      if (ev.key === "Enter") doSearch();
+      if (ev.key === "Escape") { ev.target.value = ""; clearSearch(); }
+    });
+
+    // Delegated click handler
+    document.addEventListener("click", (ev) => {
+      const target = ev.target.closest("[data-action], [data-stop-propagation]");
+      if (!target) return;
+
+      if (target.hasAttribute("data-stop-propagation")) {
+        ev.stopPropagation();
+        if (!target.hasAttribute("data-action")) return;
+      }
+
+      const action = target.dataset.action;
+      const id = target.dataset.id;
+
+      switch (action) {
+        case "search": doSearch(); break;
+        case "new-entry": openCreateModal(); break;
+        case "new-task": openCreateModal({ type: "task", status: "open" }); break;
+        case "show-detail": if (id) showDetail(id); break;
+        case "close-detail": if (id) showDetail(id); break; // same fn toggles
+        case "edit-current": openEditModal(); break;
+        case "delete-current": deleteCurrent(); break;
+        case "task-done": if (id) { ev.stopPropagation(); completeTask(id); } break;
+        case "close-modal": closeModal(); break;
+        case "close-modal-backdrop":
+          if (ev.target === $("modal-overlay")) closeModal();
+          break;
+        case "toggle-doctor":
+        case "toggle-doctor-details":
+          $("doctor-banner").hidden = false;
+          $("doctor-list").hidden = !$("doctor-list").hidden;
+          break;
+        case "close-doctor-banner":
+          $("doctor-banner").hidden = true;
+          break;
+      }
+    });
+  }
+
+  // ── Boot ─────────────────────────────────────────────────────────────────
+  document.addEventListener("DOMContentLoaded", () => {
+    wireEvents();
+    loadStatus();
+    loadProjects();
+    loadAgents();
+    loadDoctor();
+    loadEntries();
+    loadTasks();
+  });
+})();

--- a/palaia/web/static/index.html
+++ b/palaia/web/static/index.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>palaia Memory Explorer</title>
+<link rel="stylesheet" href="/style.css">
+</head>
+<body>
+<div class="app">
+
+<header class="topbar">
+  <div class="brand">
+    <span class="logo">palaia</span>
+    <span class="subtitle">Memory Explorer</span>
+  </div>
+  <div class="topbar-stats">
+    <span class="stat" id="stat-total">…</span>
+    <span class="stat" id="stat-version">…</span>
+    <button class="health-pill" id="health-pill" data-action="toggle-doctor" hidden>
+      <span class="health-dot"></span><span id="health-label">checks</span>
+    </button>
+  </div>
+</header>
+
+<!-- Doctor banner: shown when warn/error checks exist -->
+<section class="doctor-banner" id="doctor-banner" hidden>
+  <div class="doctor-banner-header">
+    <strong>Health issues detected</strong>
+    <button class="btn-link" data-action="toggle-doctor-details">Details</button>
+    <button class="btn-link" data-action="close-doctor-banner">Dismiss</button>
+  </div>
+  <ul class="doctor-list" id="doctor-list" hidden></ul>
+</section>
+
+<main class="layout">
+
+  <!-- Sidebar: filters -->
+  <aside class="sidebar">
+    <div class="search-box">
+      <input type="text" id="search-input" placeholder="Search memories…" autofocus>
+      <button data-action="search">Search</button>
+    </div>
+
+    <section class="filter-group">
+      <label>Type</label>
+      <select id="filter-type" data-filter="type">
+        <option value="">All</option>
+        <option value="memory">Memory</option>
+        <option value="process">Process</option>
+        <option value="task">Task</option>
+      </select>
+    </section>
+
+    <section class="filter-group">
+      <label>Source</label>
+      <select id="filter-source" data-filter="source">
+        <option value="">All</option>
+        <option value="manual">Manual (boosted)</option>
+        <option value="auto">Auto-capture</option>
+      </select>
+    </section>
+
+    <section class="filter-group">
+      <label>Scope</label>
+      <select id="filter-scope" data-filter="scope">
+        <option value="">All</option>
+        <option value="team">Team</option>
+        <option value="private">Private</option>
+        <option value="public">Public</option>
+      </select>
+    </section>
+
+    <section class="filter-group">
+      <label>Tier</label>
+      <select id="filter-tier" data-filter="tier">
+        <option value="">All</option>
+        <option value="hot">Hot</option>
+        <option value="warm">Warm</option>
+        <option value="cold">Cold</option>
+      </select>
+    </section>
+
+    <section class="filter-group">
+      <label>Project</label>
+      <select id="filter-project" data-filter="project"><option value="">All</option></select>
+    </section>
+
+    <section class="filter-group">
+      <label>Agent</label>
+      <select id="filter-agent" data-filter="agent"><option value="">All</option></select>
+    </section>
+
+    <section class="filter-group">
+      <label>Status</label>
+      <select id="filter-status" data-filter="status">
+        <option value="">All</option>
+        <option value="open">Open</option>
+        <option value="in-progress">In Progress</option>
+        <option value="done">Done</option>
+        <option value="wontfix">Won't fix</option>
+      </select>
+    </section>
+
+    <button class="btn-primary" data-action="new-entry">+ New Entry</button>
+  </aside>
+
+  <!-- Main content -->
+  <section class="content">
+    <div class="content-header">
+      <span class="result-count" id="result-count"></span>
+    </div>
+    <div class="entry-list" id="entry-list">
+      <div class="loading">Loading…</div>
+    </div>
+  </section>
+
+  <!-- Right sidebar: Active Tasks Panel (v2.6 post-it UX) -->
+  <aside class="tasks-panel">
+    <div class="tasks-header">
+      <h3>Active Tasks</h3>
+      <button class="btn-small" data-action="new-task">+</button>
+    </div>
+    <div class="task-list" id="task-list">
+      <div class="loading-sm">…</div>
+    </div>
+    <p class="tasks-hint">Click ✓ to complete (deletes the task).</p>
+  </aside>
+
+</main>
+
+<!-- Create/Edit modal -->
+<div class="modal-overlay" id="modal-overlay" data-action="close-modal-backdrop" hidden>
+  <div class="modal" data-stop-propagation>
+    <div class="modal-header">
+      <h2 id="modal-title">New Entry</h2>
+      <button class="btn-icon" data-action="close-modal">✕</button>
+    </div>
+    <form id="entry-form">
+      <input type="hidden" id="form-id" value="">
+
+      <label for="form-body">Content *</label>
+      <textarea id="form-body" rows="6" required placeholder="Write your memory…"></textarea>
+
+      <div class="form-row">
+        <div class="form-group">
+          <label for="form-title">Title</label>
+          <input type="text" id="form-title" placeholder="Auto-generated if empty">
+        </div>
+        <div class="form-group">
+          <label for="form-type">Type</label>
+          <select id="form-type">
+            <option value="memory">Memory</option>
+            <option value="process">Process</option>
+            <option value="task">Task (post-it)</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="form-row">
+        <div class="form-group">
+          <label for="form-scope">Scope</label>
+          <select id="form-scope">
+            <option value="team">Team</option>
+            <option value="private">Private</option>
+            <option value="public">Public</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="form-project">Project</label>
+          <input type="text" id="form-project" placeholder="optional">
+        </div>
+      </div>
+
+      <div class="form-row">
+        <div class="form-group">
+          <label for="form-tags">Tags</label>
+          <input type="text" id="form-tags" placeholder="comma,separated">
+        </div>
+        <div class="form-group">
+          <label for="form-agent">Agent</label>
+          <input type="text" id="form-agent" placeholder="optional">
+        </div>
+      </div>
+
+      <fieldset class="task-fields" id="task-fields" hidden>
+        <legend>Task fields</legend>
+        <div class="form-row">
+          <div class="form-group">
+            <label for="form-priority">Priority</label>
+            <select id="form-priority">
+              <option value="">—</option>
+              <option value="low">Low</option>
+              <option value="medium">Medium</option>
+              <option value="high">High</option>
+              <option value="critical">Critical</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label for="form-status">Status</label>
+            <select id="form-status">
+              <option value="">—</option>
+              <option value="open">Open</option>
+              <option value="in-progress">In Progress</option>
+              <option value="done">Done (deletes)</option>
+              <option value="wontfix">Won't fix (deletes)</option>
+            </select>
+          </div>
+        </div>
+        <div class="form-row">
+          <div class="form-group">
+            <label for="form-assignee">Assignee</label>
+            <input type="text" id="form-assignee" placeholder="agent name">
+          </div>
+          <div class="form-group">
+            <label for="form-due">Due Date</label>
+            <input type="date" id="form-due">
+          </div>
+        </div>
+        <p class="hint">Setting status to done/won't fix deletes the task (post-it behaviour).</p>
+      </fieldset>
+
+      <div class="form-actions">
+        <button type="button" class="btn-secondary" data-action="close-modal">Cancel</button>
+        <button type="submit" class="btn-primary" id="form-submit-btn">Create</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<div class="toast" id="toast" role="status" aria-live="polite"></div>
+</div>
+<script src="/app.js"></script>
+</body>
+</html>

--- a/palaia/web/static/style.css
+++ b/palaia/web/static/style.css
@@ -1,0 +1,580 @@
+/* palaia WebUI — dark theme, 3-column layout */
+:root {
+  --bg: #1a1b26;
+  --bg-card: #24283b;
+  --bg-soft: #1f2335;
+  --bg-hover: #2f3349;
+  --text: #c0caf5;
+  --text-dim: #7982a9;
+  --text-bright: #e0e6ff;
+  --accent: #7aa2f7;
+  --accent-dim: #3d59a1;
+  --accent-bg: rgba(122,162,247,0.12);
+  --green: #9ece6a;
+  --yellow: #e0af68;
+  --red: #f7768e;
+  --orange: #ff9e64;
+  --gold: #f0c674;
+  --border: #3b4261;
+  --radius: 8px;
+  --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --mono: "SF Mono", "Fira Code", "Cascadia Code", Consolas, monospace;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: var(--font);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.55;
+  min-height: 100vh;
+}
+
+.app {
+  max-width: 1600px;
+  margin: 0 auto;
+  padding: 16px 24px 40px;
+}
+
+/* ── Topbar ──────────────────────────────────────────────────────────── */
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 0 16px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 20px;
+}
+.brand { display: flex; align-items: baseline; gap: 10px; }
+.logo { font-size: 1.6em; color: var(--accent); font-weight: 700; letter-spacing: -0.5px; }
+.subtitle { color: var(--text-dim); font-size: 0.95em; }
+.topbar-stats { display: flex; gap: 12px; align-items: center; }
+.stat {
+  background: var(--bg-card);
+  padding: 5px 12px;
+  border-radius: var(--radius);
+  font-size: 0.82em;
+  color: var(--text-dim);
+}
+
+.health-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border-radius: 999px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 0.82em;
+  font-family: inherit;
+}
+.health-pill .health-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--text-dim);
+}
+.health-ok .health-dot { background: var(--green); }
+.health-ok { color: var(--green); }
+.health-warn .health-dot { background: var(--yellow); }
+.health-warn { color: var(--yellow); border-color: var(--yellow); }
+.health-error .health-dot { background: var(--red); }
+.health-error { color: var(--red); border-color: var(--red); }
+
+/* ── Doctor banner ───────────────────────────────────────────────────── */
+.doctor-banner {
+  background: var(--bg-card);
+  border: 1px solid var(--yellow);
+  border-left: 4px solid var(--yellow);
+  border-radius: var(--radius);
+  padding: 12px 16px;
+  margin-bottom: 18px;
+}
+.doctor-banner-header {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.doctor-banner-header strong { color: var(--yellow); font-size: 0.95em; }
+.btn-link {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 0.85em;
+  text-decoration: underline;
+  padding: 0;
+  margin-left: auto;
+  font-family: inherit;
+}
+.btn-link + .btn-link { margin-left: 12px; }
+.doctor-list {
+  list-style: none;
+  margin-top: 10px;
+  padding: 0;
+}
+.doctor-item {
+  padding: 8px 0;
+  border-top: 1px solid var(--border);
+  font-size: 0.88em;
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: 10px;
+  align-items: start;
+}
+.doctor-item .doctor-label {
+  font-weight: 600;
+  color: var(--text-bright);
+}
+.doctor-item .doctor-msg { color: var(--text-dim); }
+.doctor-item .doctor-fix {
+  display: block;
+  grid-column: 2;
+  margin-top: 6px;
+  background: var(--bg);
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-family: var(--mono);
+  font-size: 0.85em;
+  color: var(--accent);
+  border: 1px solid var(--border);
+}
+.doctor-warn .doctor-label { color: var(--yellow); }
+.doctor-error .doctor-label { color: var(--red); }
+
+/* ── 3-column layout ─────────────────────────────────────────────────── */
+.layout {
+  display: grid;
+  grid-template-columns: 240px 1fr 300px;
+  gap: 20px;
+  align-items: start;
+}
+@media (max-width: 1200px) {
+  .layout { grid-template-columns: 220px 1fr; }
+  .tasks-panel { grid-column: 1 / -1; }
+}
+@media (max-width: 800px) {
+  .layout { grid-template-columns: 1fr; }
+}
+
+/* ── Sidebar (filters) ───────────────────────────────────────────────── */
+.sidebar {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+  position: sticky;
+  top: 16px;
+  max-height: calc(100vh - 32px);
+  overflow-y: auto;
+}
+.search-box {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 14px;
+}
+.search-box input {
+  flex: 1;
+  padding: 8px 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 0.9em;
+  font-family: inherit;
+  outline: none;
+  min-width: 0;
+}
+.search-box input:focus { border-color: var(--accent); }
+.search-box button {
+  padding: 8px 14px;
+  background: var(--accent);
+  color: var(--bg);
+  border: none;
+  border-radius: var(--radius);
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+}
+.filter-group {
+  margin-bottom: 12px;
+}
+.filter-group label {
+  display: block;
+  font-size: 0.72em;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-dim);
+  margin-bottom: 4px;
+}
+.filter-group select {
+  width: 100%;
+  padding: 6px 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 0.85em;
+  font-family: inherit;
+}
+
+.btn-primary, .btn-secondary, .btn-danger {
+  padding: 9px 16px;
+  border-radius: var(--radius);
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 0.88em;
+  font-family: inherit;
+  border: none;
+  width: 100%;
+  margin-top: 6px;
+}
+.btn-primary { background: var(--green); color: var(--bg); }
+.btn-primary:hover { filter: brightness(1.1); }
+.btn-secondary { background: var(--bg); color: var(--text); border: 1px solid var(--border); width: auto; }
+.btn-secondary:hover { border-color: var(--accent); }
+.btn-danger { background: var(--red); color: var(--bg); width: auto; }
+.btn-small { padding: 5px 10px; font-size: 0.82em; width: auto; }
+.btn-icon {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  padding: 5px 10px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  font-size: 0.9em;
+}
+.btn-icon:hover { color: var(--red); border-color: var(--red); }
+
+/* ── Content (entry list) ────────────────────────────────────────────── */
+.content { min-width: 0; }
+.content-header {
+  margin-bottom: 10px;
+  font-size: 0.85em;
+  color: var(--text-dim);
+}
+.result-count { font-size: 0.85em; }
+.entry-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.entry-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--border);
+  border-radius: var(--radius);
+  padding: 12px 16px;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+}
+.entry-card:hover { background: var(--bg-hover); }
+.entry-card.active { border-color: var(--accent); }
+.entry-card.is-manual { border-left-color: var(--gold); }
+.entry-card.is-auto { border-left-color: var(--border); opacity: 0.95; }
+
+.entry-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+.entry-title {
+  font-weight: 600;
+  color: var(--text-bright);
+  font-size: 0.95em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.entry-score {
+  font-size: 0.75em;
+  color: var(--accent);
+  font-family: var(--mono);
+  flex-shrink: 0;
+}
+.entry-meta {
+  display: flex;
+  gap: 5px;
+  flex-wrap: wrap;
+  margin-bottom: 6px;
+}
+.entry-preview {
+  font-size: 0.82em;
+  color: var(--text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Badges ──────────────────────────────────────────────────────────── */
+.badge, .tag {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.72em;
+  font-weight: 600;
+  font-family: var(--font);
+}
+.tag {
+  background: var(--accent-bg);
+  color: var(--accent);
+  font-weight: 500;
+}
+.badge-hot { background: rgba(247,118,142,0.18); color: var(--red); }
+.badge-warm { background: rgba(224,175,104,0.2); color: var(--yellow); }
+.badge-cold { background: rgba(122,162,247,0.18); color: var(--accent); }
+.badge-memory { background: rgba(122,162,247,0.12); color: var(--accent); }
+.badge-task { background: rgba(158,206,106,0.15); color: var(--green); }
+.badge-process { background: rgba(255,158,100,0.15); color: var(--orange); }
+.badge-manual { background: rgba(240,198,116,0.2); color: var(--gold); }
+.badge-auto { background: transparent; color: var(--text-dim); border: 1px solid var(--border); }
+.badge-scope { background: var(--bg); color: var(--text-dim); border: 1px solid var(--border); }
+.badge-agent { background: rgba(122,162,247,0.08); color: var(--text-dim); border: 1px solid var(--border); }
+.badge-project { background: rgba(158,206,106,0.1); color: var(--green); }
+.badge-status { background: var(--bg); color: var(--text-dim); border: 1px solid var(--border); }
+.badge-priority-low { background: rgba(122,162,247,0.15); color: var(--accent); }
+.badge-priority-medium { background: rgba(224,175,104,0.22); color: var(--yellow); }
+.badge-priority-high { background: rgba(255,158,100,0.22); color: var(--orange); }
+.badge-priority-critical { background: rgba(247,118,142,0.25); color: var(--red); font-weight: 700; }
+
+/* ── Detail panel (inline) ───────────────────────────────────────────── */
+.inline-detail {
+  background: var(--bg-soft);
+  border: 1px solid var(--accent);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius);
+  padding: 16px 20px;
+  margin: 2px 0 8px 0;
+  animation: slide 0.15s ease-out;
+}
+@keyframes slide { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: none; } }
+.detail-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+.detail-toolbar h2 { font-size: 1.05em; color: var(--text-bright); }
+.detail-actions { display: flex; gap: 6px; }
+.detail-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 4px 16px;
+  margin-bottom: 14px;
+  font-size: 0.82em;
+}
+.detail-meta dt {
+  color: var(--text-dim);
+  font-size: 0.72em;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-top: 6px;
+}
+.detail-meta dd { color: var(--text-bright); font-weight: 500; margin: 0; }
+.detail-body {
+  background: var(--bg);
+  padding: 14px;
+  border-radius: var(--radius);
+  font-family: var(--mono);
+  font-size: 0.82em;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  line-height: 1.5;
+  max-height: 500px;
+  overflow-y: auto;
+}
+
+/* ── Tasks panel ─────────────────────────────────────────────────────── */
+.tasks-panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+  position: sticky;
+  top: 16px;
+  max-height: calc(100vh - 32px);
+  overflow-y: auto;
+}
+.tasks-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+.tasks-header h3 { font-size: 0.92em; color: var(--text-bright); }
+.tasks-header .btn-small {
+  background: var(--accent);
+  color: var(--bg);
+  border: none;
+  border-radius: var(--radius);
+  font-weight: 700;
+  padding: 4px 10px;
+  cursor: pointer;
+}
+.tasks-hint {
+  font-size: 0.72em;
+  color: var(--text-dim);
+  margin-top: 10px;
+  font-style: italic;
+}
+.task-list { display: flex; flex-direction: column; gap: 6px; }
+.tasks-empty {
+  color: var(--text-dim);
+  font-size: 0.82em;
+  padding: 12px 0;
+  font-style: italic;
+}
+.task-item {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 8px 10px;
+}
+.task-done {
+  background: transparent;
+  border: 1px solid var(--green);
+  color: var(--green);
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+  font-size: 0.85em;
+  font-weight: 700;
+  flex-shrink: 0;
+  padding: 0;
+  line-height: 22px;
+  text-align: center;
+}
+.task-done:hover { background: var(--green); color: var(--bg); }
+.task-body { flex: 1; min-width: 0; }
+.task-title {
+  font-size: 0.85em;
+  color: var(--text-bright);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-bottom: 3px;
+}
+.task-meta {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  font-size: 0.72em;
+  color: var(--text-dim);
+}
+.task-due { color: var(--orange); }
+
+/* ── Loading / empty ─────────────────────────────────────────────────── */
+.loading, .loading-sm {
+  color: var(--text-dim);
+  text-align: center;
+  padding: 40px 0;
+  font-size: 0.9em;
+}
+.loading-sm { padding: 12px 0; font-size: 0.82em; }
+
+/* ── Modal ───────────────────────────────────────────────────────────── */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+.modal-overlay[hidden] { display: none; }
+.modal {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 24px;
+  width: 90%;
+  max-width: 620px;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+.modal-header h2 { color: var(--text-bright); font-size: 1.1em; }
+
+#entry-form label {
+  display: block;
+  font-size: 0.72em;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-dim);
+  margin: 10px 0 4px;
+}
+#entry-form textarea,
+#entry-form input[type="text"],
+#entry-form input[type="date"],
+#entry-form select {
+  width: 100%;
+  padding: 8px 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 0.9em;
+}
+#entry-form textarea { font-family: var(--mono); resize: vertical; min-height: 120px; }
+#entry-form textarea:focus,
+#entry-form input:focus,
+#entry-form select:focus { border-color: var(--accent); outline: none; }
+.form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.form-group { min-width: 0; }
+.task-fields {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 8px 12px 12px;
+  margin-top: 14px;
+}
+.task-fields[hidden] { display: none; }
+.task-fields legend { color: var(--text-dim); font-size: 0.75em; padding: 0 6px; }
+.task-fields .hint {
+  color: var(--text-dim);
+  font-size: 0.75em;
+  margin-top: 8px;
+  font-style: italic;
+}
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 20px;
+}
+.form-actions button { width: auto; }
+
+/* ── Toast ───────────────────────────────────────────────────────────── */
+.toast {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  padding: 12px 20px;
+  border-radius: var(--radius);
+  font-size: 0.88em;
+  font-weight: 500;
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.25s, transform 0.25s;
+  pointer-events: none;
+  z-index: 200;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.4);
+}
+.toast-visible { opacity: 1; transform: none; }
+.toast-success { background: var(--green); color: var(--bg); }
+.toast-error { background: var(--red); color: var(--bg); }
+.toast-info { background: var(--accent); color: var(--bg); }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,12 +48,13 @@ sqlite-vec = ["sqlite-vec>=0.1.3"]
 postgres = ["psycopg[binary]>=3.1"]
 curate = ["scikit-learn>=1.3.0"]
 mcp = ["mcp>=1.0.0"]
+ui = ["fastapi>=0.100", "uvicorn>=0.20"]
 
 [tool.setuptools.packages.find]
 include = ["palaia*"]
 
 [tool.setuptools.package-data]
-palaia = ["SKILL.md"]
+palaia = ["SKILL.md", "web/static/*.html", "web/static/*.js", "web/static/*.css"]
 
 [tool.ruff]
 target-version = "py39"

--- a/tests/test_webui.py
+++ b/tests/test_webui.py
@@ -1,0 +1,264 @@
+"""Tests for palaia WebUI (FastAPI routes, v2.6)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+
+@pytest.fixture
+def palaia_root(tmp_path):
+    """Initialize a minimal .palaia store for testing."""
+    root = tmp_path / ".palaia"
+    root.mkdir()
+    (root / "config.json").write_text(
+        json.dumps({"default_scope": "team", "agent": "test", "store_version": "2.6"})
+    )
+    for tier in ("hot", "warm", "cold"):
+        (root / tier).mkdir()
+    return root
+
+
+@pytest.fixture
+def client(palaia_root):
+    from palaia.web.app import create_app
+
+    app = create_app(palaia_root)
+    return TestClient(app)
+
+
+# ── Smoke: every route responds ────────────────────────────────────────────
+
+def test_status_route(client):
+    r = client.get("/api/status")
+    assert r.status_code == 200
+    data = r.json()
+    assert "version" in data
+    assert "total" in data
+
+
+def test_stats_route_includes_source_split(client):
+    r = client.get("/api/stats")
+    assert r.status_code == 200
+    data = r.json()
+    assert "by_source" in data
+    assert "manual" in data["by_source"]
+    assert "auto_capture" in data["by_source"]
+
+
+def test_projects_route(client):
+    r = client.get("/api/projects")
+    assert r.status_code == 200
+    assert "projects" in r.json()
+
+
+def test_agents_route(client):
+    r = client.get("/api/agents")
+    assert r.status_code == 200
+    assert "agents" in r.json()
+
+
+def test_doctor_route(client):
+    r = client.get("/api/doctor")
+    assert r.status_code == 200
+    data = r.json()
+    assert "counts" in data
+    assert "checks" in data
+    assert "has_issues" in data
+
+
+def test_entries_empty(client):
+    r = client.get("/api/entries")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["entries"] == []
+    assert data["total"] == 0
+
+
+def test_static_index_served(client):
+    r = client.get("/")
+    assert r.status_code == 200
+    assert "palaia" in r.text
+
+
+def test_static_assets_served(client):
+    assert client.get("/app.js").status_code == 200
+    assert client.get("/style.css").status_code == 200
+
+
+# ── Create / Read / Update / Delete ────────────────────────────────────────
+
+def test_create_memory_entry(client):
+    r = client.post("/api/entries", json={
+        "body": "Important decision about database choice.",
+        "title": "DB decision",
+        "type": "memory",
+        "scope": "team",
+        "tags": ["decision"],
+    })
+    assert r.status_code == 201
+    data = r.json()
+    assert data["status"] == "created"
+    assert "id" in data
+
+
+def test_created_entry_is_manual(client):
+    r = client.post("/api/entries", json={"body": "manually written"})
+    entry_id = r.json()["id"]
+    detail = client.get(f"/api/entries/{entry_id}").json()
+    assert detail["is_manual"] is True
+    assert detail["is_auto_capture"] is False
+
+
+def test_create_with_invalid_scope_returns_422(client):
+    r = client.post("/api/entries", json={"body": "x", "scope": "shared:org"})
+    assert r.status_code == 422
+    assert "Invalid scope" in r.json()["error"]
+
+
+def test_create_with_invalid_type_returns_422(client):
+    r = client.post("/api/entries", json={"body": "x", "type": "note"})
+    assert r.status_code == 422
+
+
+def test_create_task_in_terminal_state_rejected(client):
+    """v2.6: tasks cannot be created in done/wontfix state."""
+    r = client.post("/api/entries", json={
+        "body": "already done",
+        "type": "task",
+        "status": "done",
+    })
+    assert r.status_code == 422
+    assert "post-it" in r.json()["error"]
+
+
+def test_patch_memory_body(client):
+    r = client.post("/api/entries", json={"body": "original"})
+    eid = r.json()["id"]
+    r = client.patch(f"/api/entries/{eid}", json={"body": "updated"})
+    assert r.status_code == 200
+    assert "body" in r.json()["updated_fields"]
+
+
+def test_patch_task_to_done_deletes_it(client):
+    """v2.6 post-it: setting status=done on a task deletes the entry."""
+    r = client.post("/api/entries", json={
+        "body": "take out trash",
+        "type": "task",
+        "status": "open",
+    })
+    tid = r.json()["id"]
+
+    # Complete it
+    r = client.patch(f"/api/entries/{tid}", json={"status": "done"})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["deleted"] is True
+    assert "task terminal" in data["reason"]
+
+    # Verify gone
+    r = client.get(f"/api/entries/{tid}")
+    assert r.status_code == 404
+
+
+def test_patch_task_to_wontfix_also_deletes(client):
+    r = client.post("/api/entries", json={
+        "body": "nope",
+        "type": "task",
+        "status": "open",
+    })
+    tid = r.json()["id"]
+    r = client.patch(f"/api/entries/{tid}", json={"status": "wontfix"})
+    assert r.json()["deleted"] is True
+
+
+def test_patch_memory_status_done_does_NOT_delete(client):
+    """Only tasks are post-its, memory entries stay put."""
+    r = client.post("/api/entries", json={"body": "lesson", "type": "memory"})
+    mid = r.json()["id"]
+    # Memory doesn't have a status field normally, but even if set, should not delete
+    r = client.patch(f"/api/entries/{mid}", json={"body": "updated lesson"})
+    assert r.status_code == 200
+    assert r.json().get("deleted") is not True
+    assert client.get(f"/api/entries/{mid}").status_code == 200
+
+
+def test_delete_entry(client):
+    r = client.post("/api/entries", json={"body": "to delete"})
+    eid = r.json()["id"]
+    assert client.delete(f"/api/entries/{eid}").status_code == 200
+    assert client.get(f"/api/entries/{eid}").status_code == 404
+
+
+# ── Filters ────────────────────────────────────────────────────────────────
+
+def test_filter_by_type(client):
+    client.post("/api/entries", json={"body": "m1", "type": "memory"})
+    client.post("/api/entries", json={"body": "p1", "type": "process"})
+    r = client.get("/api/entries?type=process")
+    assert r.status_code == 200
+    entries = r.json()["entries"]
+    assert len(entries) == 1
+    assert entries[0]["type"] == "process"
+
+
+def test_filter_by_scope(client):
+    client.post("/api/entries", json={"body": "public1", "scope": "public"})
+    client.post("/api/entries", json={"body": "team1", "scope": "team"})
+    r = client.get("/api/entries?scope=public")
+    assert r.status_code == 200
+    assert all(e["scope"] == "public" for e in r.json()["entries"])
+
+
+def test_filter_by_source_manual(client):
+    """Source filter distinguishes manual vs auto-capture."""
+    # Manual entry (no auto-capture tag)
+    client.post("/api/entries", json={"body": "manual one"})
+    # Auto-capture entry (explicit tag)
+    client.post("/api/entries", json={"body": "auto one", "tags": ["auto-capture"]})
+
+    r = client.get("/api/entries?source=manual")
+    assert r.status_code == 200
+    entries = r.json()["entries"]
+    assert len(entries) == 1
+    assert entries[0]["is_manual"] is True
+
+    r = client.get("/api/entries?source=auto")
+    entries = r.json()["entries"]
+    assert len(entries) == 1
+    assert entries[0]["is_auto_capture"] is True
+
+
+def test_filter_invalid_enum_returns_422(client):
+    r = client.get("/api/entries?status=blocked")
+    assert r.status_code == 422
+
+
+# ── Ranking ────────────────────────────────────────────────────────────────
+
+def test_manual_entries_rank_above_auto_at_equal_decay(client):
+    """Manual entries get a 1.3x boost in list ranking."""
+    client.post("/api/entries", json={"body": "auto written", "tags": ["auto-capture"]})
+    client.post("/api/entries", json={"body": "manually written"})
+    r = client.get("/api/entries")
+    entries = r.json()["entries"]
+    assert len(entries) == 2
+    # The manual one should be first (1.3x boost)
+    assert entries[0]["is_manual"] is True
+    assert entries[1]["is_auto_capture"] is True
+
+
+# ── Search ─────────────────────────────────────────────────────────────────
+
+def test_search_route_returns_structure(client):
+    r = client.get("/api/search?q=hello")
+    assert r.status_code == 200
+    data = r.json()
+    assert "results" in data
+    assert "count" in data
+    assert "bm25_only" in data
+    assert "timed_out" in data


### PR DESCRIPTION
## What

Local browser-based memory explorer: `pip install 'palaia[ui]' && palaia ui`.

Based on #125 (credit: Weegy), rebuilt from scratch to match v2.6 semantics.

## v2.6 alignment

- **Manual entries visually highlighted** (gold border + `manual ✦` badge) to reflect the 1.3× recall boost. List ranking applies the same boost so the UI mirrors actual recall behaviour.
- **Tasks are post-its**: clicking ✓ in the Active Tasks sidebar or setting `status=done/wontfix` in edit deletes the entry. Creating a task already in terminal state is rejected (422).
- **Dedicated Active Tasks sidebar** with one-click completion.
- **Filters cover v2.6 concepts**: source (manual|auto), scope, agent, plus type/tier/project/status.
- **Status dropdown fixed**: removed dead `blocked` option, added `wontfix`.
- **Doctor integration**: `/api/doctor` route + health pill in header. Banner auto-surfaces warn/error checks with actionable fix hints.

## Bug fixes vs #125

- Scope now correctly passed from create payload (was hardcoded `team`)
- Server-side enum validation against real palaia enums — no drift
- Event delegation instead of fragile inline `onclick` concatenation
- Consistent XSS-safe rendering (no unsafe `innerHTML` + string concat)
- Port fallback on conflict (requested + 10)
- Auto-open browser with `--no-browser` opt-out
- No pfad leak in logs

## Architecture

- FastAPI + uvicorn, localhost only (127.0.0.1), no auth (single-user local tool)
- Vanilla JS, no build step
- 3-column responsive layout (filters | content | tasks) → 1 column mobile

## Tests

24 new tests in `tests/test_webui.py` — CRUD, post-it delete, scope validation, source filter, manual ranking boost, enum rejection, static serving. All passing.