### PR TITLE
fix: WebUI codex audit run #2 — host exposure + doctor hint

### DIFF
--- a/palaia/cli.py
+++ b/palaia/cli.py
@@ -1405,6 +1405,7 @@ def cmd_ui(args):
         print("Install with: pip install 'palaia[ui]'", file=sys.stderr)
         return 1
 
+    import os as _os
     import socket
     import threading
     import webbrowser
@@ -1416,7 +1417,24 @@ def cmd_ui(args):
         print("palaia not initialized. Run: palaia init", file=sys.stderr)
         return 1
 
-    host = getattr(args, "host", None) or "127.0.0.1"
+    # Security: WebUI has no auth. Default to loopback only. A power user who
+    # understands the risk can opt out via the PALAIA_UI_UNSAFE_BIND env var.
+    # We intentionally do not expose this as a CLI flag to prevent accidental
+    # network exposure from copy-pasted commands.
+    unsafe_bind = _os.environ.get("PALAIA_UI_UNSAFE_BIND", "").strip()
+    if unsafe_bind:
+        host = unsafe_bind
+        print(
+            f"⚠  PALAIA_UI_UNSAFE_BIND={unsafe_bind}: binding WebUI to a "
+            f"non-loopback address.\n   The UI has NO authentication. "
+            f"Anyone who can reach this host on the network can read and "
+            f"modify your entire memory store.\n   Use an SSH tunnel or a "
+            f"reverse proxy with auth instead.",
+            file=sys.stderr,
+        )
+    else:
+        host = "127.0.0.1"
+
     requested_port = getattr(args, "port", None) or 8384
     no_browser = getattr(args, "no_browser", False)
 

--- a/palaia/cli_args.py
+++ b/palaia/cli_args.py
@@ -279,9 +279,8 @@ def build_parser() -> argparse.ArgumentParser:
     # upgrade
     sub.add_parser("upgrade", help="Upgrade palaia to latest version (auto-detects install method and extras)")
 
-    # ui — local WebUI memory explorer
+    # ui — local WebUI memory explorer (localhost only, no auth)
     p_ui = sub.add_parser("ui", help="Launch the palaia WebUI in the browser")
-    p_ui.add_argument("--host", default="127.0.0.1", help="Host to bind (default: 127.0.0.1, localhost only)")
     p_ui.add_argument("--port", type=int, default=8384, help="Port to bind (default: 8384, will fall back if busy)")
     p_ui.add_argument("--no-browser", action="store_true", help="Do not auto-open the browser")
 

--- a/palaia/doctor/checks.py
+++ b/palaia/doctor/checks.py
@@ -290,7 +290,12 @@ def _check_openclaw_plugin() -> dict[str, Any]:
                     "label": "OpenClaw plugin",
                     "status": "warn",
                     "message": f"{memory_plugin} is active (not palaia)",
-                    "fix": "openclaw plugins install @byte5ai/palaia",
+                    "fix": (
+                        "openclaw plugins install @byte5ai/palaia\n"
+                        "  If the warning persists after a restart, also set "
+                        "plugins.slots.memory to \"palaia\" in "
+                        f"{config_path}."
+                    ),
                     "details": {"plugin": memory_plugin, "config_path": str(config_path)},
                 }
             else:
@@ -299,7 +304,12 @@ def _check_openclaw_plugin() -> dict[str, Any]:
                     "label": "OpenClaw plugin",
                     "status": "warn",
                     "message": "No memory plugin registered (palaia not active)",
-                    "fix": "openclaw plugins install @byte5ai/palaia",
+                    "fix": (
+                        "openclaw plugins install @byte5ai/palaia\n"
+                        "  If the warning persists after a restart, also set "
+                        "plugins.slots.memory to \"palaia\" in "
+                        f"{config_path}."
+                    ),
                     "details": {"config_path": str(config_path)},
                 }
         except (json.JSONDecodeError, OSError, KeyError):

--- a/tests/test_webui.py
+++ b/tests/test_webui.py
@@ -275,6 +275,30 @@ def test_delete_missing_entry_returns_404(client):
     assert "error" in r.json()
 
 
+def test_cli_ui_has_no_host_flag():
+    """Regression (codex run #2 P1): the ui command must not accept --host.
+
+    The WebUI has no authentication. Letting users pass --host 0.0.0.0 would
+    publish the memory store on the network unauthenticated. The only escape
+    hatch is the PALAIA_UI_UNSAFE_BIND env var, intentionally not a CLI flag.
+    """
+    from palaia.cli_args import build_parser
+
+    parser = build_parser()
+    # --host should be rejected
+    with pytest.raises(SystemExit):
+        parser.parse_args(["ui", "--host", "0.0.0.0"])
+
+
+def test_cli_ui_port_flag_still_works():
+    """Positive case: --port is still accepted."""
+    from palaia.cli_args import build_parser
+
+    parser = build_parser()
+    args = parser.parse_args(["ui", "--port", "9999"])
+    assert args.port == 9999
+
+
 def test_search_timeout_does_not_block_on_slow_worker(client, monkeypatch):
     """Regression (codex P1): when the search worker exceeds the timeout,
     the handler must return the BM25 fallback quickly instead of waiting


### PR DESCRIPTION
Second codex audit pass found two more real issues:

**[P1] `palaia ui --host 0.0.0.0` exposed unauth UI on LAN** — Despite the CHANGELOG promising 127.0.0.1-only, the CLI flag let users bind to any interface. Fix: `--host` removed, hard-coded to loopback. Env-var escape hatch `PALAIA_UI_UNSAFE_BIND` for power users with explicit warning.

**[P2] Doctor fix hint could leave users in a warning loop** — If `openclaw plugins install` does not update `plugins.slots.memory`, the warning persists after the suggested fix. Added fallback instruction pointing at the concrete config file.

28/28 webui tests, doctor tests unaffected.