### PR TITLE
release: palaia v2.7.2 — Claude Code onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v2.7.2 — 2026-04-06
+
+### New Features
+- **Claude Code onboarding** — `palaia setup claude-code` auto-configures Claude Code as a first-class integration: writes MCP server config to `~/.claude/settings.json`, generates CLAUDE.md with session-start routine and proactive storage guidance. Supports `--global` (recommended), `--dry-run`, `--json`.
+- **Doctor check for Claude Code** — `palaia doctor` now checks whether Claude Code is configured to use palaia as MCP server. Suggests `palaia setup claude-code` if missing.
+- **Dedicated Claude Code docs** — New `docs/claude-code.md` guide with paste-this prompt for fully autonomous install.
+
+### Docs
+- README, getting-started.md, mcp.md updated with Claude Code sections and paste-this prompt.
+- cli-reference.md updated with `setup claude-code` subcommand.
+
+---
+
 ## v2.7.1 — 2026-04-06
 
 ### Fixed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: palaia
-version: "2.7.1"
+version: "2.7.2"
 description: >
   Local, crash-safe persistent memory for OpenClaw agents.
   SQLite-backed by default. Semantic search, projects, scopes, auto-capture.
@@ -25,9 +25,9 @@ metadata:
       - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && openclaw plugins install @byte5ai/palaia && palaia doctor --fix && palaia warmup"
         label: "Upgrade palaia with semantic search + plugin and run health checks"
     postUpdateMessage: >
-      palaia has been updated to v2.7. New: WebUI memory explorer (`palaia ui`),
-      improved doctor checks (legacy files, plugin registration), search timeout
-      fix, security hardening (localhost-only UI).
+      palaia has been updated to v2.7.2. New: `palaia setup claude-code` for
+      one-command Claude Code integration (MCP config + agent instructions),
+      doctor check for Claude Code config.
       Run `palaia doctor --fix` to upgrade.
     plugin:
       slot: memory

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -509,7 +509,19 @@ Replay pending WAL entries.
 
 Print the embedded SKILL.md documentation.
 
-### `palaia setup`
+### `palaia setup claude-code`
+
+Configure Claude Code to use palaia as MCP server. Writes `~/.claude/settings.json` and generates a CLAUDE.md with agent instructions.
+
+| Flag | Description |
+|------|-------------|
+| `--global` | Write CLAUDE.md to `~/.claude/` instead of current directory |
+| `--dry-run` | Preview planned actions without writing files |
+| `--json` | Output result as JSON |
+
+See [Claude Code Integration](claude-code.md) for the full guide.
+
+### `palaia setup --multi-agent`
 
 | Flag | Description |
 |------|-------------|

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byte5ai/palaia",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "palaia memory backend for OpenClaw",
   "main": "index.ts",
   "openclaw": {

--- a/packages/openclaw-plugin/skill/SKILL.md
+++ b/packages/openclaw-plugin/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: palaia
-version: "2.7.1"
+version: "2.7.2"
 description: >
   Local, crash-safe persistent memory for OpenClaw agents.
   SQLite-backed by default. Semantic search, projects, scopes, auto-capture.
@@ -25,9 +25,9 @@ metadata:
       - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && openclaw plugins install @byte5ai/palaia && palaia doctor --fix && palaia warmup"
         label: "Upgrade palaia with semantic search + plugin and run health checks"
     postUpdateMessage: >
-      palaia has been updated to v2.7. New: WebUI memory explorer (`palaia ui`),
-      improved doctor checks (legacy files, plugin registration), search timeout
-      fix, security hardening (localhost-only UI).
+      palaia has been updated to v2.7.2. New: `palaia setup claude-code` for
+      one-command Claude Code integration (MCP config + agent instructions),
+      doctor check for Claude Code config.
       Run `palaia doctor --fix` to upgrade.
     plugin:
       slot: memory

--- a/palaia/SKILL.md
+++ b/palaia/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: palaia
-version: "2.7.1"
+version: "2.7.2"
 description: >
   Local, crash-safe persistent memory for OpenClaw agents.
   SQLite-backed by default. Semantic search, projects, scopes, auto-capture.
@@ -25,9 +25,9 @@ metadata:
       - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && openclaw plugins install @byte5ai/palaia && palaia doctor --fix && palaia warmup"
         label: "Upgrade palaia with semantic search + plugin and run health checks"
     postUpdateMessage: >
-      palaia has been updated to v2.7. New: WebUI memory explorer (`palaia ui`),
-      improved doctor checks (legacy files, plugin registration), search timeout
-      fix, security hardening (localhost-only UI).
+      palaia has been updated to v2.7.2. New: `palaia setup claude-code` for
+      one-command Claude Code integration (MCP config + agent instructions),
+      doctor check for Claude Code config.
       Run `palaia doctor --fix` to upgrade.
     plugin:
       slot: memory

--- a/palaia/__init__.py
+++ b/palaia/__init__.py
@@ -4,5 +4,5 @@ palaia — Local, cloud-free memory for OpenClaw agents.
 
 from __future__ import annotations
 
-__version__ = "2.7.1"
+__version__ = "2.7.2"
 __author__ = "byte5 GmbH"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "palaia"
-version = "2.7.1"
+version = "2.7.2"
 description = "Local, cloud-free memory for OpenClaw agents."
 readme = "README.md"
 license = {text = "MIT"}

--- a/skills/palaia/SKILL.md
+++ b/skills/palaia/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: palaia
-version: "2.7.1"
+version: "2.7.2"
 description: >
   Local, crash-safe persistent memory for OpenClaw agents.
   SQLite-backed by default. Semantic search, projects, scopes, auto-capture.
@@ -25,9 +25,9 @@ metadata:
       - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && openclaw plugins install @byte5ai/palaia && palaia doctor --fix && palaia warmup"
         label: "Upgrade palaia with semantic search + plugin and run health checks"
     postUpdateMessage: >
-      palaia has been updated to v2.7. New: WebUI memory explorer (`palaia ui`),
-      improved doctor checks (legacy files, plugin registration), search timeout
-      fix, security hardening (localhost-only UI).
+      palaia has been updated to v2.7.2. New: `palaia setup claude-code` for
+      one-command Claude Code integration (MCP config + agent instructions),
+      doctor check for Claude Code config.
       Run `palaia doctor --fix` to upgrade.
     plugin:
       slot: memory


### PR DESCRIPTION
## Summary

- Version bump to 2.7.2
- CHANGELOG entry for v2.7.2
- SKILL.md postUpdateMessage updated
- cli-reference.md: `setup claude-code` subcommand documented
- All SKILL.md copies synced

Feature work was merged in #178. This PR is the release paperwork.

## Test plan

- [x] 1137 tests passed, 0 failures
- [x] ruff lint clean
- [x] SKILL.md copies identical
- [x] Risk assessment: no breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)