### PR TITLE
feat(v3): MVP auth — per-client tokens + profiles (SPEC-108)

### DIFF
--- a/v3/server/pyproject.toml
+++ b/v3/server/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "platformdirs>=4.2",
     "fastmcp==3.4.7",
     "watchfiles>=0.22",
+    "argon2-cffi>=23.1",
 ]
 
 [project.scripts]

--- a/v3/server/src/palaia_hub/app.py
+++ b/v3/server/src/palaia_hub/app.py
@@ -1,9 +1,9 @@
 """ASGI app factory for the hub daemon.
 
-One FastAPI app hosting the REST/dashboard API (this SPEC: ``/api/health``
-and ``/api/info`` only) and, from SPEC-105 onward, the MCP gateway mount
-point. No MCP serving, auth, or persistence here — see SPEC-101's
-non-goals.
+One FastAPI app hosting the REST/dashboard API, the MCP gateway mount
+point (SPEC-105, opt-in via the ``gateway`` parameter), and the
+``/api/auth/tokens`` token-management surface (SPEC-108, opt-in via the
+``token_store`` parameter).
 """
 
 from __future__ import annotations
@@ -18,6 +18,7 @@ from typing import Any
 from fastapi import FastAPI
 
 from . import __version__
+from .auth import TokenStore, build_auth_router, check_gateway_auth_policy
 from .config import HubConfig, load_config
 from .events import EventBus, build_events_router, start_background_tasks, stop_background_tasks
 from .gateway import GatewayASGI
@@ -32,7 +33,12 @@ from .static import mount_dashboard
 _TEST_SLOW_ENDPOINT_ENV = "PALAIA_TEST_SLOW_ENDPOINT_SECONDS"
 
 
-def create_app(config: HubConfig | None = None, *, gateway: GatewayASGI | None = None) -> FastAPI:
+def create_app(
+    config: HubConfig | None = None,
+    *,
+    gateway: GatewayASGI | None = None,
+    token_store: TokenStore | None = None,
+) -> FastAPI:
     """Build the hub's ASGI app.
 
     Args:
@@ -44,9 +50,27 @@ def create_app(config: HubConfig | None = None, *, gateway: GatewayASGI | None =
             before this parameter existed. Its lifespan MUST be attached to
             this app's lifespan (done below) or its mounted profile(s) hang
             on their first request — see ``gateway/build.py``'s docstring.
+        token_store: the client-token store (SPEC-108); given, mounts the
+            ``/api/auth/tokens`` REST surface (:func:`palaia_hub.auth.
+            build_auth_router`). Omitted (the default), the hub runs with
+            no token-management API at all, same as before this parameter
+            existed — a caller that only needs the gateway's *enforcement*
+            of tokens already-issued via the CLI does not need to pass one.
+
+    Raises:
+        palaia_hub.auth.AuthPolicyError: ``gateway`` is given, ``config.mode``
+            is ``cloud``/``open``, and one or more of the gateway's mounted
+            profiles has no auth attached (see ``auth/policy.py`` — this is
+            the "hub refuses to start MCP endpoints without auth enabled"
+            enforcement, checked against the gateway actually built rather
+            than against config alone; :mod:`palaia_hub.config` already
+            refuses the config-level version of this mistake earlier, at
+            ``load_config()`` time).
     """
     config = config or load_config()
     setup_logging(config)
+    if gateway is not None:
+        check_gateway_auth_policy(config.mode, gateway.profile_servers)
 
     start_time = time.monotonic()
     event_bus = EventBus()
@@ -96,6 +120,9 @@ def create_app(config: HubConfig | None = None, *, gateway: GatewayASGI | None =
     # dashboard build itself. The dashboard mount goes last so it never
     # shadows an /api/* route (see static.mount_dashboard).
     app.include_router(build_events_router(event_bus, health_snapshot=health_snapshot))
+
+    if token_store is not None:
+        app.include_router(build_auth_router(token_store))
 
     _maybe_add_test_slow_route(app)
 

--- a/v3/server/src/palaia_hub/auth/__init__.py
+++ b/v3/server/src/palaia_hub/auth/__init__.py
@@ -1,0 +1,53 @@
+"""palaia's MVP auth: named, argon2id-hashed per-client tokens (SPEC-108).
+
+Public surface:
+
+- :class:`~palaia_hub.auth.store.TokenStore` — create/list/revoke/verify
+  named tokens, hashed at rest. Never holds a plaintext token after
+  :meth:`~palaia_hub.auth.store.TokenStore.create` returns it.
+- :class:`~palaia_hub.auth.verifier.PalaiaTokenVerifier` — adapts a
+  ``TokenStore`` to fastmcp's ``TokenVerifier`` seam
+  (``FastMCP(auth=...)``); see that module's docstring for the Phase-2
+  OAuth upgrade path this exists to keep open.
+- :func:`~palaia_hub.auth.wiring.build_profile_verifiers` — one verifier
+  per gateway profile, for :func:`palaia_hub.gateway.build.build_gateway`'s
+  ``token_verifiers`` parameter.
+- :func:`~palaia_hub.auth.enforcement.missing_scope_error` — the per-tool
+  read/write scope check :mod:`palaia_hub.gateway.memory_tools` calls.
+- :mod:`palaia_hub.auth.scopes` — the ``vault:<key>:read|write`` scope
+  vocabulary and which of the eight memory-tool actions need which.
+- :func:`~palaia_hub.auth.policy.check_gateway_auth_policy` — the
+  cloud/open "every mounted profile must have a verifier" guard
+  :func:`palaia_hub.app.create_app` runs before mounting a gateway.
+- :func:`~palaia_hub.auth.routes.build_auth_router` — the
+  ``/api/auth/tokens`` REST surface.
+"""
+
+from __future__ import annotations
+
+from .enforcement import missing_scope_error
+from .models import CreatedToken, TokenInfo, TokenRecord
+from .policy import AuthPolicyError, check_gateway_auth_policy
+from .routes import build_auth_router
+from .scopes import READ_ACTIONS, WRITE_ACTIONS, required_scope_for_action, vault_scope
+from .store import TokenError, TokenStore
+from .verifier import PalaiaTokenVerifier
+from .wiring import build_profile_verifiers
+
+__all__ = [
+    "READ_ACTIONS",
+    "WRITE_ACTIONS",
+    "AuthPolicyError",
+    "CreatedToken",
+    "PalaiaTokenVerifier",
+    "TokenError",
+    "TokenInfo",
+    "TokenRecord",
+    "TokenStore",
+    "build_auth_router",
+    "build_profile_verifiers",
+    "check_gateway_auth_policy",
+    "missing_scope_error",
+    "required_scope_for_action",
+    "vault_scope",
+]

--- a/v3/server/src/palaia_hub/auth/enforcement.py
+++ b/v3/server/src/palaia_hub/auth/enforcement.py
@@ -1,0 +1,54 @@
+"""Per-tool scope enforcement — the gateway's fine-grained half of auth.
+
+fastmcp's ``RequireAuthMiddleware`` (wired in via ``FastMCP(auth=...)``,
+see :mod:`palaia_hub.auth.verifier`) is coarse: it gates an entire mounted
+profile on "is there any valid token at all", because a profile can host
+several vaults with different read/write grants on the *same* token. This
+module is the other half: called from inside a memory tool
+(:mod:`palaia_hub.gateway.memory_tools`), after the transport layer has
+already authenticated the call, to check whether *this* token's scopes
+cover *this* specific action on *this* specific vault.
+
+The result is deliberately a plain string, not an exception:
+:mod:`palaia_hub.gateway.memory_tools` turns it into
+``ToolResult(is_error=True, ...)`` — an MCP-level tool error the calling
+model sees and can react to, not an HTTP failure or a crash (SPEC-108
+acceptance criterion: "read-scoped token calling a write tool -> MCP error
+naming the missing scope").
+"""
+
+from __future__ import annotations
+
+from fastmcp.server.dependencies import get_access_token
+
+from .scopes import required_scope_for_action
+
+
+def missing_scope_error(vault_key: str, action: str) -> str | None:
+    """``None`` if the current call may proceed; else the error to return.
+
+    ``get_access_token()`` returns ``None`` when no ``TokenVerifier`` is
+    attached to the profile currently serving this request — i.e. auth was
+    never required for this mount (locked mode's default-optional
+    posture). That is a transport-layer decision already made before any
+    tool code runs (see :mod:`palaia_hub.auth.policy` /
+    :mod:`palaia_hub.gateway.build`): a profile *with* a verifier attached
+    already refused an unauthenticated call with a 401 via
+    ``RequireAuthMiddleware`` before reaching here, so a token-less call
+    that does reach a tool body can only mean this mount never required
+    one — every action is allowed in that case, same as before this SPEC.
+    """
+    access_token = get_access_token()
+    if access_token is None:
+        return None
+    needed = required_scope_for_action(vault_key, action)
+    if needed in access_token.scopes:
+        return None
+    return (
+        f"this token is missing scope {needed!r} "
+        f"(it has: {sorted(access_token.scopes)!r}). Fix: create or use a token "
+        f"that includes {needed!r} for this vault."
+    )
+
+
+__all__ = ["missing_scope_error"]

--- a/v3/server/src/palaia_hub/auth/hashing.py
+++ b/v3/server/src/palaia_hub/auth/hashing.py
@@ -1,0 +1,66 @@
+"""argon2id hashing for client-token secrets, with a constant-time-miss helper.
+
+This is the only module in the codebase that calls into ``argon2``. Every
+other piece of the token store goes through :func:`hash_secret` /
+:func:`verify_secret` — a security surface stays auditable by staying in
+exactly one place.
+
+``argon2.PasswordHasher()`` defaults to the argon2id variant (has been since
+argon2-cffi 18.2), which is what SPEC-108 requires. Its ``verify()`` re-hashes
+the candidate secret and compares the two digests; that comparison is done
+by the underlying C library in constant time by design — this module adds
+nothing on top for the *hash-mismatch* case (the acceptance criterion's
+"timing-safe comparison"), but see :func:`spend_constant_time_miss` for the
+one case argon2 itself cannot cover: a token whose id was never issued at
+all, which never reaches ``verify()`` and would otherwise return in
+near-zero time.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import secrets
+
+from argon2 import PasswordHasher
+from argon2.exceptions import VerificationError, VerifyMismatchError
+
+_hasher = PasswordHasher()
+
+# A hash of a value nobody will ever present as a real secret. Verifying
+# against it spends the same wall-clock time as a real (mismatching) verify,
+# so "no token with this id exists" and "this id exists but the secret is
+# wrong" cost the same — the id half of a token is not meant to be secret
+# (see store.py's module docstring), but paying this cost anyway is cheap
+# insurance against relying on that assumption elsewhere.
+_DUMMY_HASH = _hasher.hash("palaia-constant-time-padding-not-a-real-token")
+
+
+def hash_secret(secret: str) -> str:
+    """Return the argon2id hash of ``secret``, ready to store."""
+    return _hasher.hash(secret)
+
+
+def verify_secret(secret: str, stored_hash: str) -> bool:
+    """Constant-time-compare ``secret`` against ``stored_hash``.
+
+    Returns ``False`` for a mismatch, a malformed hash, or any other
+    argon2 verification failure — never raises for caller-facing reasons.
+    """
+    try:
+        _hasher.verify(stored_hash, secret)
+    except (VerifyMismatchError, VerificationError):
+        return False
+    return True
+
+
+def spend_constant_time_miss() -> None:
+    """Burn one argon2 verify's worth of time on a fixed dummy hash.
+
+    Call this on a "no such token id" path so it costs the same as a real
+    mismatch (see the module docstring and :data:`_DUMMY_HASH`).
+    """
+    with contextlib.suppress(VerifyMismatchError, VerificationError):
+        _hasher.verify(_DUMMY_HASH, secrets.token_urlsafe(32))
+
+
+__all__ = ["hash_secret", "spend_constant_time_miss", "verify_secret"]

--- a/v3/server/src/palaia_hub/auth/models.py
+++ b/v3/server/src/palaia_hub/auth/models.py
@@ -1,0 +1,70 @@
+"""Token data shapes: the stored record, and its hash-free public views."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TokenRecord(BaseModel):
+    """One client token as persisted in the store — includes the hash.
+
+    Never serialize this to a REST response or a CLI listing; use
+    :class:`TokenInfo` for that (see :meth:`TokenInfo.from_record`). ``id``
+    is a public, non-secret identifier (see ``store.py``'s module
+    docstring) — only ``hash`` is sensitive, and it never leaves the store.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    name: str
+    profile: str
+    scopes: list[str] = Field(default_factory=list)
+    hash: str
+    created_at: str
+    revoked_at: str | None = None
+
+    @property
+    def is_revoked(self) -> bool:
+        return self.revoked_at is not None
+
+
+class TokenInfo(BaseModel):
+    """The hash-free, safe-to-show view of a :class:`TokenRecord`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    name: str
+    profile: str
+    scopes: list[str]
+    created_at: str
+    revoked_at: str | None = None
+
+    @classmethod
+    def from_record(cls, record: TokenRecord) -> TokenInfo:
+        return cls(
+            id=record.id,
+            name=record.name,
+            profile=record.profile,
+            scopes=record.scopes,
+            created_at=record.created_at,
+            revoked_at=record.revoked_at,
+        )
+
+
+class CreatedToken(BaseModel):
+    """A freshly created token: its info, plus the plaintext — shown once.
+
+    Nothing else in this codebase ever holds the plaintext after this
+    object is handed back to whoever called :meth:`TokenStore.create`; the
+    store itself only ever wrote the hash.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    info: TokenInfo
+    token: str
+
+
+__all__ = ["CreatedToken", "TokenInfo", "TokenRecord"]

--- a/v3/server/src/palaia_hub/auth/policy.py
+++ b/v3/server/src/palaia_hub/auth/policy.py
@@ -1,0 +1,46 @@
+"""Operating-mode auth policy checked against an actually-built gateway.
+
+:mod:`palaia_hub.config` already refuses (at config-load time) a
+``cloud``/``open`` mode with ``auth_enabled: false`` — before any gateway
+or app object exists. This module is the second, later layer: given a real
+:class:`~palaia_hub.gateway.build.GatewayASGI` about to be mounted, confirm
+every one of its profiles actually has a verifier attached, catching the
+case config-level validation cannot — auth *configured* on but a profile
+*built* without a verifier wired in (a wiring bug, not a config mistake).
+Called from :func:`palaia_hub.app.create_app`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from fastmcp import FastMCP
+
+
+class AuthPolicyError(RuntimeError):
+    """Raised when a mode's auth requirement isn't met by the built gateway."""
+
+
+def check_gateway_auth_policy(mode: str, profile_servers: Mapping[str, FastMCP]) -> None:
+    """Refuse to proceed if ``mode`` requires auth but a profile has none.
+
+    A no-op in ``locked`` mode (auth is optional there) or when there are
+    no profiles at all (nothing to refuse).
+    """
+    if mode not in ("cloud", "open"):
+        return
+    unauthenticated = sorted(
+        path for path, server in profile_servers.items() if server.auth is None
+    )
+    if unauthenticated:
+        raise AuthPolicyError(
+            f"mode {mode!r} requires every mounted MCP profile to have a token "
+            f"verifier attached, but {unauthenticated} do not. Fix: build the "
+            f"gateway with `token_verifiers` covering every profile (see "
+            f"palaia_hub.auth.wiring.build_profile_verifiers), or set "
+            f"`mode: locked` in config.yaml if these profiles are meant to stay "
+            f"VPN/tailnet-only."
+        )
+
+
+__all__ = ["AuthPolicyError", "check_gateway_auth_policy"]

--- a/v3/server/src/palaia_hub/auth/routes.py
+++ b/v3/server/src/palaia_hub/auth/routes.py
@@ -1,0 +1,56 @@
+"""REST surface for token management (SPEC-108 deliverable #1).
+
+Mounted at ``/api/auth/tokens`` by :func:`palaia_hub.app.create_app` when it
+is given a ``token_store`` (see that function's docstring for why the
+parameter is opt-in). Like ``/api/health``/``/api/info`` today, these
+routes carry no auth of their own — the admin/dashboard surface as a whole
+is protected by network topology (the operating mode's VPN/tailnet-only
+posture), not by a per-request credential check; SPEC-108's token/profile
+auth is for MCP *clients*, not the dashboard. A dashboard login is
+tracked separately (MASTERPLAN §5.5's "local account" / IdP sign-in,
+Phase 2) and out of this SPEC's scope.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+
+from .models import CreatedToken, TokenInfo
+from .store import TokenError, TokenStore
+
+
+class CreateTokenRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    profile: str
+    scopes: list[str] = Field(default_factory=list)
+
+
+def build_auth_router(store: TokenStore) -> APIRouter:
+    """Build the ``/api/auth/tokens`` router, backed by ``store``."""
+    router = APIRouter(prefix="/api/auth/tokens", tags=["auth"])
+
+    @router.post("", response_model=CreatedToken)
+    async def create_token(body: CreateTokenRequest) -> CreatedToken:
+        try:
+            return store.create(body.name, body.profile, body.scopes)
+        except TokenError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    @router.get("", response_model=list[TokenInfo])
+    async def list_tokens() -> list[TokenInfo]:
+        return store.list_tokens()
+
+    @router.delete("/{token_id}", response_model=TokenInfo)
+    async def revoke_token(token_id: str) -> TokenInfo:
+        try:
+            return store.revoke(token_id)
+        except TokenError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return router
+
+
+__all__ = ["build_auth_router"]

--- a/v3/server/src/palaia_hub/auth/scopes.py
+++ b/v3/server/src/palaia_hub/auth/scopes.py
@@ -1,0 +1,56 @@
+"""Scope strings: the vocabulary token permissions and tool checks share.
+
+A scope is a plain string, ``vault:<key>:read`` or ``vault:<key>:write`` —
+stored verbatim in a token's :class:`~palaia_hub.auth.models.TokenRecord`
+and, unchanged, on the ``AccessToken.scopes`` a verifier hands back to
+FastMCP (see :mod:`palaia_hub.auth.verifier`). Nothing here is fastmcp- or
+gateway-specific: this module is the single source of truth for which of
+the gateway's eight memory-tool actions need ``read`` vs. ``write``, kept
+independent of :mod:`palaia_hub.gateway.vault_protocol` so the auth package
+never has to import the gateway package to know that.
+
+MASTERPLAN §5.5: "a tool counts as read-only only if it explicitly says so
+*and* isn't on a known-writes list" — fail-closed. :data:`READ_ACTIONS` is
+that explicit allow-list; anything not on it (including a name this module
+has never heard of) is treated as a write.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+Permission = Literal["read", "write"]
+
+# The gateway's memory tool family (palaia_hub.gateway.vault_protocol.
+# MEMORY_TOOL_ACTIONS) split by whether they mutate the vault. Kept as an
+# explicit allow-list rather than an "everything except these" denylist —
+# per the fail-closed rule above, an action this set has never seen (a
+# future ninth tool, a typo) requires the stronger scope, not the weaker
+# one.
+READ_ACTIONS: frozenset[str] = frozenset({"search", "read", "list", "recent_activity"})
+WRITE_ACTIONS: frozenset[str] = frozenset({"write", "edit", "move", "delete"})
+
+
+def vault_scope(vault_key: str, permission: Permission) -> str:
+    """The scope string for ``permission`` on vault ``vault_key``."""
+    return f"vault:{vault_key}:{permission}"
+
+
+def required_scope_for_action(vault_key: str, action: str) -> str:
+    """The scope a token needs to call memory-tool ``action`` on ``vault_key``.
+
+    Fail-closed (see module docstring): only actions in :data:`READ_ACTIONS`
+    get the weaker ``read`` scope; every other action name — including one
+    this module does not recognize — requires ``write``.
+    """
+    permission: Permission = "read" if action in READ_ACTIONS else "write"
+    return vault_scope(vault_key, permission)
+
+
+__all__ = [
+    "READ_ACTIONS",
+    "WRITE_ACTIONS",
+    "Permission",
+    "required_scope_for_action",
+    "vault_scope",
+]

--- a/v3/server/src/palaia_hub/auth/store.py
+++ b/v3/server/src/palaia_hub/auth/store.py
@@ -1,0 +1,239 @@
+"""The token store: named per-client tokens, hashed at rest.
+
+Persisted as ``tokens.yaml`` under the hub's home directory (same directory
+as ``config.yaml`` and the vault registry's ``vaults.yaml`` — see
+:mod:`palaia_hub.config` / :mod:`palaia_hub.vault.registry`), written with
+the same atomic-write primitive the vault engine uses
+(:func:`palaia_hub.vault.atomic.atomic_write_text`) so a crash mid-write
+never leaves a half-written store. Only the argon2id hash of each token's
+secret half is ever written to that file — never the plaintext, never a
+reversible encoding of it.
+
+**Token shape**: ``plt_<id>.<secret>``. ``id`` is a public, non-secret
+identifier — like a username, or a Stripe/GitHub API key's visible prefix —
+used only to look up *which* record's hash to check; it carries no
+authentication weight itself. ``secret`` is the actual credential: 32 bytes
+of ``secrets.token_urlsafe`` entropy, never stored anywhere except as its
+argon2id hash. Splitting the two avoids the alternative (argon2-verifying
+the presented token against every stored hash to find a match), which would
+make each request's cost scale with the number of issued tokens; looking
+the id up first keeps verification O(1) regardless of how many tokens
+exist, with the *secret* half still checked by argon2's constant-time
+compare (:mod:`palaia_hub.auth.hashing`) — the only half that needs it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import re
+import secrets
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from ..config import palaia_home
+from ..vault.atomic import atomic_write_text
+from .hashing import hash_secret, spend_constant_time_miss, verify_secret
+from .models import CreatedToken, TokenInfo, TokenRecord
+
+logger = logging.getLogger("palaia_hub.auth.store")
+
+TOKENS_FILE = "tokens.yaml"
+TOKEN_PREFIX = "plt"
+
+# vault:<key>:read|write — the only scope shape store.create() accepts.
+# Deliberately not importing the gateway's key charset validator: the auth
+# package must not depend on the gateway package (see the module docstring
+# of palaia_hub.gateway.vault_protocol for the mirror-image rule), so this
+# is its own narrow, self-contained check.
+_SCOPE_RE = re.compile(r"^vault:[a-z0-9_-]+:(read|write)$")
+
+_TOKEN_RE = re.compile(rf"^{TOKEN_PREFIX}_([A-Za-z0-9_-]{{8,}})\.([A-Za-z0-9_-]{{16,}})$")
+
+_HEADER = (
+    "# palaia client tokens — argon2id hashes only. Never edit the 'hash'\n"
+    "# field by hand; use `palaia-hub token create/revoke` or the REST API.\n"
+)
+
+
+class TokenError(RuntimeError):
+    """Raised for a caller-facing token-store failure (bad scope, no such id)."""
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _validate_scopes(scopes: Sequence[str]) -> list[str]:
+    bad = [s for s in scopes if not _SCOPE_RE.match(s)]
+    if bad:
+        raise TokenError(
+            f"invalid scope(s) {bad!r}. Fix: use 'vault:<key>:read' or "
+            f"'vault:<key>:write' — see palaia_hub.auth.scopes.vault_scope()."
+        )
+    return list(scopes)
+
+
+def _parse_token(token: str) -> tuple[str, str] | None:
+    match = _TOKEN_RE.match(token)
+    if match is None:
+        return None
+    return match.group(1), match.group(2)
+
+
+class TokenStore:
+    """Create, list, revoke, and verify named per-client tokens.
+
+    Args:
+        home: directory holding ``tokens.yaml``. Defaults to the hub's data
+            directory (``PALAIA_HOME`` or the platform data dir) so a
+            `palaia-hub token ...` CLI invocation and the running hub agree
+            on where tokens live without extra wiring — mirrors
+            :class:`palaia_hub.vault.registry.VaultRegistry`.
+    """
+
+    def __init__(self, home: Path | None = None) -> None:
+        self.home = Path(home).expanduser() if home is not None else palaia_home()
+        self._records: dict[str, TokenRecord] = {}
+        self._load()
+
+    @property
+    def store_path(self) -> Path:
+        """Path to ``tokens.yaml``."""
+        return self.home / TOKENS_FILE
+
+    # ------------------------------------------------------------- persistence
+
+    def _load(self) -> None:
+        path = self.store_path
+        if not path.exists():
+            return
+        try:
+            raw: Any = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            raise TokenError(
+                f"{path}: could not parse YAML ({exc}). Fix: correct the syntax, or "
+                f"delete the file to start with no tokens (every client will need a "
+                f"new one)."
+            ) from exc
+        if not raw:
+            return
+        if not isinstance(raw, Mapping) or not isinstance(raw.get("tokens"), list):
+            raise TokenError(
+                f"{path}: expected a 'tokens:' list of records. Fix: correct the "
+                f"file, or delete it to start over."
+            )
+        for item in raw["tokens"]:
+            record = TokenRecord.model_validate(item)
+            self._records[record.id] = record
+
+    def _save(self) -> None:
+        self.home.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "tokens": [r.model_dump(mode="json") for r in self._records.values()]
+        }
+        text = _HEADER + yaml.safe_dump(payload, sort_keys=False, allow_unicode=True)
+        atomic_write_text(self.store_path, text)
+        with contextlib.suppress(OSError):  # pragma: no cover - platform dependent
+            self.store_path.chmod(0o600)
+
+    # ----------------------------------------------------------------- queries
+
+    def list_tokens(self) -> list[TokenInfo]:
+        """Every token, in creation order — never includes a hash or secret.
+
+        Named ``list_tokens`` rather than ``list`` at the Python level for
+        the same reason :meth:`palaia_hub.gateway.vault_protocol.VaultService.
+        list_notes` is: a method literally named ``list`` would shadow the
+        builtin for every subsequent ``list[...]`` annotation in this class
+        body.
+        """
+        return [TokenInfo.from_record(r) for r in self._records.values()]
+
+    def get(self, token_id: str) -> TokenInfo:
+        record = self._records.get(token_id)
+        if record is None:
+            raise TokenError(
+                f"no token with id {token_id!r}. Fix: check the id with list_tokens()."
+            )
+        return TokenInfo.from_record(record)
+
+    # ------------------------------------------------------------- mutations
+
+    def create(self, name: str, profile: str, scopes: Sequence[str]) -> CreatedToken:
+        """Issue a new token bound to ``profile`` with ``scopes``.
+
+        Returns the plaintext exactly once, alongside the stored (hash-free)
+        info — the caller (REST handler, CLI command) must show it to the
+        operator immediately; it cannot be recovered afterward.
+        """
+        if not name:
+            raise TokenError("token name must not be empty. Fix: pass a descriptive --name.")
+        if not profile:
+            raise TokenError("token profile must not be empty. Fix: pass --profile <path>.")
+        validated_scopes = _validate_scopes(scopes)
+
+        token_id = secrets.token_urlsafe(9)
+        secret = secrets.token_urlsafe(32)
+        record = TokenRecord(
+            id=token_id,
+            name=name,
+            profile=profile,
+            scopes=validated_scopes,
+            hash=hash_secret(secret),
+            created_at=_now(),
+        )
+        self._records[token_id] = record
+        self._save()
+        logger.info("created token %r (id=%s, profile=%s)", name, token_id, profile)
+        return CreatedToken(
+            info=TokenInfo.from_record(record), token=f"{TOKEN_PREFIX}_{token_id}.{secret}"
+        )
+
+    def revoke(self, token_id: str) -> TokenInfo:
+        """Revoke a token. Idempotent: revoking an already-revoked token is a no-op."""
+        record = self._records.get(token_id)
+        if record is None:
+            raise TokenError(
+                f"no token with id {token_id!r}. Fix: check the id with list_tokens()."
+            )
+        if record.is_revoked:
+            return TokenInfo.from_record(record)
+        updated = record.model_copy(update={"revoked_at": _now()})
+        self._records[token_id] = updated
+        self._save()
+        logger.info("revoked token %r (id=%s)", updated.name, token_id)
+        return TokenInfo.from_record(updated)
+
+    # ------------------------------------------------------------- verification
+
+    def verify(self, token: str) -> TokenRecord | None:
+        """Verify a presented token; return its record if valid and live.
+
+        ``None`` covers every rejection reason alike (malformed, unknown id,
+        wrong secret, revoked) — the caller (an
+        :class:`~palaia_hub.auth.verifier.PalaiaTokenVerifier`) turns that
+        into the same 401 either way, never distinguishing *why* a token
+        failed to a client.
+        """
+        parsed = _parse_token(token)
+        if parsed is None:
+            spend_constant_time_miss()
+            return None
+        token_id, secret = parsed
+        record = self._records.get(token_id)
+        if record is None:
+            spend_constant_time_miss()
+            return None
+        if not verify_secret(secret, record.hash):
+            return None
+        if record.is_revoked:
+            return None
+        return record
+
+
+__all__ = ["TOKEN_PREFIX", "TokenError", "TokenStore"]

--- a/v3/server/src/palaia_hub/auth/verifier.py
+++ b/v3/server/src/palaia_hub/auth/verifier.py
@@ -1,0 +1,65 @@
+"""Adapts :class:`~palaia_hub.auth.store.TokenStore` to fastmcp's own auth seam.
+
+``fastmcp.server.auth.TokenVerifier`` is fastmcp's abstract base for "check
+a bearer token, hand back an ``AccessToken`` or ``None``" — the same base
+class its own ``JWTVerifier`` (OAuth/OIDC-issued JWTs) implements. Handing a
+``TokenVerifier`` instance to ``FastMCP(auth=...)`` is what makes fastmcp's
+own ``RequireAuthMiddleware``/``BearerAuthBackend`` enforce it: every
+request to that profile's MCP endpoint needs a bearer token this verifier
+accepts, and a missing/invalid one gets fastmcp's own RFC 6750-compliant
+401 + ``WWW-Authenticate`` — none of that is reimplemented here.
+
+**This is the upgrade seam the SPEC asks for.** A Phase-2 OAuth
+authorization server hands its issued JWTs to fastmcp's existing
+``JWTVerifier`` instead of a :class:`PalaiaTokenVerifier` — a different
+``TokenVerifier`` subclass on the same ``FastMCP(auth=...)`` parameter.
+Nothing downstream cares which one produced the ``AccessToken``:
+:mod:`palaia_hub.gateway.build` mounts whatever verifier it is given, and
+:mod:`palaia_hub.auth.enforcement` (the per-tool scope check) reads only
+``AccessToken.scopes``/``.client_id`` off whatever came back. Swapping the
+verifier is the entire migration.
+
+Deliberately NOT ``fastmcp.server.auth.StaticTokenVerifier``: that class
+keeps its tokens in a plaintext ``dict`` and says so in its own docstring
+("Never use this in production — tokens are stored in plain text!"). SPEC-
+108 requires argon2id-hashed storage, which is exactly what
+:class:`TokenStore` (and nothing else in this codebase) does.
+"""
+
+from __future__ import annotations
+
+from fastmcp.server.auth import AccessToken, TokenVerifier
+
+from .store import TokenStore
+
+
+class PalaiaTokenVerifier(TokenVerifier):
+    """Verifies a bearer token against ``store``, scoped to one MCP profile.
+
+    Profile binding (SPEC-108 deliverable #2 — "a valid token bound to
+    profile A cannot list/call profile B's tools") is enforced right here:
+    one instance of this class is built per mounted profile (see
+    :func:`palaia_hub.auth.wiring.build_profile_verifiers`), and a token
+    whose record names a different profile fails verification exactly like
+    an unknown or revoked one — indistinguishable to the client, all of
+    them collapsing to fastmcp's standard 401.
+    """
+
+    def __init__(self, store: TokenStore, profile: str) -> None:
+        super().__init__()
+        self._store = store
+        self._profile = profile
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        record = self._store.verify(token)
+        if record is None or record.profile != self._profile:
+            return None
+        return AccessToken(
+            token=token,
+            client_id=record.id,
+            scopes=list(record.scopes),
+            subject=record.name,
+        )
+
+
+__all__ = ["PalaiaTokenVerifier"]

--- a/v3/server/src/palaia_hub/auth/wiring.py
+++ b/v3/server/src/palaia_hub/auth/wiring.py
@@ -1,0 +1,25 @@
+"""Assembles per-profile :class:`PalaiaTokenVerifier` instances from a store.
+
+The one function a gateway-wiring caller (today: tests; once SPEC-113
+wires a real gateway into the running hub, that call site too) needs to go
+from "a token store" + "a list of profile paths" to the
+``dict[str, TokenVerifier]`` :func:`palaia_hub.gateway.build.build_gateway`
+accepts as ``token_verifiers``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from .store import TokenStore
+from .verifier import PalaiaTokenVerifier
+
+
+def build_profile_verifiers(
+    profile_paths: Iterable[str], store: TokenStore
+) -> dict[str, PalaiaTokenVerifier]:
+    """One :class:`PalaiaTokenVerifier` per profile path, sharing ``store``."""
+    return {path: PalaiaTokenVerifier(store, path) for path in profile_paths}
+
+
+__all__ = ["build_profile_verifiers"]

--- a/v3/server/src/palaia_hub/cli.py
+++ b/v3/server/src/palaia_hub/cli.py
@@ -15,6 +15,7 @@ from collections.abc import Sequence
 import uvicorn
 
 from .app import create_app
+from .auth import TokenError, TokenStore
 from .config import ConfigError, load_config
 
 
@@ -25,6 +26,25 @@ def _build_parser() -> argparse.ArgumentParser:
     serve_parser = subparsers.add_parser("serve", help="Run the hub daemon")
     serve_parser.add_argument("--host", default=None, help="Override config host")
     serve_parser.add_argument("--port", type=int, default=None, help="Override config port")
+
+    token_parser = subparsers.add_parser("token", help="Manage MCP client tokens")
+    token_subparsers = token_parser.add_subparsers(dest="token_command", required=True)
+
+    create_parser = token_subparsers.add_parser("create", help="Issue a new client token")
+    create_parser.add_argument("--name", required=True, help="Human-readable client name")
+    create_parser.add_argument("--profile", required=True, help="Gateway profile path to bind to")
+    create_parser.add_argument(
+        "--scope",
+        dest="scopes",
+        action="append",
+        default=[],
+        help="'vault:<key>:read' or 'vault:<key>:write'; repeatable",
+    )
+
+    token_subparsers.add_parser("list", help="List known tokens (no secrets shown)")
+
+    revoke_parser = token_subparsers.add_parser("revoke", help="Revoke a token by id")
+    revoke_parser.add_argument("token_id", help="Token id, from 'token list'")
 
     return parser
 
@@ -45,7 +65,7 @@ def serve(host: str | None = None, port: int | None = None) -> None:
     if overrides:
         config = config.model_copy(update=overrides)
 
-    app = create_app(config)
+    app = create_app(config, token_store=TokenStore())
 
     uvicorn_config = uvicorn.Config(
         app,
@@ -58,11 +78,54 @@ def serve(host: str | None = None, port: int | None = None) -> None:
     server.run()
 
 
+def _token_create(name: str, profile: str, scopes: list[str]) -> None:
+    store = TokenStore()
+    try:
+        created = store.create(name, profile, scopes)
+    except TokenError as exc:
+        print(f"palaia-hub: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    print(f"Created token {created.info.id!r} for {name!r} (profile={profile!r}).")
+    print("Copy it now — it will not be shown again:")
+    print(f"  {created.token}")
+
+
+def _token_list() -> None:
+    store = TokenStore()
+    tokens = store.list_tokens()
+    if not tokens:
+        print("No tokens yet. Create one with `palaia-hub token create`.")
+        return
+    for info in tokens:
+        status = "revoked" if info.revoked_at else "active"
+        print(
+            f"{info.id}  {status:8}  {info.name!r}  "
+            f"profile={info.profile!r}  scopes={info.scopes}"
+        )
+
+
+def _token_revoke(token_id: str) -> None:
+    store = TokenStore()
+    try:
+        info = store.revoke(token_id)
+    except TokenError as exc:
+        print(f"palaia-hub: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    print(f"Revoked token {info.id!r} ({info.name!r}).")
+
+
 def main(argv: Sequence[str] | None = None) -> None:
     parser = _build_parser()
     args = parser.parse_args(argv)
     if args.command == "serve":
         serve(host=args.host, port=args.port)
+    elif args.command == "token":
+        if args.token_command == "create":
+            _token_create(args.name, args.profile, args.scopes)
+        elif args.token_command == "list":
+            _token_list()
+        elif args.token_command == "revoke":
+            _token_revoke(args.token_id)
 
 
 if __name__ == "__main__":

--- a/v3/server/src/palaia_hub/config.py
+++ b/v3/server/src/palaia_hub/config.py
@@ -8,13 +8,14 @@ naming the file, the offending key, and how to fix it.
 
 from __future__ import annotations
 
+import ipaddress
 import os
 from pathlib import Path
 from typing import Any, Literal
 
 import yaml
 from platformdirs import user_data_dir
-from pydantic import BaseModel, ConfigDict, ValidationError
+from pydantic import BaseModel, ConfigDict, ValidationError, model_validator
 
 APP_NAME = "palaia-hub"
 
@@ -30,6 +31,7 @@ _ENV_KEYS = (
     "log_level",
     "log_format",
     "graceful_shutdown_timeout",
+    "auth_enabled",
 )
 
 DEFAULT_CONFIG_TEMPLATE = """\
@@ -45,12 +47,17 @@ DEFAULT_CONFIG_TEMPLATE = """\
 
 # Operating mode: locked | cloud | open
 #   locked (default) - MCP + dashboard reachable only over VPN/tailnet
-#   cloud             - MCP reachable publicly (tunnel/open port);
-#                        dashboard stays VPN-only; auth mandatory
-#   open              - both public; auth mandatory + hardening checklist
+#   cloud             - MCP reachable publicly via a tunnel (Tailscale
+#                        Funnel, cloudflared) terminating on a private
+#                        `host` below; dashboard stays VPN-only; auth
+#                        mandatory. Binding `host` directly to a public
+#                        address isn't supported yet — use 'open' for that.
+#   open              - both public, `host` may be a public/wildcard bind;
+#                        auth mandatory + hardening checklist
 mode: locked
 
-# Host/port the hub binds to.
+# Host/port the hub binds to. In 'cloud' mode this must be a private/VPN
+# address (e.g. 127.0.0.1 or a tailnet IP) — see 'mode' above.
 host: 127.0.0.1
 port: 8420
 
@@ -61,6 +68,13 @@ log_format: human
 # Seconds to wait for in-flight requests to finish before exiting on
 # shutdown (e.g. SIGTERM).
 graceful_shutdown_timeout: 30
+
+# Whether MCP clients must present a bearer token (SPEC-108).
+#   locked mode - optional; defaults to on anyway (turn off only if every
+#                 client on your VPN/tailnet is already trusted).
+#   cloud/open  - mandatory; the hub refuses to start MCP endpoints
+#                 otherwise. Cannot be turned off in these modes.
+auth_enabled: true
 """
 
 
@@ -70,6 +84,35 @@ class ConfigError(RuntimeError):
     The message always names the config file path, the offending key, and a
     concrete fix, per SPEC-101's acceptance criteria.
     """
+
+
+# RFC 6598 shared address space (100.64.0.0/10) — the CGNAT range Tailscale
+# and similar tailnets hand out. Not covered by ipaddress.is_private, so it
+# is checked separately below.
+_SHARED_ADDRESS_SPACE = ipaddress.ip_network("100.64.0.0/10")
+
+
+def _is_private_bind_host(host: str) -> bool:
+    """Is ``host`` a bind address that stays off the public internet?
+
+    True for loopback, RFC1918 private ranges, link-local, and the
+    Tailscale/tailnet CGNAT range. False for a wildcard bind (``0.0.0.0``/
+    ``::`` — reachable on every interface a box has, public ones included),
+    an unrecognized literal address, or anything that is not a literal IP
+    (a hostname cannot be checked without a DNS lookup, so it is rejected
+    rather than trusted).
+    """
+    if host.lower() == "localhost":
+        return True
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    if addr.is_unspecified:
+        return False
+    if addr in _SHARED_ADDRESS_SPACE:
+        return True
+    return bool(addr.is_private or addr.is_loopback or addr.is_link_local)
 
 
 class HubConfig(BaseModel):
@@ -83,6 +126,43 @@ class HubConfig(BaseModel):
     log_level: Literal["debug", "info", "warning", "error"] = "info"
     log_format: Literal["human", "json"] = "human"
     graceful_shutdown_timeout: float = 30.0
+    auth_enabled: bool = True
+
+    @model_validator(mode="after")
+    def _check_operating_mode_policy(self) -> HubConfig:
+        """MASTERPLAN §5.5's per-mode auth policy, enforced in code (SPEC-108).
+
+        ``cloud``/``open`` MUST have auth on — those modes exist to make MCP
+        endpoints reachable off the operator's own network, and the hub must
+        never serve one that way with no token check. ``cloud`` additionally
+        keeps its bind address private: the hub has one listener for both
+        the MCP endpoints and the admin dashboard, and the dashboard must
+        stay VPN/tailnet-only in ``cloud`` mode (masterplan's mode table) —
+        so for Phase 1 (no dual-listener/reverse-proxy split yet), reaching
+        the public internet in ``cloud`` mode means a tunnel (Tailscale
+        Funnel, cloudflared) terminating on a private address, not a direct
+        public/wildcard bind. ``open`` mode has no such restriction — its
+        whole point is that the dashboard itself is public too.
+        """
+        if self.mode in ("cloud", "open") and not self.auth_enabled:
+            raise ValueError(
+                f"mode '{self.mode}' requires auth_enabled=true — MCP endpoints "
+                f"would otherwise be reachable over the network with no token "
+                f"check at all. Fix: set `auth_enabled: true` in config.yaml (or "
+                f"PALAIA_AUTH_ENABLED=true), or set `mode: locked` if every "
+                f"client only ever reaches this hub over your own VPN/tailnet."
+            )
+        if self.mode == "cloud" and not _is_private_bind_host(self.host):
+            raise ValueError(
+                f"mode 'cloud' requires a private/VPN bind address so the admin "
+                f"dashboard never becomes reachable through the same listener "
+                f"MCP is exposed on (host is currently {self.host!r}). Fix: set "
+                f"`host` to a private address (e.g. 127.0.0.1, or your "
+                f"tailnet/Tailscale IP) in config.yaml and reach it publicly via "
+                f"a tunnel (Tailscale Funnel, cloudflared); or set `mode: open` "
+                f"if you intend the dashboard itself to be public."
+            )
+        return self
 
 
 def palaia_home() -> Path:
@@ -139,9 +219,17 @@ def _format_validation_error(path: Path, exc: ValidationError) -> str:
     lines = []
     for error in exc.errors():
         loc = ".".join(str(part) for part in error["loc"]) or "<root>"
+        msg = error["msg"]
+        if loc == "<root>" and "Fix:" in msg:
+            # A cross-field validator (e.g. _check_operating_mode_policy)
+            # already spelled out its own actionable fix — appending the
+            # generic "correct '<root>' ... override via PALAIA_<ROOT>"
+            # suffix below would only make its message confusing.
+            lines.append(f"{path}: {msg.removeprefix('Value error, ')}")
+            continue
         env_name = f"{_ENV_PREFIX}{loc.upper()}"
         lines.append(
-            f"{path}: key '{loc}' — {error['msg']}. "
+            f"{path}: key '{loc}' — {msg}. "
             f"Fix: correct '{loc}' in {path}, or override it via {env_name}."
         )
     return "\n".join(lines)

--- a/v3/server/src/palaia_hub/gateway/build.py
+++ b/v3/server/src/palaia_hub/gateway/build.py
@@ -31,6 +31,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from fastmcp import FastMCP
+from fastmcp.server.auth import TokenVerifier
 from fastmcp.utilities.lifespan import combine_lifespans
 from starlette.types import ASGIApp
 
@@ -97,6 +98,7 @@ def _build_profile_server(
     profile: ProfileConfig,
     config: GatewayConfig,
     vault_servers: Mapping[str, FastMCP],
+    auth: TokenVerifier | None,
 ) -> FastMCP:
     # `mount()` does not propagate a mounted server's `instructions` to its
     # parent, so a real client connecting to this profile would otherwise
@@ -109,7 +111,16 @@ def _build_profile_server(
         if vault_configs
         else None
     )
-    server = FastMCP(name=f"palaia-gateway-{profile.path}", instructions=instructions)
+    # `auth` (SPEC-108): a TokenVerifier here makes FastMCP wrap this
+    # profile's HTTP endpoint in its own RequireAuthMiddleware/
+    # BearerAuthBackend — every request needs a bearer token this verifier
+    # accepts, with a missing/invalid one getting FastMCP's own RFC
+    # 6750-compliant 401 + WWW-Authenticate. `None` (the default) preserves
+    # this SPEC's exact prior behavior: no auth at all, same as before this
+    # parameter existed.
+    server = FastMCP(
+        name=f"palaia-gateway-{profile.path}", instructions=instructions, auth=auth
+    )
     for vault_config in vault_configs:
         tool_names = resolve_tool_names(vault_config.namespace, vault_config.tool_renames)
         server.mount(
@@ -121,9 +132,22 @@ def _build_profile_server(
 
 
 def build_gateway(
-    config: GatewayConfig, vault_services: Mapping[str, VaultService]
+    config: GatewayConfig,
+    vault_services: Mapping[str, VaultService],
+    *,
+    token_verifiers: Mapping[str, TokenVerifier] | None = None,
 ) -> GatewayASGI:
     """Build the full gateway from a validated config and its backing services.
+
+    Args:
+        config: the validated gateway shape.
+        vault_services: backing service per configured vault key.
+        token_verifiers: optional per-profile-path :class:`TokenVerifier`
+            (SPEC-108 — see :func:`palaia_hub.auth.wiring.
+            build_profile_verifiers`). A profile whose path has no entry
+            here is mounted with no auth at all, exactly as before this
+            parameter existed; a profile with an entry requires every
+            request to present a bearer token that verifier accepts.
 
     Raises :class:`GatewayConfigError` if a configured vault has no entry in
     ``vault_services``. Structural config problems (duplicate keys, unknown
@@ -136,7 +160,8 @@ def build_gateway(
     profile_servers: dict[str, FastMCP] = {}
     lifespans: list[Lifespan] = []
     for profile in config.profiles:
-        server = _build_profile_server(profile, config, vault_servers)
+        auth = (token_verifiers or {}).get(profile.path)
+        server = _build_profile_server(profile, config, vault_servers, auth)
         profile_servers[profile.path] = server
         asgi_app = server.http_app(path="/")
         mounts[f"/mcp/{profile.path}"] = asgi_app

--- a/v3/server/src/palaia_hub/gateway/memory_tools.py
+++ b/v3/server/src/palaia_hub/gateway/memory_tools.py
@@ -41,6 +41,7 @@ from fastmcp.tools.base import ToolResult
 from mcp.types import ToolAnnotations
 from pydantic import AliasChoices, BaseModel, Field
 
+from ..auth.enforcement import missing_scope_error
 from .config import VaultMountConfig
 from .vault_protocol import NoteRecord, NoteSummary, SearchHit, VaultService, VaultServiceError
 
@@ -139,6 +140,15 @@ def build_vault_server(vault: VaultMountConfig, service: VaultService) -> FastMC
     def desc(detail: str) -> str:
         return f"{purpose}\n\n{detail}"
 
+    def scope_error(action: str) -> ToolResult | None:
+        """``None`` if this call's token (if any) covers ``action``; else a
+        ready-to-return ``ToolResult(is_error=True)`` naming the missing
+        scope (SPEC-108 — see :func:`palaia_hub.auth.enforcement.
+        missing_scope_error` for what "if any" means here).
+        """
+        message = missing_scope_error(vault.key, action)
+        return ToolResult(content=message, is_error=True) if message else None
+
     @server.tool(
         name="search",
         description=desc("Search this vault's notes. Returns best matches first."),
@@ -147,6 +157,8 @@ def build_vault_server(vault: VaultMountConfig, service: VaultService) -> FastMC
         ),
     )
     async def search(query: QueryParam, limit: int = 10) -> ToolResult:
+        if (err := scope_error("search")) is not None:
+            return err
         hits = await service.search(query, limit=limit)
         text = (
             f"{len(hits)} match(es) for {query!r}: "
@@ -162,6 +174,8 @@ def build_vault_server(vault: VaultMountConfig, service: VaultService) -> FastMC
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True),
     )
     async def read(permalink: str) -> ToolResult:
+        if (err := scope_error("read")) is not None:
+            return err
         try:
             note = await service.read(permalink)
         except VaultServiceError as exc:
@@ -182,6 +196,8 @@ def build_vault_server(vault: VaultMountConfig, service: VaultService) -> FastMC
         type: str = "note",  # noqa: A002 - matches the vault-format field name
         tags: list[str] | None = None,
     ) -> ToolResult:
+        if (err := scope_error("write")) is not None:
+            return err
         try:
             note = await service.write(title, body, folder=folder, type=type, tags=tags)
         except VaultServiceError as exc:
@@ -201,6 +217,8 @@ def build_vault_server(vault: VaultMountConfig, service: VaultService) -> FastMC
         append: str | None = None,
         tags: list[str] | None = None,
     ) -> ToolResult:
+        if (err := scope_error("edit")) is not None:
+            return err
         try:
             note = await service.edit(permalink, body=body, append=append, tags=tags)
         except VaultServiceError as exc:
@@ -215,6 +233,8 @@ def build_vault_server(vault: VaultMountConfig, service: VaultService) -> FastMC
         ),
     )
     async def move(permalink: str, folder: FolderParam = "") -> ToolResult:
+        if (err := scope_error("move")) is not None:
+            return err
         try:
             note = await service.move(permalink, folder)
         except VaultServiceError as exc:
@@ -229,6 +249,8 @@ def build_vault_server(vault: VaultMountConfig, service: VaultService) -> FastMC
         ),
     )
     async def delete(permalink: str) -> ToolResult:
+        if (err := scope_error("delete")) is not None:
+            return err
         deleted = await service.delete(permalink)
         text = f"deleted {permalink!r}" if deleted else f"nothing to delete at {permalink!r}"
         return ToolResult(
@@ -241,6 +263,8 @@ def build_vault_server(vault: VaultMountConfig, service: VaultService) -> FastMC
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True),
     )
     async def list_notes(folder: FolderParam = "") -> ToolResult:
+        if (err := scope_error("list")) is not None:
+            return err
         notes = await service.list_notes(folder=folder)
         text = f"{len(notes)} note(s)" + (f" in {folder!r}" if folder else "")
         return ToolResult(content=text, structured_content=ListResult(folder=folder, notes=notes))
@@ -251,6 +275,8 @@ def build_vault_server(vault: VaultMountConfig, service: VaultService) -> FastMC
         annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True),
     )
     async def recent_activity(limit: int = 10) -> ToolResult:
+        if (err := scope_error("recent_activity")) is not None:
+            return err
         notes = await service.recent_activity(limit=limit)
         text = f"{len(notes)} recently modified note(s)"
         return ToolResult(content=text, structured_content=RecentActivityResult(notes=notes))

--- a/v3/server/tests/auth/_asgi_mcp_client.py
+++ b/v3/server/tests/auth/_asgi_mcp_client.py
@@ -1,0 +1,50 @@
+"""Drive a mounted MCP profile over real HTTP semantics, no real socket.
+
+Builds an ``httpx.AsyncClient`` on ``httpx.ASGITransport`` so a
+``fastmcp.Client`` speaks the actual streamable-HTTP wire protocol —
+including FastMCP's ``RequireAuthMiddleware``/``BearerAuthBackend`` auth
+layer — against an in-process ASGI app. This is what lets the SPEC-108
+tests exercise real 401s and real bearer-token handling without spawning a
+subprocess/socket (contrast ``tests/gateway/test_e2e_claude_code.py``,
+which does spawn one, for a different acceptance criterion).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+from fastmcp.client.transports import StreamableHttpTransport
+from starlette.types import ASGIApp
+
+
+def mcp_client_transport(
+    app: ASGIApp, url: str, *, token: str | None = None
+) -> StreamableHttpTransport:
+    """A ``StreamableHttpTransport`` for ``fastmcp.Client`` bound to ``app``.
+
+    ``url`` should be the full path the app expects (e.g.
+    ``"http://testserver/mcp/default/"``); no real DNS/socket is used —
+    ``ASGITransport`` dispatches directly into ``app``.
+    """
+
+    def factory(
+        *,
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+        auth: httpx.Auth | None = None,
+        **_: Any,
+    ) -> httpx.AsyncClient:
+        kwargs: dict[str, Any] = {
+            "transport": httpx.ASGITransport(app=app),
+            "follow_redirects": True,
+        }
+        if headers is not None:
+            kwargs["headers"] = headers
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+        if auth is not None:
+            kwargs["auth"] = auth
+        return httpx.AsyncClient(**kwargs)
+
+    return StreamableHttpTransport(url=url, auth=token, httpx_client_factory=factory)

--- a/v3/server/tests/auth/conftest.py
+++ b/v3/server/tests/auth/conftest.py
@@ -1,0 +1,10 @@
+"""``anyio_backend`` fixture for the ``@pytest.mark.anyio`` async tests below."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"

--- a/v3/server/tests/auth/test_app_auth_policy.py
+++ b/v3/server/tests/auth/test_app_auth_policy.py
@@ -1,0 +1,50 @@
+"""``create_app`` refuses to mount an unauthenticated gateway in cloud/open mode."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from palaia_hub.app import create_app
+from palaia_hub.auth.policy import AuthPolicyError
+from palaia_hub.auth.store import TokenStore
+from palaia_hub.auth.wiring import build_profile_verifiers
+from palaia_hub.config import HubConfig
+from palaia_hub.gateway.build import build_gateway
+from palaia_hub.gateway.config import GatewayConfig, ProfileConfig, VaultMountConfig
+from palaia_hub.gateway.fake_vault import FakeVaultService
+
+
+def _gateway_config() -> GatewayConfig:
+    return GatewayConfig(
+        vaults=[VaultMountConfig(key="work", name="work")],
+        profiles=[ProfileConfig(path="default", vaults=["work"])],
+    )
+
+
+def test_cloud_mode_with_unauthenticated_gateway_refuses_to_start() -> None:
+    gateway = build_gateway(_gateway_config(), {"work": FakeVaultService()})
+
+    with pytest.raises(AuthPolicyError, match="default"):
+        create_app(HubConfig(mode="cloud", host="127.0.0.1"), gateway=gateway)
+
+
+def test_cloud_mode_with_authenticated_gateway_starts_fine(tmp_path: Path) -> None:
+    store = TokenStore(home=tmp_path)
+    verifiers = build_profile_verifiers(["default"], store)
+    gateway = build_gateway(
+        _gateway_config(), {"work": FakeVaultService()}, token_verifiers=verifiers
+    )
+
+    app = create_app(HubConfig(mode="cloud", host="127.0.0.1"), gateway=gateway)
+
+    assert app is not None
+
+
+def test_locked_mode_with_unauthenticated_gateway_starts_fine() -> None:
+    gateway = build_gateway(_gateway_config(), {"work": FakeVaultService()})
+
+    app = create_app(HubConfig(mode="locked"), gateway=gateway)
+
+    assert app is not None

--- a/v3/server/tests/auth/test_cli_token.py
+++ b/v3/server/tests/auth/test_cli_token.py
@@ -1,0 +1,71 @@
+"""``palaia-hub token create/list/revoke`` in-process (no subprocess needed)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from palaia_hub.cli import main
+
+
+def _run(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, argv: list[str]) -> None:
+    monkeypatch.setenv("PALAIA_HOME", str(tmp_path))
+    main(argv)
+
+
+def test_create_prints_plaintext_once(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _run(
+        monkeypatch,
+        tmp_path,
+        ["token", "create", "--name", "Codex on devbox", "--profile", "default"],
+    )
+
+    out = capsys.readouterr().out
+    assert "Codex on devbox" in out
+    assert "plt_" in out
+
+
+def test_list_shows_created_tokens(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _run(
+        monkeypatch,
+        tmp_path,
+        ["token", "create", "--name", "client-a", "--profile", "default"],
+    )
+
+    import io
+    from contextlib import redirect_stdout
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        _run(monkeypatch, tmp_path, ["token", "list"])
+
+    assert "client-a" in buf.getvalue()
+    assert "active" in buf.getvalue()
+
+
+def test_revoke_marks_token_revoked(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from palaia_hub.auth.store import TokenStore
+
+    monkeypatch.setenv("PALAIA_HOME", str(tmp_path))
+    store = TokenStore(home=tmp_path)
+    created = store.create("client-a", "default", [])
+    del store  # force a fresh load from disk, like a separate CLI invocation would
+
+    main(["token", "revoke", created.info.id])
+
+    reloaded = TokenStore(home=tmp_path)
+    assert reloaded.verify(created.token) is None
+
+
+def test_revoke_unknown_id_exits_nonzero(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("PALAIA_HOME", str(tmp_path))
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(["token", "revoke", "does-not-exist"])
+
+    assert excinfo.value.code != 0

--- a/v3/server/tests/auth/test_enforcement.py
+++ b/v3/server/tests/auth/test_enforcement.py
@@ -1,0 +1,57 @@
+"""``missing_scope_error`` in isolation, with ``get_access_token`` mocked.
+
+The real end-to-end path (a token actually authenticated by fastmcp, then a
+tool checking its scopes) is covered by ``test_http_auth_e2e.py``; this
+file isolates the decision logic itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from palaia_hub.auth import enforcement
+
+
+@dataclass
+class _FakeAccessToken:
+    scopes: list[str] = field(default_factory=list)
+
+
+def test_no_access_token_allows_everything(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(enforcement, "get_access_token", lambda: None)
+
+    assert enforcement.missing_scope_error("work", "write") is None
+    assert enforcement.missing_scope_error("work", "delete") is None
+
+
+def test_sufficient_scope_allows(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        enforcement, "get_access_token", lambda: _FakeAccessToken(["vault:work:write"])
+    )
+
+    assert enforcement.missing_scope_error("work", "write") is None
+    assert enforcement.missing_scope_error("work", "edit") is None
+
+
+def test_missing_scope_names_it(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        enforcement, "get_access_token", lambda: _FakeAccessToken(["vault:work:read"])
+    )
+
+    error = enforcement.missing_scope_error("work", "write")
+
+    assert error is not None
+    assert "vault:work:write" in error
+
+
+def test_read_scope_does_not_cover_a_different_vault(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        enforcement, "get_access_token", lambda: _FakeAccessToken(["vault:personal:read"])
+    )
+
+    error = enforcement.missing_scope_error("work", "search")
+
+    assert error is not None
+    assert "vault:work:read" in error

--- a/v3/server/tests/auth/test_http_auth_e2e.py
+++ b/v3/server/tests/auth/test_http_auth_e2e.py
@@ -1,0 +1,166 @@
+"""End-to-end SPEC-108 acceptance criteria over real HTTP semantics.
+
+Uses an ASGI-transport-backed ``fastmcp.Client`` (see ``_asgi_mcp_client.py``)
+so these tests exercise FastMCP's real ``RequireAuthMiddleware``/
+``BearerAuthBackend`` stack — the actual 401 + ``WWW-Authenticate`` a real
+client would see — without a subprocess or a real socket.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+from fastmcp import Client
+from starlette.applications import Starlette
+
+from palaia_hub.app import create_app
+from palaia_hub.auth.store import TokenStore
+from palaia_hub.auth.wiring import build_profile_verifiers
+from palaia_hub.config import HubConfig
+from palaia_hub.gateway.build import build_gateway
+from palaia_hub.gateway.config import GatewayConfig, ProfileConfig, VaultMountConfig
+from palaia_hub.gateway.fake_vault import FakeVaultService
+
+from ._asgi_mcp_client import mcp_client_transport
+
+
+def _build_app(tmp_path: Path) -> tuple[Starlette, TokenStore]:
+    store = TokenStore(home=tmp_path)
+    gateway_config = GatewayConfig(
+        vaults=[VaultMountConfig(key="work", name="work", purpose="Work vault.")],
+        profiles=[
+            ProfileConfig(path="alpha", vaults=["work"]),
+            ProfileConfig(path="beta", vaults=["work"]),
+        ],
+    )
+    services = {"work": FakeVaultService()}
+    verifiers = build_profile_verifiers(["alpha", "beta"], store)
+    gateway = build_gateway(gateway_config, services, token_verifiers=verifiers)
+    # cloud mode: the mode SPEC-108 says MUST have auth on every endpoint —
+    # exercising these tests under it is itself part of the acceptance
+    # evidence that mode's policy doesn't block a properly-authed gateway.
+    app = create_app(HubConfig(mode="cloud", host="127.0.0.1"), gateway=gateway)
+    return app, store
+
+
+@pytest.mark.anyio
+async def test_missing_token_gets_401_with_rfc_compliant_www_authenticate(
+    tmp_path: Path,
+) -> None:
+    app, _store = _build_app(tmp_path)
+    async with app.router.lifespan_context(app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+        ) as client:
+            response = await client.get("/mcp/alpha/")
+
+    assert response.status_code == 401
+    www_authenticate = response.headers.get("www-authenticate", "")
+    assert www_authenticate.lower().startswith("bearer")
+    # RFC 6750 §3.1: no Authorization header at all -> no `error` attribute
+    # (that's reserved for a header that *is* present but invalid, checked
+    # in the next test) — FastMCP's RequireAuthMiddleware implements this
+    # distinction; this assertion documents it rather than fighting it.
+    assert "error=" not in www_authenticate
+
+
+@pytest.mark.anyio
+async def test_wrong_token_gets_401_with_error_attribute(tmp_path: Path) -> None:
+    app, _store = _build_app(tmp_path)
+    async with app.router.lifespan_context(app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+        ) as client:
+            response = await client.get(
+                "/mcp/alpha/",
+                headers={"Authorization": "Bearer plt_bogus-id.not-a-real-secret-value-at-all"},
+            )
+
+    assert response.status_code == 401
+    # RFC 6750 §3.1: an Authorization header that *is* present but invalid
+    # gets the `error` attribute (unlike the missing-header case above).
+    www_authenticate = response.headers.get("www-authenticate", "")
+    assert 'error="invalid_token"' in www_authenticate
+
+
+@pytest.mark.anyio
+async def test_valid_token_with_write_scope_can_write(tmp_path: Path) -> None:
+    app, store = _build_app(tmp_path)
+    created = store.create("client", "alpha", ["vault:work:read", "vault:work:write"])
+
+    async with app.router.lifespan_context(app):
+        transport = mcp_client_transport(app, "http://testserver/mcp/alpha/", token=created.token)
+        async with Client(transport) as client:
+            result = await client.call_tool_mcp(
+                "work_memory_write", {"title": "Hello", "body": "World"}
+            )
+
+    assert result.isError is not True
+
+
+@pytest.mark.anyio
+async def test_read_only_token_calling_write_tool_gets_clean_mcp_error(
+    tmp_path: Path,
+) -> None:
+    app, store = _build_app(tmp_path)
+    created = store.create("client", "alpha", ["vault:work:read"])
+
+    async with app.router.lifespan_context(app):
+        transport = mcp_client_transport(app, "http://testserver/mcp/alpha/", token=created.token)
+        async with Client(transport) as client:
+            result = await client.call_tool_mcp(
+                "work_memory_write", {"title": "Hello", "body": "World"}
+            )
+
+    # A clean MCP-level tool error naming the missing scope, not a crash
+    # and not an HTTP-level failure — the whole point of per-tool
+    # enforcement living inside the tool, not the transport middleware.
+    assert result.isError is True
+    text = "".join(getattr(block, "text", "") for block in result.content)
+    assert "vault:work:write" in text
+
+
+@pytest.mark.anyio
+async def test_read_only_token_can_still_search(tmp_path: Path) -> None:
+    app, store = _build_app(tmp_path)
+    created = store.create("client", "alpha", ["vault:work:read"])
+
+    async with app.router.lifespan_context(app):
+        transport = mcp_client_transport(app, "http://testserver/mcp/alpha/", token=created.token)
+        async with Client(transport) as client:
+            result = await client.call_tool_mcp("work_memory_search", {"query": "anything"})
+
+    assert result.isError is not True
+
+
+@pytest.mark.anyio
+async def test_token_bound_to_profile_alpha_cannot_reach_profile_beta(
+    tmp_path: Path,
+) -> None:
+    app, store = _build_app(tmp_path)
+    created = store.create("client", "alpha", ["vault:work:read", "vault:work:write"])
+
+    async with app.router.lifespan_context(app):
+        transport = mcp_client_transport(app, "http://testserver/mcp/beta/", token=created.token)
+        with pytest.raises(Exception):  # noqa: B017 - transport-level auth failure, not ours to name
+            async with Client(transport) as client:
+                await client.call_tool_mcp("work_memory_search", {"query": "anything"})
+
+
+@pytest.mark.anyio
+async def test_revoked_token_is_refused_at_the_transport(tmp_path: Path) -> None:
+    app, store = _build_app(tmp_path)
+    created = store.create("client", "alpha", ["vault:work:read"])
+    store.revoke(created.info.id)
+
+    async with app.router.lifespan_context(app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+        ) as client:
+            response = await client.get(
+                "/mcp/alpha/", headers={"Authorization": f"Bearer {created.token}"}
+            )
+
+    assert response.status_code == 401

--- a/v3/server/tests/auth/test_policy.py
+++ b/v3/server/tests/auth/test_policy.py
@@ -1,0 +1,53 @@
+"""``check_gateway_auth_policy``: the built-gateway half of the mode/auth check."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from palaia_hub.auth.policy import AuthPolicyError, check_gateway_auth_policy
+from palaia_hub.auth.store import TokenStore
+from palaia_hub.auth.wiring import build_profile_verifiers
+from palaia_hub.gateway.build import build_gateway
+from palaia_hub.gateway.config import GatewayConfig, ProfileConfig, VaultMountConfig
+from palaia_hub.gateway.fake_vault import FakeVaultService
+
+
+def _gateway_config() -> GatewayConfig:
+    return GatewayConfig(
+        vaults=[VaultMountConfig(key="work", name="work")],
+        profiles=[ProfileConfig(path="default", vaults=["work"])],
+    )
+
+
+def test_locked_mode_allows_a_gateway_with_no_auth_at_all() -> None:
+    gateway = build_gateway(_gateway_config(), {"work": FakeVaultService()})
+
+    check_gateway_auth_policy("locked", gateway.profile_servers)  # does not raise
+
+
+def test_cloud_mode_refuses_a_profile_with_no_verifier(tmp_path: Path) -> None:
+    gateway = build_gateway(_gateway_config(), {"work": FakeVaultService()})
+
+    with pytest.raises(AuthPolicyError, match="default"):
+        check_gateway_auth_policy("cloud", gateway.profile_servers)
+
+
+def test_open_mode_refuses_a_profile_with_no_verifier() -> None:
+    gateway = build_gateway(_gateway_config(), {"work": FakeVaultService()})
+
+    with pytest.raises(AuthPolicyError):
+        check_gateway_auth_policy("open", gateway.profile_servers)
+
+
+def test_cloud_mode_accepts_a_gateway_with_every_profile_authenticated(
+    tmp_path: Path,
+) -> None:
+    store = TokenStore(home=tmp_path)
+    verifiers = build_profile_verifiers(["default"], store)
+    gateway = build_gateway(
+        _gateway_config(), {"work": FakeVaultService()}, token_verifiers=verifiers
+    )
+
+    check_gateway_auth_policy("cloud", gateway.profile_servers)  # does not raise

--- a/v3/server/tests/auth/test_routes.py
+++ b/v3/server/tests/auth/test_routes.py
@@ -1,0 +1,84 @@
+"""The ``/api/auth/tokens`` REST surface: create/list/revoke."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from palaia_hub.app import create_app
+from palaia_hub.auth.store import TokenStore
+from palaia_hub.config import HubConfig
+
+
+def _client(tmp_path: Path) -> TestClient:
+    app = create_app(HubConfig(), token_store=TokenStore(home=tmp_path))
+    return TestClient(app)
+
+
+def test_create_returns_plaintext_once(tmp_path: Path) -> None:
+    client = _client(tmp_path)
+
+    response = client.post(
+        "/api/auth/tokens",
+        json={"name": "Codex on devbox", "profile": "default", "scopes": ["vault:work:read"]},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["token"].startswith("plt_")
+    assert body["info"]["name"] == "Codex on devbox"
+    assert "hash" not in body["info"]
+
+
+def test_list_never_includes_plaintext_or_hash(tmp_path: Path) -> None:
+    client = _client(tmp_path)
+    client.post("/api/auth/tokens", json={"name": "a", "profile": "default", "scopes": []})
+
+    response = client.get("/api/auth/tokens")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) == 1
+    assert "token" not in body[0]
+    assert "hash" not in body[0]
+
+
+def test_revoke_then_list_shows_revoked(tmp_path: Path) -> None:
+    client = _client(tmp_path)
+    created = client.post(
+        "/api/auth/tokens", json={"name": "a", "profile": "default", "scopes": []}
+    ).json()
+
+    response = client.delete(f"/api/auth/tokens/{created['info']['id']}")
+
+    assert response.status_code == 200
+    assert response.json()["revoked_at"] is not None
+
+
+def test_revoke_unknown_id_is_404(tmp_path: Path) -> None:
+    client = _client(tmp_path)
+
+    response = client.delete("/api/auth/tokens/does-not-exist")
+
+    assert response.status_code == 404
+
+
+def test_invalid_scope_is_400(tmp_path: Path) -> None:
+    client = _client(tmp_path)
+
+    response = client.post(
+        "/api/auth/tokens",
+        json={"name": "a", "profile": "default", "scopes": ["not-a-scope"]},
+    )
+
+    assert response.status_code == 400
+
+
+def test_router_absent_when_no_token_store_given() -> None:
+    app = create_app(HubConfig())
+    client = TestClient(app)
+
+    response = client.get("/api/auth/tokens")
+
+    assert response.status_code == 404

--- a/v3/server/tests/auth/test_scopes.py
+++ b/v3/server/tests/auth/test_scopes.py
@@ -1,0 +1,38 @@
+"""Scope string composition and the read/write action classification."""
+
+from __future__ import annotations
+
+from palaia_hub.auth.scopes import (
+    READ_ACTIONS,
+    WRITE_ACTIONS,
+    required_scope_for_action,
+    vault_scope,
+)
+from palaia_hub.gateway.vault_protocol import MEMORY_TOOL_ACTIONS
+
+
+def test_vault_scope_format() -> None:
+    assert vault_scope("work", "read") == "vault:work:read"
+    assert vault_scope("work", "write") == "vault:work:write"
+
+
+def test_every_memory_tool_action_is_classified_exactly_once() -> None:
+    # No overlap, and together they cover every action the gateway exposes
+    # (MEMORY_TOOL_ACTIONS is the gateway's own single source of truth for
+    # "what actions exist" — see palaia_hub.gateway.vault_protocol).
+    assert READ_ACTIONS & WRITE_ACTIONS == frozenset()
+    assert READ_ACTIONS | WRITE_ACTIONS == frozenset(MEMORY_TOOL_ACTIONS)
+
+
+def test_read_actions_require_read_scope() -> None:
+    for action in READ_ACTIONS:
+        assert required_scope_for_action("work", action) == "vault:work:read"
+
+
+def test_write_actions_require_write_scope() -> None:
+    for action in WRITE_ACTIONS:
+        assert required_scope_for_action("work", action) == "vault:work:write"
+
+
+def test_unknown_action_fails_closed_to_write() -> None:
+    assert required_scope_for_action("work", "some_future_action") == "vault:work:write"

--- a/v3/server/tests/auth/test_store.py
+++ b/v3/server/tests/auth/test_store.py
@@ -1,0 +1,136 @@
+"""TokenStore: create/list/revoke/verify, hashing, rotation, persistence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from palaia_hub.auth.store import TokenError, TokenStore
+
+
+def test_create_returns_plaintext_once_and_it_verifies(tmp_path: Path) -> None:
+    store = TokenStore(home=tmp_path)
+
+    created = store.create("Codex on devbox", "default", ["vault:work:read"])
+
+    assert created.token.startswith("plt_")
+    assert created.info.name == "Codex on devbox"
+    assert created.info.profile == "default"
+    assert created.info.scopes == ["vault:work:read"]
+    assert created.info.revoked_at is None
+
+    record = store.verify(created.token)
+    assert record is not None
+    assert record.id == created.info.id
+    assert record.name == "Codex on devbox"
+
+
+def test_only_the_hash_is_ever_written_to_disk(tmp_path: Path) -> None:
+    store = TokenStore(home=tmp_path)
+    created = store.create("Codex on devbox", "default", ["vault:work:read"])
+
+    raw = store.store_path.read_text(encoding="utf-8")
+
+    # The plaintext token and its bare secret half never appear in storage.
+    assert created.token not in raw
+    secret_half = created.token.split(".", 1)[1]
+    assert secret_half not in raw
+    # ...but an argon2id hash does.
+    assert "$argon2id$" in raw
+
+
+def test_wrong_secret_does_not_verify(tmp_path: Path) -> None:
+    store = TokenStore(home=tmp_path)
+    created = store.create("client", "default", [])
+    token_id = created.token.removeprefix("plt_").split(".", 1)[0]
+
+    forged = f"plt_{token_id}.wrong-secret-wrong-secret-wrong12"
+
+    assert store.verify(forged) is None
+
+
+def test_unknown_token_id_does_not_verify(tmp_path: Path) -> None:
+    store = TokenStore(home=tmp_path)
+    store.create("client", "default", [])
+
+    assert store.verify("plt_totally-unknown-id.some-secret-value-here") is None
+
+
+def test_malformed_token_does_not_verify(tmp_path: Path) -> None:
+    store = TokenStore(home=tmp_path)
+    assert store.verify("not-a-palaia-token") is None
+    assert store.verify("") is None
+
+
+def test_rotation_new_token_works_old_fails_immediately(tmp_path: Path) -> None:
+    store = TokenStore(home=tmp_path)
+    old = store.create("client", "default", ["vault:work:read"])
+
+    assert store.verify(old.token) is not None
+
+    new = store.create("client (rotated)", "default", ["vault:work:read"])
+    store.revoke(old.info.id)
+
+    assert store.verify(old.token) is None
+    assert store.verify(new.token) is not None
+
+
+def test_revoke_is_idempotent(tmp_path: Path) -> None:
+    store = TokenStore(home=tmp_path)
+    created = store.create("client", "default", [])
+
+    first = store.revoke(created.info.id)
+    second = store.revoke(created.info.id)
+
+    assert first.revoked_at is not None
+    assert second.revoked_at == first.revoked_at
+
+
+def test_revoke_unknown_id_raises_token_error(tmp_path: Path) -> None:
+    store = TokenStore(home=tmp_path)
+    with pytest.raises(TokenError, match="no token with id"):
+        store.revoke("does-not-exist")
+
+
+def test_list_tokens_never_exposes_hash_or_secret(tmp_path: Path) -> None:
+    store = TokenStore(home=tmp_path)
+    store.create("client", "default", ["vault:work:read"])
+
+    infos = store.list_tokens()
+
+    assert len(infos) == 1
+    assert not hasattr(infos[0], "hash")
+    assert "hash" not in infos[0].model_dump()
+
+
+def test_invalid_scope_format_is_rejected(tmp_path: Path) -> None:
+    store = TokenStore(home=tmp_path)
+    with pytest.raises(TokenError, match="invalid scope"):
+        store.create("client", "default", ["not-a-real-scope"])
+
+
+def test_empty_name_or_profile_is_rejected(tmp_path: Path) -> None:
+    store = TokenStore(home=tmp_path)
+    with pytest.raises(TokenError):
+        store.create("", "default", [])
+    with pytest.raises(TokenError):
+        store.create("client", "", [])
+
+
+def test_store_persists_across_instances(tmp_path: Path) -> None:
+    store = TokenStore(home=tmp_path)
+    created = store.create("client", "default", ["vault:work:write"])
+
+    reloaded = TokenStore(home=tmp_path)
+
+    record = reloaded.verify(created.token)
+    assert record is not None
+    assert record.name == "client"
+
+
+def test_malformed_store_file_reports_fix(tmp_path: Path) -> None:
+    (tmp_path / "tokens.yaml").write_text("not: [a, valid, token, file\n", encoding="utf-8")
+
+    with pytest.raises(TokenError, match="Fix"):
+        TokenStore(home=tmp_path)

--- a/v3/server/tests/auth/test_verifier.py
+++ b/v3/server/tests/auth/test_verifier.py
@@ -1,0 +1,55 @@
+"""PalaiaTokenVerifier: the fastmcp-facing adapter, including profile binding."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from palaia_hub.auth.store import TokenStore
+from palaia_hub.auth.verifier import PalaiaTokenVerifier
+
+
+@pytest.mark.anyio
+async def test_valid_token_for_its_own_profile_verifies(tmp_path: Path) -> None:
+    store = TokenStore(home=tmp_path)
+    created = store.create("client", "default", ["vault:work:read", "vault:work:write"])
+    verifier = PalaiaTokenVerifier(store, "default")
+
+    access_token = await verifier.verify_token(created.token)
+
+    assert access_token is not None
+    assert access_token.client_id == created.info.id
+    assert set(access_token.scopes) == {"vault:work:read", "vault:work:write"}
+    assert access_token.subject == "client"
+
+
+@pytest.mark.anyio
+async def test_token_bound_to_profile_a_is_rejected_by_profile_b(tmp_path: Path) -> None:
+    store = TokenStore(home=tmp_path)
+    created = store.create("client", "profile-a", ["vault:work:read"])
+    verifier_b = PalaiaTokenVerifier(store, "profile-b")
+
+    assert await verifier_b.verify_token(created.token) is None
+
+    # The matching profile's verifier still accepts it.
+    verifier_a = PalaiaTokenVerifier(store, "profile-a")
+    assert await verifier_a.verify_token(created.token) is not None
+
+
+@pytest.mark.anyio
+async def test_revoked_token_is_rejected(tmp_path: Path) -> None:
+    store = TokenStore(home=tmp_path)
+    created = store.create("client", "default", [])
+    store.revoke(created.info.id)
+    verifier = PalaiaTokenVerifier(store, "default")
+
+    assert await verifier.verify_token(created.token) is None
+
+
+@pytest.mark.anyio
+async def test_garbage_token_is_rejected(tmp_path: Path) -> None:
+    store = TokenStore(home=tmp_path)
+    verifier = PalaiaTokenVerifier(store, "default")
+
+    assert await verifier.verify_token("garbage") is None

--- a/v3/server/tests/auth/test_wiring.py
+++ b/v3/server/tests/auth/test_wiring.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from palaia_hub.auth.store import TokenStore
+from palaia_hub.auth.verifier import PalaiaTokenVerifier
+from palaia_hub.auth.wiring import build_profile_verifiers
+
+
+def test_builds_one_verifier_per_profile_path_sharing_the_store(tmp_path: Path) -> None:
+    store = TokenStore(home=tmp_path)
+
+    verifiers = build_profile_verifiers(["alpha", "beta"], store)
+
+    assert set(verifiers) == {"alpha", "beta"}
+    assert all(isinstance(v, PalaiaTokenVerifier) for v in verifiers.values())
+    assert verifiers["alpha"]._store is store
+    assert verifiers["alpha"]._profile == "alpha"
+    assert verifiers["beta"]._profile == "beta"

--- a/v3/server/tests/test_config.py
+++ b/v3/server/tests/test_config.py
@@ -113,3 +113,97 @@ def test_palaia_home_expands_user(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PALAIA_HOME", "~/palaia-test-home")
 
     assert "~" not in str(palaia_home())
+
+
+# --- SPEC-108: operating-mode auth policy -----------------------------------
+
+
+def test_cloud_mode_defaults_to_auth_enabled_and_starts_fine(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text("mode: cloud\n", encoding="utf-8")
+
+    config = load_config(home=tmp_path)
+
+    assert config.mode == "cloud"
+    assert config.auth_enabled is True
+
+
+def test_cloud_mode_with_auth_disabled_fails_startup_with_exact_fix(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text("mode: cloud\nauth_enabled: false\n", encoding="utf-8")
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config(home=tmp_path)
+
+    message = str(excinfo.value)
+    assert "auth_enabled: true" in message
+    assert "PALAIA_AUTH_ENABLED" in message
+    assert "Fix:" in message
+
+
+def test_open_mode_with_auth_disabled_fails_startup(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text("mode: open\nauth_enabled: false\n", encoding="utf-8")
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config(home=tmp_path)
+
+    assert "Fix:" in str(excinfo.value)
+
+
+def test_locked_mode_with_auth_disabled_is_allowed(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text("mode: locked\nauth_enabled: false\n", encoding="utf-8")
+
+    config = load_config(home=tmp_path)
+
+    assert config.auth_enabled is False
+
+
+def test_auth_enabled_env_override_disables_and_fails_in_cloud_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "config.yaml").write_text("mode: cloud\n", encoding="utf-8")
+    monkeypatch.setenv("PALAIA_AUTH_ENABLED", "false")
+
+    with pytest.raises(ConfigError):
+        load_config(home=tmp_path)
+
+
+def test_cloud_mode_with_wildcard_bind_host_fails_startup(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text("mode: cloud\nhost: 0.0.0.0\n", encoding="utf-8")
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config(home=tmp_path)
+
+    message = str(excinfo.value)
+    assert "private" in message
+    assert "Fix:" in message
+
+
+def test_cloud_mode_with_public_ip_host_fails_startup(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text("mode: cloud\nhost: 8.8.8.8\n", encoding="utf-8")
+
+    with pytest.raises(ConfigError):
+        load_config(home=tmp_path)
+
+
+def test_cloud_mode_with_tailscale_range_host_is_allowed(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text("mode: cloud\nhost: 100.64.1.2\n", encoding="utf-8")
+
+    config = load_config(home=tmp_path)
+
+    assert config.host == "100.64.1.2"
+
+
+def test_open_mode_with_wildcard_bind_host_is_allowed(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text("mode: open\nhost: 0.0.0.0\n", encoding="utf-8")
+
+    config = load_config(home=tmp_path)
+
+    assert config.mode == "open"
+    assert config.host == "0.0.0.0"
+
+
+def test_locked_mode_with_wildcard_bind_host_is_allowed(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text("mode: locked\nhost: 0.0.0.0\n", encoding="utf-8")
+
+    config = load_config(home=tmp_path)
+
+    assert config.host == "0.0.0.0"

--- a/v3/server/tests/test_logging_redaction.py
+++ b/v3/server/tests/test_logging_redaction.py
@@ -1,7 +1,9 @@
 import logging
+from pathlib import Path
 
 import pytest
 
+from palaia_hub.auth.store import TokenStore
 from palaia_hub.config import HubConfig
 from palaia_hub.logging import redact, setup_logging
 
@@ -53,6 +55,34 @@ def test_logging_json_format_redacts_token(capsys: pytest.CaptureFixture[str]) -
     captured = capsys.readouterr()
     assert SECRET not in captured.out
     assert "REDACTED" in captured.out
+
+
+# --- SPEC-108: the redaction filter covers real palaia client tokens too --
+
+
+def test_real_palaia_token_is_redacted_in_bearer_form() -> None:
+    token = "plt_AbCdEfGh12.zzZZzz09-_aaaBBBcccDDDeeeFFFggg1234567"
+    message = f"Authorization: Bearer {token}"
+
+    redacted = redact(message)
+
+    assert token not in redacted
+    assert "REDACTED" in redacted
+
+
+def test_token_store_never_logs_the_plaintext_secret(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.INFO, logger="palaia_hub.auth.store")
+    store = TokenStore(home=tmp_path)
+
+    created = store.create("Codex on devbox", "default", ["vault:work:read"])
+    store.revoke(created.info.id)
+
+    secret_half = created.token.split(".", 1)[1]
+    log_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert created.token not in log_text
+    assert secret_half not in log_text
 
 
 def test_component_level_override(capsys: pytest.CaptureFixture[str]) -> None:

--- a/v3/uv.lock
+++ b/v3/uv.lock
@@ -59,6 +59,61 @@ wheels = [
 ]
 
 [[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/43/bb8b6e8708d49a5ab36781333af092d9f483b198a2710d01281204640055/argon2_cffi_bindings-26.1.0.tar.gz", hash = "sha256:63505c71542a44b68b1e38060450fb006404170da375feb31af153e7f9c6205d", size = 1790807, upload-time = "2026-08-20T07:44:22.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/d2/0ae991f1b2181e5be49007c574710a800ad36c2978683addb3e67c474e55/argon2_cffi_bindings-26.1.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:21ca0396fe5ec995dd54431c32698189666f9224810acfa752e50d2bd94d9df2", size = 25521, upload-time = "2026-08-20T07:32:43.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e4/ad91d8297638aa2258aad4501c306aca99480dfe76ccd638173fa3702db9/argon2_cffi_bindings-26.1.0-cp310-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78de2d65e0b9ea7ce9d1b1c3e87297b2d7305a02c266ee2a2d6910daddd7ee69", size = 27177, upload-time = "2026-08-20T07:32:44.158Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/86/5363df11b86d02cf3662208e7406496327649cc90eb365bf6f4e8a54a41f/argon2_cffi_bindings-26.1.0-cp310-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27f1821903e2ceadcb88ec2b45ef190897b7682449c772f4d9b53e42c520cf29", size = 26597, upload-time = "2026-08-20T07:32:45.172Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/b5/a14dcc592652347dad23ee93b278a4da5d2a25c9ed3ebd10d68eea823a4f/argon2_cffi_bindings-26.1.0-cp310-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d88e5f7e60f28ae0b0cc6b2f16c43e87cd642a196a86f85e0d8bb6fe016fc16d", size = 27403, upload-time = "2026-08-20T07:32:46.13Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/81/b4a20d4902af7f796390bf9245ff83c5217dfa7367efa1d14986956c482b/argon2_cffi_bindings-26.1.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:34b7d9c24a4165a2c61cc8ae11d44d48c9ce2830fb536cb7914e11fdd9962728", size = 27132, upload-time = "2026-08-20T07:32:47.13Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/1b/c8de358af07b1c490e0fcb863ef98e46ddb486e45567aca5a60bd68d9daa/argon2_cffi_bindings-26.1.0-cp310-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:224865cbbcb7a2bd1356741dff12b0134df726b6d44bb7b500df8e303cbd9e81", size = 27588, upload-time = "2026-08-20T07:32:48.087Z" },
+    { url = "https://files.pythonhosted.org/packages/48/2f/7ee62a6e79f9309f9d9982d301b22a00010adb580c05c8109b94d7b33de0/argon2_cffi_bindings-26.1.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ffff613aaa9ce6236766e2fc6dc560bb5abde7a2e2416e3db1f9ae395a2b4dd4", size = 26785, upload-time = "2026-08-20T07:32:48.977Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/10/960d0ee93d4897741bcaf4799c697dae2d81499f66fd1ed042a7dd54c1f4/argon2_cffi_bindings-26.1.0-cp310-abi3-win32.whl", hash = "sha256:a86c069c91a747a2c4e5c51473590aeb48172fff9b2130d23729a42d98665ecb", size = 23898, upload-time = "2026-08-20T07:32:50.114Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/3a/0cc14a05810e6add9bce5e87693334baa2222de5f647fa31781885b6573f/argon2_cffi_bindings-26.1.0-cp310-abi3-win_amd64.whl", hash = "sha256:2c36ff87b5dfaa477d0bd51e9d7f6abdae7c8955d2983c97419085d842154b3e", size = 25730, upload-time = "2026-08-20T07:32:51.091Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/db/d83cf2af140547f0b9cdaece05b2dc2dcbf991be4667331d073eff771435/argon2_cffi_bindings-26.1.0-cp310-abi3-win_arm64.whl", hash = "sha256:f9c4420a7a864fe1b86ce35befc95b8e39fb852493b81cf798671ddc265de638", size = 24478, upload-time = "2026-08-20T07:32:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/5f/f652055e18d2627e2eed94c7f31a792127cfe38df786635395d742321674/argon2_cffi_bindings-26.1.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:af11ac37a7c53dc16cb7950a6190851b0870fe218b6c60c0bb7ac355234e3083", size = 15434, upload-time = "2026-08-20T07:32:53.143Z" },
+    { url = "https://files.pythonhosted.org/packages/76/38/de696045960f5b846d428c0fb6c130ed3da87aac2af209b05c193815404c/argon2_cffi_bindings-26.1.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:db0fcd827ca61622a01b220aadfbece01939acf53888f2cb98cd93e9b1e2c97e", size = 15449, upload-time = "2026-08-20T07:32:54.075Z" },
+    { url = "https://files.pythonhosted.org/packages/91/0a/c25af768f6b75a5a71e31207f87c540656b2808c015260444a22763221ad/argon2_cffi_bindings-26.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:28524438cd3e723f25412f63d4fd516ff5bae9ae5aa56acbe2a1404398a0cf31", size = 25683, upload-time = "2026-08-20T07:32:55.05Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/7e/be212c751ab0bcea7f646615f933bf262e8e50b3f7bef32f861d0a2d066b/argon2_cffi_bindings-26.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac82fc756a446b6ccd7139ce70efa9d8bbe541e7ad579a12dcb52764b7175c5f", size = 27311, upload-time = "2026-08-20T07:32:56.166Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/ee/f84b28e4afd13d3cac36c1d8fa8c239d2dc2c51cd978d02ee5d5ad98d9bb/argon2_cffi_bindings-26.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6a4e68eed961a8de6928d1c17ff3dc2a547e0e923c17f8f1cd79fb7bc9502f98", size = 26771, upload-time = "2026-08-20T07:32:57.206Z" },
+    { url = "https://files.pythonhosted.org/packages/21/c3/95c07a023691ecd529da9cb6a8f0779e13ebc1bdfaa86d145fdc1c6e7e79/argon2_cffi_bindings-26.1.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:151dfaad9de753f4af2a7854e707e4784f2acc434340ade64239c5b104b2d605", size = 27568, upload-time = "2026-08-20T07:32:58.361Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/31/3a18e31406d8694b4d6a31573c3e572fff6bed318bb744453eb653766d22/argon2_cffi_bindings-26.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:061a6919145bbf282ebf1f9c59d3135d4833c25313c8595c0d68cf7712ddfce2", size = 27280, upload-time = "2026-08-20T07:32:59.343Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/39/d4be4577e178b2397aa5b5575c8a309bf0da2afe05fe0c72c8f398662d63/argon2_cffi_bindings-26.1.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:62ff20cd130c956c7c9144d5fe35228f98b51c579b2439e988b27ef93e16c02a", size = 27776, upload-time = "2026-08-20T07:33:00.325Z" },
+    { url = "https://files.pythonhosted.org/packages/71/47/78f4dd96f7411339f723b96fe24039c1bd5835102b8a5ba71ac4ec712ac7/argon2_cffi_bindings-26.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:19423e5d7ac1cc354baab59eaabf18db2ec04ef6593b5abe5a34f323c4a8f87a", size = 26932, upload-time = "2026-08-20T07:33:01.272Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cd/96bfd37434cc0a848a9066c291d84b28846c4c9ea289ed9866b1164d622b/argon2_cffi_bindings-26.1.0-cp314-cp314t-win32.whl", hash = "sha256:4f84cdd868978d7b7350a566c254042d44216d9e37f241f3a6d3b1dfebeede35", size = 24878, upload-time = "2026-08-20T07:33:02.189Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/42/d8b6810abd9b1bd2f47ebbccf460da59c9f32e94888bea4f7b137d998797/argon2_cffi_bindings-26.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2b741888c93147444fdfc851abd81cc207f37f7f7da42062a00deb3888e57da8", size = 26656, upload-time = "2026-08-20T07:33:03.222Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d1/095d95eaf2ed1d9f77268cf3291bde148c6cd56121f8db2c74c1ba618a0e/argon2_cffi_bindings-26.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:6ab674f668d5962a3a4136ae0812519b0f1586874263723a32181d60d64137e1", size = 25378, upload-time = "2026-08-20T07:33:04.332Z" },
+    { url = "https://files.pythonhosted.org/packages/66/cb/214092c39c4dbcb72cf98b12234ddac2221f8fe2c0acf29c6a70fa83be53/argon2_cffi_bindings-26.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:1d98e33bd8bd67d7206c124e200bf2229c4cfa8c9c19f7b44a897f0fc71837eb", size = 25683, upload-time = "2026-08-20T07:33:05.337Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e5/02015b83e9b05ccb85ff2ced424cf6e83a12d3810bc7f66d679a92b69ffb/argon2_cffi_bindings-26.1.0-cp315-cp315t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ccaf0a46cbb380f1fd102a874e32aa629fd3cb0c0e94f4943fa1f6d5edc5dac6", size = 27310, upload-time = "2026-08-20T07:33:06.344Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/4a/85e612787d0796878b3b4f6bd53dcd5484b6fe7b64cc6fc7b6e6a04cf835/argon2_cffi_bindings-26.1.0-cp315-cp315t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f0c3103fcff20183e593459cfea6e012281c0e76ae3ed8b5565ad1b92eac3990", size = 26771, upload-time = "2026-08-20T07:33:07.429Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/84/ccb003b6f9969820e87656398f4d49c857def71a85ca1588a0e809afd7ce/argon2_cffi_bindings-26.1.0-cp315-cp315t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c49e853a3bef9dd10329f31f702e7fa9b5c58229ff9c2ff6d069efaf09177c08", size = 27569, upload-time = "2026-08-20T07:33:08.598Z" },
+    { url = "https://files.pythonhosted.org/packages/88/07/c26b76debf0998ee08fbe947ab2058ac5de37d4b9d46b06c17abaa6c4ce9/argon2_cffi_bindings-26.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:6376d4b3aca039375ca8bf92f770da0ec424a1ce3a37077a8d3c557411aa56ca", size = 27279, upload-time = "2026-08-20T07:33:09.518Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/0d/ead6ddc029f91bc9b9390686dad3c808ab08100d348f6266b5f93f8970ee/argon2_cffi_bindings-26.1.0-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:9bacedc04b0402837586a17f0919e3dfdd95291f441f1f56bd80ec274c2840a1", size = 27774, upload-time = "2026-08-20T07:33:10.728Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/47/c108530d9eb86036b78d3af4de28b83b4a2d9a70512bd10ff8e59966aab4/argon2_cffi_bindings-26.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:76ae29acace5d33355344612844d588e19deaaba4639d8bb01601e4b1418ef36", size = 26933, upload-time = "2026-08-20T07:33:11.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/02/0bfc59e781c89acf64c31c388aade9d9d1c1ea38aa1ba1292fe07f607fe9/argon2_cffi_bindings-26.1.0-cp315-cp315t-win32.whl", hash = "sha256:df612391feca41c44d20118f3b88d1b86419465cd1f5496859f715ca60ec2210", size = 24875, upload-time = "2026-08-20T07:33:12.616Z" },
+    { url = "https://files.pythonhosted.org/packages/61/c7/c3e46068cddffccecb8ad94d71135e9bf62bbc789589e7dfadc7c6f59214/argon2_cffi_bindings-26.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:1a0a29ed86960e44eaace7e081bdfab4f08b012fd96ec8edba71e2ad020939e4", size = 26655, upload-time = "2026-08-20T07:33:13.521Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ca/18b9c8c45fecf34b9100ec6d7946057f14a158f2eaa20ea123a3e82351cb/argon2_cffi_bindings-26.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:d157ddfab1e8b21f2f1dedda9c09645d98b5ed0b667b0626be600a345d426440", size = 25376, upload-time = "2026-08-20T07:33:14.491Z" },
+]
+
+[[package]]
 name = "ast-serialize"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -945,6 +1000,7 @@ wheels = [
 name = "palaia-hub"
 source = { editable = "server" }
 dependencies = [
+    { name = "argon2-cffi" },
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "platformdirs" },
@@ -967,6 +1023,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", marker = "extra == 'dev'", specifier = ">=4" },
+    { name = "argon2-cffi", specifier = ">=23.1" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "fastmcp", specifier = "==3.4.7" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },


### PR DESCRIPTION
## Summary

Implements SPEC-108: Phase-1 auth for the MCP gateway — named, argon2id-hashed
per-client bearer tokens, scoped to a profile and per-vault read/write
permissions, plus the cloud/open operating-mode auth policy enforced in code.

- **Token store** (`palaia_hub.auth.store.TokenStore`): named tokens (e.g.
  "Codex on devbox"), persisted as `tokens.yaml` (same home dir as
  `config.yaml`/`vaults.yaml`), atomic writes, `0600` permissions. Plaintext
  is `plt_<id>.<secret>` — the `id` half is a public lookup key (like a
  GitHub PAT's visible prefix); only the argon2id hash of the `secret` half
  is ever written to disk, and it is returned to the caller exactly once, at
  creation. CLI (`palaia-hub token create|list|revoke`) and REST
  (`/api/auth/tokens`, POST/GET/DELETE) both wrap the same store.
- **Scopes + profile binding**: a token names one profile and a list of
  `vault:<key>:read|write` scopes. `PalaiaTokenVerifier` (one per profile)
  rejects a token bound to a different profile — indistinguishable from an
  unknown token, both collapsing to the same 401. Per-tool scope checks
  (`palaia_hub.auth.enforcement.missing_scope_error`, wired into every one of
  the gateway's 8 memory tools) return a clean `ToolResult(is_error=True)`
  naming the missing scope, not a crash, when a read-only token calls a
  write tool. The read/write classification (`palaia_hub.auth.scopes`) is
  fail-closed: an action outside the explicit read allow-list requires
  `write`.
- **Operating-mode policy, enforced in code, two layers**: (1)
  `HubConfig`'s own validator refuses `cloud`/`open` with `auth_enabled:
  false` at config-load time, with the exact fix in the message, and
  additionally refuses `cloud` mode with anything but a private/VPN bind
  host (0.0.0.0/public IPs excluded — cloud-mode public reachability means a
  tunnel terminating on a private address, since there's one listener for
  both MCP and the dashboard and the dashboard must stay VPN-only in that
  mode); (2) `palaia_hub.auth.policy.check_gateway_auth_policy`, called from
  `create_app`, refuses to mount a gateway with any unauthenticated profile
  in cloud/open mode — catching a wiring bug config validation alone can't
  see.
- **Upgrade seam**: the verifier is `fastmcp.server.auth.TokenVerifier` —
  the exact base class fastmcp's own `JWTVerifier` (OAuth/OIDC) implements.
  `build_gateway()` gained an optional `token_verifiers: Mapping[str,
  TokenVerifier]` parameter; swapping in a Phase-2 OAuth verifier means
  handing it a different `TokenVerifier` subclass there — nothing in
  `memory_tools.py`/`build.py` changes, since both only ever look at
  `AccessToken.scopes`/`.client_id`.
- **401 + WWW-Authenticate**: comes from fastmcp's own
  `RequireAuthMiddleware`/`BearerAuthBackend` (wired in automatically once a
  `TokenVerifier` is attached to a profile) — not reimplemented. It is
  RFC 6750 §3.1-compliant: a missing `Authorization` header gets `WWW-
  Authenticate: Bearer` with no `error` attribute; a present-but-invalid one
  gets `error="invalid_token"`.
- **Redaction**: SPEC-101's `RedactionFilter` already matches
  `Bearer <token>` shapes; verified against a real `plt_...` token, and the
  token store's own log lines are asserted to never contain the secret.

Deliberately **not** used: `fastmcp.server.auth.StaticTokenVerifier` — its
own docstring says "Never use this in production — tokens are stored in
plain text!". SPEC-108 requires hashed storage, hence a real `TokenStore`.

## Acceptance checklist

- [x] wrong/absent token → 401 with RFC-compliant `WWW-Authenticate`; valid
      token bound to profile A cannot list/call profile B's tools
      (`tests/auth/test_http_auth_e2e.py`, `tests/auth/test_verifier.py`)
- [x] read-scoped token calling a write tool → MCP error naming the missing
      scope (`tests/auth/test_http_auth_e2e.py::test_read_only_token_calling_write_tool_gets_clean_mcp_error`,
      `tests/auth/test_enforcement.py`)
- [x] `cloud` mode with auth disabled → startup fails with the exact fix in
      the message (`tests/test_config.py`, plus a gateway-level guard in
      `tests/auth/test_app_auth_policy.py`)
- [x] token hashes only in storage (test greps the store); rotation works
      (create new, revoke old, old fails immediately)
      (`tests/auth/test_store.py`)
- [x] timing-safe comparison used (constant-time verify) — argon2id's own
      `verify()` does the constant-time digest compare; a fixed-dummy-hash
      verify (`hashing.spend_constant_time_miss`) pays the same cost for an
      unknown token id, so that path isn't a timing tell either. Not
      exercised by an actual timing measurement in CI (inherently flaky);
      reviewed for correctness instead.

## Verification evidence

```
cd v3 && uv sync
uv run ruff check server        # All checks passed!
uv run mypy server/src           # Success: no issues found in 38 source files
uv run pytest server/tests -q    # 273 passed, 1 skipped (claude CLI e2e, no binary on PATH here)
```

## Scope / notes

- Touches only `v3/server/**`, `v3/pyproject.toml` deps, and `v3/uv.lock`
  (added `argon2-cffi`). No v2 files.
- Shared-file changes kept additive: `build_gateway()` gained one optional
  kwarg (default `None`, existing call sites unchanged); `create_app()`
  gained one optional kwarg (`token_store`, default `None`) plus a guard
  that only runs when a `gateway` is actually passed in.
- The `/api/auth/tokens` REST surface carries no auth of its own — like
  `/api/health`/`/api/info` today, it relies on the operating mode's network
  posture. A dashboard login (MASTERPLAN §5.5's local account / IdP sign-in)
  is a separate, later concern and out of this SPEC's scope.
- Not in scope (SPEC non-goals): OAuth/CIMD/IdP login, tunnels/exposure
  wizard — Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp


---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790096678&installation_model_id=428086&pr_number=216&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F216&signature=708b8ba05afc3a60d758d3496ee2634d482359dcb606765d2e19ac575654b04e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->