### PR TITLE
feat: Claude Code onboarding — setup command, agent instructions, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,18 @@ Note: `palaia[fastembed]` already includes sqlite-vec for native vector search a
 
 **Upgrading?** `palaia upgrade` — auto-detects install method, preserves extras, runs doctor.
 
-### MCP Setup (Claude Desktop, Cursor, Claude Code — no OpenClaw needed)
+### Claude Code
+
+Paste this into Claude Code:
+
+> Install palaia for persistent memory in this Claude Code environment.
+> Run: `pip install "palaia[mcp,fastembed]" && palaia init && palaia setup claude-code --global`
+> Then tell me to restart Claude Code so the MCP tools become active.
+> After restart, read the CLAUDE.md and follow its instructions.
+
+See [Claude Code Integration](docs/claude-code.md) for the full guide.
+
+### MCP Setup (Claude Desktop, Cursor — no OpenClaw needed)
 
 ```bash
 pip install "palaia[mcp,fastembed]"
@@ -121,7 +132,6 @@ palaia init
 Add to your MCP config:
 - Claude Desktop: `~/.config/claude/claude_desktop_config.json`
 - Cursor: `.cursor/mcp.json`
-- Claude Code: `~/.claude/settings.json`
 ```json
 {
   "mcpServers": {
@@ -149,6 +159,7 @@ palaia status                                        # Check health
 |----------|-------------|
 | [Getting Started](docs/getting-started.md) | Installation, first steps, quick tour |
 | [Storage & Search](docs/backends.md) | SQLite, PostgreSQL, sqlite-vec, pgvector, embedding providers |
+| [Claude Code](docs/claude-code.md) | Claude Code integration, setup command, paste-this prompt |
 | [MCP Server](docs/mcp.md) | Setup for Claude Desktop, Cursor, tool reference, read-only mode |
 | [Embed Server](docs/embed-server.md) | Performance optimization, socket transport, daemon mode |
 | [Multi-Agent](docs/multi-agent.md) | Scopes, agent identity, team setup, aliases |

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -1,0 +1,134 @@
+# Claude Code Integration
+
+palaia works as a fully autonomous memory system for Claude Code. One command sets up everything — MCP server config, agent instructions, and proactive memory behavior.
+
+## Quick Start
+
+Paste this into Claude Code:
+
+> Install palaia for persistent memory in this Claude Code environment.
+> Run: `pip install "palaia[mcp,fastembed]" && palaia init && palaia setup claude-code --global`
+> Then tell me to restart Claude Code so the MCP tools become active.
+> After restart, read the CLAUDE.md and follow its instructions.
+
+That's it. After the restart, Claude Code has 7 memory tools and knows how to use them proactively.
+
+## What `palaia setup claude-code` Does
+
+1. **MCP server config** — adds `palaia` to `~/.claude/settings.json` so Claude Code loads the memory tools at startup
+2. **CLAUDE.md** — generates agent instructions that teach Claude Code when and how to store and recall knowledge
+
+```bash
+palaia setup claude-code            # CLAUDE.md in current directory
+palaia setup claude-code --global   # CLAUDE.md in ~/.claude/ (recommended)
+palaia setup claude-code --dry-run  # Preview without writing files
+```
+
+`--global` is recommended because it makes palaia available in every project, not just the current directory.
+
+## Why Two Sessions?
+
+Claude Code loads MCP servers only at startup. After `palaia setup claude-code` writes the config, you need to restart Claude Code for the tools to become available. This is a Claude Code limitation — there's no way around it.
+
+**Session 1**: Install + setup (tools not yet active)
+**Session 2+**: palaia tools available, agent stores and recalls knowledge automatically
+
+## What Claude Code Gets
+
+After setup, Claude Code has access to 7 MCP tools:
+
+| Tool | Purpose |
+|------|---------|
+| `palaia_search` | Find memories by meaning (hybrid BM25 + vector) |
+| `palaia_store` | Save knowledge (decisions, tasks, processes) |
+| `palaia_read` | Read a specific entry by ID |
+| `palaia_edit` | Update entries (close tasks, add context) |
+| `palaia_list` | Browse entries by tier, type, or project |
+| `palaia_status` | Check store health and entry counts |
+| `palaia_gc` | Run garbage collection (tier rotation) |
+
+The CLAUDE.md instructions teach Claude Code to:
+- **Search at session start** — load relevant context before working
+- **Store proactively** — save decisions, discoveries, and tasks without being asked
+- **Use structured types** — memory, process, task with appropriate metadata
+
+## Manual Setup
+
+If you prefer to configure manually instead of using the setup command:
+
+### 1. MCP Config
+
+Add to `~/.claude/settings.json`:
+```json
+{
+  "mcpServers": {
+    "palaia": {
+      "command": "palaia-mcp"
+    }
+  }
+}
+```
+
+If palaia is in a virtualenv, use the full path:
+```json
+{
+  "mcpServers": {
+    "palaia": {
+      "command": "/path/to/.venv/bin/palaia-mcp"
+    }
+  }
+}
+```
+
+### 2. CLAUDE.md
+
+The setup command generates a CLAUDE.md with session-start routines, storage triggers, and tool reference. Without it, Claude Code has the tools but doesn't know *when* to use them. You can write your own or use the generated one as a starting point.
+
+## Flags
+
+| Flag | Effect |
+|------|--------|
+| `--global` | Write CLAUDE.md to `~/.claude/CLAUDE.md` (all projects) |
+| `--dry-run` | Preview planned actions without writing files |
+| `--json` | Output result as JSON (for scripting) |
+
+## Diagnostics
+
+`palaia doctor` checks Claude Code configuration automatically:
+
+```bash
+palaia doctor
+# ...
+# ✓ claude_code_config: palaia-mcp configured in ~/.claude/settings.json
+```
+
+If the config is missing, doctor suggests running `palaia setup claude-code`.
+
+## Comparison with OpenClaw
+
+| Aspect | OpenClaw | Claude Code |
+|--------|----------|-------------|
+| Install | Paste prompt → ClawHub → fully autonomous | Paste prompt → pip + setup → restart |
+| Agent instructions | SKILL.md via ClawHub | CLAUDE.md via setup command |
+| Auto-capture | ContextEngine hooks (every turn) | Agent-driven (via CLAUDE.md guidance) |
+| Nudging | Adaptive nudging system | CLAUDE.md instructions |
+| Sessions | 1 (immediate) | 2 (restart required for MCP) |
+| Memory tools | Plugin API (7 tools) | MCP protocol (7 tools) |
+
+Both platforms get the same 7 tools and the same knowledge store. The difference is in how the agent learns to use them — OpenClaw has deep lifecycle hooks, Claude Code relies on CLAUDE.md instructions.
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Tools not available after setup | Restart Claude Code — MCP loads at startup only |
+| `palaia-mcp` not found | `pip install 'palaia[mcp]'` or use full path in config |
+| Store empty after first session | Normal — knowledge accumulates over time |
+| Agent not storing proactively | Check CLAUDE.md exists and mentions palaia |
+| Doctor shows warning | Run `palaia setup claude-code --global` |
+
+## See Also
+
+- [MCP Server](mcp.md) — Full MCP tool reference and transport options
+- [Getting Started](getting-started.md) — Installation overview
+- [Multi-Agent](multi-agent.md) — Team setup with scopes and isolation

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,6 +16,17 @@ palaia init
 palaia doctor --fix
 ```
 
+### With Claude Code
+
+Paste this into Claude Code:
+
+> Install palaia for persistent memory in this Claude Code environment.
+> Run: `pip install "palaia[mcp,fastembed]" && palaia init && palaia setup claude-code --global`
+> Then tell me to restart Claude Code so the MCP tools become active.
+> After restart, read the CLAUDE.md and follow its instructions.
+
+See [Claude Code Integration](claude-code.md) for details.
+
 ### With MCP (Claude Desktop, Cursor)
 
 ```bash
@@ -91,6 +102,7 @@ If `palaia upgrade` is not recognized (versions before v2.3.0), see the [SKILL.m
 ## Next Steps
 
 - [Storage & Search](backends.md) — Backend options, embedding providers
+- [Claude Code](claude-code.md) — Claude Code integration and setup
 - [MCP Server](mcp.md) — Claude Desktop / Cursor setup
 - [Multi-Agent](multi-agent.md) — Team setup, scopes, aliases
 - [CLI Reference](cli-reference.md) — All commands and flags

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -56,7 +56,17 @@ Or add to `.cursor/mcp.json`:
 
 ### Claude Code
 
-Add to `~/.claude/settings.json`:
+The easiest way to set up Claude Code is the automated setup command:
+
+```bash
+palaia setup claude-code --global
+```
+
+This configures `~/.claude/settings.json` and generates a CLAUDE.md with agent instructions. Restart Claude Code after setup.
+
+See [Claude Code Integration](claude-code.md) for the full guide, including the paste-this prompt for fully autonomous setup.
+
+For manual configuration, add to `~/.claude/settings.json`:
 ```json
 {
   "mcpServers": {
@@ -66,19 +76,6 @@ Add to `~/.claude/settings.json`:
   }
 }
 ```
-
-If palaia is installed in a virtualenv, use the full path:
-```json
-{
-  "mcpServers": {
-    "palaia": {
-      "command": "/path/to/.venv/bin/palaia-mcp"
-    }
-  }
-}
-```
-
-Restart Claude Code after adding the config. palaia tools (`palaia_search`, `palaia_store`, etc.) will be available automatically.
 
 ### Other MCP Hosts
 

--- a/palaia/cli.py
+++ b/palaia/cli.py
@@ -57,7 +57,9 @@ from palaia.ui import (  # noqa: E402
     section,
     success,
     sym_arrow,
+    sym_info,
     table_multi,
+    warn_msg,
 )
 
 
@@ -82,7 +84,6 @@ GATED_COMMANDS = frozenset(
         "package",
         "lock",
         "unlock",
-        "setup",
         "warmup",
         "migrate",
         "embed-server",
@@ -101,6 +102,7 @@ UNGATED_COMMANDS = frozenset(
         "doctor",
         "config",
         "instance",
+        "setup",
         "skill",
         "mcp-server",
         "upgrade",
@@ -792,12 +794,73 @@ def _cmd_migrate_suggest(store, root, args):
 
 
 def cmd_setup(args):
+    """Setup integrations: claude-code or multi-agent."""
+    setup_target = getattr(args, "setup_target", None)
+
+    if setup_target == "claude-code":
+        return _cmd_setup_claude_code(args)
+
+    # Legacy / multi-agent path
+    if not getattr(args, "multi_agent", None):
+        print("Usage: palaia setup claude-code [--global] [--dry-run]", file=sys.stderr)
+        print("       palaia setup --multi-agent <agents-dir>", file=sys.stderr)
+        return 1
+
+    return _cmd_setup_multi_agent(args)
+
+
+def _cmd_setup_claude_code(args):
+    """Configure Claude Code to use palaia as MCP server."""
+    from palaia.services.admin import setup_claude_code
+
+    root = find_palaia_root()
+    if root is None:
+        print("palaia not initialized. Run: palaia init", file=sys.stderr)
+        return 1
+
+    result = setup_claude_code(
+        root,
+        global_config=getattr(args, "global_config", False),
+        dry_run=getattr(args, "dry_run", False),
+    )
+
+    if "error" in result:
+        if _json_out(result, args):
+            return 1
+        print(f"Error: {result['error']}", file=sys.stderr)
+        return 1
+
+    if not getattr(args, "json", False):
+        dry = result.get("dry_run", False)
+        if dry:
+            print(bold("Dry run — no changes made:\n"))
+
+        for action in result.get("actions", []):
+            label = action["action"]
+            target = action.get("target", "")
+            detail = action.get("detail", "")
+            if label == "skip":
+                print(f"  {sym_info()} {dim(detail)}")
+            elif label == "plan":
+                print(f"  {sym_info()} Would: {detail}")
+                print(f"       {dim(target)}")
+            elif label in ("configured", "created", "appended"):
+                print(success(f"{detail}"))
+                print(f"       {dim(target)}")
+
+        for w in result.get("warnings", []):
+            print(warn_msg(w))
+
+        if not dry and not result.get("already_configured"):
+            print(f"\n{bold('Next step:')} Restart Claude Code to activate palaia tools.")
+
+    _json_out(result, args)
+    return 0
+
+
+def _cmd_setup_multi_agent(args):
     """Multi-agent setup: create .palaia symlinks for agent directories."""
     from palaia.services.admin import setup_multi_agent
-
-    if not args.multi_agent:
-        print("Usage: palaia setup --multi-agent <agents-dir>", file=sys.stderr)
-        return 1
 
     root = get_root()
     result = setup_multi_agent(

--- a/palaia/cli_args.py
+++ b/palaia/cli_args.py
@@ -214,7 +214,19 @@ def build_parser() -> argparse.ArgumentParser:
     p_instance_clear.add_argument("--json", action="store_true", help="Output as JSON")
 
     # setup
-    p_setup = sub.add_parser("setup", help="Multi-agent setup")
+    p_setup = sub.add_parser("setup", help="Setup integrations (claude-code, multi-agent)")
+    setup_sub = p_setup.add_subparsers(dest="setup_target")
+
+    # setup claude-code
+    p_setup_cc = setup_sub.add_parser("claude-code", help="Configure Claude Code to use palaia")
+    p_setup_cc.add_argument(
+        "--global", action="store_true", dest="global_config",
+        help="Write CLAUDE.md to ~/.claude/ instead of current directory",
+    )
+    p_setup_cc.add_argument("--dry-run", action="store_true", help="Preview without writing files")
+    p_setup_cc.add_argument("--json", action="store_true", help="Output as JSON")
+
+    # setup multi-agent (backwards compat)
     p_setup.add_argument("--multi-agent", default=None, help="Path to agents directory")
     p_setup.add_argument("--dry-run", action="store_true", help="Preview without creating symlinks")
     p_setup.add_argument("--json", action="store_true", help="Output as JSON")

--- a/palaia/doctor/__init__.py
+++ b/palaia/doctor/__init__.py
@@ -12,6 +12,7 @@ from palaia.doctor.checks import (
     _check_capture_health,
     _check_capture_level,
     _check_capture_model,
+    _check_claude_code_config,
     _check_default_agent_alias,
     _check_deprecated_config,
     _check_embedding_chain,
@@ -79,6 +80,7 @@ def run_doctor(palaia_root: Path | None = None) -> list[dict[str, Any]]:
         _check_storage_backend(palaia_root),
         _check_native_vector_search(palaia_root),
         _check_mcp_server(palaia_root),
+        _check_claude_code_config(palaia_root),
     ]
     return results
 
@@ -93,6 +95,7 @@ __all__ = [
     "_check_capture_health",
     "_check_capture_level",
     "_check_capture_model",
+    "_check_claude_code_config",
     "_check_default_agent_alias",
     "_check_deprecated_config",
     "_check_embedding_chain",

--- a/palaia/doctor/checks.py
+++ b/palaia/doctor/checks.py
@@ -1803,7 +1803,7 @@ def _check_native_vector_search(palaia_root: Path | None) -> dict[str, Any]:
 
 
 def _check_mcp_server(palaia_root: Path | None) -> dict[str, Any]:
-    """Check if MCP server is available for Claude Desktop / Cursor integration."""
+    """Check if MCP server is available for Claude Code / Claude Desktop / Cursor."""
     try:
         import mcp  # noqa: F401
 
@@ -1811,15 +1811,54 @@ def _check_mcp_server(palaia_root: Path | None) -> dict[str, Any]:
             "name": "mcp_server",
             "label": "MCP server",
             "status": "ok",
-            "message": "MCP SDK installed — palaia-mcp available for Claude Desktop, Cursor",
+            "message": "MCP SDK installed — palaia-mcp available for Claude Code, Claude Desktop, Cursor",
         }
     except ImportError:
         return {
             "name": "mcp_server",
             "label": "MCP server",
             "status": "info",
-            "message": "MCP SDK not installed. For Claude Desktop / Cursor: pip install 'palaia[mcp]'",
+            "message": "MCP SDK not installed. For Claude Code / Claude Desktop / Cursor: pip install 'palaia[mcp]'",
         }
+
+
+def _check_claude_code_config(palaia_root: Path | None) -> dict[str, Any]:
+    """Check if Claude Code is configured to use palaia as MCP server."""
+    settings_path = Path.home() / ".claude" / "settings.json"
+
+    if not settings_path.exists():
+        return {
+            "name": "claude_code_config",
+            "label": "Claude Code config",
+            "status": "info",
+            "message": "~/.claude/settings.json not found. Set up with: palaia setup claude-code",
+        }
+
+    try:
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {
+            "name": "claude_code_config",
+            "label": "Claude Code config",
+            "status": "warn",
+            "message": "~/.claude/settings.json exists but is not valid JSON",
+        }
+
+    mcp_servers = settings.get("mcpServers", {})
+    if "palaia" not in mcp_servers:
+        return {
+            "name": "claude_code_config",
+            "label": "Claude Code config",
+            "status": "info",
+            "message": "palaia not in Claude Code MCP config. Set up with: palaia setup claude-code",
+        }
+
+    return {
+        "name": "claude_code_config",
+        "label": "Claude Code config",
+        "status": "ok",
+        "message": f"palaia registered in Claude Code (command: {mcp_servers['palaia'].get('command', '?')})",
+    }
 
 
 def _check_stale_unassigned_tasks(palaia_root: Path | None) -> dict[str, Any]:

--- a/palaia/services/admin.py
+++ b/palaia/services/admin.py
@@ -709,6 +709,212 @@ def migrate_suggest(root: Path) -> dict:
 # setup
 # ---------------------------------------------------------------------------
 
+
+# ── CLAUDE.md template (injected into project or global config) ────────────
+CLAUDE_CODE_TEMPLATE = """\
+# palaia — Persistent Memory
+
+You have access to palaia, a persistent knowledge store that survives across sessions.
+Use it to remember decisions, context, patterns, and tasks — so every session builds
+on the last instead of starting from scratch.
+
+## First session after setup
+
+Run `palaia_status` to confirm palaia is active. If the store is empty, that's
+normal — start storing knowledge as you work. It accumulates over time.
+
+## Session start routine
+
+1. Run `palaia_search` with the current project or topic to load relevant context.
+2. Run `palaia_list(tier="hot")` to see recent active memories.
+3. If there are results, read the most relevant ones before proceeding.
+4. If the store is empty or has no matches, proceed normally — store what you learn.
+
+## When to store knowledge
+
+Store proactively — don't wait for the user to ask. Good triggers:
+
+- **Decisions**: "We chose X because Y" — store as `entry_type: "memory"`
+- **Discoveries**: Bugs found, API quirks, undocumented behavior — `entry_type: "memory"`
+- **Tasks**: Work items for later sessions — `entry_type: "task"`, `status: "open"`
+- **Processes**: Step-by-step workflows, deploy procedures — `entry_type: "process"`
+- **Architecture**: System design, module responsibilities, data flows — `entry_type: "memory"`
+
+```
+palaia_store(
+  content="<what you learned>",
+  title="<short title>",
+  tags=["<relevant>", "<tags>"],
+  entry_type="memory",
+)
+```
+
+## When NOT to store
+
+- Code that's already in the repo (use git)
+- Temporary debugging state (clutters the store)
+- Anything sensitive (API keys, passwords)
+
+## Tool reference
+
+| Tool | When to use |
+|------|-------------|
+| `palaia_search(query=...)` | Find relevant memories by meaning |
+| `palaia_store(content=..., title=..., tags=..., entry_type=...)` | Save knowledge |
+| `palaia_list(tier="hot")` | Browse recent entries |
+| `palaia_read(entry_id=...)` | Read full entry details |
+| `palaia_edit(entry_id=..., status="done")` | Update entries (e.g. close tasks) |
+| `palaia_status()` | Check store health |
+| `palaia_gc(dry_run=True)` | Preview tier rotation |
+
+## palaia vs. built-in memory
+
+| Use palaia for | Use built-in memory for |
+|----------------|------------------------|
+| Project decisions & architecture | Personal preferences (editor settings, style) |
+| Learnings that apply across sessions | Ephemeral conversation context |
+| Tasks and processes | User interaction patterns |
+| Knowledge shared between tools (Cursor, Claude Desktop) | Tool-specific configuration |
+"""
+
+
+def setup_claude_code(
+    root: Path,
+    *,
+    global_config: bool = False,
+    dry_run: bool = False,
+) -> dict:
+    """Configure Claude Code to use palaia as MCP server.
+
+    1. Writes mcpServers entry to ~/.claude/settings.json
+    2. Generates a CLAUDE.md snippet (project-local or global)
+
+    Returns dict with actions taken and any warnings.
+    """
+    import shutil
+
+    actions: list[dict] = []
+    warnings: list[str] = []
+
+    # ── Step 1: Determine palaia-mcp binary path ──────────────────
+    palaia_mcp_bin = shutil.which("palaia-mcp")
+    if not palaia_mcp_bin:
+        # Fallback: try to find it relative to the running Python
+        import sys
+
+        candidate = Path(sys.executable).parent / "palaia-mcp"
+        if candidate.exists():
+            palaia_mcp_bin = str(candidate)
+        else:
+            return {"error": "palaia-mcp binary not found. Install with: pip install 'palaia[mcp]'"}
+
+    # ── Step 2: Write MCP config to ~/.claude/settings.json ───────
+    settings_path = Path.home() / ".claude" / "settings.json"
+    settings_dir = settings_path.parent
+
+    if not settings_dir.exists():
+        if dry_run:
+            actions.append({"action": "plan", "target": str(settings_dir), "detail": "create directory"})
+        else:
+            settings_dir.mkdir(parents=True, exist_ok=True)
+            actions.append({"action": "created", "target": str(settings_dir)})
+
+    # Load existing settings (preserve everything else)
+    settings: dict = {}
+    if settings_path.exists():
+        try:
+            import json as _json
+
+            settings = _json.loads(settings_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            warnings.append(f"Could not parse {settings_path} — creating fresh config")
+
+    mcp_servers = settings.setdefault("mcpServers", {})
+    already_configured = "palaia" in mcp_servers
+
+    if already_configured:
+        existing_cmd = mcp_servers["palaia"].get("command", "")
+        actions.append({
+            "action": "skip",
+            "target": str(settings_path),
+            "detail": f"palaia MCP already configured (command: {existing_cmd})",
+        })
+    else:
+        mcp_servers["palaia"] = {"command": palaia_mcp_bin}
+        if dry_run:
+            actions.append({
+                "action": "plan",
+                "target": str(settings_path),
+                "detail": f"add palaia MCP server (command: {palaia_mcp_bin})",
+            })
+        else:
+            import json as _json
+
+            settings_path.write_text(
+                _json.dumps(settings, indent=2) + "\n", encoding="utf-8",
+            )
+            actions.append({
+                "action": "configured",
+                "target": str(settings_path),
+                "detail": f"palaia MCP server added (command: {palaia_mcp_bin})",
+            })
+
+    # ── Step 3: Generate CLAUDE.md snippet ────────────────────────
+    if global_config:
+        claude_md_path = Path.home() / ".claude" / "CLAUDE.md"
+    else:
+        claude_md_path = Path.cwd() / "CLAUDE.md"
+
+    if claude_md_path.exists():
+        existing = claude_md_path.read_text(encoding="utf-8")
+        if "palaia" in existing.lower():
+            actions.append({
+                "action": "skip",
+                "target": str(claude_md_path),
+                "detail": "CLAUDE.md already mentions palaia",
+            })
+        else:
+            if dry_run:
+                actions.append({
+                    "action": "plan",
+                    "target": str(claude_md_path),
+                    "detail": "append palaia section to existing CLAUDE.md",
+                })
+            else:
+                with open(claude_md_path, "a", encoding="utf-8") as f:
+                    f.write("\n\n" + CLAUDE_CODE_TEMPLATE)
+                actions.append({
+                    "action": "appended",
+                    "target": str(claude_md_path),
+                    "detail": "palaia section appended to existing CLAUDE.md",
+                })
+    else:
+        if dry_run:
+            actions.append({
+                "action": "plan",
+                "target": str(claude_md_path),
+                "detail": "create CLAUDE.md with palaia instructions",
+            })
+        else:
+            claude_md_path.write_text(CLAUDE_CODE_TEMPLATE, encoding="utf-8")
+            actions.append({
+                "action": "created",
+                "target": str(claude_md_path),
+                "detail": "CLAUDE.md created with palaia instructions",
+            })
+
+    return {
+        "status": "ok",
+        "actions": actions,
+        "warnings": warnings,
+        "settings_path": str(settings_path),
+        "claude_md_path": str(claude_md_path),
+        "palaia_mcp_bin": palaia_mcp_bin,
+        "already_configured": already_configured,
+        "dry_run": dry_run,
+    }
+
+
 def setup_multi_agent(
     root: Path,
     agents_dir_path: str,

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -328,7 +328,7 @@ class TestRunDoctor:
     def test_run_all_checks(self, palaia_root, tmp_path, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))
         results = run_doctor(palaia_root)
-        assert len(results) == 29  # +4: native_vector_search, mcp_server, capture_health, plugin_version_match
+        assert len(results) == 30  # +5: native_vector_search, mcp_server, claude_code_config, capture_health, plugin_version_match
         assert all("status" in r for r in results)
         assert all("name" in r for r in results)
 

--- a/tests/test_doctor_version.py
+++ b/tests/test_doctor_version.py
@@ -102,4 +102,4 @@ def test_version_check_count(palaia_root):
         mock_urlopen.return_value = _mock_pypi_response(__version__)
         results = run_doctor(palaia_root)
 
-    assert len(results) == 29  # +4: native_vector_search, mcp_server, capture_health, plugin_version_match
+    assert len(results) == 30  # +5: native_vector_search, mcp_server, claude_code_config, capture_health, plugin_version_match

--- a/tests/test_setup_claude_code.py
+++ b/tests/test_setup_claude_code.py
@@ -1,0 +1,215 @@
+"""Tests for palaia setup claude-code command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from palaia.doctor.checks import _check_claude_code_config
+from palaia.services.admin import CLAUDE_CODE_TEMPLATE, setup_claude_code
+
+
+@pytest.fixture
+def palaia_root(tmp_path):
+    """Create a minimal .palaia directory."""
+    root = tmp_path / ".palaia"
+    root.mkdir()
+    for sub in ("hot", "warm", "cold", "wal", "index"):
+        (root / sub).mkdir()
+    config = {
+        "version": 1,
+        "embedding_chain": ["bm25"],
+        "agent": "test",
+    }
+    (root / "config.json").write_text(json.dumps(config))
+    return root
+
+
+# ── setup_claude_code service tests ──────────────────────────────────────
+
+
+class TestSetupClaudeCode:
+    def test_dry_run_creates_nothing(self, palaia_root, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+        result = setup_claude_code(palaia_root, dry_run=True)
+
+        assert result["status"] == "ok"
+        assert result["dry_run"] is True
+        # Nothing should actually be written
+        assert not (tmp_path / ".claude" / "settings.json").exists()
+        assert not (tmp_path / "CLAUDE.md").exists()
+        # But actions should be planned
+        actions = {a["action"] for a in result["actions"]}
+        assert "plan" in actions
+
+    def test_creates_settings_and_claude_md(self, palaia_root, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+        result = setup_claude_code(palaia_root)
+
+        assert result["status"] == "ok"
+
+        # Check settings.json was created
+        settings_path = tmp_path / ".claude" / "settings.json"
+        assert settings_path.exists()
+        settings = json.loads(settings_path.read_text())
+        assert "palaia" in settings["mcpServers"]
+        assert "palaia-mcp" in settings["mcpServers"]["palaia"]["command"]
+
+        # Check CLAUDE.md was created
+        claude_md = tmp_path / "CLAUDE.md"
+        assert claude_md.exists()
+        content = claude_md.read_text()
+        assert "palaia_search" in content
+        assert "palaia_store" in content
+
+    def test_skips_if_already_configured(self, palaia_root, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        # Pre-create settings with palaia configured
+        settings_dir = tmp_path / ".claude"
+        settings_dir.mkdir(parents=True)
+        (settings_dir / "settings.json").write_text(json.dumps({
+            "mcpServers": {"palaia": {"command": "custom-palaia-mcp"}}
+        }))
+
+        result = setup_claude_code(palaia_root)
+
+        assert result["already_configured"] is True
+        # Should not overwrite the existing config
+        settings = json.loads((settings_dir / "settings.json").read_text())
+        assert settings["mcpServers"]["palaia"]["command"] == "custom-palaia-mcp"
+
+    def test_preserves_existing_settings(self, palaia_root, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        # Pre-create settings with other MCP servers
+        settings_dir = tmp_path / ".claude"
+        settings_dir.mkdir(parents=True)
+        (settings_dir / "settings.json").write_text(json.dumps({
+            "mcpServers": {"other-tool": {"command": "other-mcp"}},
+            "customSetting": True,
+        }))
+
+        result = setup_claude_code(palaia_root)
+
+        settings = json.loads((settings_dir / "settings.json").read_text())
+        assert "palaia" in settings["mcpServers"]
+        assert "other-tool" in settings["mcpServers"]
+        assert settings["customSetting"] is True
+
+    def test_appends_to_existing_claude_md(self, palaia_root, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        # Pre-create CLAUDE.md without palaia
+        existing = "# My Project\n\nExisting instructions.\n"
+        (tmp_path / "CLAUDE.md").write_text(existing)
+
+        result = setup_claude_code(palaia_root)
+
+        content = (tmp_path / "CLAUDE.md").read_text()
+        assert content.startswith("# My Project")
+        assert "palaia_search" in content
+        assert "Existing instructions." in content
+
+    def test_skips_claude_md_if_already_has_palaia(self, palaia_root, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        existing = "# My Project\n\nUse palaia for memory.\n"
+        (tmp_path / "CLAUDE.md").write_text(existing)
+
+        result = setup_claude_code(palaia_root)
+
+        content = (tmp_path / "CLAUDE.md").read_text()
+        assert content == existing
+
+    def test_global_config_writes_to_claude_dir(self, palaia_root, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+        result = setup_claude_code(palaia_root, global_config=True)
+
+        assert result["status"] == "ok"
+        assert (tmp_path / ".claude" / "CLAUDE.md").exists()
+        assert not (tmp_path / "CLAUDE.md").exists()
+
+    def test_error_when_palaia_mcp_not_found(self, palaia_root, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        import shutil
+        monkeypatch.setattr(shutil, "which", lambda x: None)
+
+        import sys
+        fake_exe = tmp_path / "nonexistent" / "python"
+        monkeypatch.setattr(sys, "executable", str(fake_exe))
+
+        result = setup_claude_code(palaia_root)
+        assert "error" in result
+        assert "palaia-mcp" in result["error"]
+
+
+# ── Doctor check tests ───────────────────────────────────────────────────
+
+
+class TestDoctorClaudeCodeConfig:
+    def test_no_settings_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = _check_claude_code_config(None)
+        assert result["status"] == "info"
+        assert "setup claude-code" in result["message"]
+
+    def test_settings_without_palaia(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        settings_dir = tmp_path / ".claude"
+        settings_dir.mkdir()
+        (settings_dir / "settings.json").write_text(json.dumps({
+            "mcpServers": {"other": {"command": "other"}}
+        }))
+        result = _check_claude_code_config(None)
+        assert result["status"] == "info"
+
+    def test_settings_with_palaia(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        settings_dir = tmp_path / ".claude"
+        settings_dir.mkdir()
+        (settings_dir / "settings.json").write_text(json.dumps({
+            "mcpServers": {"palaia": {"command": "palaia-mcp"}}
+        }))
+        result = _check_claude_code_config(None)
+        assert result["status"] == "ok"
+        assert "palaia-mcp" in result["message"]
+
+    def test_invalid_json(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        settings_dir = tmp_path / ".claude"
+        settings_dir.mkdir()
+        (settings_dir / "settings.json").write_text("not json {{{")
+        result = _check_claude_code_config(None)
+        assert result["status"] == "warn"
+
+
+# ── CLAUDE.md template tests ────────────────────────────────────────────
+
+
+class TestClaudeMdTemplate:
+    def test_template_contains_essential_tools(self):
+        assert "palaia_search" in CLAUDE_CODE_TEMPLATE
+        assert "palaia_store" in CLAUDE_CODE_TEMPLATE
+        assert "palaia_read" in CLAUDE_CODE_TEMPLATE
+        assert "palaia_edit" in CLAUDE_CODE_TEMPLATE
+
+    def test_template_has_guidance_sections(self):
+        assert "Session start routine" in CLAUDE_CODE_TEMPLATE
+        assert "When NOT to store" in CLAUDE_CODE_TEMPLATE
+        assert "built-in memory" in CLAUDE_CODE_TEMPLATE
+        assert "First session" in CLAUDE_CODE_TEMPLATE
+
+    def test_template_instructs_proactive_storage(self):
+        assert "Store proactively" in CLAUDE_CODE_TEMPLATE

--- a/tests/test_setup_claude_code.py
+++ b/tests/test_setup_claude_code.py
@@ -96,7 +96,7 @@ class TestSetupClaudeCode:
             "customSetting": True,
         }))
 
-        result = setup_claude_code(palaia_root)
+        setup_claude_code(palaia_root)
 
         settings = json.loads((settings_dir / "settings.json").read_text())
         assert "palaia" in settings["mcpServers"]
@@ -111,7 +111,7 @@ class TestSetupClaudeCode:
         existing = "# My Project\n\nExisting instructions.\n"
         (tmp_path / "CLAUDE.md").write_text(existing)
 
-        result = setup_claude_code(palaia_root)
+        setup_claude_code(palaia_root)
 
         content = (tmp_path / "CLAUDE.md").read_text()
         assert content.startswith("# My Project")
@@ -125,7 +125,7 @@ class TestSetupClaudeCode:
         existing = "# My Project\n\nUse palaia for memory.\n"
         (tmp_path / "CLAUDE.md").write_text(existing)
 
-        result = setup_claude_code(palaia_root)
+        setup_claude_code(palaia_root)
 
         content = (tmp_path / "CLAUDE.md").read_text()
         assert content == existing


### PR DESCRIPTION
## Summary

- Add `palaia setup claude-code` command that auto-configures Claude Code as a first-class integration (MCP config + CLAUDE.md agent instructions)
- Add doctor check for Claude Code configuration status
- Add `docs/claude-code.md` with paste-this prompt for fully autonomous install
- Update README, getting-started.md, mcp.md with Claude Code sections
- 15 new tests, all existing tests green

## Test plan

- [x] `pytest tests/test_setup_claude_code.py` — 15/15 pass
- [x] `pytest tests/test_doctor.py tests/test_doctor_version.py` — count assertions updated, pass
- [x] Full suite: 370 passed (1 pre-existing failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)