### PR TITLE
fix: WebUI codex audit findings (P1 timeout, P2 delete 404)

### DIFF
--- a/palaia/web/routes/entries.py
+++ b/palaia/web/routes/entries.py
@@ -299,7 +299,7 @@ def patch_entry(request: Request, entry_id: str, payload: EntryPatch) -> dict:
 
 @router.delete("/entries/{entry_id}")
 def delete_entry(request: Request, entry_id: str) -> dict:
-    """Delete an entry by ID."""
+    """Delete an entry by ID. Returns 404 if the entry does not exist."""
     from palaia.store import Store
 
     root = request.app.state.palaia_root
@@ -307,8 +307,14 @@ def delete_entry(request: Request, entry_id: str) -> dict:
     store.recover()
 
     try:
-        store.delete(entry_id)
+        deleted = store.delete(entry_id)
     except ValueError as exc:
         return JSONResponse(status_code=404, content={"error": str(exc)})
+
+    if not deleted:
+        return JSONResponse(
+            status_code=404,
+            content={"error": f"Entry not found: {entry_id}"},
+        )
 
     return {"id": entry_id, "status": "deleted"}

--- a/palaia/web/routes/search.py
+++ b/palaia/web/routes/search.py
@@ -17,6 +17,11 @@ router = APIRouter(tags=["search"])
 
 SEARCH_TIMEOUT_SECONDS = 5.0
 
+# Persistent executor so we can *abandon* slow workers instead of blocking on
+# their shutdown. A `with ThreadPoolExecutor(...)` would call
+# shutdown(wait=True) on exit, which undoes the whole point of the timeout.
+_SEARCH_EXECUTOR = concurrent.futures.ThreadPoolExecutor(max_workers=2, thread_name_prefix="palaia-search")
+
 
 @router.get("/search")
 def search(
@@ -30,7 +35,13 @@ def search(
     include_cold: bool = Query(False),
     timeout: float = Query(SEARCH_TIMEOUT_SECONDS, ge=0.5, le=30),
 ) -> dict:
-    """Hybrid search (BM25 + embeddings) with graceful BM25 fallback."""
+    """Hybrid search (BM25 + embeddings) with graceful BM25 fallback.
+
+    If the full search does not return within `timeout` seconds, we abandon
+    that worker (leaving it to finish in the background) and run a fresh
+    BM25-only search synchronously. This guarantees the response time stays
+    bounded regardless of embed-server cold starts.
+    """
     from palaia.services.query import search_entries
 
     root = request.app.state.palaia_root
@@ -48,12 +59,15 @@ def search(
         )
 
     timed_out = False
+    future = _SEARCH_EXECUTOR.submit(_run)
     try:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
-            result = ex.submit(_run).result(timeout=timeout)
+        result = future.result(timeout=timeout)
     except (concurrent.futures.TimeoutError, TimeoutError):
         logger.warning("search exceeded %.1fs, falling back to BM25", timeout)
         timed_out = True
+        # Abandon the slow worker: don't wait for it, don't cancel
+        # (Python can't interrupt running threads). It will complete and
+        # its result will be discarded when the future is garbage collected.
         try:
             result = _bm25_only(
                 root, q,

--- a/tests/test_webui.py
+++ b/tests/test_webui.py
@@ -262,3 +262,49 @@ def test_search_route_returns_structure(client):
     assert "count" in data
     assert "bm25_only" in data
     assert "timed_out" in data
+
+
+# ── Regression: codex audit findings ───────────────────────────────────────
+
+def test_delete_missing_entry_returns_404(client):
+    """Regression (codex P2): deleting a non-existent entry must return 404,
+    not 200. Store.delete() returns False (not ValueError) when the ID is
+    absent — the route must translate that to an HTTP error."""
+    r = client.delete("/api/entries/does-not-exist-abc123")
+    assert r.status_code == 404
+    assert "error" in r.json()
+
+
+def test_search_timeout_does_not_block_on_slow_worker(client, monkeypatch):
+    """Regression (codex P1): when the search worker exceeds the timeout,
+    the handler must return the BM25 fallback quickly instead of waiting
+    for the slow worker to finish (which is what happens when you use
+    `with ThreadPoolExecutor(...)` because exit calls shutdown(wait=True)).
+
+    We fake a slow search by monkeypatching search_entries to sleep."""
+    import time as _time
+
+    from palaia.services import query as query_mod
+
+    slow_duration = 3.0  # simulate a 3-second cold start
+    client_timeout = 0.5  # but we only wait 0.5s
+
+    def _slow_search(*args, **kwargs):
+        _time.sleep(slow_duration)
+        return {"results": [{"id": "slow-hit", "body": "should never return"}],
+                "has_embeddings": True, "bm25_only": False}
+
+    monkeypatch.setattr(query_mod, "search_entries", _slow_search)
+
+    start = _time.monotonic()
+    r = client.get(f"/api/search?q=anything&timeout={client_timeout}")
+    elapsed = _time.monotonic() - start
+
+    assert r.status_code == 200
+    # Must not have waited for the slow worker to complete
+    # (allow some headroom for BM25 fallback itself, but well under slow_duration)
+    assert elapsed < slow_duration - 0.5, (
+        f"Handler blocked for {elapsed:.2f}s waiting on slow worker "
+        f"(expected < {slow_duration - 0.5:.1f}s)"
+    )
+    assert r.json()["timed_out"] is True


### PR DESCRIPTION
Codex audit against v2.6 found two real bugs in the WebUI:

**[P1] Search timeout did nothing**
`with ThreadPoolExecutor(...)` calls `shutdown(wait=True)` on exit, so the handler blocked for the full original search duration after the timeout fired. Fix: module-level persistent executor + abandon slow workers.

**[P2] DELETE returned 200 for missing IDs**
`Store.delete()` returns `False` (not ValueError) on missing entries. Route ignored the return value. Fix: check and return 404.

Regression tests added for both. 26/26 webui tests pass.