### PR TITLE
release: palaia v2.7.3

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -25,10 +25,9 @@ metadata:
       - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && openclaw plugins install @byte5ai/palaia && palaia doctor --fix && palaia warmup"
         label: "Upgrade palaia with semantic search + plugin and run health checks"
     postUpdateMessage: >
-      palaia has been updated to v2.7.2. New: `palaia setup claude-code` for
-      one-command Claude Code integration (MCP config + agent instructions),
-      doctor check for Claude Code config.
-      Run `palaia doctor --fix` to upgrade.
+      palaia has been updated to v2.7.3. Fixes: ContextEngine compaction conflict
+      with OpenClaw, doctor phantom stale-task warnings, invisible entries with
+      empty scope. Run `palaia doctor --fix` to verify.
     plugin:
       slot: memory
       package: "@byte5ai/palaia"

--- a/packages/openclaw-plugin/skill/SKILL.md
+++ b/packages/openclaw-plugin/skill/SKILL.md
@@ -25,10 +25,9 @@ metadata:
       - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && openclaw plugins install @byte5ai/palaia && palaia doctor --fix && palaia warmup"
         label: "Upgrade palaia with semantic search + plugin and run health checks"
     postUpdateMessage: >
-      palaia has been updated to v2.7.2. New: `palaia setup claude-code` for
-      one-command Claude Code integration (MCP config + agent instructions),
-      doctor check for Claude Code config.
-      Run `palaia doctor --fix` to upgrade.
+      palaia has been updated to v2.7.3. Fixes: ContextEngine compaction conflict
+      with OpenClaw, doctor phantom stale-task warnings, invisible entries with
+      empty scope. Run `palaia doctor --fix` to verify.
     plugin:
       slot: memory
       package: "@byte5ai/palaia"

--- a/palaia/SKILL.md
+++ b/palaia/SKILL.md
@@ -25,10 +25,9 @@ metadata:
       - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && openclaw plugins install @byte5ai/palaia && palaia doctor --fix && palaia warmup"
         label: "Upgrade palaia with semantic search + plugin and run health checks"
     postUpdateMessage: >
-      palaia has been updated to v2.7.2. New: `palaia setup claude-code` for
-      one-command Claude Code integration (MCP config + agent instructions),
-      doctor check for Claude Code config.
-      Run `palaia doctor --fix` to upgrade.
+      palaia has been updated to v2.7.3. Fixes: ContextEngine compaction conflict
+      with OpenClaw, doctor phantom stale-task warnings, invisible entries with
+      empty scope. Run `palaia doctor --fix` to verify.
     plugin:
       slot: memory
       package: "@byte5ai/palaia"

--- a/skills/palaia/SKILL.md
+++ b/skills/palaia/SKILL.md
@@ -25,10 +25,9 @@ metadata:
       - command: "python3 -m pip install --upgrade 'palaia[fastembed]' && openclaw plugins install @byte5ai/palaia && palaia doctor --fix && palaia warmup"
         label: "Upgrade palaia with semantic search + plugin and run health checks"
     postUpdateMessage: >
-      palaia has been updated to v2.7.2. New: `palaia setup claude-code` for
-      one-command Claude Code integration (MCP config + agent instructions),
-      doctor check for Claude Code config.
-      Run `palaia doctor --fix` to upgrade.
+      palaia has been updated to v2.7.3. Fixes: ContextEngine compaction conflict
+      with OpenClaw, doctor phantom stale-task warnings, invisible entries with
+      empty scope. Run `palaia doctor --fix` to verify.
     plugin:
       slot: memory
       package: "@byte5ai/palaia"


### PR DESCRIPTION
## Summary
- SKILL.md `postUpdateMessage` updated for v2.7.3
- All 4 SKILL.md copies synchronized

Docs-only release commit. Code fixes already on main via #186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)