### PR TITLE
feat(v3): inbox capture tool + inbox_status (SPEC-107)

### DIFF
--- a/v3/server/src/palaia_hub/app.py
+++ b/v3/server/src/palaia_hub/app.py
@@ -11,16 +11,16 @@ from __future__ import annotations
 import asyncio
 import os
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
 from typing import Any
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 
 from . import __version__
 from .config import HubConfig, load_config
 from .events import EventBus, build_events_router, start_background_tasks, stop_background_tasks
-from .gateway import GatewayASGI
+from .gateway import GatewayASGI, VaultService
 from .logging import setup_logging
 from .static import mount_dashboard
 
@@ -32,7 +32,12 @@ from .static import mount_dashboard
 _TEST_SLOW_ENDPOINT_ENV = "PALAIA_TEST_SLOW_ENDPOINT_SECONDS"
 
 
-def create_app(config: HubConfig | None = None, *, gateway: GatewayASGI | None = None) -> FastAPI:
+def create_app(
+    config: HubConfig | None = None,
+    *,
+    gateway: GatewayASGI | None = None,
+    vault_services: Mapping[str, VaultService] | None = None,
+) -> FastAPI:
     """Build the hub's ASGI app.
 
     Args:
@@ -44,8 +49,14 @@ def create_app(config: HubConfig | None = None, *, gateway: GatewayASGI | None =
             before this parameter existed. Its lifespan MUST be attached to
             this app's lifespan (done below) or its mounted profile(s) hang
             on their first request — see ``gateway/build.py``'s docstring.
+        vault_services: the same ``{vault_key: VaultService}`` mapping passed
+            to ``build_gateway`` (SPEC-107), used only to back the
+            ``/api/vaults/{vault_key}/inbox_status`` REST endpoint below.
+            Independent of ``gateway`` on purpose: a caller can expose the
+            REST endpoint without an MCP gateway mounted, and vice versa.
     """
     config = config or load_config()
+    vault_services = vault_services or {}
     setup_logging(config)
 
     start_time = time.monotonic()
@@ -90,6 +101,18 @@ def create_app(config: HubConfig | None = None, *, gateway: GatewayASGI | None =
             "mode": config.mode,
             "uptime_seconds": round(time.monotonic() - start_time, 3),
         }
+
+    # SPEC-107: inbox visibility outside the MCP surface (deliverable #3).
+    @app.get("/api/vaults/{vault_key}/inbox_status")
+    async def inbox_status(vault_key: str) -> dict[str, Any]:
+        service = vault_services.get(vault_key)
+        if service is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"no vault {vault_key!r} configured with a backing service",
+            )
+        status = await service.inbox_status()
+        return status.model_dump()
 
     # SPEC-109: the dashboard's live-state layer (health + vault-change
     # events) and, once `npm run build` has produced one, the static

--- a/v3/server/src/palaia_hub/gateway/__init__.py
+++ b/v3/server/src/palaia_hub/gateway/__init__.py
@@ -21,7 +21,10 @@ from .build import GatewayASGI, GatewayConfigError, build_gateway
 from .config import GatewayConfig, ProfileConfig, VaultMountConfig
 from .fake_vault import FakeVaultService
 from .vault_protocol import (
+    INBOX_TOOL_ACTIONS,
     MEMORY_TOOL_ACTIONS,
+    CaptureResult,
+    InboxStatusResult,
     NoteRecord,
     NoteSummary,
     SearchHit,
@@ -30,11 +33,14 @@ from .vault_protocol import (
 )
 
 __all__ = [
+    "INBOX_TOOL_ACTIONS",
     "MEMORY_TOOL_ACTIONS",
+    "CaptureResult",
     "FakeVaultService",
     "GatewayASGI",
     "GatewayConfig",
     "GatewayConfigError",
+    "InboxStatusResult",
     "NoteRecord",
     "NoteSummary",
     "ProfileConfig",

--- a/v3/server/src/palaia_hub/gateway/fake_vault.py
+++ b/v3/server/src/palaia_hub/gateway/fake_vault.py
@@ -12,7 +12,10 @@ from __future__ import annotations
 import re
 from datetime import UTC, datetime
 
+from . import inbox as inbox_shape
 from .vault_protocol import (
+    CaptureResult,
+    InboxStatusResult,
     NoteRecord,
     NoteSummary,
     SearchHit,
@@ -145,3 +148,80 @@ class FakeVaultService:
         return [
             NoteSummary(**note.model_dump(exclude={"body", "created"})) for note in notes[:limit]
         ]
+
+    def _inbox_notes(self) -> list[NoteRecord]:
+        return [note for note in self._notes.values() if note.folder == "inbox"]
+
+    async def capture(
+        self,
+        *,
+        what_it_concerns: str,
+        why_keep: str,
+        content: str,
+        source: str | None = None,
+    ) -> CaptureResult:
+        what_it_concerns = what_it_concerns.strip()
+        why_keep = why_keep.strip()
+        content = content.strip()
+        content_hash = inbox_shape.content_hash_for(what_it_concerns, why_keep, content)
+
+        for existing in self._inbox_notes():
+            if inbox_shape.extract_capture_hash(existing.body) == content_hash:
+                return CaptureResult(
+                    permalink=existing.permalink,
+                    title=existing.title,
+                    capture_id=existing.capture_id,
+                    status=existing.status,
+                    duplicate=True,
+                )
+
+        resolved_source = (source or "").strip() or inbox_shape.default_source()
+        slug = _slugify(what_it_concerns)
+        permalink = f"inbox/{slug}"
+        suffix = 2
+        while permalink in self._notes:
+            permalink = f"inbox/{slug}-{suffix}"
+            suffix += 1
+        capture_id = inbox_shape.capture_id_for(permalink)
+        body = inbox_shape.compose_capture_body(
+            what_it_concerns=what_it_concerns,
+            why_keep=why_keep,
+            content=content,
+            source=resolved_source,
+            content_hash=content_hash,
+        )
+        now = _now()
+        note = NoteRecord(
+            permalink=permalink,
+            title=what_it_concerns,
+            type="capture",
+            tags=["inbox"],
+            folder="inbox",
+            status="uncurated",
+            capture_id=capture_id,
+            body=body,
+            created=now,
+            modified=now,
+        )
+        self._notes[permalink] = note
+        return CaptureResult(
+            permalink=permalink, title=note.title, capture_id=capture_id, status="uncurated"
+        )
+
+    async def inbox_status(self) -> InboxStatusResult:
+        captures = [note for note in self._inbox_notes() if note.status == "uncurated"]
+        if not captures:
+            return InboxStatusResult(count=0)
+        captures.sort(key=lambda n: n.created)
+        oldest = captures[0]
+        newest = max(captures, key=lambda n: n.created)
+        now = datetime.now(UTC)
+        oldest_created = datetime.fromisoformat(oldest.created.replace("Z", "+00:00"))
+        age = (now - oldest_created).total_seconds()
+        return InboxStatusResult(
+            count=len(captures),
+            oldest_capture_id=oldest.capture_id,
+            oldest_age_seconds=max(age, 0.0),
+            last_capture_id=newest.capture_id,
+            last_captured_at=newest.created,
+        )

--- a/v3/server/src/palaia_hub/gateway/inbox.py
+++ b/v3/server/src/palaia_hub/gateway/inbox.py
@@ -1,0 +1,154 @@
+"""Composition helpers for the inbox/capture contract (SPEC-107).
+
+Reference: ``v3/docs/vault-format.md`` §7 — a capture is a note a busy agent
+can drop without knowing the vault taxonomy. This module owns the *shape* of
+that note (frontmatter extras, canonical body, ``capture_id`` derivation,
+exact-duplicate hashing) as pure functions with no I/O.
+
+Deliberately free of any ``palaia_hub.vault`` import — same isolation rule as
+:mod:`palaia_hub.gateway.vault_protocol` (see that module's docstring): both
+:class:`~palaia_hub.gateway.fake_vault.FakeVaultService` and a future real
+adapter over :class:`palaia_hub.vault.engine.VaultEngine` (SPEC-113) call
+into these functions so the composed note has exactly one definition. The
+real-engine integration test (``tests/gateway/test_inbox_real_vault.py``)
+drives ``VaultEngine.write_note`` directly with this module's output to prove
+the result is format-spec valid end to end, without this package depending
+on the vault engine itself.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import UTC, datetime
+
+#: Format spec §7: ``capture_id = "cap-" + sha256(permalink)[:10]``.
+CAPTURE_ID_PREFIX = "cap-"
+
+#: The three mandatory ``capture`` tool fields (deliverable #1). ``source``
+#: is optional and defaults via :func:`default_source`.
+MANDATORY_CAPTURE_FIELDS: tuple[str, ...] = ("what_it_concerns", "why_keep", "content")
+
+_EXAMPLE_CALL = (
+    "capture(what_it_concerns='API Gateway', "
+    "why_keep='The rate limit was chosen deliberately; future work will trip over "
+    "it otherwise.', "
+    "content='We capped ingest at 100 req/min because the embed queue saturates "
+    "above that; raising it requires batching first.')"
+)
+
+# The `[capture_hash]` bullet this module appends to every capture body (see
+# `compose_capture_body`) so an exact-duplicate re-capture can be recognized
+# just by reading a note back — no side index needed, and no schema key the
+# format spec does not already reserve as free-form body content.
+_CAPTURE_HASH_RE = re.compile(r"^- \[capture_hash\] (?P<hash>[0-9a-f]+)\s*$", re.MULTILINE)
+
+
+def missing_capture_fields(
+    *, what_it_concerns: str | None, why_keep: str | None, content: str | None
+) -> list[str]:
+    """Return the mandatory capture fields that are missing or blank, in order."""
+    values = {
+        "what_it_concerns": what_it_concerns,
+        "why_keep": why_keep,
+        "content": content,
+    }
+    return [name for name in MANDATORY_CAPTURE_FIELDS if not (values[name] or "").strip()]
+
+
+def missing_fields_message(missing: list[str]) -> str:
+    """A helpful error naming the missing field(s) plus a worked example.
+
+    Acceptance criterion: "missing mandatory field -> helpful error naming
+    the field and an example."
+    """
+    joined = ", ".join(missing)
+    return (
+        f"capture is missing mandatory field(s): {joined}. what_it_concerns, "
+        f"why_keep and content are all required — capture never guesses at "
+        f"them. Example: {_EXAMPLE_CALL}"
+    )
+
+
+def capture_id_for(permalink: str) -> str:
+    """``capture_id`` = ``"cap-" + sha256(permalink)[:10]`` (format spec §7)."""
+    digest = hashlib.sha256(permalink.encode("utf-8")).hexdigest()
+    return f"{CAPTURE_ID_PREFIX}{digest[:10]}"
+
+
+def content_hash_for(what_it_concerns: str, why_keep: str, content: str) -> str:
+    """A cheap hash of the three mandatory fields for exact-duplicate detection.
+
+    Normalizes case/whitespace so trivially-reformatted resubmits still
+    count as the same capture. Not a format-spec frontmatter key — recovered
+    from the body's ``[capture_hash]`` bullet by :func:`extract_capture_hash`.
+    """
+    normalized = "\x1f".join(part.strip().lower() for part in (what_it_concerns, why_keep, content))
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+
+
+def default_source(now: datetime | None = None) -> str:
+    """Default ``[source]`` text when the caller omits one (deliverable #1).
+
+    Today's gateway tool call carries no richer per-request client identity
+    than what :class:`~palaia_hub.gateway.vault_protocol.VaultService`
+    already exposes, so the default is deliberately plain: "agent capture,
+    <date>". A future SPEC that threads MCP client/session identity through
+    to tool calls can sharpen this without changing the contract.
+    """
+    when = (now or datetime.now(UTC)).date().isoformat()
+    return f"agent capture, {when}"
+
+
+def compose_capture_body(
+    *,
+    what_it_concerns: str,
+    why_keep: str,
+    content: str,
+    source: str,
+    content_hash: str,
+) -> str:
+    """The canonical inbox note body (format spec §7 example shape)."""
+    return (
+        f"{why_keep}\n\n"
+        f"- [entity] {what_it_concerns}\n"
+        f"- [why] {why_keep}\n"
+        f"- [raw] {content}\n"
+        f"- [source] {source}\n"
+        f"- [capture_hash] {content_hash}\n"
+    )
+
+
+def extract_capture_hash(body: str) -> str | None:
+    """Recover the ``[capture_hash]`` bullet written by :func:`compose_capture_body`."""
+    match = _CAPTURE_HASH_RE.search(body)
+    return match.group("hash") if match else None
+
+
+def capture_frontmatter(*, capture_id: str) -> dict[str, object]:
+    """Frontmatter keys a capture note needs beyond the identity ones every
+    writer already sets (``title``/``permalink``/``created``/``modified``).
+
+    ``type: capture``, ``tags: [inbox]``, ``status: uncurated`` and
+    ``capture_id`` all match format spec §7's canonical form.
+    """
+    return {
+        "type": "capture",
+        "tags": ["inbox"],
+        "status": "uncurated",
+        "capture_id": capture_id,
+    }
+
+
+__all__ = [
+    "CAPTURE_ID_PREFIX",
+    "MANDATORY_CAPTURE_FIELDS",
+    "capture_frontmatter",
+    "capture_id_for",
+    "compose_capture_body",
+    "content_hash_for",
+    "default_source",
+    "extract_capture_hash",
+    "missing_capture_fields",
+    "missing_fields_message",
+]

--- a/v3/server/src/palaia_hub/gateway/memory_tools.py
+++ b/v3/server/src/palaia_hub/gateway/memory_tools.py
@@ -2,7 +2,10 @@
 
 Deliverable #2 of SPEC-105: search / read / write / edit / move / delete /
 list / recent_activity, mounted once per configured vault (see
-:mod:`palaia_hub.gateway.build`). Deliverable #4 (tool ergonomics) is
+:mod:`palaia_hub.gateway.build`). SPEC-107 adds two more tools to the same
+server — ``capture`` and ``inbox_status`` (the inbox/capture contract,
+``v3/docs/vault-format.md`` §7); their composition logic lives in
+:mod:`palaia_hub.gateway.inbox`. Deliverable #4 (tool ergonomics) is
 implemented here directly on each tool:
 
 - **Behavior annotations** (``readOnlyHint``/``destructiveHint``/
@@ -42,7 +45,16 @@ from mcp.types import ToolAnnotations
 from pydantic import AliasChoices, BaseModel, Field
 
 from .config import VaultMountConfig
-from .vault_protocol import NoteRecord, NoteSummary, SearchHit, VaultService, VaultServiceError
+from .inbox import missing_capture_fields, missing_fields_message
+from .vault_protocol import (
+    CaptureResult,
+    InboxStatusResult,
+    NoteRecord,
+    NoteSummary,
+    SearchHit,
+    VaultService,
+    VaultServiceError,
+)
 
 # --- alias-absorbing parameter types ---------------------------------------
 # SPEC-105 deliverable #4 names these two alias groups explicitly: a query
@@ -255,6 +267,65 @@ def build_vault_server(vault: VaultMountConfig, service: VaultService) -> FastMC
         text = f"{len(notes)} recently modified note(s)"
         return ToolResult(content=text, structured_content=RecentActivityResult(notes=notes))
 
+    @server.tool(
+        name="capture",
+        description=desc(
+            "Zero-friction drop target: capture something mid-work without "
+            "deciding placement, dedup or structure — the curator files it "
+            "later. Writes an inbox/ note (format spec §7)."
+        ),
+        annotations=ToolAnnotations(
+            readOnlyHint=False, destructiveHint=False, idempotentHint=False
+        ),
+    )
+    async def capture(
+        what_it_concerns: str | None = None,
+        why_keep: str | None = None,
+        content: str | None = None,
+        source: str | None = None,
+    ) -> ToolResult:
+        missing = missing_capture_fields(
+            what_it_concerns=what_it_concerns, why_keep=why_keep, content=content
+        )
+        if missing:
+            return ToolResult(content=missing_fields_message(missing), is_error=True)
+        assert what_it_concerns is not None
+        assert why_keep is not None
+        assert content is not None
+        try:
+            result = await service.capture(
+                what_it_concerns=what_it_concerns,
+                why_keep=why_keep,
+                content=content,
+                source=source,
+            )
+        except VaultServiceError as exc:
+            return _error_result(exc)
+        text = (
+            f"already captured as {result.permalink!r} (capture_id {result.capture_id}) "
+            "— duplicate acknowledged, nothing new written"
+            if result.duplicate
+            else f"captured to {result.permalink!r} (capture_id {result.capture_id})"
+        )
+        return ToolResult(content=text, structured_content=result)
+
+    @server.tool(
+        name="inbox_status",
+        description=desc(
+            "Inbox health: how many uncurated captures are waiting, the "
+            "oldest entry's age, and the most recent capture."
+        ),
+        annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True),
+    )
+    async def inbox_status() -> ToolResult:
+        status = await service.inbox_status()
+        text = f"{status.count} uncurated capture(s)"
+        if status.oldest_age_seconds is not None:
+            text += f", oldest {status.oldest_age_seconds:.0f}s old"
+        if status.last_capture_id:
+            text += f", last capture {status.last_capture_id!r}"
+        return ToolResult(content=text, structured_content=status)
+
     @server.resource(
         f"guide://{vault.key}/ai_assistant_guide",
         name="ai_assistant_guide",
@@ -272,7 +343,11 @@ def build_vault_server(vault: VaultMountConfig, service: VaultService) -> FastMC
             "4. **list** / **recent_activity** to browse or catch up without a "
             "specific query.\n"
             "5. **move** relocates a note without changing its identity "
-            "(permalink); **delete** removes it.\n\n"
+            "(permalink); **delete** removes it.\n"
+            "6. **capture** when you don't have time to place something "
+            "properly — drop it into inbox/ with what it concerns and why "
+            "it's worth keeping; a curator files it later. **inbox_status** "
+            "shows how much is waiting.\n\n"
             "## Parameter notes\n"
             "`search`'s query and every `folder` parameter accept a few common "
             "misnamings (e.g. `q`, `dir`, `path`) — use the documented name "
@@ -291,4 +366,6 @@ _RESULT_MODELS: dict[str, type[Any]] = {
     "list": ListResult,
     "recent_activity": RecentActivityResult,
     "delete": DeleteResult,
+    "capture": CaptureResult,
+    "inbox_status": InboxStatusResult,
 }

--- a/v3/server/src/palaia_hub/gateway/vault_protocol.py
+++ b/v3/server/src/palaia_hub/gateway/vault_protocol.py
@@ -14,6 +14,11 @@ and SPEC-113 wires it in — can back the tools built in
 Field names below intentionally mirror ``v3/docs/vault-format.md`` (permalink,
 title, type, tags, folder) so a future real adapter is a thin pass-through,
 not a translation layer.
+
+SPEC-107 adds ``capture``/``inbox_status`` (the inbox/capture contract,
+format spec §7) to this same protocol, kept as their own
+:data:`INBOX_TOOL_ACTIONS` tuple rather than folded into
+:data:`MEMORY_TOOL_ACTIONS` — see that constant's comment.
 """
 
 from __future__ import annotations
@@ -37,6 +42,14 @@ MEMORY_TOOL_ACTIONS: tuple[str, ...] = (
     "recent_activity",
 )
 
+# SPEC-107's two inbox/capture actions. Kept as a separate tuple rather than
+# folded into MEMORY_TOOL_ACTIONS: that tuple is also used by
+# gateway/config.py to validate `tool_renames` keys against the eight
+# original actions specifically, and existing config/tests referencing "the
+# eight actions" should not silently start meaning ten. Both tuples are
+# exposed together in the same tool family server (memory_tools.py).
+INBOX_TOOL_ACTIONS: tuple[str, ...] = ("capture", "inbox_status")
+
 
 class NoteSummary(BaseModel):
     """Enough to list, browse, or pick a note without fetching its body."""
@@ -47,6 +60,11 @@ class NoteSummary(BaseModel):
     tags: list[str] = Field(default_factory=list)
     folder: str = ""
     modified: str = ""
+    # Format spec §2.1 schema keys, relevant beyond captures (any note may
+    # carry a lifecycle `status`) but populated in practice by SPEC-107's
+    # inbox contract: `status: uncurated` and a derived `capture_id`.
+    status: str = ""
+    capture_id: str = ""
 
 
 class NoteRecord(NoteSummary):
@@ -54,6 +72,32 @@ class NoteRecord(NoteSummary):
 
     body: str = ""
     created: str = ""
+
+
+class CaptureResult(BaseModel):
+    """What a ``capture`` call reports: where it landed, or that it didn't.
+
+    ``duplicate=True`` means an exact-duplicate capture already exists in
+    ``inbox/`` (format spec §7's dedup guard) — the call is acknowledged but
+    no second file is created; ``permalink``/``capture_id`` then identify the
+    existing entry.
+    """
+
+    permalink: str
+    title: str
+    capture_id: str
+    status: str = "uncurated"
+    duplicate: bool = False
+
+
+class InboxStatusResult(BaseModel):
+    """Inbox health: how many uncurated captures, the oldest, the newest."""
+
+    count: int
+    oldest_capture_id: str | None = None
+    oldest_age_seconds: float | None = None
+    last_capture_id: str | None = None
+    last_captured_at: str | None = None
 
 
 class SearchHit(BaseModel):
@@ -139,4 +183,25 @@ class VaultService(Protocol):
 
     async def recent_activity(self, *, limit: int = 10) -> list[NoteSummary]:
         """Return the most recently modified notes, most recent first."""
+        ...
+
+    async def capture(
+        self,
+        *,
+        what_it_concerns: str,
+        why_keep: str,
+        content: str,
+        source: str | None = None,
+    ) -> CaptureResult:
+        """Drop a zero-friction capture into ``inbox/`` (format spec §7).
+
+        ``what_it_concerns`` and ``why_keep`` are mandatory (never guessed
+        at by an implementation). An exact-duplicate of an existing
+        ``inbox/`` entry is acknowledged without creating a second file —
+        see :class:`CaptureResult`.
+        """
+        ...
+
+    async def inbox_status(self) -> InboxStatusResult:
+        """Summarize ``inbox/``: uncurated count, oldest entry age, last capture."""
         ...

--- a/v3/server/tests/gateway/test_inbox_real_vault.py
+++ b/v3/server/tests/gateway/test_inbox_real_vault.py
@@ -1,0 +1,182 @@
+"""SPEC-107 integration test: a capture note composed by
+:mod:`palaia_hub.gateway.inbox` and written through the *real* vault engine
+(SPEC-102) is a format-spec-valid ``inbox/`` note (``v3/docs/vault-format.md``
+§7) — mandatory ``[entity]``/``[why]`` bullets present, deterministic
+``capture_id``, ``status: uncurated``, canonical frontmatter/body shape.
+
+Deliberately independent of the gateway's ``VaultService`` abstraction: this
+proves the note *shape* the gateway package composes (with zero
+``palaia_hub.vault`` import there) survives a real engine round-trip,
+without building the full production adapter that wiring a real vault into
+the gateway would need (that adapter is SPEC-113's scope).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from palaia_hub.gateway import inbox as inbox_shape
+from palaia_hub.vault import VaultEngine
+
+pytestmark = pytest.mark.anyio
+
+_CAPTURE_ID_RE = re.compile(r"^cap-[0-9a-f]{10}$")
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+async def _open_engine(tmp_path: Path) -> VaultEngine:
+    engine = VaultEngine(tmp_path / "vault", "work")
+    await engine.open(purpose="integration test vault")
+    return engine
+
+
+async def _write_capture(
+    engine: VaultEngine,
+    *,
+    what_it_concerns: str,
+    why_keep: str,
+    content: str,
+    source: str | None = None,
+) -> tuple[str, str, str]:
+    """Compose and write one capture the way a real ``VaultService.capture``
+    adapter would: mint the permalink under ``inbox/`` via ``write_note``
+    (letting the engine own permalink minting/uniqueness), then patch in the
+    capture-specific frontmatter this SPEC's gateway layer defines.
+
+    Returns ``(permalink, path, capture_id)``. ``path`` is the vault-relative
+    file path (which may differ from the permalink — a real capture adapter
+    would pass its own slugified path; here the engine's `write_note` mints
+    the note file at ``inbox/<what_it_concerns>.md`` and mints its *own*
+    slugified permalink from the title, per format spec §3.1).
+    """
+    resolved_source = (source or "").strip() or inbox_shape.default_source()
+    content_hash = inbox_shape.content_hash_for(what_it_concerns, why_keep, content)
+    body = inbox_shape.compose_capture_body(
+        what_it_concerns=what_it_concerns,
+        why_keep=why_keep,
+        content=content,
+        source=resolved_source,
+        content_hash=content_hash,
+    )
+    result = await engine.write_note(
+        f"inbox/{what_it_concerns}",
+        body=body,
+        title=what_it_concerns,
+        frontmatter={"type": "capture", "tags": ["inbox"], "status": "uncurated"},
+    )
+    assert result.note is not None
+    permalink = result.note.permalink
+    path = result.note.path
+    assert permalink is not None
+    capture_id = inbox_shape.capture_id_for(permalink)
+    # capture_id depends on the final (post-uniquing) permalink, so it is a
+    # second write — the same "engine mints identity, capture stamps
+    # capture_id" two-step a real capture() adapter would perform.
+    await engine.edit_note(
+        permalink,
+        expected_checksum=result.note.checksum,
+        frontmatter={"capture_id": capture_id},
+    )
+    return permalink, path, capture_id
+
+
+async def test_capture_with_only_mandatory_fields_is_format_valid(tmp_path: Path) -> None:
+    engine = await _open_engine(tmp_path)
+    permalink, path, capture_id = await _write_capture(
+        engine,
+        what_it_concerns="API Gateway",
+        why_keep="The rate limit was chosen deliberately; future work will trip over it.",
+        content="We capped ingest at 100 req/min because the embed queue saturates above that.",
+    )
+
+    note = await engine.read_note(permalink)
+
+    # Frontmatter shape (format spec §2.1/§7).
+    assert note.frontmatter["type"] == "capture"
+    assert note.frontmatter["status"] == "uncurated"
+    assert note.frontmatter["tags"] == ["inbox"]
+    assert note.frontmatter["capture_id"] == capture_id
+    assert _CAPTURE_ID_RE.match(note.frontmatter["capture_id"])
+    assert note.permalink is not None
+    assert note.permalink.startswith("inbox/")
+    assert not note.malformed_frontmatter
+
+    # Mandatory body bullets (§7): entity and why must both be present.
+    assert "- [entity] API Gateway" in note.body
+    assert "- [why] The rate limit was chosen deliberately" in note.body
+
+    # File itself is on disk, LF-only, one blank line after the closing fence
+    # — the canonical write form (§2.2), for free from `fm.render`/`write_note`.
+    raw = (engine.root / path).read_text(encoding="utf-8")
+    assert "\r" not in raw
+    assert raw.startswith("---\n")
+
+    # It is a real, git-committed write (SPEC-102 write-through guarantee).
+    assert engine.git.head() is not None
+
+
+async def test_capture_id_is_deterministic_from_the_permalink(tmp_path: Path) -> None:
+    engine = await _open_engine(tmp_path)
+    permalink, _path, capture_id = await _write_capture(
+        engine,
+        what_it_concerns="Deterministic ID Check",
+        why_keep="Proves capture_id is a pure function of the permalink.",
+        content="Nothing interesting; just a fixture.",
+    )
+    assert capture_id == inbox_shape.capture_id_for(permalink)
+
+
+async def test_capture_note_is_immediately_readable_and_listed_in_inbox(tmp_path: Path) -> None:
+    engine = await _open_engine(tmp_path)
+    permalink, _path, _capture_id = await _write_capture(
+        engine,
+        what_it_concerns="Immediately Searchable",
+        why_keep="Uncurated captures must be visible right away (§7).",
+        content="No curation step should be required to find this.",
+    )
+
+    entries = await engine.list_dir("inbox")
+    assert any(entry.permalink == permalink for entry in entries)
+
+
+async def test_source_defaults_when_omitted_and_is_honored_when_given(tmp_path: Path) -> None:
+    engine = await _open_engine(tmp_path)
+    permalink, _path, _capture_id = await _write_capture(
+        engine,
+        what_it_concerns="Default Source",
+        why_keep="Source should default to something plausible.",
+        content="content body",
+    )
+    note = await engine.read_note(permalink)
+    assert "- [source] agent capture, " in note.body
+
+    permalink2, _path2, _capture_id2 = await _write_capture(
+        engine,
+        what_it_concerns="Explicit Source",
+        why_keep="Source should be honored when the caller supplies one.",
+        content="content body",
+        source="PR #88 review, cwendler, 2026-08-22",
+    )
+    note2 = await engine.read_note(permalink2)
+    assert "- [source] PR #88 review, cwendler, 2026-08-22" in note2.body
+
+
+async def test_two_distinct_captures_get_distinct_permalinks_and_capture_ids(
+    tmp_path: Path,
+) -> None:
+    engine = await _open_engine(tmp_path)
+    permalink_a, _path_a, capture_id_a = await _write_capture(
+        engine, what_it_concerns="Thing A", why_keep="why A", content="content A"
+    )
+    permalink_b, _path_b, capture_id_b = await _write_capture(
+        engine, what_it_concerns="Thing B", why_keep="why B", content="content B"
+    )
+    assert permalink_a != permalink_b
+    assert capture_id_a != capture_id_b

--- a/v3/server/tests/gateway/test_inbox_shape.py
+++ b/v3/server/tests/gateway/test_inbox_shape.py
@@ -1,0 +1,86 @@
+"""Unit tests for the pure composition helpers in
+:mod:`palaia_hub.gateway.inbox` (capture_id derivation, dedup hashing,
+missing-field messaging) — independent of any ``VaultService`` backend.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from palaia_hub.gateway import inbox
+
+
+def test_capture_id_matches_the_format_spec_formula() -> None:
+    permalink = "inbox/api-gateway"
+    expected = "cap-" + hashlib.sha256(permalink.encode("utf-8")).hexdigest()[:10]
+    assert inbox.capture_id_for(permalink) == expected
+
+
+def test_capture_id_is_deterministic_and_permalink_specific() -> None:
+    a = inbox.capture_id_for("inbox/foo")
+    b = inbox.capture_id_for("inbox/foo")
+    c = inbox.capture_id_for("inbox/bar")
+    assert a == b
+    assert a != c
+
+
+def test_content_hash_is_stable_under_case_and_whitespace_reformatting() -> None:
+    h1 = inbox.content_hash_for("API Gateway", "why it matters", "the raw detail")
+    h2 = inbox.content_hash_for("  api gateway  ", "WHY IT MATTERS", "the raw detail")
+    assert h1 == h2
+
+
+def test_content_hash_differs_for_different_content() -> None:
+    h1 = inbox.content_hash_for("A", "why", "content")
+    h2 = inbox.content_hash_for("B", "why", "content")
+    assert h1 != h2
+
+
+def test_missing_capture_fields_detects_blank_and_absent_values() -> None:
+    missing = inbox.missing_capture_fields(what_it_concerns="x", why_keep="   ", content=None)
+    assert missing == ["why_keep", "content"]
+
+
+def test_missing_capture_fields_empty_when_all_present() -> None:
+    assert inbox.missing_capture_fields(what_it_concerns="x", why_keep="y", content="z") == []
+
+
+def test_missing_fields_message_names_the_field_and_gives_an_example() -> None:
+    message = inbox.missing_fields_message(["why_keep"])
+    assert "why_keep" in message
+    assert "Example:" in message
+
+
+def test_compose_and_extract_capture_hash_round_trip() -> None:
+    content_hash = inbox.content_hash_for("A", "why", "content")
+    body = inbox.compose_capture_body(
+        what_it_concerns="A",
+        why_keep="why",
+        content="content",
+        source="src",
+        content_hash=content_hash,
+    )
+    assert inbox.extract_capture_hash(body) == content_hash
+    assert "- [entity] A" in body
+    assert "- [why] why" in body
+    assert "- [raw] content" in body
+    assert "- [source] src" in body
+
+
+def test_extract_capture_hash_returns_none_when_absent() -> None:
+    assert inbox.extract_capture_hash("no hash bullet here") is None
+
+
+def test_default_source_names_a_date() -> None:
+    source = inbox.default_source()
+    assert source.startswith("agent capture, ")
+
+
+def test_capture_frontmatter_matches_format_spec_section_7() -> None:
+    fm = inbox.capture_frontmatter(capture_id="cap-0123456789")
+    assert fm == {
+        "type": "capture",
+        "tags": ["inbox"],
+        "status": "uncurated",
+        "capture_id": "cap-0123456789",
+    }

--- a/v3/server/tests/gateway/test_inbox_tools.py
+++ b/v3/server/tests/gateway/test_inbox_tools.py
@@ -1,0 +1,175 @@
+"""SPEC-107 acceptance tests: the ``capture``/``inbox_status`` tools built
+into each vault's memory tool family, exercised through
+:class:`~palaia_hub.gateway.fake_vault.FakeVaultService`.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from fastmcp import Client
+
+from palaia_hub.gateway.config import VaultMountConfig
+from palaia_hub.gateway.fake_vault import FakeVaultService
+from palaia_hub.gateway.memory_tools import build_vault_server
+
+_CAPTURE_ID_RE = re.compile(r"^cap-[0-9a-f]{10}$")
+
+
+@pytest.fixture
+def vault_config() -> VaultMountConfig:
+    return VaultMountConfig(key="work", name="work", purpose="Team knowledge.")
+
+
+@pytest.fixture
+def service() -> FakeVaultService:
+    return FakeVaultService()
+
+
+@pytest.fixture
+def server(vault_config: VaultMountConfig, service: FakeVaultService):  # noqa: ANN201
+    return build_vault_server(vault_config, service)
+
+
+async def _capture(client: Client, **overrides: str) -> object:  # noqa: ANN401
+    payload = {
+        "what_it_concerns": "API Gateway",
+        "why_keep": "The rate limit was chosen deliberately; future work will trip over it.",
+        "content": "We capped ingest at 100 req/min because the embed queue saturates above that.",
+    }
+    payload.update(overrides)
+    return await client.call_tool("capture", payload)
+
+
+@pytest.mark.anyio
+async def test_capture_with_only_mandatory_fields_succeeds(server) -> None:  # noqa: ANN001
+    async with Client(server) as client:
+        result = await _capture(client)
+    assert result.is_error is not True
+    sc = result.structured_content
+    assert sc["permalink"].startswith("inbox/")
+    assert sc["status"] == "uncurated"
+    assert _CAPTURE_ID_RE.match(sc["capture_id"])
+    assert sc["duplicate"] is False
+
+
+@pytest.mark.anyio
+async def test_capture_missing_mandatory_field_names_it_with_an_example(server) -> None:  # noqa: ANN001
+    async with Client(server) as client:
+        result = await client.call_tool(
+            "capture",
+            {"what_it_concerns": "API Gateway", "content": "some raw detail"},
+            raise_on_error=False,
+        )
+    assert result.is_error is True
+    text = result.content[0].text
+    assert "why_keep" in text
+    assert "Example:" in text
+
+
+@pytest.mark.anyio
+async def test_capture_missing_all_mandatory_fields_names_all_of_them(server) -> None:  # noqa: ANN001
+    async with Client(server) as client:
+        result = await client.call_tool("capture", {}, raise_on_error=False)
+    assert result.is_error is True
+    text = result.content[0].text
+    for field in ("what_it_concerns", "why_keep", "content"):
+        assert field in text
+
+
+@pytest.mark.anyio
+async def test_exact_duplicate_capture_is_acked_not_duplicated(server) -> None:  # noqa: ANN001
+    async with Client(server) as client:
+        first = await _capture(client)
+        second = await _capture(client)
+
+        listing = await client.call_tool("list", {"folder": "inbox"})
+
+    assert first.structured_content["duplicate"] is False
+    assert second.structured_content["duplicate"] is True
+    assert second.structured_content["permalink"] == first.structured_content["permalink"]
+    assert len(listing.structured_content["notes"]) == 1
+
+
+@pytest.mark.anyio
+async def test_near_duplicate_with_different_content_is_not_deduped(server) -> None:  # noqa: ANN001
+    async with Client(server) as client:
+        await _capture(client)
+        second = await _capture(client, content="a completely different observation")
+        listing = await client.call_tool("list", {"folder": "inbox"})
+
+    assert second.structured_content["duplicate"] is False
+    assert len(listing.structured_content["notes"]) == 2
+
+
+@pytest.mark.anyio
+async def test_capture_id_is_deterministic_for_the_same_permalink(server) -> None:  # noqa: ANN001
+    async with Client(server) as client:
+        result = await _capture(client)
+    permalink = result.structured_content["permalink"]
+    capture_id = result.structured_content["capture_id"]
+
+    from palaia_hub.gateway.inbox import capture_id_for
+
+    assert capture_id == capture_id_for(permalink)
+
+
+@pytest.mark.anyio
+async def test_captured_note_carries_entity_and_why_bullets_and_is_searchable(server) -> None:  # noqa: ANN001
+    async with Client(server) as client:
+        await _capture(client)
+        read_result = await client.call_tool("read", {"permalink": "inbox/api-gateway"})
+        search_result = await client.call_tool("search", {"query": "API Gateway"})
+
+    body = read_result.structured_content["body"]
+    assert "- [entity] API Gateway" in body
+    assert "- [why] The rate limit was chosen deliberately" in body
+    assert read_result.structured_content["status"] == "uncurated"
+    assert any(
+        hit["permalink"] == "inbox/api-gateway" for hit in search_result.structured_content["hits"]
+    )
+
+
+@pytest.mark.anyio
+async def test_inbox_status_reports_zero_when_empty(server) -> None:  # noqa: ANN001
+    async with Client(server) as client:
+        result = await client.call_tool("inbox_status", {})
+    assert result.structured_content["count"] == 0
+    assert result.structured_content["oldest_age_seconds"] is None
+
+
+@pytest.mark.anyio
+async def test_inbox_status_counts_captures_and_tracks_oldest_and_last(server) -> None:  # noqa: ANN001
+    async with Client(server) as client:
+        first = await _capture(client, what_it_concerns="First thing")
+        await _capture(client, what_it_concerns="Second thing")
+        status = await client.call_tool("inbox_status", {})
+
+    sc = status.structured_content
+    assert sc["count"] == 2
+    assert sc["oldest_capture_id"] == first.structured_content["capture_id"]
+    assert sc["oldest_age_seconds"] is not None
+    assert sc["oldest_age_seconds"] >= 0
+    assert sc["last_capture_id"] is not None
+
+
+@pytest.mark.anyio
+async def test_capture_default_source_when_omitted(server) -> None:  # noqa: ANN001
+    async with Client(server) as client:
+        result = await _capture(client)
+        read_result = await client.call_tool(
+            "read", {"permalink": result.structured_content["permalink"]}
+        )
+    assert "- [source]" in read_result.structured_content["body"]
+
+
+@pytest.mark.anyio
+async def test_capture_uses_caller_supplied_source(server) -> None:  # noqa: ANN001
+    async with Client(server) as client:
+        result = await _capture(client, source="PR #88 review, cwendler, 2026-08-22")
+        read_result = await client.call_tool(
+            "read", {"permalink": result.structured_content["permalink"]}
+        )
+    body = read_result.structured_content["body"]
+    assert "- [source] PR #88 review, cwendler, 2026-08-22" in body

--- a/v3/server/tests/gateway/test_memory_tools.py
+++ b/v3/server/tests/gateway/test_memory_tools.py
@@ -14,7 +14,7 @@ from fastmcp import Client
 from palaia_hub.gateway.config import VaultMountConfig
 from palaia_hub.gateway.fake_vault import FakeVaultService
 from palaia_hub.gateway.memory_tools import build_vault_server
-from palaia_hub.gateway.vault_protocol import MEMORY_TOOL_ACTIONS
+from palaia_hub.gateway.vault_protocol import INBOX_TOOL_ACTIONS, MEMORY_TOOL_ACTIONS
 
 
 @pytest.fixture
@@ -36,7 +36,11 @@ async def test_every_action_is_exposed_as_a_tool(server) -> None:  # noqa: ANN00
     async with Client(server) as client:
         tools = await client.list_tools()
     names = {t.name for t in tools}
-    assert names == set(MEMORY_TOOL_ACTIONS)
+    # SPEC-107 adds capture/inbox_status to the same server as the original
+    # eight memory actions (see vault_protocol.INBOX_TOOL_ACTIONS's comment
+    # for why they're a separate tuple rather than folded into
+    # MEMORY_TOOL_ACTIONS).
+    assert names == set(MEMORY_TOOL_ACTIONS) | set(INBOX_TOOL_ACTIONS)
 
 
 @pytest.mark.anyio
@@ -73,9 +77,9 @@ async def test_annotations_lint_every_tool_description_leads_with_purpose(
 async def test_readonly_tools_are_marked_readonly_and_mutators_are_not(server) -> None:  # noqa: ANN001
     async with Client(server) as client:
         tools = {t.name: t for t in await client.list_tools()}
-    for name in ("search", "read", "list", "recent_activity"):
+    for name in ("search", "read", "list", "recent_activity", "inbox_status"):
         assert tools[name].annotations.readOnlyHint is True, name
-    for name in ("write", "edit", "move", "delete"):
+    for name in ("write", "edit", "move", "delete", "capture"):
         assert tools[name].annotations.readOnlyHint is False, name
 
 

--- a/v3/server/tests/test_app_inbox_status.py
+++ b/v3/server/tests/test_app_inbox_status.py
@@ -1,0 +1,57 @@
+"""SPEC-107 deliverable #3: the ``/api/vaults/{vault_key}/inbox_status`` REST
+endpoint, independent of any MCP gateway being mounted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from fastapi.testclient import TestClient
+
+from palaia_hub.app import create_app
+from palaia_hub.config import HubConfig
+from palaia_hub.gateway.fake_vault import FakeVaultService
+
+
+def test_inbox_status_endpoint_absent_without_vault_services() -> None:
+    app = create_app(HubConfig())
+    client = TestClient(app)
+    response = client.get("/api/vaults/work/inbox_status")
+    assert response.status_code == 404
+
+
+def test_inbox_status_endpoint_unknown_vault_key_is_404() -> None:
+    app = create_app(HubConfig(), vault_services={"work": FakeVaultService()})
+    client = TestClient(app)
+    response = client.get("/api/vaults/personal/inbox_status")
+    assert response.status_code == 404
+
+
+def test_inbox_status_endpoint_reports_zero_with_no_captures() -> None:
+    app = create_app(HubConfig(), vault_services={"work": FakeVaultService()})
+    client = TestClient(app)
+    response = client.get("/api/vaults/work/inbox_status")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["count"] == 0
+    assert body["oldest_age_seconds"] is None
+
+
+def test_inbox_status_endpoint_reflects_captures() -> None:
+    service = FakeVaultService()
+    app = create_app(HubConfig(), vault_services={"work": service})
+    client = TestClient(app)
+
+    asyncio.run(
+        service.capture(
+            what_it_concerns="API Gateway",
+            why_keep="the limit was chosen deliberately",
+            content="raw detail here",
+        )
+    )
+
+    response = client.get("/api/vaults/work/inbox_status")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["count"] == 1
+    assert body["oldest_capture_id"] is not None


### PR DESCRIPTION
## Summary

Implements SPEC-107: the inbox/capture contract (`v3/docs/vault-format.md` §7).

- **`capture` tool** (added to each vault's existing memory tool family, `palaia_hub/gateway/memory_tools.py`): mandatory `what_it_concerns`/`why_keep`/`content`, optional `source` (defaults to `"agent capture, <date>"`). Writes a format-spec-valid `inbox/` note: `type: capture`, `tags: [inbox]`, `status: uncurated`, `capture_id` derived per §7 (`"cap-" + sha256(permalink)[:10]`), body with mandatory `[entity]`/`[why]` bullets plus `[raw]`/`[source]`.
- **Duplicate guard**: a cheap hash over the normalized three mandatory fields is stored as a `[capture_hash]` body bullet; an exact-duplicate re-capture is acknowledged (`duplicate: true`, existing permalink/capture_id returned) without writing a second file.
- **`inbox_status` tool** + **REST endpoint** `GET /api/vaults/{vault_key}/inbox_status`: uncurated count, oldest entry age, last capture id/timestamp.
- **Composition logic** lives in a new `palaia_hub/gateway/inbox.py` — pure functions (capture_id derivation, dedup hashing, body/frontmatter composition, the missing-field error message), with zero `palaia_hub.vault` import, matching the existing gateway/vault_protocol.py isolation rule so the gateway package stays decoupled from the vault-engine lane.
- `VaultService` protocol extended with `capture()`/`inbox_status()`; `FakeVaultService` implements both for tests. `NoteSummary`/`NoteRecord` gained `status`/`capture_id` fields (format spec §2.1 schema keys).

## Acceptance checklist

- [x] capture with only mandatory fields yields a format-spec-valid inbox note — verified two ways: unit/tool tests against `FakeVaultService`, **and** an integration test (`tests/gateway/test_inbox_real_vault.py`) that drives the real `VaultEngine.write_note` and asserts on the parsed frontmatter/body. (Note: SPEC-103's parser is not yet merged on this base branch, so validation is against the format spec's documented rules directly rather than SPEC-103's conformance corpus — flagged for a follow-up conformance pass once SPEC-103 lands.)
- [x] missing mandatory field → helpful error naming the field and an example (`test_capture_missing_mandatory_field_names_it_with_an_example`, `test_capture_missing_all_mandatory_fields_names_all_of_them`)
- [x] capture_id deterministic and present in frontmatter (`test_capture_id_is_deterministic_for_the_same_permalink`, `test_capture_id_is_deterministic_from_the_permalink`, plus a pure-function unit test)
- [x] exact duplicate capture does not create a second file (`test_exact_duplicate_capture_is_acked_not_duplicated`)
- [x] inbox entries rank in normal search with their uncurated status visible (`test_captured_note_carries_entity_and_why_bullets_and_is_searchable`)
- [ ] Dashboard v0 hook (SPEC-110, not yet started) — out of this SPEC's scope; non-goal note in the spec file already excludes curation but the dashboard hook is deliverable #4. Left for SPEC-110, which owns the dashboard explorer.

## Verification evidence

```
cd v3 && uv sync
uv run ruff check server        # All checks passed!
uv run mypy server/src          # Success: no issues found in 29 source files
uv run pytest server/tests -q   # 241 passed, 1 skipped
```

## Design notes (adjacent-improvement disclosures, not new scope)

- `capture`/`inbox_status` are kept in a separate `INBOX_TOOL_ACTIONS` tuple rather than folded into `MEMORY_TOOL_ACTIONS`, since the latter is also used by `gateway/config.py` to validate `tool_renames` keys against specifically the original eight actions — renaming capture/inbox_status via config is not wired up in this SPEC (non-goal).
- The `/api/vaults/{vault_key}/inbox_status` REST endpoint needed a `vault_services` mapping in `create_app()`; added as an optional, additive parameter independent of the existing `gateway` parameter.
- The exact-duplicate hash is stored as a body bullet (`[capture_hash]`), not a frontmatter key — it's not a format-spec key, and storing it in the body lets both a fake and a real vault-engine-backed implementation recover it just by reading the note back, no side index needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790094699&installation_model_id=428086&pr_number=214&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F214&signature=b71c0a10a3f5fe4cfa635c79f4b464e5745419f4584777370ac54e78c51d26ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->