### PR TITLE
docs: document PALAIA_UI_UNSAFE_BIND for remote access

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -452,7 +452,15 @@ palaia ui --port 9000      # Custom port (auto-fallback if busy)
 palaia ui --no-browser     # Don't auto-open browser
 ```
 
-Browse, search, create, edit, and delete entries in the browser. Manual entries are highlighted with a gold border (1.3× recall boost). Tasks are post-its: clicking ✓ deletes them. The health pill in the header shows doctor status with actionable warnings. Localhost only — no authentication, no network exposure.
+Browse, search, create, edit, and delete entries in the browser. Manual entries are highlighted with a gold border (1.3× recall boost). Tasks are post-its: clicking ✓ deletes them. The health pill in the header shows doctor status with actionable warnings.
+
+**Security:** Binds to `127.0.0.1` (localhost) by default — no authentication, no network exposure. For remote access (e.g. headless server via Tailscale/SSH):
+
+```bash
+PALAIA_UI_UNSAFE_BIND=0.0.0.0 palaia ui --no-browser --port 8384
+```
+
+This binds to all interfaces. The env var (not a CLI flag) is intentional — prevents accidental network exposure from copy-pasted commands. A warning is printed on startup. Consider an SSH tunnel or reverse proxy with auth for untrusted networks.
 
 ### `palaia doctor` — Diagnostics and auto-fix
 

--- a/packages/openclaw-plugin/skill/SKILL.md
+++ b/packages/openclaw-plugin/skill/SKILL.md
@@ -452,7 +452,15 @@ palaia ui --port 9000      # Custom port (auto-fallback if busy)
 palaia ui --no-browser     # Don't auto-open browser
 ```
 
-Browse, search, create, edit, and delete entries in the browser. Manual entries are highlighted with a gold border (1.3× recall boost). Tasks are post-its: clicking ✓ deletes them. The health pill in the header shows doctor status with actionable warnings. Localhost only — no authentication, no network exposure.
+Browse, search, create, edit, and delete entries in the browser. Manual entries are highlighted with a gold border (1.3× recall boost). Tasks are post-its: clicking ✓ deletes them. The health pill in the header shows doctor status with actionable warnings.
+
+**Security:** Binds to `127.0.0.1` (localhost) by default — no authentication, no network exposure. For remote access (e.g. headless server via Tailscale/SSH):
+
+```bash
+PALAIA_UI_UNSAFE_BIND=0.0.0.0 palaia ui --no-browser --port 8384
+```
+
+This binds to all interfaces. The env var (not a CLI flag) is intentional — prevents accidental network exposure from copy-pasted commands. A warning is printed on startup. Consider an SSH tunnel or reverse proxy with auth for untrusted networks.
 
 ### `palaia doctor` — Diagnostics and auto-fix
 

--- a/palaia/SKILL.md
+++ b/palaia/SKILL.md
@@ -452,7 +452,15 @@ palaia ui --port 9000      # Custom port (auto-fallback if busy)
 palaia ui --no-browser     # Don't auto-open browser
 ```
 
-Browse, search, create, edit, and delete entries in the browser. Manual entries are highlighted with a gold border (1.3× recall boost). Tasks are post-its: clicking ✓ deletes them. The health pill in the header shows doctor status with actionable warnings. Localhost only — no authentication, no network exposure.
+Browse, search, create, edit, and delete entries in the browser. Manual entries are highlighted with a gold border (1.3× recall boost). Tasks are post-its: clicking ✓ deletes them. The health pill in the header shows doctor status with actionable warnings.
+
+**Security:** Binds to `127.0.0.1` (localhost) by default — no authentication, no network exposure. For remote access (e.g. headless server via Tailscale/SSH):
+
+```bash
+PALAIA_UI_UNSAFE_BIND=0.0.0.0 palaia ui --no-browser --port 8384
+```
+
+This binds to all interfaces. The env var (not a CLI flag) is intentional — prevents accidental network exposure from copy-pasted commands. A warning is printed on startup. Consider an SSH tunnel or reverse proxy with auth for untrusted networks.
 
 ### `palaia doctor` — Diagnostics and auto-fix
 

--- a/palaia/cli_args.py
+++ b/palaia/cli_args.py
@@ -292,7 +292,11 @@ def build_parser() -> argparse.ArgumentParser:
     sub.add_parser("upgrade", help="Upgrade palaia to latest version (auto-detects install method and extras)")
 
     # ui — local WebUI memory explorer (localhost only, no auth)
-    p_ui = sub.add_parser("ui", help="Launch the palaia WebUI in the browser")
+    p_ui = sub.add_parser(
+        "ui",
+        help="Launch the palaia WebUI in the browser",
+        epilog="Remote access: set PALAIA_UI_UNSAFE_BIND=0.0.0.0 to bind to all interfaces (no auth — use with care).",
+    )
     p_ui.add_argument("--port", type=int, default=8384, help="Port to bind (default: 8384, will fall back if busy)")
     p_ui.add_argument("--no-browser", action="store_true", help="Do not auto-open the browser")
 

--- a/skills/palaia/SKILL.md
+++ b/skills/palaia/SKILL.md
@@ -452,7 +452,15 @@ palaia ui --port 9000      # Custom port (auto-fallback if busy)
 palaia ui --no-browser     # Don't auto-open browser
 ```
 
-Browse, search, create, edit, and delete entries in the browser. Manual entries are highlighted with a gold border (1.3× recall boost). Tasks are post-its: clicking ✓ deletes them. The health pill in the header shows doctor status with actionable warnings. Localhost only — no authentication, no network exposure.
+Browse, search, create, edit, and delete entries in the browser. Manual entries are highlighted with a gold border (1.3× recall boost). Tasks are post-its: clicking ✓ deletes them. The health pill in the header shows doctor status with actionable warnings.
+
+**Security:** Binds to `127.0.0.1` (localhost) by default — no authentication, no network exposure. For remote access (e.g. headless server via Tailscale/SSH):
+
+```bash
+PALAIA_UI_UNSAFE_BIND=0.0.0.0 palaia ui --no-browser --port 8384
+```
+
+This binds to all interfaces. The env var (not a CLI flag) is intentional — prevents accidental network exposure from copy-pasted commands. A warning is printed on startup. Consider an SSH tunnel or reverse proxy with auth for untrusted networks.
 
 ### `palaia doctor` — Diagnostics and auto-fix
 


### PR DESCRIPTION
## Summary
- Document `PALAIA_UI_UNSAFE_BIND` env var in all 4 SKILL.md copies and `palaia ui --help`
- The env var existed since v2.7 but was only discoverable by reading source code
- Agents (and users) reading the docs saw "Localhost only" with no escape hatch documented

## Context
User's agent on a headless OpenClaw instance suggested adding a `--host` CLI flag — the correct mechanism already existed but was undocumented.

## Test plan
- [ ] `palaia ui --help` shows epilog with `PALAIA_UI_UNSAFE_BIND` hint
- [ ] All 4 SKILL.md files contain the remote access section

🤖 Generated with [Claude Code](https://claude.com/claude-code)