### PR TITLE
release: palaia v2.7.1 — documentation update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v2.7.1 — 2026-04-06
+
+### Fixed
+- **SKILL.md**: Added missing `palaia ui` and `palaia prune` command documentation.
+- **README.md**: WebUI added to feature table.
+- **docs/cli-reference.md**: `palaia ui`, `palaia prune` flags documented.
+- **docs/multi-agent.md**: Capture health check section added, removed obsolete `shared:<name>` scope.
+
+---
+
 ## v2.7 — 2026-04-05
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ palaia gives your agents a persistent, searchable knowledge store. They save wha
 | **Agent isolation** | `--isolated` mode for strict per-agent memory boundaries |
 | **Crash-safe by default** | SQLite WAL mode survives power loss, kills, OOM |
 | **Fast** | Embed server keeps model in RAM — CLI queries ~1.5s, MCP/Plugin <500ms |
+| **WebUI memory explorer** | `palaia ui` — browse, search, create entries in the browser. Localhost only. |
 | **Scales when needed** | Swap to PostgreSQL + pgvector for distributed teams, no code changes |
 
 ---

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: palaia
-version: "2.7"
+version: "2.7.1"
 description: >
   Local, crash-safe persistent memory for OpenClaw agents.
   SQLite-backed by default. Semantic search, projects, scopes, auto-capture.
@@ -444,6 +444,17 @@ palaia upgrade
 
 Auto-detects the install method (pip/uv/pipx/brew), preserves all installed extras (fastembed, mcp, sqlite-vec, curate), runs `palaia doctor --fix`, and upgrades the OpenClaw npm plugin if present. Always use this instead of manual pip commands.
 
+### `palaia ui` — Local memory explorer (NEW in v2.7)
+
+```bash
+pip install 'palaia[ui]'   # One-time: install FastAPI + uvicorn
+palaia ui                  # Opens browser at http://127.0.0.1:8384
+palaia ui --port 9000      # Custom port (auto-fallback if busy)
+palaia ui --no-browser     # Don't auto-open browser
+```
+
+Browse, search, create, edit, and delete entries in the browser. Manual entries are highlighted with a gold border (1.3× recall boost). Tasks are post-its: clicking ✓ deletes them. The health pill in the header shows doctor status with actionable warnings. Localhost only — no authentication, no network exposure.
+
 ### `palaia doctor` — Diagnostics and auto-fix
 
 ```bash
@@ -461,6 +472,15 @@ palaia gc                  # Tier rotation (HOT -> WARM -> COLD)
 palaia gc --dry-run         # Preview what would change
 palaia gc --aggressive      # Also clears COLD tier
 palaia gc --budget 200      # Keep max N entries
+```
+
+### `palaia prune` — Selective cleanup (NEW in v2.5)
+
+```bash
+palaia prune --agent moneypenny     # Remove auto-captured entries by agent
+palaia prune --tags auto-capture    # Remove all auto-captured entries
+palaia prune --dry-run              # Preview what would be removed
+palaia prune --protect-type process # Never delete process entries
 ```
 
 ### `palaia config` — Configuration

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -14,6 +14,8 @@ palaia edit <id> [--status done] [--title T]         Edit entry
 palaia status                                         System health
 palaia doctor [--fix]                                 Diagnose + fix
 palaia upgrade                                        Update palaia
+palaia ui [--port] [--no-browser]                     WebUI explorer
+palaia prune [--agent] [--tags] [--dry-run]           Selective cleanup
 palaia project create|list|show|write|query|...      Projects
 palaia memo send|inbox|ack|broadcast|gc              Messaging
 palaia priorities [block|unblock|set|list-blocked]   Injection control
@@ -163,6 +165,28 @@ Detects and fixes:
 ### `palaia upgrade`
 
 Update palaia to latest version. Auto-detects install method, preserves extras, runs doctor, upgrades OpenClaw plugin.
+
+### `palaia ui`
+
+Launch the local WebUI memory explorer in the browser. Requires `pip install 'palaia[ui]'`.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--port` | 8384 | Port to bind (auto-fallback if busy, tries +10) |
+| `--no-browser` | off | Don't auto-open the browser |
+
+Binds to 127.0.0.1 only (no auth). Features: browse/search/create/edit/delete entries, manual/auto-capture highlighting, task post-it sidebar, doctor health banner.
+
+### `palaia prune`
+
+Selective cleanup of auto-captured entries.
+
+| Flag | Description |
+|------|-------------|
+| `--agent NAME` | Remove entries by specific agent |
+| `--tags TAG,...` | Remove entries with matching tags |
+| `--protect-type TYPE` | Never delete entries of this type |
+| `--dry-run` | Preview what would be removed |
 
 ### `palaia detect`
 

--- a/docs/multi-agent.md
+++ b/docs/multi-agent.md
@@ -25,7 +25,6 @@ Every entry has a scope that controls who can read and edit it:
 | `team` | All agents | All agents | Yes |
 | `private` | Only the owner (+ aliases) | Only the owner | No |
 | `public` | All agents + exportable | All agents | No |
-| `shared:<name>` | Agents in the shared group | Agents in the group | No |
 
 ```bash
 palaia write "Secret rotation procedure" --scope private
@@ -138,6 +137,18 @@ palaia init --agent lead
 ```
 
 Isolation mode is purely additive — it doesn't affect existing entries or other agents.
+
+## Capture Health Check
+
+In multi-agent setups, auto-capture can silently fail for sub-agents (e.g. when the plugin is not correctly registered or the workspace is misconfigured). `palaia doctor` detects this:
+
+- **`capture_health` check**: Warns when `autoCapture=true` but zero entries have been captured. Run `palaia doctor` on each agent's workspace to verify auto-capture is working.
+- **`plugin_version_match` check**: Warns when the CLI version differs from the installed plugin version (e.g. after a partial upgrade).
+
+If auto-capture is not firing, verify:
+1. The OpenClaw plugin is registered: `openclaw plugins install @byte5ai/palaia`
+2. The workspace path is correct: check `ctx.workspaceDir` in plugin logs
+3. The plugin version matches the CLI: `palaia doctor`
 
 ---
 

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byte5ai/palaia",
-  "version": "2.7",
+  "version": "2.7.1",
   "description": "palaia memory backend for OpenClaw",
   "main": "index.ts",
   "openclaw": {

--- a/packages/openclaw-plugin/skill/SKILL.md
+++ b/packages/openclaw-plugin/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: palaia
-version: "2.7"
+version: "2.7.1"
 description: >
   Local, crash-safe persistent memory for OpenClaw agents.
   SQLite-backed by default. Semantic search, projects, scopes, auto-capture.
@@ -444,6 +444,17 @@ palaia upgrade
 
 Auto-detects the install method (pip/uv/pipx/brew), preserves all installed extras (fastembed, mcp, sqlite-vec, curate), runs `palaia doctor --fix`, and upgrades the OpenClaw npm plugin if present. Always use this instead of manual pip commands.
 
+### `palaia ui` — Local memory explorer (NEW in v2.7)
+
+```bash
+pip install 'palaia[ui]'   # One-time: install FastAPI + uvicorn
+palaia ui                  # Opens browser at http://127.0.0.1:8384
+palaia ui --port 9000      # Custom port (auto-fallback if busy)
+palaia ui --no-browser     # Don't auto-open browser
+```
+
+Browse, search, create, edit, and delete entries in the browser. Manual entries are highlighted with a gold border (1.3× recall boost). Tasks are post-its: clicking ✓ deletes them. The health pill in the header shows doctor status with actionable warnings. Localhost only — no authentication, no network exposure.
+
 ### `palaia doctor` — Diagnostics and auto-fix
 
 ```bash
@@ -461,6 +472,15 @@ palaia gc                  # Tier rotation (HOT -> WARM -> COLD)
 palaia gc --dry-run         # Preview what would change
 palaia gc --aggressive      # Also clears COLD tier
 palaia gc --budget 200      # Keep max N entries
+```
+
+### `palaia prune` — Selective cleanup (NEW in v2.5)
+
+```bash
+palaia prune --agent moneypenny     # Remove auto-captured entries by agent
+palaia prune --tags auto-capture    # Remove all auto-captured entries
+palaia prune --dry-run              # Preview what would be removed
+palaia prune --protect-type process # Never delete process entries
 ```
 
 ### `palaia config` — Configuration

--- a/palaia/SKILL.md
+++ b/palaia/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: palaia
-version: "2.7"
+version: "2.7.1"
 description: >
   Local, crash-safe persistent memory for OpenClaw agents.
   SQLite-backed by default. Semantic search, projects, scopes, auto-capture.
@@ -444,6 +444,17 @@ palaia upgrade
 
 Auto-detects the install method (pip/uv/pipx/brew), preserves all installed extras (fastembed, mcp, sqlite-vec, curate), runs `palaia doctor --fix`, and upgrades the OpenClaw npm plugin if present. Always use this instead of manual pip commands.
 
+### `palaia ui` — Local memory explorer (NEW in v2.7)
+
+```bash
+pip install 'palaia[ui]'   # One-time: install FastAPI + uvicorn
+palaia ui                  # Opens browser at http://127.0.0.1:8384
+palaia ui --port 9000      # Custom port (auto-fallback if busy)
+palaia ui --no-browser     # Don't auto-open browser
+```
+
+Browse, search, create, edit, and delete entries in the browser. Manual entries are highlighted with a gold border (1.3× recall boost). Tasks are post-its: clicking ✓ deletes them. The health pill in the header shows doctor status with actionable warnings. Localhost only — no authentication, no network exposure.
+
 ### `palaia doctor` — Diagnostics and auto-fix
 
 ```bash
@@ -461,6 +472,15 @@ palaia gc                  # Tier rotation (HOT -> WARM -> COLD)
 palaia gc --dry-run         # Preview what would change
 palaia gc --aggressive      # Also clears COLD tier
 palaia gc --budget 200      # Keep max N entries
+```
+
+### `palaia prune` — Selective cleanup (NEW in v2.5)
+
+```bash
+palaia prune --agent moneypenny     # Remove auto-captured entries by agent
+palaia prune --tags auto-capture    # Remove all auto-captured entries
+palaia prune --dry-run              # Preview what would be removed
+palaia prune --protect-type process # Never delete process entries
 ```
 
 ### `palaia config` — Configuration

--- a/palaia/__init__.py
+++ b/palaia/__init__.py
@@ -4,5 +4,5 @@ palaia — Local, cloud-free memory for OpenClaw agents.
 
 from __future__ import annotations
 
-__version__ = "2.7"
+__version__ = "2.7.1"
 __author__ = "byte5 GmbH"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "palaia"
-version = "2.7"
+version = "2.7.1"
 description = "Local, cloud-free memory for OpenClaw agents."
 readme = "README.md"
 license = {text = "MIT"}

--- a/skills/palaia/SKILL.md
+++ b/skills/palaia/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: palaia
-version: "2.7"
+version: "2.7.1"
 description: >
   Local, crash-safe persistent memory for OpenClaw agents.
   SQLite-backed by default. Semantic search, projects, scopes, auto-capture.
@@ -444,6 +444,17 @@ palaia upgrade
 
 Auto-detects the install method (pip/uv/pipx/brew), preserves all installed extras (fastembed, mcp, sqlite-vec, curate), runs `palaia doctor --fix`, and upgrades the OpenClaw npm plugin if present. Always use this instead of manual pip commands.
 
+### `palaia ui` — Local memory explorer (NEW in v2.7)
+
+```bash
+pip install 'palaia[ui]'   # One-time: install FastAPI + uvicorn
+palaia ui                  # Opens browser at http://127.0.0.1:8384
+palaia ui --port 9000      # Custom port (auto-fallback if busy)
+palaia ui --no-browser     # Don't auto-open browser
+```
+
+Browse, search, create, edit, and delete entries in the browser. Manual entries are highlighted with a gold border (1.3× recall boost). Tasks are post-its: clicking ✓ deletes them. The health pill in the header shows doctor status with actionable warnings. Localhost only — no authentication, no network exposure.
+
 ### `palaia doctor` — Diagnostics and auto-fix
 
 ```bash
@@ -461,6 +472,15 @@ palaia gc                  # Tier rotation (HOT -> WARM -> COLD)
 palaia gc --dry-run         # Preview what would change
 palaia gc --aggressive      # Also clears COLD tier
 palaia gc --budget 200      # Keep max N entries
+```
+
+### `palaia prune` — Selective cleanup (NEW in v2.5)
+
+```bash
+palaia prune --agent moneypenny     # Remove auto-captured entries by agent
+palaia prune --tags auto-capture    # Remove all auto-captured entries
+palaia prune --dry-run              # Preview what would be removed
+palaia prune --protect-type process # Never delete process entries
 ```
 
 ### `palaia config` — Configuration


### PR DESCRIPTION
Docs-Check from the release process that was skipped during v2.7.

SKILL.md, README, cli-reference, multi-agent docs updated with WebUI, prune, capture health check.