### PR TITLE
feat: SPEC-003 vault engine round-trip spike + findings

### DIFF
--- a/v3/spikes/vault/FINDINGS.md
+++ b/v3/spikes/vault/FINDINGS.md
@@ -1,0 +1,274 @@
+# SPEC-003 findings: vault engine round-trip proof
+
+All numbers below were measured on this run's container: 4 vCPU, 15 GiB RAM,
+Python 3.11.15, `uv` 0.8.17, git 2.43.0, SQLite 3.45.1, `/tmp` on the
+container's root filesystem (not tmpfs). Re-running on different hardware
+will shift absolute numbers but the *shapes* (round-trip fidelity, git
+growth pattern, embed cost dominating everything else, kill-test safety)
+should hold. Every number here comes from a script in this directory —
+see [README.md](README.md) for exact invocations.
+
+## Q1 — Round-trip: write → index → search → delete DB → rebuild → identical?
+
+**Answer: yes, at every scale tested — 500 / 1,000 / 10,000 notes, search
+results identical before and after rebuild in all three runs.**
+
+| N notes | generate | fresh build | rebuild (after `rm db`) | search results | FTS5 db size |
+|---|---|---|---|---|---|
+| 500 | 0.04 s | 0.284 s | 0.278 s | identical (PASS) | 700 KiB |
+| 1,000 | ~0.08 s | 0.591 s | 0.571 s | identical (PASS) | 1.31 MiB |
+| 10,000 | 1.44 s | 5.649 s | 5.457 s | identical (PASS) | 12.84 MiB |
+
+Build cost is close to linear (0.57 ms/note at 1k, 0.57 ms/note at 10k) —
+mostly parse + insert cost, dominated by per-row `INSERT` statements
+without a transaction-batching optimization (this spike does one implicit
+transaction per file via autocommit-off default connection; SPEC-102
+should batch inserts and it will be materially faster).
+
+**Surprise:** none — this is the one question that came back exactly as
+architecturally promised. The "database is disposable" claim in
+MASTERPLAN §5.1 holds at 10k notes with zero special-cased recovery logic:
+delete the `.db` file, re-run the same build function, get the same
+answers back.
+
+**What this changes for SPEC-102/103/104:** nothing structurally — proceed
+with FTS5 content tables as planned. SPEC-104 should still batch writes in
+one transaction per build (this spike is once-per-row) since that's the
+easy 5-10x win visible in the per-note cost above.
+
+## Q2 — External-edit loop: does the watcher pick up changes within ~2s?
+
+**Answer: yes, with enormous margin — ~50-80 ms observed, not the ~2s
+budget, at 200 ms debounce.** Ran against a 100-note vault (`watch_spike.py
+--n 100 --debounce-ms 200`):
+
+| Scenario | Latency (edit → watcher observes it) | Batches | Notes |
+|---|---|---|---|
+| Single content edit | 51.5 ms | 1 | well within 2s |
+| Rapid rename + edit | 51.4 ms | 1 | reported as one `deleted` + one `added` change in the *same* debounce batch, not two |
+| Burst of 20 near-simultaneous edits | 79.5 ms (first == only batch) | 1, 20 changes | all 20 coalesced into a single batch |
+
+**Sane debounce:** 200 ms is already generous relative to observed
+latency; even at that setting all three scenarios resolved in under 100 ms
+of *watcher-observed* latency, well inside the ~2s target. Editors that
+write in multiple syscalls close together (Obsidian's save-as-rename
+pattern) do **not** produce a storm of separate reindex events — `watchfiles`
+folds them into one batch per debounce window.
+
+**Surprise:** a rename+edit is reported to the consumer as `deleted(old)` +
+`added(new)`, not as a `renamed` event — there is no rename event type in
+`watchfiles`'s output. A naive reindexer that treats `deleted` as
+"forget this permalink" and `added` as "index this as a brand new entity"
+will silently **lose the old entity's history/relations** on every
+Obsidian-style rename unless the indexer explicitly does checksum-based
+move detection (exactly the mitigation basic-memory research flagged,
+research/basic-memory.md §2 — "move detection by checksum match").
+
+**What this changes for SPEC-102/103:** SPEC-102's watcher consumer must
+implement checksum-based move detection on `deleted`+`added` pairs inside
+the *same* debounce batch (cheap: batches are small and same-batch
+same-content deleted/added pairs are the common case), not treat them as
+independent delete-then-create. This is now a named requirement, not an
+optional nice-to-have.
+
+## Q3 — Git layer cost: is one-commit-per-write viable, or is batching needed?
+
+**Answer: commit *latency* stays acceptable even per-write at 10k notes
+(≤240 ms), but per-write commits without periodic `git gc` cause
+quadratic-looking `.git` growth that is not viable unmanaged past a
+few thousand notes. Batching (or gc'ing) fixes it completely.**
+
+### Per-commit latency, one commit per write
+
+| N notes | backend | mean | p50 | p95 | max | `git status` (median) |
+|---|---|---|---|---|---|---|
+| 50 | pygit2 | 4.8 ms | 4.3 ms | 6.9 ms | 7.3 ms | 3.3 ms |
+| 50 | subprocess | 93.6 ms | 93.0 ms | 105.9 ms | 122.5 ms | 3.0 ms |
+| 1,000 | pygit2 | 9.2 ms | 8.8 ms | 15.9 ms | 32.2 ms | 5.6 ms |
+| 1,000 | subprocess | 94.7 ms | 90.6 ms | 107.6 ms | 1,202.7 ms | 5.6 ms |
+| 10,000 | pygit2 | 78.5 ms | 78.6 ms | 152.4 ms | 238.2 ms | 19.5 ms |
+| 10,000 | subprocess | 117.8 ms | 113.4 ms | 147.7 ms | 1,876.9 ms | 19.8 ms |
+
+`git status` **does** stay fast (single-digit to low-double-digit
+milliseconds even at 10k commits / 10k tracked files) — that specific
+worry from the SPEC is unfounded. What is *not* fast is the ~8.5x growth in
+pygit2 per-commit latency from 1k→10k (9.2 ms → 78.5 ms mean): index
+add-all + write rescans the whole working tree every call, so per-commit
+cost grows with vault size, not just commit count. subprocess's overhead is
+dominated by process-spawn cost (~90 ms baseline) at small N but the same
+rescan effect pushes it up too (94.7 ms → 117.8 ms).
+
+### Repo size: this is the real problem with naive one-commit-per-write
+
+| N notes, mode | backend | working-tree+.git size | `.git` alone |
+|---|---|---|---|
+| 1,000, percommit | pygit2 | 13.9 MiB | **13.4 MiB** |
+| 1,000, batch (1 commit) | pygit2 | 1.0 MiB | 0.43 MiB |
+| 10,000, percommit | pygit2 | 1,255.3 MiB (1.17 GiB) | **1,249.7 MiB (1.16 GiB)** |
+| 10,000, percommit | subprocess | 148.2 MiB | **142.6 MiB** |
+| 10,000, batch (1 commit) | pygit2 | 10.07 MiB | 4.51 MiB |
+| 10,000, batch (1 commit) | subprocess | 10.09 MiB | 4.54 MiB |
+
+**Surprise #1:** at 10k notes, one-commit-per-write with **pygit2** bloats
+`.git` to **1.16 GiB** for a vault whose actual content is ~10 MiB — a
+~116x blow-up, and the pattern (13.4 MiB at 1k → 1,249.7 MiB at 10k, a
+~93x increase for a 10x increase in N) is consistent with each commit
+writing an unpacked tree object listing the entire (growing) flat
+directory, i.e. **O(n²) loose-object growth** for one-commit-per-write into
+a flat directory, not O(n). This is the actual scaling risk the SPEC asked
+about — not commit latency.
+
+**Surprise #2:** the **subprocess `git`** backend does *not* show the same
+blow-up (142.6 MiB vs pygit2's 1.16 GiB for the identical 10k-commit
+workload) despite being slower per commit. The most likely explanation is
+git's built-in `gc.auto` housekeeping (default threshold ~6,700 loose
+objects) firing transparently partway through the 10,000 commit
+invocations and incrementally repacking — a safety net porcelain `git`
+gives you for free that **libgit2 (pygit2) does not**. This is a concrete
+backend trade-off, not just a speed one.
+
+**Confirmed fix — `git gc` recovers the bloat completely:** ran
+`git gc --aggressive` (via `git_gc_bench.py`) against the 1k-note
+pygit2 percommit repo:
+
+```
+git_dir_bytes_before: 13,389,707  (13.4 MiB)
+git_dir_bytes_after:   1,231,076  (1.23 MiB)
+gc_seconds: 1.77
+shrink_ratio: 10.9x
+```
+
+**Verdict: one-commit-per-write is viable, but only paired with periodic
+`git gc`** (either scheduled, or delegate to `git` subprocess and rely on
+its `gc.auto`, or both). Pure in-process libgit2 with no gc plan is not
+viable past low thousands of notes on flat storage.
+
+**What this changes for SPEC-102:** (1) do not call an unconditional
+index add-all + write-tree on the *whole* index every write — stage
+only the changed path(s) to keep per-commit cost flat instead of growing
+with vault size; (2) schedule `git gc --auto` (cheap, incremental) after
+every N commits or on a timer, and document the loose-object bloat as an
+explicit operational concern, not an edge case; (3) prefer sharding notes
+into subdirectories (e.g. by first two chars of permalink hash) over one
+flat directory once vault size is expected to exceed a few thousand notes,
+since tree-object cost per commit scales with *directory* size, not vault
+size, if sharded.
+
+## Q4 — Vector search: fastembed + sqlite-vec cold-start, per-note cost, hybrid sketch
+
+Ran against a 500-note vault (`vector_spike.py --n 500`), model
+`BAAI/bge-small-en-v1.5` (fastembed's default, dim 384), matching the
+research dossier's stated default.
+
+| Metric | Value |
+|---|---|
+| Cold start (embedding-model object construction, model already cached) | 0.59 s |
+| Embed cost, 500 notes (title+body+observations text) | 218.6 s total → **437.3 ms/note** |
+| sqlite-vec insert cost | 0.031 ms/note (negligible) |
+| Query embed (single query string) | 107.8 ms |
+| vec0 kNN search (top 10, 500 rows) | 1.27 ms |
+| FTS5 search (top 10, 500 rows) | 5.6 ms |
+| DB size, FTS5 only | 696 KiB |
+| DB size, FTS5 + 500×384-dim float vectors | 2.24 MiB |
+
+**Surprise (the big one):** embedding is **by far** the slowest operation
+in this entire spike — 437 ms/note, roughly **1,500x slower than the FTS5
+index build** (0.57 ms/note) on the same hardware. Extrapolated (not
+re-measured, since a real run would take this long): embedding 1,000 notes
+would take **~7.3 minutes**; 10,000 notes **~73 minutes**, serially,
+single-threaded, on this 4-vCPU container. This is a hard operational
+constraint the masterplan's "hybrid search by default" language does not
+currently price in.
+
+**Hybrid merge sketch:** implemented simple rank-fusion
+(`score = 1/(rank_fts+1) + 1/(rank_vec+1)`), confirmed it runs and produces
+a merged top-10 that differs from either individual ranking (FTS and
+vector top-10 for the same query shared only 2 of 10 results before
+fusion) — proof of concept only, no claim this is the right fusion formula
+(SPEC-104's job).
+
+**What this changes for SPEC-102/103/104:** (1) embedding cannot run
+synchronously on the write path if "synchronous writes" (MASTERPLAN §5.1)
+is to remain true for perceived latency — FTS indexing can stay on the
+synchronous path (sub-millisecond), but vector embedding needs to be
+async/deferred/batched-in-the-background from day one, not treated as a
+"just add embeddings too" afterthought; (2) initial vault import / first-run
+cold-embed of an existing large vault (e.g. a basic-memory import) is a
+multi-minute-to-multi-hour operation at realistic vault sizes and needs a
+visible progress/background-job story in SPEC-111; (3) investigate
+fastembed batch-size/thread tuning or a smaller/faster model before
+committing to `bge-small-en-v1.5` as *the* default — 437 ms/note on 4
+vCPUs is worth a follow-up spike of its own before SPEC-104 locks it in.
+
+## Q5 — Atomicity: does `kill -9` during a write burst ever corrupt the vault?
+
+**Answer: no corruption in 28 trials (3 smoke + 25 full run) of the
+write-then-commit loop, with kill delays randomized across 0.05-1.2s to
+land at different points in the loop.** Method
+(`writer.py` + `checker.py` + `kill_test.sh`): loop of
+{write to temp file in the vault dir → fsync → atomic rename into place →
+git add/commit via pygit2}, SIGKILLed from outside at a
+randomized point, then inspected.
+
+25-trial aggregate (`./kill_test.sh 25`):
+
+| Check | Result |
+|---|---|
+| Vault corrupt (truncated/unparseable note, or index rebuild crashed) | **0 / 25** |
+| Zero-byte or partially-written `.md` files | **0 / 25** |
+| Stray orphaned temp files left behind (expected/harmless — a write-in-flight when killed, never renamed into place) | 7 / 25 trials, always exactly 1 |
+| git/libgit2 index lock left behind (kill landed mid index-write) | **2 / 25** |
+| ...of those, was removing the stale lock file alone sufficient to recover? | **2 / 2 (100%)** — no further repair needed |
+| SQLite index rebuildable from files after the kill, with entity count == on-disk `.md` file count | **25 / 25** |
+
+**Commands used** (see `kill_test.sh` in full): for each trial, launch
+`uv run writer.py --vault-dir <unique tmp dir> --n 200000 &`, `sleep
+<seed-derived random 0.05-1.2s delay>`, then `pkill -9 -f "writer.py
+--vault-dir <that dir>"` (looped up to 10x100ms to confirm the process
+tree is actually gone — see surprise below), then
+`uv run checker.py --vault-dir <dir> ...`.
+
+**Surprise:** `uv run <script>.py &`, backgrounded from bash and killed by
+its `$!` PID, does **not** kill the actual work — `uv run` execs a *child*
+Python interpreter process rather than replacing itself on this platform
+(confirmed with process listing: the `uv run writer.py` PID and the real
+python-interpreter `writer.py` PID are different processes, parent/child).
+The first version of this test killed only the `uv` wrapper, leaving the
+real writer alive and racing the checker — it produced internally
+inconsistent-looking results (fewer `.md` files present than the writer's
+own progress log claimed to have confirmed) purely from that race, not
+from any real corruption. Fixed by matching-and-killing on the unique
+`--vault-dir` argument via `pkill -9 -f`, confirmed dead before inspecting.
+**This is a real gotcha for anyone building process-supervision or crash
+tests around `uv run`-launched processes, not specific to this spike.**
+
+**What this changes for SPEC-102:** the write protocol (temp file, fsync,
+atomic rename) as described in MASTERPLAN §5.1 is validated — no note
+file was ever observed corrupted or partially written across 25 kill
+trials. The one real operational finding: **pygit2's index-write path can
+leave a stale index-lock file after a kill** (8% of trials here) that
+blocks further git operations until removed; SPEC-102's hub startup
+sequence must check for and clear a stale lock file (with a
+staleness/liveness check — not blindly delete one belonging to a live
+process) as a normal part of crash recovery, not an exceptional path. No
+other repair was ever needed in any trial — a doctor/rebuild-from-files
+step as designed is sufficient beyond that.
+
+## Summary: what changes for SPEC-102/103/104
+
+1. **Round-trip and crash-safety claims hold as designed** — no changes to
+   the core files-as-truth model. (Q1, Q5)
+2. **Watcher must do checksum-based move detection** on same-batch
+   delete+add pairs — `watchfiles` reports renames as delete+add, not as a
+   rename event. (Q2)
+3. **Git layer needs an explicit gc plan and narrower per-write staging** —
+   naive add-all-every-write is roughly quadratic in loose-object growth
+   and linear-growing in per-commit latency; stage only the changed path,
+   and schedule `git gc` (or shell out to `git` and lean on its
+   `gc.auto`). Startup must clear a stale index lock file as routine crash
+   recovery. (Q3, Q5)
+4. **Vector embedding cannot be on the synchronous write path** — at
+   ~437 ms/note on modest hardware it is 2-3 orders of magnitude slower
+   than everything else measured here; needs an async/background job
+   design from SPEC-102 onward, and the default model choice deserves its
+   own follow-up spike before SPEC-104 locks it in. (Q4)

--- a/v3/spikes/vault/README.md
+++ b/v3/spikes/vault/README.md
@@ -1,0 +1,55 @@
+# Vault engine spike (SPEC-003)
+
+Throwaway-quality code that proves (or disproves) five load-bearing claims
+in [MASTERPLAN.md §5.1](../../MASTERPLAN.md) about the files-as-truth vault
+architecture, before [SPEC-102](../../specs/SPEC-102-vault-engine.md) builds
+it for real. See [FINDINGS.md](FINDINGS.md) for the answers.
+
+**Self-contained by design:** every script below is a [PEP 723](https://peps.python.org/pep-0723/)
+inline-metadata script, runnable directly with [`uv`](https://docs.astral.sh/uv/)
+— no `pyproject.toml`, no shared virtualenv, nothing outside this directory.
+`uv run <script>.py` resolves and caches each script's own dependencies on
+first run. Nothing here touches `v3/pyproject.toml` (it does not exist) or
+the repo root.
+
+## Layout
+
+| File | Question | Purpose |
+|---|---|---|
+| `grammar.py` | — | Shared toy note parser (frontmatter + observations + relations). Not the formal v3 grammar — SPEC-004 owns that. |
+| `gen_vault.py` | — | Generates N toy notes (with ~15% forward references, tags, relations). Importable + standalone CLI. |
+| `index_lib.py` | — | Build/rebuild a SQLite FTS5 index from a vault dir; search by phrase. |
+| `round_trip.py` | Q1 | Generate → index → search → delete DB → rebuild → re-search → diff. |
+| `watch_spike.py` | Q2 | `watchfiles`-based watcher; scripted single-edit, rename+edit, and 20-file-burst scenarios with latency measurement. |
+| `git_bench.py` | Q3 | Per-commit cost, pygit2 vs `git` subprocess, percommit vs batch mode, at configurable N. |
+| `vector_spike.py` | Q4 | `fastembed` + `sqlite-vec`: cold start, per-note embed cost, a rank-fusion hybrid-merge sketch. |
+| `writer.py`, `checker.py`, `kill_test.sh` | Q5 | Atomic-write-then-commit loop, repeated SIGKILL at randomized delays, and a post-mortem vault/git/index inspector. |
+
+## Running it
+
+```bash
+# Q1 — round trip, at whatever scale you want numbers for
+uv run round_trip.py --n 1000
+uv run round_trip.py --n 10000
+
+# Q2 — watcher latency
+uv run watch_spike.py --n 200 --debounce-ms 200
+
+# Q3 — git cost. Repeat with --backend {pygit2,subprocess} and --mode {percommit,batch}
+uv run git_bench.py --n 1000  --backend pygit2
+uv run git_bench.py --n 1000  --backend subprocess
+uv run git_bench.py --n 10000 --backend pygit2
+
+# Q4 — vector search (slow: ~0.4s/note to embed on this hardware, see FINDINGS.md)
+uv run vector_spike.py --n 500
+
+# Q5 — kill -9 atomicity, N trials, results as JSONL + a summary table
+./kill_test.sh 25 /tmp/kill_test_results.jsonl
+```
+
+## Non-goals (per SPEC-003)
+
+No production quality, no full/formal grammar (SPEC-004 defines it), no
+recall logic. The note grammar here is deliberately the minimum needed to
+exercise parsing + FTS5 + relations — it is not a preview of the real
+format.

--- a/v3/spikes/vault/checker.py
+++ b/v3/spikes/vault/checker.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pyyaml"]
+# ///
+"""Post-kill inspector used by kill_test.sh (SPEC-003 Q5).
+
+Given a vault directory that a writer.py process was SIGKILLed inside of,
+checks:
+  - are there stray temp files (expected/harmless — a write-in-progress
+    that never got its atomic rename)?
+  - is every *.md file on disk fully parseable (no truncation/corruption)?
+  - is there a stale .git/index.lock (pygit2/libgit2 leaves one if killed
+    mid index-write)?
+  - does `git status` work as-is, and if not, is removing the stale lock
+    sufficient to recover (no other repair needed)?
+  - can the SQLite index be rebuilt from files afterwards, and does the
+    resulting entity count match the number of valid .md files on disk?
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import grammar  # noqa: E402
+import index_lib  # noqa: E402
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--vault-dir", required=True)
+    ap.add_argument("--trial", type=int, required=True)
+    ap.add_argument("--delay", type=float, required=True)
+    args = ap.parse_args()
+
+    vault_dir = Path(args.vault_dir)
+    md_files = sorted(vault_dir.glob("*.md"))
+    tmp_files = sorted(p for p in vault_dir.iterdir() if p.name.startswith(".") and p.name.endswith(".tmp"))
+
+    parse_failures = []
+    for p in md_files:
+        try:
+            grammar.parse_file(str(p), str(vault_dir))
+        except grammar.ParseError as exc:
+            parse_failures.append({"file": p.name, "error": str(exc)})
+        except Exception as exc:  # any other exception is itself a finding
+            parse_failures.append({"file": p.name, "error": f"unexpected: {exc!r}"})
+
+    zero_byte_files = [p.name for p in md_files if p.stat().st_size == 0]
+
+    index_lock = vault_dir / ".git" / "index.lock"
+    lock_present = index_lock.exists()
+
+    status_before = subprocess.run(
+        ["git", "-C", str(vault_dir), "status", "--porcelain"],
+        capture_output=True, text=True,
+    )
+    status_before_ok = status_before.returncode == 0
+
+    recovery_needed = False
+    recovery_sufficient = None
+    if lock_present:
+        recovery_needed = True
+        index_lock.unlink()
+        status_after = subprocess.run(
+            ["git", "-C", str(vault_dir), "status", "--porcelain"],
+            capture_output=True, text=True,
+        )
+        recovery_sufficient = status_after.returncode == 0
+
+    progress_log = vault_dir / "progress.log"
+    last_confirmed = None
+    n_confirmed_lines = 0
+    if progress_log.exists():
+        lines = progress_log.read_text(encoding="utf-8").strip().splitlines()
+        n_confirmed_lines = len(lines)
+        if lines:
+            last_confirmed = lines[-1].split("\t")
+
+    db_path = tempfile.mktemp(suffix=".db")
+    rebuild_error = None
+    build_stats = None
+    try:
+        build_stats = index_lib.build_index(str(vault_dir), db_path)
+    except Exception as exc:  # noqa: BLE001
+        rebuild_error = repr(exc)
+    finally:
+        Path(db_path).unlink(missing_ok=True)
+
+    report = {
+        "trial": args.trial,
+        "kill_delay_seconds": args.delay,
+        "n_md_files": len(md_files),
+        "n_stray_tmp_files": len(tmp_files),
+        "stray_tmp_files": [p.name for p in tmp_files],
+        "n_parse_failures": len(parse_failures),
+        "parse_failures": parse_failures,
+        "n_zero_byte_md_files": len(zero_byte_files),
+        "git_index_lock_present": lock_present,
+        "git_status_ok_immediately": status_before_ok,
+        "recovery_needed": recovery_needed,
+        "recovery_sufficient_lock_removal_only": recovery_sufficient,
+        "n_confirmed_writes_in_progress_log": n_confirmed_lines,
+        "last_confirmed_write": last_confirmed,
+        "rebuild_error": rebuild_error,
+        "rebuild_n_entities": build_stats["n_entities"] if build_stats else None,
+        "rebuild_matches_md_file_count": (
+            build_stats["n_entities"] == len(md_files) if build_stats else None
+        ),
+        "vault_corrupt": bool(parse_failures) or bool(zero_byte_files) or bool(rebuild_error),
+    }
+    print(json.dumps(report))
+
+
+if __name__ == "__main__":
+    main()

--- a/v3/spikes/vault/gen_vault.py
+++ b/v3/spikes/vault/gen_vault.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pyyaml"]
+# ///
+"""Generator for a toy vault of N notes (frontmatter + observations +
+wikilinks), per SPEC-003 deliverable #1.
+
+Usable as a library (import gen_vault; gen_vault.write_vault(...)) by the
+other spike scripts, or standalone:
+
+    uv run gen_vault.py --n 1000 --out /tmp/toy-vault --seed 42
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import os
+import random
+from pathlib import Path
+
+CATEGORIES = ["fact", "decision", "preference", "technique", "issue", "idea"]
+REL_TYPES = ["relates_to", "depends_on", "part_of", "contradicts", "follows"]
+TOPICS = [
+    "authentication", "vault-format", "recall-scoring", "git-layer",
+    "dashboard-ux", "mcp-gateway", "curator-policy", "inbox-contract",
+    "embedding-model", "search-ranking", "schema-inference", "event-bus",
+    "oauth-flow", "session-scoping", "importer-basic-memory", "hub-config",
+    "watcher-debounce", "sqlite-index", "graph-traversal", "token-budget",
+]
+WORDS = (
+    "the system should always prefer synchronous writes over eventual "
+    "consistency because agents need to see their own writes immediately "
+    "and the vault is the source of truth for every derived index we build "
+    "on top of it later during recall and search"
+).split()
+
+
+def _permalink(n: int) -> str:
+    return f"note-{n:06d}"
+
+
+def _title(n: int, rng: random.Random) -> str:
+    topic = rng.choice(TOPICS)
+    return f"{topic.replace('-', ' ').title()} — note {n}"
+
+
+def _prose(rng: random.Random, forward_ref: str | None) -> str:
+    sentence = " ".join(rng.choices(WORDS, k=rng.randint(8, 16)))
+    if forward_ref:
+        sentence += f" See also [[{forward_ref}]] for more context."
+    return sentence.capitalize() + "."
+
+
+def make_note_text(n: int, total: int, rng: random.Random) -> tuple[str, str]:
+    """Return (permalink, markdown_text) for note n of `total`."""
+    permalink = _permalink(n)
+    title = _title(n, rng)
+    tags = rng.sample(TOPICS, k=rng.randint(1, 3))
+    created = (
+        dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc)
+        + dt.timedelta(minutes=n)
+    ).isoformat()
+
+    # ~15% of notes carry a forward reference to a note that does not exist
+    # yet (higher permalink number), per research/basic-memory.md §1.
+    forward_target = None
+    if total > 1 and rng.random() < 0.15:
+        forward_target = _permalink(rng.randint(n + 1, total - 1) if n < total - 1 else n)
+
+    prose = _prose(rng, forward_target)
+
+    n_obs = rng.randint(1, 4)
+    obs_lines = []
+    for _ in range(n_obs):
+        cat = rng.choice(CATEGORIES)
+        text = " ".join(rng.choices(WORDS, k=rng.randint(4, 10)))
+        obs_tags = " ".join(f"#{t}" for t in rng.sample(TOPICS, k=rng.randint(0, 2)))
+        ctx = f" ({rng.choice(['from review', 'user reported', 'design call'])})" if rng.random() < 0.4 else ""
+        obs_lines.append(f"- [{cat}] {text} {obs_tags}{ctx}".rstrip())
+
+    n_rel = rng.randint(0, 2)
+    rel_lines = []
+    for _ in range(n_rel):
+        target_n = rng.randint(0, total - 1)
+        if target_n == n:
+            continue
+        rel_type = rng.choice(REL_TYPES)
+        ctx = f" ({rng.choice(['supersedes v2', 'discussed in standup', ''])})".rstrip()
+        ctx = ctx if ctx.strip() != "()" else ""
+        rel_lines.append(f"- {rel_type} [[{_permalink(target_n)}]]{ctx}")
+
+    text = (
+        "---\n"
+        f"title: {title}\n"
+        "type: note\n"
+        f"permalink: {permalink}\n"
+        f"tags: [{', '.join(tags)}]\n"
+        f"created: {created}\n"
+        f"modified: {created}\n"
+        "---\n\n"
+        f"# {title}\n\n"
+        f"{prose}\n\n"
+        "## Observations\n"
+        + "\n".join(obs_lines)
+        + "\n\n## Relations\n"
+        + ("\n".join(rel_lines) if rel_lines else "(none)")
+        + "\n"
+    )
+    return permalink, text
+
+
+def write_vault(out_dir: str | os.PathLike, n: int, seed: int = 42) -> list[str]:
+    """Write n toy notes into out_dir (flat, one file per note). Returns
+    the list of file paths written, in generation order."""
+    rng = random.Random(seed)
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    paths = []
+    for i in range(n):
+        permalink, text = make_note_text(i, n, rng)
+        p = out / f"{permalink}.md"
+        p.write_text(text, encoding="utf-8")
+        paths.append(str(p))
+    return paths
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--n", type=int, default=1000)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--seed", type=int, default=42)
+    args = ap.parse_args()
+    paths = write_vault(args.out, args.n, args.seed)
+    print(f"wrote {len(paths)} notes to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/v3/spikes/vault/git_bench.py
+++ b/v3/spikes/vault/git_bench.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pyyaml", "pygit2"]
+# ///
+"""SPEC-003 Q3 — git layer cost.
+
+Auto-commit per write with attributed messages: measure cost per commit at
+1k/10k notes (pygit2 vs subprocess git); does `git status` stay fast?
+Is one-commit-per-write viable or is batching needed?
+
+    uv run git_bench.py --n 1000 --backend pygit2
+    uv run git_bench.py --n 1000 --backend subprocess
+    uv run git_bench.py --n 1000 --backend pygit2 --mode batch
+
+Each run creates a fresh temp git repo, writes --n toy notes one at a time,
+and (per --mode) either commits after every single write ("percommit", the
+architecture's default per MASTERPLAN §5.1) or once at the end ("batch").
+Prints total/mean/p50/p95 commit latency, final repo/.git size, and
+`git status` wall time in the resulting repo.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import gen_vault  # noqa: E402
+import pygit2  # noqa: E402
+
+AUTHOR = pygit2.Signature("palaia-v3-spike", "spike@palaia.v3")
+
+
+def du_bytes(path: str) -> int:
+    total = 0
+    for p in Path(path).rglob("*"):
+        if p.is_file():
+            total += p.stat().st_size
+    return total
+
+
+def run_pygit2(repo_dir: str, n: int, seed: int, mode: str) -> dict:
+    pygit2.init_repository(repo_dir, bare=False)
+    repo = pygit2.Repository(repo_dir)
+    import random
+
+    rng = random.Random(seed)
+    commit_times: list[float] = []
+    parent = None
+
+    for i in range(n):
+        permalink, text = gen_vault.make_note_text(i, n, rng)
+        (Path(repo_dir) / f"{permalink}.md").write_text(text, encoding="utf-8")
+
+        if mode == "batch" and i != n - 1:
+            continue
+
+        t0 = time.perf_counter()
+        index = repo.index
+        index.add_all()
+        index.write()
+        tree = index.write_tree()
+        parents = [parent] if parent is not None else []
+        msg = (
+            f"chore(vault): batch write of {n} notes"
+            if mode == "batch"
+            else f"chore(vault): write {permalink} (agent=spike, client=git_bench)"
+        )
+        parent = repo.create_commit("HEAD", AUTHOR, AUTHOR, msg, tree, parents)
+        commit_times.append(time.perf_counter() - t0)
+
+    return {"commit_seconds": commit_times}
+
+
+def run_subprocess(repo_dir: str, n: int, seed: int, mode: str) -> dict:
+    subprocess.run(["git", "init", "-q", repo_dir], check=True)
+    env_author = {
+        "GIT_AUTHOR_NAME": "palaia-v3-spike",
+        "GIT_AUTHOR_EMAIL": "spike@palaia.v3",
+        "GIT_COMMITTER_NAME": "palaia-v3-spike",
+        "GIT_COMMITTER_EMAIL": "spike@palaia.v3",
+    }
+    import os
+    import random
+
+    env = {**os.environ, **env_author}
+    rng = random.Random(seed)
+    commit_times: list[float] = []
+
+    for i in range(n):
+        permalink, text = gen_vault.make_note_text(i, n, rng)
+        (Path(repo_dir) / f"{permalink}.md").write_text(text, encoding="utf-8")
+
+        if mode == "batch" and i != n - 1:
+            continue
+
+        t0 = time.perf_counter()
+        subprocess.run(["git", "-C", repo_dir, "add", "-A"], check=True, env=env,
+                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        msg = (
+            f"chore(vault): batch write of {n} notes"
+            if mode == "batch"
+            else f"chore(vault): write {permalink} (agent=spike, client=git_bench)"
+        )
+        subprocess.run(["git", "-C", repo_dir, "commit", "-q", "-m", msg], check=True, env=env,
+                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        commit_times.append(time.perf_counter() - t0)
+
+    return {"commit_seconds": commit_times}
+
+
+def git_status_seconds(repo_dir: str, runs: int = 5) -> float:
+    times = []
+    for _ in range(runs):
+        t0 = time.perf_counter()
+        subprocess.run(["git", "-C", repo_dir, "status"], check=True,
+                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        times.append(time.perf_counter() - t0)
+    return statistics.median(times)
+
+
+def pctile(data: list[float], p: float) -> float:
+    if not data:
+        return 0.0
+    s = sorted(data)
+    idx = min(len(s) - 1, int(len(s) * p))
+    return s[idx]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--n", type=int, required=True)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--backend", choices=["pygit2", "subprocess"], required=True)
+    ap.add_argument("--mode", choices=["percommit", "batch"], default="percommit")
+    ap.add_argument("--keep", action="store_true", help="don't delete the repo afterwards")
+    args = ap.parse_args()
+
+    repo_dir = tempfile.mkdtemp(prefix=f"git-bench-{args.backend}-{args.mode}-")
+    t0 = time.perf_counter()
+    if args.backend == "pygit2":
+        result = run_pygit2(repo_dir, args.n, args.seed, args.mode)
+    else:
+        result = run_subprocess(repo_dir, args.n, args.seed, args.mode)
+    total = time.perf_counter() - t0
+
+    ct = result["commit_seconds"]
+    status_s = git_status_seconds(repo_dir)
+    repo_size = du_bytes(repo_dir)
+    git_size = du_bytes(str(Path(repo_dir) / ".git"))
+
+    n_commits = subprocess.run(
+        ["git", "-C", repo_dir, "rev-list", "--count", "HEAD"],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+
+    report = {
+        "backend": args.backend,
+        "mode": args.mode,
+        "n_notes": args.n,
+        "n_commits": int(n_commits),
+        "total_seconds": total,
+        "mean_commit_ms": (statistics.mean(ct) * 1000) if ct else None,
+        "p50_commit_ms": pctile(ct, 0.50) * 1000 if ct else None,
+        "p95_commit_ms": pctile(ct, 0.95) * 1000 if ct else None,
+        "max_commit_ms": (max(ct) * 1000) if ct else None,
+        "git_status_median_seconds": status_s,
+        "repo_size_bytes": repo_size,
+        "git_dir_size_bytes": git_size,
+        "repo_dir": repo_dir,
+    }
+    print(json.dumps(report, indent=2))
+
+    if not args.keep:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/v3/spikes/vault/git_gc_bench.py
+++ b/v3/spikes/vault/git_gc_bench.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""SPEC-003 Q3 addendum — does `git gc` recover the loose-object bloat that
+one-commit-per-write leaves behind?
+
+    uv run git_gc_bench.py --repo /path/to/repo [--aggressive]
+
+Reports .git size before/after gc and how long gc took.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+from pathlib import Path
+
+
+def du_bytes(path: str) -> int:
+    total = 0
+    for p in Path(path).rglob("*"):
+        if p.is_file():
+            total += p.stat().st_size
+    return total
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo", required=True)
+    ap.add_argument("--aggressive", action="store_true")
+    args = ap.parse_args()
+
+    before = du_bytes(str(Path(args.repo) / ".git"))
+    cmd = ["git", "-C", args.repo, "gc"] + (["--aggressive"] if args.aggressive else [])
+    t0 = time.perf_counter()
+    subprocess.run(cmd, check=True, capture_output=True, text=True)
+    gc_seconds = time.perf_counter() - t0
+    after = du_bytes(str(Path(args.repo) / ".git"))
+
+    print(json.dumps({
+        "repo": args.repo,
+        "aggressive": args.aggressive,
+        "git_dir_bytes_before": before,
+        "git_dir_bytes_after": after,
+        "gc_seconds": gc_seconds,
+        "shrink_ratio": before / after if after else None,
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/v3/spikes/vault/grammar.py
+++ b/v3/spikes/vault/grammar.py
@@ -1,0 +1,194 @@
+"""Minimal parser for the toy vault note grammar used by this spike.
+
+NOT the formal v3 vault grammar (SPEC-004 defines that). This is just enough
+to prove the round-trip / index / rebuild loop end to end, per the shape
+described in v3/research/basic-memory.md §1:
+
+    ---
+    title: <str>
+    type: <str>
+    permalink: <str>
+    tags: [<str>, ...]
+    created: <iso8601>
+    modified: <iso8601>
+    ---
+
+    # <title>
+
+    <freeform prose paragraph, may contain [[Wikilinks]] -> implicit links_to>
+
+    ## Observations
+    - [category] content text #tag1 #tag2 (optional context)
+
+    ## Relations
+    - relation_type [[Target]] (optional context)
+
+No external dependency beyond PyYAML, which every script in this spike that
+imports this module already declares in its own PEP 723 header.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+import yaml
+
+FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n(.*)\Z", re.DOTALL)
+OBS_HEADER_RE = re.compile(r"^##\s*Observations\s*$", re.MULTILINE)
+REL_HEADER_RE = re.compile(r"^##\s*Relations\s*$", re.MULTILINE)
+NEXT_HEADER_RE = re.compile(r"^##\s+\S", re.MULTILINE)
+
+OBS_LINE_RE = re.compile(
+    r"^-\s*\[(?P<category>[^\]]+)\]\s*(?P<rest>.*)$"
+)
+REL_LINE_RE = re.compile(
+    r"^-\s*(?P<rel_type>[a-zA-Z0-9_\-]+)\s+\[\[(?P<target>[^\]]+)\]\]\s*(?:\((?P<context>[^)]*)\))?\s*$"
+)
+TAG_RE = re.compile(r"#(\w+)")
+CONTEXT_RE = re.compile(r"\(([^)]*)\)\s*$")
+WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
+
+
+@dataclass
+class Observation:
+    entity_permalink: str
+    category: str
+    content: str
+    tags: list[str] = field(default_factory=list)
+    context: str | None = None
+
+
+@dataclass
+class Relation:
+    source_permalink: str
+    relation_type: str
+    target_raw: str
+    context: str | None = None
+
+
+@dataclass
+class Entity:
+    permalink: str
+    path: str
+    title: str
+    type: str
+    tags: list[str]
+    created: str
+    modified: str
+    body: str
+    observations: list[Observation] = field(default_factory=list)
+    relations: list[Relation] = field(default_factory=list)
+
+
+class ParseError(ValueError):
+    pass
+
+
+def _split_section(body: str, header_re: re.Pattern) -> str | None:
+    m = header_re.search(body)
+    if not m:
+        return None
+    start = m.end()
+    rest = body[start:]
+    nxt = NEXT_HEADER_RE.search(rest)
+    return rest[: nxt.start()] if nxt else rest
+
+
+def parse_note(text: str, path: str) -> Entity:
+    m = FRONTMATTER_RE.match(text)
+    if not m:
+        raise ParseError(f"{path}: missing/malformed frontmatter block")
+    fm_raw, body = m.group(1), m.group(2)
+    try:
+        fm = yaml.safe_load(fm_raw) or {}
+    except yaml.YAMLError as exc:
+        raise ParseError(f"{path}: invalid YAML frontmatter: {exc}") from exc
+
+    for required in ("title", "permalink"):
+        if required not in fm:
+            raise ParseError(f"{path}: frontmatter missing required key '{required}'")
+
+    permalink = str(fm["permalink"])
+    entity = Entity(
+        permalink=permalink,
+        path=path,
+        title=str(fm["title"]),
+        type=str(fm.get("type", "note")),
+        tags=list(fm.get("tags", []) or []),
+        created=str(fm.get("created", "")),
+        modified=str(fm.get("modified", "")),
+        body=body,
+    )
+
+    obs_section = _split_section(body, OBS_HEADER_RE) or ""
+    for line in obs_section.splitlines():
+        line = line.strip()
+        if not line.startswith("-"):
+            continue
+        om = OBS_LINE_RE.match(line)
+        if not om:
+            continue
+        rest = om.group("rest")
+        ctx_m = CONTEXT_RE.search(rest)
+        context = ctx_m.group(1) if ctx_m else None
+        rest_wo_ctx = rest[: ctx_m.start()] if ctx_m else rest
+        tags = TAG_RE.findall(rest_wo_ctx)
+        content = TAG_RE.sub("", rest_wo_ctx).strip()
+        entity.observations.append(
+            Observation(
+                entity_permalink=permalink,
+                category=om.group("category").strip(),
+                content=content,
+                tags=tags,
+                context=context,
+            )
+        )
+
+    rel_section = _split_section(body, REL_HEADER_RE) or ""
+    explicit_targets: set[str] = set()
+    for line in rel_section.splitlines():
+        line = line.strip()
+        if not line.startswith("-"):
+            continue
+        rm = REL_LINE_RE.match(line)
+        if not rm:
+            continue
+        target = rm.group("target").strip()
+        explicit_targets.add(target)
+        entity.relations.append(
+            Relation(
+                source_permalink=permalink,
+                relation_type=rm.group("rel_type"),
+                target_raw=target,
+                context=rm.group("context"),
+            )
+        )
+
+    # Implicit links_to: any [[Wikilink]] in prose outside the Relations
+    # section that wasn't already captured as an explicit relation target.
+    prose = body
+    rel_m = REL_HEADER_RE.search(body)
+    if rel_m:
+        prose = body[: rel_m.start()]
+    for wl in WIKILINK_RE.findall(prose):
+        target = wl.strip()
+        if target in explicit_targets:
+            continue
+        entity.relations.append(
+            Relation(
+                source_permalink=permalink,
+                relation_type="links_to",
+                target_raw=target,
+                context=None,
+            )
+        )
+        explicit_targets.add(target)
+
+    return entity
+
+
+def parse_file(fs_path: str, vault_root: str) -> Entity:
+    with open(fs_path, "r", encoding="utf-8") as f:
+        text = f.read()
+    rel_path = fs_path[len(vault_root) :].lstrip("/")
+    return parse_note(text, rel_path)

--- a/v3/spikes/vault/index_lib.py
+++ b/v3/spikes/vault/index_lib.py
@@ -1,0 +1,145 @@
+"""SQLite (FTS5) index build/rebuild + search, for the vault round-trip spike.
+
+Plain module (no PEP 723 header) — imported by round_trip.py and index.py,
+which declare its transitive dependency (PyYAML, via grammar.py) themselves.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+
+import grammar
+
+SCHEMA = """
+CREATE TABLE entities (
+    permalink   TEXT PRIMARY KEY,
+    path        TEXT NOT NULL,
+    title       TEXT NOT NULL,
+    type        TEXT NOT NULL,
+    tags        TEXT NOT NULL,
+    created     TEXT,
+    modified    TEXT
+);
+
+CREATE TABLE observations (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_permalink  TEXT NOT NULL REFERENCES entities(permalink),
+    category          TEXT NOT NULL,
+    content           TEXT NOT NULL,
+    tags              TEXT NOT NULL,
+    context           TEXT
+);
+
+CREATE TABLE relations (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_permalink    TEXT NOT NULL REFERENCES entities(permalink),
+    relation_type       TEXT NOT NULL,
+    target_raw          TEXT NOT NULL,
+    context             TEXT
+);
+
+CREATE VIRTUAL TABLE fts USING fts5(
+    permalink UNINDEXED,
+    title,
+    body
+);
+"""
+
+
+def list_vault_files(vault_dir: str) -> list[str]:
+    return sorted(
+        str(p) for p in Path(vault_dir).rglob("*.md")
+    )
+
+
+def build_index(vault_dir: str, db_path: str) -> dict:
+    """(Re)build the index at db_path from scratch by parsing every .md
+    file under vault_dir. Returns timing/count stats."""
+    import time
+
+    if os.path.exists(db_path):
+        os.remove(db_path)
+
+    t0 = time.perf_counter()
+    files = list_vault_files(vault_dir)
+    t_list = time.perf_counter()
+
+    conn = sqlite3.connect(db_path)
+    conn.executescript(SCHEMA)
+
+    n_entities = n_obs = n_rel = n_errors = 0
+    for fs_path in files:
+        try:
+            entity = grammar.parse_file(fs_path, vault_dir)
+        except grammar.ParseError:
+            n_errors += 1
+            continue
+        conn.execute(
+            "INSERT INTO entities(permalink, path, title, type, tags, created, modified) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                entity.permalink,
+                entity.path,
+                entity.title,
+                entity.type,
+                ",".join(entity.tags),
+                entity.created,
+                entity.modified,
+            ),
+        )
+        for obs in entity.observations:
+            n_obs += 1
+            conn.execute(
+                "INSERT INTO observations(entity_permalink, category, content, tags, context) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (obs.entity_permalink, obs.category, obs.content, ",".join(obs.tags), obs.context),
+            )
+        for rel in entity.relations:
+            n_rel += 1
+            conn.execute(
+                "INSERT INTO relations(source_permalink, relation_type, target_raw, context) "
+                "VALUES (?, ?, ?, ?)",
+                (rel.source_permalink, rel.relation_type, rel.target_raw, rel.context),
+            )
+        body_text = entity.body + "\n" + "\n".join(o.content for o in entity.observations)
+        conn.execute(
+            "INSERT INTO fts(permalink, title, body) VALUES (?, ?, ?)",
+            (entity.permalink, entity.title, body_text),
+        )
+        n_entities += 1
+    conn.commit()
+    t_build = time.perf_counter()
+
+    conn.close()
+    db_size = os.path.getsize(db_path)
+    return {
+        "n_files": len(files),
+        "n_entities": n_entities,
+        "n_observations": n_obs,
+        "n_relations": n_rel,
+        "n_parse_errors": n_errors,
+        "list_seconds": t_list - t0,
+        "build_seconds": t_build - t_list,
+        "total_seconds": t_build - t0,
+        "db_size_bytes": db_size,
+    }
+
+
+def search(db_path: str, query: str, limit: int = 10) -> list[str]:
+    """Return matching entity permalinks, ranked, for a search string.
+
+    The raw string is quoted as an FTS5 phrase so callers can pass
+    hyphenated/plain tokens without needing to know FTS5 query-syntax
+    operators (`-`, `:`, ...) — good enough for this spike's purposes.
+    """
+    phrase = '"' + query.replace('"', '""') + '"'
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT permalink FROM fts WHERE fts MATCH ? ORDER BY rank LIMIT ?",
+            (phrase, limit),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [r[0] for r in rows]

--- a/v3/spikes/vault/kill_test.sh
+++ b/v3/spikes/vault/kill_test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# SPEC-003 Q5 — atomicity under kill -9.
+#
+# Repeatedly: launch writer.py (atomic-write-then-git-commit loop), let it
+# run for a short RANDOM delay so different trials interrupt it at
+# different points (mid content write, mid rename, mid git add, mid git
+# commit/index-write), SIGKILL it, then run checker.py against the vault
+# it left behind.
+#
+# Usage: ./kill_test.sh [trials] [results_file]
+set -euo pipefail
+
+TRIALS="${1:-20}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESULTS_FILE="${2:-/tmp/kill_test_results.jsonl}"
+: > "$RESULTS_FILE"
+
+for i in $(seq 1 "$TRIALS"); do
+  VAULT_DIR="$(mktemp -d /tmp/kill-vault.XXXXXX)"
+  # `uv run` execs a *child* python process rather than replacing itself on
+  # this platform (verified: `uv run writer.py` PID stays a separate uv
+  # process, with the real interpreter as its child) — so we must kill by
+  # matching the unique --vault-dir argument, not by the wrapper's PID,
+  # or the actual writer keeps running (and racing the checker) after
+  # `kill -9 $PID` returns.
+  MATCH="writer.py --vault-dir $VAULT_DIR "
+  uv run "$SCRIPT_DIR/writer.py" --vault-dir "$VAULT_DIR" --n 200000 >"$VAULT_DIR/.writer.stdout" 2>"$VAULT_DIR/.writer.stderr" &
+
+  DELAY="$(python3 -c "import random; random.seed(${i}); print(round(random.uniform(0.05, 1.2), 3))")"
+  sleep "$DELAY"
+
+  # SIGKILL every process (uv wrapper + real interpreter) matching this
+  # trial's unique vault path: uncatchable, no cleanup handler runs.
+  pkill -9 -f "$MATCH" 2>/dev/null || true
+  # Confirm nothing matching this trial is still alive before inspecting.
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    pgrep -f "$MATCH" >/dev/null 2>&1 || break
+    sleep 0.1
+    pkill -9 -f "$MATCH" 2>/dev/null || true
+  done
+  wait 2>/dev/null || true
+
+  uv run "$SCRIPT_DIR/checker.py" --vault-dir "$VAULT_DIR" --trial "$i" --delay "$DELAY" >> "$RESULTS_FILE"
+  echo "trial $i (delay=${DELAY}s) -> $(tail -n1 "$RESULTS_FILE")" 1>&2
+
+  rm -rf "$VAULT_DIR"
+done
+
+echo "---"
+echo "raw per-trial results: $RESULTS_FILE"
+python3 - "$RESULTS_FILE" <<'PYEOF'
+import json
+import sys
+
+path = sys.argv[1]
+rows = [json.loads(l) for l in open(path) if l.strip()]
+n = len(rows)
+corrupt = sum(1 for r in rows if r["vault_corrupt"])
+lock_present = sum(1 for r in rows if r["git_index_lock_present"])
+recovered = sum(1 for r in rows if r["recovery_needed"] and r["recovery_sufficient_lock_removal_only"])
+recovery_failed = sum(1 for r in rows if r["recovery_needed"] and not r["recovery_sufficient_lock_removal_only"])
+rebuild_ok = sum(1 for r in rows if r["rebuild_error"] is None)
+
+print(f"trials: {n}")
+print(f"vault_corrupt (truncated/unparseable note, or rebuild crashed): {corrupt}/{n}")
+print(f"git index.lock left behind: {lock_present}/{n}")
+print(f"  of those, lock removal alone was sufficient recovery: {recovered}/{lock_present if lock_present else 0}")
+print(f"  of those, lock removal was NOT sufficient: {recovery_failed}/{lock_present if lock_present else 0}")
+print(f"index rebuildable from files afterwards: {rebuild_ok}/{n}")
+PYEOF

--- a/v3/spikes/vault/round_trip.py
+++ b/v3/spikes/vault/round_trip.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pyyaml"]
+# ///
+"""SPEC-003 Q1 — round-trip proof.
+
+write notes -> parse -> index (SQLite FTS5) -> search -> delete DB ->
+rebuild from files -> identical search results?
+
+    uv run round_trip.py --n 2000 --seed 42 [--out /tmp/rt-vault]
+
+Prints per-query result sets before/after rebuild and a PASS/FAIL verdict,
+plus build timings and sizes.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import gen_vault  # noqa: E402
+import index_lib  # noqa: E402
+
+QUERIES = [
+    "vault-format",
+    "authentication",
+    "recall-scoring",
+    "synchronous",
+    "decision",
+    "note-000042",
+]
+
+
+def run(n: int, seed: int, out_dir: str | None) -> dict:
+    cleanup = out_dir is None
+    vault_dir = out_dir or tempfile.mkdtemp(prefix="rt-vault-")
+    db_path = str(Path(vault_dir).with_name(Path(vault_dir).name + "-index.db"))
+
+    t0 = time.perf_counter()
+    gen_vault.write_vault(vault_dir, n, seed)
+    t_gen = time.perf_counter()
+
+    stats_1 = index_lib.build_index(vault_dir, db_path)
+    results_1 = {q: index_lib.search(db_path, q) for q in QUERIES}
+
+    Path(db_path).unlink()
+
+    stats_2 = index_lib.build_index(vault_dir, db_path)
+    results_2 = {q: index_lib.search(db_path, q) for q in QUERIES}
+
+    identical = results_1 == results_2
+    t_end = time.perf_counter()
+
+    report = {
+        "n_notes_requested": n,
+        "seed": seed,
+        "vault_dir": vault_dir,
+        "generate_seconds": t_gen - t0,
+        "build_1": stats_1,
+        "build_2_after_delete": stats_2,
+        "queries": QUERIES,
+        "results_before_rebuild": results_1,
+        "results_after_rebuild": results_2,
+        "identical_search_results": identical,
+        "total_wall_seconds": t_end - t0,
+    }
+
+    if cleanup:
+        shutil.rmtree(vault_dir, ignore_errors=True)
+        Path(db_path).unlink(missing_ok=True)
+
+    return report
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--n", type=int, default=2000)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--out", default=None, help="keep the generated vault here instead of a throwaway tmpdir")
+    ap.add_argument("--json", action="store_true", help="print machine-readable JSON only")
+    args = ap.parse_args()
+
+    report = run(args.n, args.seed, args.out)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+        return
+
+    print(f"generated {report['n_notes_requested']} notes in {report['generate_seconds']:.3f}s -> {report['vault_dir']}")
+    b1, b2 = report["build_1"], report["build_2_after_delete"]
+    print(
+        f"build #1 (fresh):        {b1['n_entities']} entities, {b1['n_observations']} obs, "
+        f"{b1['n_relations']} rel, {b1['n_parse_errors']} parse errors, "
+        f"{b1['total_seconds']:.3f}s, db={b1['db_size_bytes']/1024:.1f} KiB"
+    )
+    print(
+        f"build #2 (after rm db):  {b2['n_entities']} entities, {b2['n_observations']} obs, "
+        f"{b2['n_relations']} rel, {b2['n_parse_errors']} parse errors, "
+        f"{b2['total_seconds']:.3f}s, db={b2['db_size_bytes']/1024:.1f} KiB"
+    )
+    print()
+    for q in report["queries"]:
+        before = report["results_before_rebuild"][q]
+        after = report["results_after_rebuild"][q]
+        mark = "==" if before == after else "!="
+        print(f'  query {q!r:24s} before={before!r} {mark} after={after!r}')
+    print()
+    verdict = "PASS" if report["identical_search_results"] else "FAIL"
+    print(f"identical_search_results: {report['identical_search_results']}  [{verdict}]")
+    print(f"total wall time: {report['total_wall_seconds']:.3f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/v3/spikes/vault/vector_spike.py
+++ b/v3/spikes/vault/vector_spike.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pyyaml", "fastembed", "sqlite-vec"]
+# ///
+"""SPEC-003 Q4 — vector search spike.
+
+fastembed + sqlite-vec on the same toy vault — cold-start time, per-note
+embed cost, hybrid merge sketch.
+
+    uv run vector_spike.py --n 1000
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sqlite3
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import gen_vault  # noqa: E402
+import grammar  # noqa: E402
+import index_lib  # noqa: E402
+import sqlite_vec  # noqa: E402
+
+MODEL_NAME = "BAAI/bge-small-en-v1.5"  # fastembed default, per research/basic-memory.md §3
+
+
+def entity_text(entity) -> str:
+    return entity.title + "\n" + entity.body + "\n" + "\n".join(o.content for o in entity.observations)
+
+
+def run(n: int) -> dict:
+    vault_dir = tempfile.mkdtemp(prefix="vec-vault-")
+    db_path = str(Path(vault_dir).with_name(Path(vault_dir).name + "-index.db"))
+
+    gen_vault.write_vault(vault_dir, n, seed=7)
+    build_stats = index_lib.build_index(vault_dir, db_path)
+
+    t0 = time.perf_counter()
+    from fastembed import TextEmbedding
+
+    model = TextEmbedding(model_name=MODEL_NAME)
+    t_cold_start = time.perf_counter() - t0  # includes first-run ONNX model load (+ download if not cached)
+
+    files = index_lib.list_vault_files(vault_dir)
+    entities = [grammar.parse_file(f, vault_dir) for f in files]
+    texts = [entity_text(e) for e in entities]
+
+    t0 = time.perf_counter()
+    embeddings = list(model.embed(texts))
+    t_embed_all = time.perf_counter() - t0
+    dim = len(embeddings[0])
+
+    conn = sqlite3.connect(db_path)
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+    conn.enable_load_extension(False)
+    conn.execute(f"CREATE VIRTUAL TABLE vec_entities USING vec0(embedding float[{dim}])")
+    # sqlite-vec vec0 rowids must be assigned explicitly to align with entities.
+    conn.execute(
+        "CREATE TABLE vec_rowid_map (rowid_ INTEGER PRIMARY KEY, permalink TEXT NOT NULL)"
+    )
+
+    t0 = time.perf_counter()
+    for i, (entity, emb) in enumerate(zip(entities, embeddings)):
+        conn.execute(
+            "INSERT INTO vec_entities(rowid, embedding) VALUES (?, ?)",
+            (i, sqlite_vec.serialize_float32(emb.tolist())),
+        )
+        conn.execute("INSERT INTO vec_rowid_map(rowid_, permalink) VALUES (?, ?)", (i, entity.permalink))
+    conn.commit()
+    t_insert_vec = time.perf_counter() - t0
+
+    # Hybrid merge sketch: run one query both ways and merge by simple
+    # weighted rank-fusion (not a final ranking design — SPEC-104 owns that).
+    query_text = "synchronous writes and files as source of truth"
+    t0 = time.perf_counter()
+    q_emb = list(model.embed([query_text]))[0]
+    t_query_embed = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    vec_rows = conn.execute(
+        """
+        SELECT m.permalink, v.distance
+        FROM (
+            SELECT rowid, distance FROM vec_entities
+            WHERE embedding MATCH ? ORDER BY distance LIMIT 10
+        ) v
+        JOIN vec_rowid_map m ON m.rowid_ = v.rowid
+        """,
+        (sqlite_vec.serialize_float32(q_emb.tolist()),),
+    ).fetchall()
+    t_vec_search = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    fts_rows = conn.execute(
+        "SELECT permalink, rank FROM fts WHERE fts MATCH ? ORDER BY rank LIMIT 10",
+        ('"' + query_text.replace('"', ' ') + '"',),
+    ).fetchall()
+    # Phrase queries rarely hit in free prose; fall back to OR-of-terms for the sketch.
+    if not fts_rows:
+        or_query = " OR ".join(w for w in query_text.split() if w.isalpha())
+        fts_rows = conn.execute(
+            "SELECT permalink, rank FROM fts WHERE fts MATCH ? ORDER BY rank LIMIT 10",
+            (or_query,),
+        ).fetchall()
+    t_fts_search = time.perf_counter() - t0
+
+    # Rank-fusion sketch: score = 1/(rank_fts+1) + 1/(rank_vec+1), higher wins.
+    fts_rank = {p: i for i, (p, _r) in enumerate(fts_rows)}
+    vec_rank = {p: i for i, (p, _d) in enumerate(vec_rows)}
+    fused: dict[str, float] = {}
+    for p in set(fts_rank) | set(vec_rank):
+        fused[p] = 1.0 / (fts_rank.get(p, 999) + 1) + 1.0 / (vec_rank.get(p, 999) + 1)
+    hybrid_top = sorted(fused.items(), key=lambda kv: -kv[1])[:10]
+
+    conn.close()
+    db_size = Path(db_path).stat().st_size
+
+    report = {
+        "n_notes": n,
+        "model": MODEL_NAME,
+        "embedding_dim": dim,
+        "fts_build": build_stats,
+        "cold_start_seconds": t_cold_start,
+        "embed_all_seconds": t_embed_all,
+        "embed_per_note_ms": (t_embed_all / n) * 1000,
+        "vec_insert_seconds": t_insert_vec,
+        "vec_insert_per_note_ms": (t_insert_vec / n) * 1000,
+        "query_embed_ms": t_query_embed * 1000,
+        "vec_search_ms": t_vec_search * 1000,
+        "fts_search_ms": t_fts_search * 1000,
+        "db_size_bytes_with_vectors": db_size,
+        "fts_only_db_size_bytes": build_stats["db_size_bytes"],
+        "vec_top10": [p for p, _ in vec_rows],
+        "fts_top10": [p for p, _ in fts_rows],
+        "hybrid_top10_rank_fusion": [p for p, _ in hybrid_top],
+    }
+
+    shutil.rmtree(vault_dir, ignore_errors=True)
+    Path(db_path).unlink(missing_ok=True)
+    return report
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--n", type=int, default=1000)
+    args = ap.parse_args()
+    report = run(args.n)
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/v3/spikes/vault/watch_spike.py
+++ b/v3/spikes/vault/watch_spike.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pyyaml", "watchfiles"]
+# ///
+"""SPEC-003 Q2 — external-edit loop.
+
+Modify a note on disk (simulating Obsidian) — does a watchfiles watcher pick
+it up and reindex within ~2s? What debounce is sane? What happens with a
+rapid rename+edit?
+
+    uv run watch_spike.py --n 200
+
+Runs three scenarios against a live watchfiles.watch() generator in a
+background thread: (1) single content edit, (2) rapid rename+edit
+(rename note A -> note A-renamed, then immediately edit its content), and
+(3) a burst of 20 near-simultaneous edits, to see how many discrete
+"changes" batches come out and with what latency from the edit to the
+watcher observing it.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import queue
+import shutil
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import gen_vault  # noqa: E402
+from watchfiles import watch  # noqa: E402
+
+
+def watcher_thread(vault_dir: str, out_q: "queue.Queue", stop_event: threading.Event, debounce_ms: int):
+    for changes in watch(vault_dir, debounce=debounce_ms, stop_event=stop_event):
+        out_q.put((time.perf_counter(), changes))
+
+
+def drain_first(out_q: "queue.Queue", timeout: float):
+    try:
+        return out_q.get(timeout=timeout)
+    except queue.Empty:
+        return None
+
+
+def run(n: int, debounce_ms: int) -> dict:
+    vault_dir = tempfile.mkdtemp(prefix="watch-vault-")
+    gen_vault.write_vault(vault_dir, n, seed=3)
+
+    out_q: "queue.Queue" = queue.Queue()
+    stop_event = threading.Event()
+    t = threading.Thread(target=watcher_thread, args=(vault_dir, out_q, stop_event, debounce_ms), daemon=True)
+    t.start()
+    time.sleep(0.5)  # let the watcher establish its baseline snapshot
+
+    results: dict = {"n_notes": n, "debounce_ms": debounce_ms}
+
+    # Scenario 1: single content edit.
+    target = Path(vault_dir) / "note-000005.md"
+    text = target.read_text(encoding="utf-8")
+    t_edit = time.perf_counter()
+    target.write_text(text + "\n<!-- edited -->\n", encoding="utf-8")
+    seen = drain_first(out_q, timeout=5.0)
+    results["scenario_1_single_edit"] = {
+        "latency_seconds": (seen[0] - t_edit) if seen else None,
+        "n_changes_in_batch": len(seen[1]) if seen else 0,
+        "detected_within_2s": bool(seen and (seen[0] - t_edit) <= 2.0),
+    }
+
+    time.sleep(debounce_ms / 1000 + 0.3)
+    while not out_q.empty():
+        out_q.get_nowait()
+
+    # Scenario 2: rapid rename + edit (simulate Obsidian rename-on-save).
+    src = Path(vault_dir) / "note-000010.md"
+    dst = Path(vault_dir) / "note-000010-renamed.md"
+    t0 = time.perf_counter()
+    src.rename(dst)
+    dst.write_text(dst.read_text(encoding="utf-8") + "\n<!-- renamed+edited -->\n", encoding="utf-8")
+    batches = []
+    deadline = time.perf_counter() + 5.0
+    while time.perf_counter() < deadline:
+        item = drain_first(out_q, timeout=max(0.05, deadline - time.perf_counter()))
+        if item is None:
+            break
+        batches.append(item)
+    results["scenario_2_rename_plus_edit"] = {
+        "n_batches_observed": len(batches),
+        "first_batch_latency_seconds": (batches[0][0] - t0) if batches else None,
+        "batches": [
+            {"latency_seconds": ts - t0, "changes": [(str(kind), str(Path(p).name)) for kind, p in ch]}
+            for ts, ch in batches
+        ],
+    }
+
+    time.sleep(debounce_ms / 1000 + 0.3)
+    while not out_q.empty():
+        out_q.get_nowait()
+
+    # Scenario 3: burst of 20 near-simultaneous edits.
+    t0 = time.perf_counter()
+    burst_files = [Path(vault_dir) / f"note-{i:06d}.md" for i in range(20, 40)]
+    for f in burst_files:
+        f.write_text(f.read_text(encoding="utf-8") + "\n<!-- burst -->\n", encoding="utf-8")
+    batches = []
+    deadline = time.perf_counter() + 5.0
+    while time.perf_counter() < deadline:
+        item = drain_first(out_q, timeout=max(0.05, deadline - time.perf_counter()))
+        if item is None:
+            break
+        batches.append(item)
+    n_changes_total = sum(len(ch) for _, ch in batches)
+    results["scenario_3_burst_20_edits"] = {
+        "n_batches_observed": len(batches),
+        "n_changes_total_reported": n_changes_total,
+        "first_batch_latency_seconds": (batches[0][0] - t0) if batches else None,
+        "last_batch_latency_seconds": (batches[-1][0] - t0) if batches else None,
+    }
+
+    stop_event.set()
+    t.join(timeout=3.0)
+    shutil.rmtree(vault_dir, ignore_errors=True)
+    return results
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--n", type=int, default=200)
+    ap.add_argument("--debounce-ms", type=int, default=200)
+    args = ap.parse_args()
+    report = run(args.n, args.debounce_ms)
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/v3/spikes/vault/writer.py
+++ b/v3/spikes/vault/writer.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pyyaml", "pygit2"]
+# ///
+"""Writer used by kill_test.sh (SPEC-003 Q5).
+
+Loops forever (until killed) writing notes into --vault-dir using the
+architecture's promised write protocol: write to a temp file in the same
+directory, fsync, os.replace() (atomic rename) into place, THEN git-commit
+the change. After each fully-completed iteration it appends the note's
+permalink to progress.log so the checker can tell how many writes were
+confirmed complete before the kill landed.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import gen_vault  # noqa: E402
+import pygit2  # noqa: E402
+
+AUTHOR = pygit2.Signature("palaia-v3-spike", "spike@palaia.v3")
+
+
+def atomic_write(vault_dir: Path, permalink: str, text: str) -> Path:
+    final_path = vault_dir / f"{permalink}.md"
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{permalink}.", suffix=".tmp", dir=str(vault_dir))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_name, final_path)  # atomic on POSIX
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+    return final_path
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--vault-dir", required=True)
+    ap.add_argument("--n", type=int, default=100000)
+    ap.add_argument("--seed", type=int, default=99)
+    args = ap.parse_args()
+
+    vault_dir = Path(args.vault_dir)
+    vault_dir.mkdir(parents=True, exist_ok=True)
+    pygit2.init_repository(str(vault_dir), bare=False)
+    repo = pygit2.Repository(str(vault_dir))
+    progress_path = vault_dir / "progress.log"
+
+    import random
+
+    rng = random.Random(args.seed)
+    parent = None
+    if not repo.head_is_unborn:
+        parent = repo.head.target
+
+    with open(progress_path, "a", encoding="utf-8") as progress:
+        for i in range(args.n):
+            permalink, text = gen_vault.make_note_text(i, args.n, rng)
+            atomic_write(vault_dir, permalink, text)
+
+            index = repo.index
+            index.add_all()
+            index.write()
+            tree = index.write_tree()
+            parents = [parent] if parent is not None else []
+            parent = repo.create_commit(
+                "HEAD", AUTHOR, AUTHOR,
+                f"chore(vault): write {permalink} (agent=spike, client=kill_test)",
+                tree, parents,
+            )
+            progress.write(f"{i}\t{permalink}\t{time.time()}\n")
+            progress.flush()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Self-contained `uv`-script spike (`v3/spikes/vault/`) proving the
files-as-truth vault architecture (MASTERPLAN §5.1) end to end at toy
scale, per SPEC-003. Full answers, numbers, surprises, and per-question
implications for SPEC-102/103/104 are in `v3/spikes/vault/FINDINGS.md`.

Headline results:
- **Round-trip (Q1):** write → FTS5 index → search → delete DB → rebuild →
  identical search results, verified at 500 / 1,000 / 10,000 notes.
- **Watcher (Q2):** ~50-80ms edit-to-detect latency, far under the ~2s
  budget — but Obsidian-style renames surface as `deleted`+`added`, not a
  rename event, so move detection must be checksum-based.
- **Git layer (Q3):** commit latency stays acceptable (≤240ms at 10k
  notes) but naive one-commit-per-write without `git gc` bloats `.git` to
  1.16 GiB at 10k notes (~116x); `git gc --aggressive` recovers it to
  ~1/11th size in under 2s.
- **Vector search (Q4):** fastembed (`bge-small-en-v1.5`) costs ~437ms/note
  to embed on this hardware — 1,500x slower than FTS indexing, so it
  cannot sit on the synchronous write path.
- **Kill test (Q5):** 25 `kill -9` trials against a live write+commit
  loop, randomized interrupt timing — 0 corrupted notes, 2 left a stale
  `git index.lock` (both recovered by deleting the lock alone), index
  always rebuildable from files.

## Acceptance criteria (SPEC-003)

- [x] all five questions answered with numbers (timings, sizes), not adjectives
- [x] rebuild-from-files proven byte-identical in search behavior (identical result sets at 500/1k/10k notes)
- [x] kill-test performed and documented (commands included) — 25-trial run + a 3-trial smoke run, `kill_test.sh`/`writer.py`/`checker.py` in the diff
- [x] git cost table at 1k/10k notes present — pygit2 vs subprocess, percommit vs batch, latency + repo/`.git` size

## Verification evidence

```
$ uv run round_trip.py --n 10000
... build #1 5.649s, build #2 5.457s, identical_search_results: True

$ uv run git_bench.py --n 10000 --backend pygit2 --mode percommit
mean_commit_ms: 78.5   git_dir_size_bytes: 1,249,731,724 (1.16 GiB)

$ uv run git_bench.py --n 10000 --backend subprocess --mode percommit
mean_commit_ms: 117.8  git_dir_size_bytes: 142,630,892 (142.6 MiB)

$ uv run git_gc_bench.py --repo <1k-percommit-repo> --aggressive
git_dir_bytes_before: 13,389,707 -> after: 1,231,076 (10.9x shrink, 1.77s)

$ uv run vector_spike.py --n 500
cold_start_seconds: 0.59  embed_per_note_ms: 437.3

$ ./kill_test.sh 25
vault_corrupt: 0/25   git index.lock left behind: 2/25 (100% recovered by
lock removal)   index rebuildable from files: 25/25

$ ruff check v3/spikes/vault/
All checks passed!
```

Every script is a PEP 723 inline-metadata `uv` script (`gen_vault.py`,
`round_trip.py`, `watch_spike.py`, `git_bench.py`, `git_gc_bench.py`,
`vector_spike.py`, `writer.py`, `checker.py`) or a plain module imported by
them (`grammar.py`, `index_lib.py`) — nothing here touches
`v3/pyproject.toml` (it doesn't exist) or any repo-root config.

## Notes for reviewers

- No production quality, no formal grammar, no recall logic — per
  SPEC-003 non-goals. `grammar.py` is a deliberately minimal toy parser,
  not a preview of SPEC-004's format.
- `mypy`/`eslint`/`tsc` don't apply (throwaway Python spike scripts, no
  shared project config to type-check against); `ruff check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp


---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789998092&installation_model_id=428086&pr_number=205&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F205&signature=48e0898378ec9c9d593d687c0b189a0715abcfc97cbf1ed860d149ddcb7712f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->