### PR TITLE
feat(v3): SPEC-113 e2e harness, golden vault, real vault wiring

### DIFF
--- a/.github/workflows/v3-ci.yml
+++ b/.github/workflows/v3-ci.yml
@@ -39,7 +39,49 @@ jobs:
         run: uv run mypy server/src
 
       - name: pytest
-        run: uv run pytest
+        # SPEC-113's e2e scenario suite gets its own job below (dedicated
+        # timeout + failure-artifact capture), so it is excluded here to
+        # avoid running it twice on every push/PR.
+        run: uv run pytest --ignore=server/tests/e2e
+
+  e2e:
+    # SPEC-113: the Phase-1 exit-criterion harness (S1-S5) — real hub
+    # subprocesses over the golden vault fixture, real streamable HTTP,
+    # amd64 (this runner's arch).
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: v3
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "0.8.x"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: uv sync
+        run: uv sync --all-packages
+
+      - name: e2e scenario suite
+        # --basetemp puts every scenario's tmp_path (hub subprocess logs,
+        # the golden-vault copy each scenario mutates, progress logs) under
+        # a directory this job controls, so a failure's reproducible bundle
+        # (SPEC-113 acceptance: "logs + vault + config") is exactly what
+        # gets uploaded below, pass or fail.
+        run: uv run pytest server/tests/e2e -v --basetemp=e2e-artifacts
+
+      - name: upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-failure-bundle
+          path: v3/e2e-artifacts
+          retention-days: 14
 
   web:
     runs-on: ubuntu-latest

--- a/v3/server/src/palaia_hub/gateway/__init__.py
+++ b/v3/server/src/palaia_hub/gateway/__init__.py
@@ -4,9 +4,13 @@ Public surface:
 
 - :class:`~palaia_hub.gateway.vault_protocol.VaultService` — the narrow
   protocol the memory tools are written against (search/read/write/edit/
-  move/delete/list/recent_activity). SPEC-102's real vault engine and this
-  SPEC's :class:`~palaia_hub.gateway.fake_vault.FakeVaultService` both
-  satisfy it; nothing in this package imports ``palaia_hub.vault``.
+  move/delete/list/recent_activity). :class:`~palaia_hub.gateway.fake_vault.FakeVaultService`
+  (in-memory, tests) and :class:`~palaia_hub.gateway.wiring.EngineVaultService`
+  (SPEC-113's real adapter over SPEC-102's vault engine) both satisfy it.
+  Everything else in this package (``build``, ``config``, ``memory_tools``,
+  ``naming``, ``vault_protocol``) is still independent of ``palaia_hub.vault``
+  by design — only ``wiring`` imports it, so the memory tool family stays
+  written against the protocol, not the engine.
 - :func:`~palaia_hub.gateway.build.build_gateway` — turns a
   :class:`~palaia_hub.gateway.config.GatewayConfig` plus a
   ``dict[str, VaultService]`` into a
@@ -28,9 +32,11 @@ from .vault_protocol import (
     VaultService,
     VaultServiceError,
 )
+from .wiring import EngineVaultService
 
 __all__ = [
     "MEMORY_TOOL_ACTIONS",
+    "EngineVaultService",
     "FakeVaultService",
     "GatewayASGI",
     "GatewayConfig",

--- a/v3/server/src/palaia_hub/gateway/wiring.py
+++ b/v3/server/src/palaia_hub/gateway/wiring.py
@@ -1,0 +1,268 @@
+"""Real wiring: a :class:`~.vault_protocol.VaultService` backed by the vault
+engine (SPEC-102).
+
+SPEC-105 deliberately deferred this adapter — its module docstring says so
+verbatim (:mod:`palaia_hub.gateway.vault_protocol`): the vault engine ran on
+a parallel branch and was not merged when the memory tool family was built.
+This module is that adapter, now that SPEC-102 has landed. It is a thin
+pass-through: field names already mirror ``vault-format.md`` on both sides
+(:class:`~.vault_protocol.NoteRecord` / :class:`~palaia_hub.vault.Note`), so
+no translation layer is needed beyond unpacking frontmatter and mapping
+engine exceptions to :class:`~.vault_protocol.VaultServiceError`.
+
+**Search** here is a linear substring scan over already-open notes — the
+same trade-off :class:`~.fake_vault.FakeVaultService` made, now over real
+files and frontmatter instead of an in-memory dict. SPEC-104 (the hybrid
+index) is not in this SPEC's ``depends_on`` and is not merged yet; when it
+lands, ``search`` is the one method here a future SPEC should replace with
+an index-backed query, everything else already talks to the real vault.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+from palaia_hub.vault import (
+    AmbiguousReferenceError,
+    ChecksumConflictError,
+    InvalidPathError,
+    Note,
+    NoteExistsError,
+    NoteNotFoundError,
+    PermalinkConflictError,
+    VaultEngine,
+    VolatileNameError,
+)
+from palaia_hub.vault import permalink as pl
+
+from .vault_protocol import NoteRecord, NoteSummary, SearchHit, VaultService, VaultServiceError
+
+# Every caller-facing engine failure this adapter might see, translated to
+# VaultServiceError (see vault_protocol.VaultService's docstring: tool
+# wrappers catch that type and turn it into a tool-level error result rather
+# than an uncaught exception). VaultConfigError/VaultNotFoundError/GitError/
+# VaultFormatVersionError are open/registry/git-plumbing failures, not
+# per-call caller mistakes, so they are intentionally left to propagate.
+_ENGINE_CALLER_ERRORS: tuple[type[Exception], ...] = (
+    AmbiguousReferenceError,
+    ChecksumConflictError,
+    InvalidPathError,
+    NoteExistsError,
+    NoteNotFoundError,
+    PermalinkConflictError,
+    VolatileNameError,
+)
+
+
+def _tag_list(value: Any) -> list[str]:
+    """Normalize a frontmatter ``tags`` value (list or comma-string) to a
+    lowercase list, per vault-format.md §2.1."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [tag.strip().lower() for tag in value.split(",") if tag.strip()]
+    return [str(tag).strip().lower() for tag in value if str(tag).strip()]
+
+
+def _folder_of(path: str) -> str:
+    return path.rsplit("/", 1)[0] if "/" in path else ""
+
+
+def _is_meta(note: Note) -> bool:
+    """True for the vault manifest and any other ``type: meta`` note.
+
+    Format spec §6: ``meta`` is "vault self-description... excluded from
+    normal recall". ``search``/``list_notes``/``recent_activity`` are the
+    tool family's normal-recall surface, so they filter it out; ``read`` and
+    ``write``/``edit``/``move``/``delete`` do not — a caller that names
+    ``meta/vault`` explicitly still gets it.
+    """
+    return str(note.frontmatter.get("type", "note")) == "meta"
+
+
+def _note_to_record(note: Note) -> NoteRecord:
+    frontmatter = note.frontmatter
+    return NoteRecord(
+        permalink=note.permalink or note.path,
+        title=note.title,
+        type=str(frontmatter.get("type", "note")),
+        tags=_tag_list(frontmatter.get("tags")),
+        folder=_folder_of(note.path),
+        modified=str(frontmatter.get("modified") or ""),
+        created=str(frontmatter.get("created") or ""),
+        body=note.body,
+    )
+
+
+def _note_to_summary(note: Note) -> NoteSummary:
+    record = _note_to_record(note)
+    return NoteSummary(**record.model_dump(exclude={"body", "created"}))
+
+
+class EngineVaultService:
+    """:class:`VaultService` over one open :class:`~palaia_hub.vault.VaultEngine`.
+
+    The engine must already be opened (``await engine.open(...)``) — this
+    adapter does not manage the engine's lifecycle, only translates calls.
+    """
+
+    def __init__(self, engine: VaultEngine) -> None:
+        self._engine = engine
+
+    async def search(self, query: str, *, limit: int = 10) -> list[SearchHit]:
+        needle = query.lower()
+        hits: list[SearchHit] = []
+        # Snapshot before iterating: every step below `await`s (read_note),
+        # and the vault watcher can mutate the engine's catalog dict
+        # concurrently between those awaits (external edits land while a
+        # search is in flight) — iterating the live mapping would then
+        # raise "dictionary changed size during iteration".
+        for entry in list(self._engine.catalog.values()):
+            note = await self._engine.read_note(entry.path)
+            if _is_meta(note):
+                continue
+            haystack = f"{note.title}\n{note.body}".lower()
+            if needle not in haystack:
+                continue
+            idx = haystack.find(needle)
+            start = max(0, idx - 20)
+            snippet = note.body[start : start + len(query) + 40].strip()
+            hits.append(
+                SearchHit(
+                    permalink=note.permalink or note.path,
+                    title=note.title,
+                    snippet=snippet,
+                    score=1.0 if needle in note.title.lower() else 0.5,
+                )
+            )
+        hits.sort(key=lambda h: h.score, reverse=True)
+        return hits[:limit]
+
+    async def read(self, permalink: str) -> NoteRecord:
+        try:
+            note = await self._engine.read_note(permalink)
+        except _ENGINE_CALLER_ERRORS as exc:
+            raise VaultServiceError(str(exc)) from exc
+        return _note_to_record(note)
+
+    async def write(
+        self,
+        title: str,
+        body: str,
+        *,
+        folder: str = "",
+        type: str = "note",  # noqa: A002 - matches the vault-format field name
+        tags: list[str] | None = None,
+    ) -> NoteRecord:
+        folder = folder.strip("/")
+        slug = pl.slugify(title) or "note"
+        relative = f"{folder}/{slug}.md" if folder else f"{slug}.md"
+        frontmatter: dict[str, Any] = {"type": type}
+        if tags is not None:
+            frontmatter["tags"] = list(tags)
+        try:
+            result = await self._engine.write_note(
+                relative,
+                body=body,
+                title=title,
+                frontmatter=frontmatter,
+                must_create=True,
+            )
+        except _ENGINE_CALLER_ERRORS as exc:
+            raise VaultServiceError(str(exc)) from exc
+        assert result.note is not None  # write_note always returns a note
+        return _note_to_record(result.note)
+
+    async def edit(
+        self,
+        permalink: str,
+        *,
+        body: str | None = None,
+        append: str | None = None,
+        tags: list[str] | None = None,
+    ) -> NoteRecord:
+        try:
+            current = await self._engine.read_note(permalink)
+        except _ENGINE_CALLER_ERRORS as exc:
+            raise VaultServiceError(str(exc)) from exc
+        new_body = current.body
+        if body is not None:
+            new_body = body
+        if append is not None:
+            # `current.body` (and any caller-supplied `body`) already ends
+            # in a trailing newline once written through the engine (its
+            # canonical write form always does) — strip it first so append
+            # does not leave a blank line between the old and new content.
+            base = new_body.rstrip("\n")
+            new_body = f"{base}\n{append}" if base else append
+        frontmatter = {"tags": list(tags)} if tags is not None else None
+        try:
+            result = await self._engine.edit_note(
+                permalink,
+                body=new_body,
+                frontmatter=frontmatter,
+                expected_checksum=current.checksum,
+            )
+        except _ENGINE_CALLER_ERRORS as exc:
+            raise VaultServiceError(str(exc)) from exc
+        assert result.note is not None
+        return _note_to_record(result.note)
+
+    async def move(self, permalink: str, folder: str) -> NoteRecord:
+        try:
+            entry = self._engine.resolve(permalink)
+        except _ENGINE_CALLER_ERRORS as exc:
+            raise VaultServiceError(str(exc)) from exc
+        filename = entry.path.rsplit("/", 1)[-1]
+        folder = folder.strip("/")
+        new_path = f"{folder}/{filename}" if folder else filename
+        try:
+            result = await self._engine.move_note(permalink, new_path)
+        except _ENGINE_CALLER_ERRORS as exc:
+            raise VaultServiceError(str(exc)) from exc
+        assert result.note is not None
+        return _note_to_record(result.note)
+
+    async def delete(self, permalink: str) -> bool:
+        try:
+            await self._engine.delete_note(permalink)
+        except NoteNotFoundError:
+            return False
+        except _ENGINE_CALLER_ERRORS as exc:
+            raise VaultServiceError(str(exc)) from exc
+        return True
+
+    async def list_notes(self, *, folder: str = "") -> list[NoteSummary]:
+        folder = folder.strip("/")
+        summaries: list[NoteSummary] = []
+        for entry in list(self._engine.catalog.values()):
+            if folder and _folder_of(entry.path) != folder:
+                continue
+            note = await self._engine.read_note(entry.path)
+            if _is_meta(note):
+                continue
+            summaries.append(_note_to_summary(note))
+        summaries.sort(key=lambda s: s.permalink)
+        return summaries
+
+    async def recent_activity(self, *, limit: int = 10) -> list[NoteSummary]:
+        entries = sorted(
+            self._engine.catalog.values(), key=lambda entry: entry.mtime_ns, reverse=True
+        )
+        summaries: list[NoteSummary] = []
+        for entry in entries:
+            if len(summaries) >= limit:
+                break
+            note = await self._engine.read_note(entry.path)
+            if _is_meta(note):
+                continue
+            summaries.append(_note_to_summary(note))
+        return summaries
+
+
+if TYPE_CHECKING:
+    # Static-only check (never executed): EngineVaultService must satisfy
+    # the VaultService protocol exactly like FakeVaultService does.
+    _typecheck: VaultService = EngineVaultService(cast(VaultEngine, None))
+
+__all__ = ["EngineVaultService"]

--- a/v3/server/tests/e2e/conftest.py
+++ b/v3/server/tests/e2e/conftest.py
@@ -1,0 +1,192 @@
+"""Shared fixtures for the SPEC-113 e2e scenario suite.
+
+Any other SPEC's tests can import :func:`golden_vault_copy` and
+:class:`RunningHub` from here too — the SPEC-113 acceptance criterion "any
+SPEC can import the simulator + golden vault as pytest fixtures" is why
+these live in a plain fixtures module rather than being private to one test
+file.
+"""
+
+from __future__ import annotations
+
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+#: The golden vault fixture tree (SPEC-113 deliverable #1): two physically
+#: isolated vault roots, ``work/`` and ``personal/``, per vault-format.md.
+GOLDEN_VAULT_ROOT = Path(__file__).parent.parent / "fixtures" / "golden-vault"
+
+_HUB_SERVER_SCRIPT = Path(__file__).parent / "support" / "hub_server.py"
+_STARTUP_TIMEOUT = 15.0
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def golden_vault_copy(dest: Path, name: str = "work") -> Path:
+    """Copy one golden-vault vault (``"work"`` or ``"personal"``) to ``dest``.
+
+    Returns the copy's root. The fixture tree itself is never mutated —
+    every scenario gets its own disposable copy, since scenarios (S2, S3)
+    deliberately mutate the vault on disk.
+    """
+    source = GOLDEN_VAULT_ROOT / name
+    if not source.is_dir():
+        raise FileNotFoundError(f"no golden-vault vault named {name!r} at {source}")
+    target = dest / name
+    shutil.copytree(source, target)
+    return target
+
+
+@pytest.fixture
+def golden_work_vault(tmp_path: Path) -> Path:
+    """A disposable copy of the golden vault's ``work`` vault."""
+    return golden_vault_copy(tmp_path, "work")
+
+
+@pytest.fixture
+def golden_personal_vault(tmp_path: Path) -> Path:
+    """A disposable copy of the golden vault's ``personal`` vault."""
+    return golden_vault_copy(tmp_path, "personal")
+
+
+def free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def wait_for_health(port: int, timeout: float = _STARTUP_TIMEOUT) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/api/health", timeout=0.5
+            ) as resp:
+                if resp.status == 200:
+                    return
+        except (OSError, urllib.error.URLError) as exc:
+            last_error = exc
+            time.sleep(0.1)
+    raise RuntimeError(f"hub did not become healthy within {timeout}s: {last_error}")
+
+
+@dataclass
+class RunningHub:
+    """A live hub subprocess, its port, and the profile URLs it mounts."""
+
+    process: subprocess.Popen[bytes]
+    port: int
+    profiles: list[str]
+    log_path: Path
+
+    def profile_url(self, profile: str = "default") -> str:
+        return f"http://127.0.0.1:{self.port}/mcp/{profile}/"
+
+    def is_alive(self) -> bool:
+        return self.process.poll() is None
+
+    def kill(self, *, wait: float = 10.0) -> None:
+        """SIGKILL the hub process (simulates a crash, SPEC-113 S3)."""
+        self.process.kill()
+        self.process.wait(timeout=wait)
+
+    def stop(self, *, wait: float = 10.0) -> None:
+        """Terminate gracefully; escalate to kill if it does not exit in time."""
+        if self.process.poll() is not None:
+            return
+        self.process.terminate()
+        try:
+            self.process.wait(timeout=wait)
+        except subprocess.TimeoutExpired:
+            self.process.kill()
+            self.process.wait(timeout=5)
+
+
+def spawn_hub(
+    *,
+    vault_dir: Path,
+    log_path: Path,
+    vault_key: str = "work",
+    vault_name: str = "work",
+    profiles: list[str] | None = None,
+) -> RunningHub:
+    """Launch a real hub subprocess over ``vault_dir`` and wait for it to be healthy.
+
+    Uses ``sys.executable`` directly (never a ``uv run`` wrapper) so a later
+    ``kill()`` actually kills the server process — see SPEC-102/103's kill
+    -9 findings, restated in ``support/hub_server.py``'s module docstring.
+    """
+    profiles = profiles or ["default"]
+    port = free_port()
+    args = [
+        sys.executable,
+        str(_HUB_SERVER_SCRIPT),
+        "--port",
+        str(port),
+        "--vault-dir",
+        str(vault_dir),
+        "--vault-key",
+        vault_key,
+        "--vault-name",
+        vault_name,
+    ]
+    for profile in profiles:
+        args += ["--profile", profile]
+
+    log_file = log_path.open("w")
+    process = subprocess.Popen(  # noqa: S603 - fixed argv, no shell
+        args, stdout=log_file, stderr=subprocess.STDOUT
+    )
+    try:
+        wait_for_health(port)
+    except Exception:
+        process.kill()
+        process.wait(timeout=5)
+        raise
+    return RunningHub(process=process, port=port, profiles=profiles, log_path=log_path)
+
+
+HubFactory = Callable[..., RunningHub]
+
+
+@pytest.fixture
+def hub_factory(tmp_path: Path) -> Iterator[HubFactory]:
+    """Yield ``spawn_hub``-like factory; tears down every hub it started."""
+    started: list[RunningHub] = []
+
+    def factory(
+        *,
+        vault_dir: Path,
+        vault_key: str = "work",
+        vault_name: str = "work",
+        profiles: list[str] | None = None,
+        log_name: str = "hub.log",
+    ) -> RunningHub:
+        hub = spawn_hub(
+            vault_dir=vault_dir,
+            log_path=tmp_path / log_name,
+            vault_key=vault_key,
+            vault_name=vault_name,
+            profiles=profiles,
+        )
+        started.append(hub)
+        return hub
+
+    yield factory
+
+    for hub in started:
+        hub.stop()

--- a/v3/server/tests/e2e/golden_tools_snapshot.json
+++ b/v3/server/tests/e2e/golden_tools_snapshot.json
@@ -1,0 +1,248 @@
+{
+  "delete": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": null,
+      "readOnlyHint": false,
+      "title": null
+    },
+    "description": "A palaia memory vault.\n\nDelete a note by permalink. Irreversible outside git history.",
+    "input_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "permalink": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "permalink"
+      ],
+      "type": "object"
+    }
+  },
+  "edit": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": null,
+      "readOnlyHint": false,
+      "title": null
+    },
+    "description": "A palaia memory vault.\n\nUpdate an existing note's body and/or tags.",
+    "input_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "append": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "body": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "permalink": {
+          "type": "string"
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "permalink"
+      ],
+      "type": "object"
+    }
+  },
+  "list": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": null,
+      "readOnlyHint": true,
+      "title": null
+    },
+    "description": "A palaia memory vault.\n\nList notes in this vault, optionally scoped to a folder.",
+    "input_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "folder": {
+          "default": "",
+          "description": "Folder to scope to. Empty means the whole vault.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "move": {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": null,
+      "readOnlyHint": false,
+      "title": null
+    },
+    "description": "A palaia memory vault.\n\nMove a note to a different folder. Its permalink never changes.",
+    "input_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "folder": {
+          "default": "",
+          "description": "Folder to scope to. Empty means the whole vault.",
+          "type": "string"
+        },
+        "permalink": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "permalink"
+      ],
+      "type": "object"
+    }
+  },
+  "read": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": null,
+      "readOnlyHint": true,
+      "title": null
+    },
+    "description": "A palaia memory vault.\n\nRead one note in full by its permalink.",
+    "input_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "permalink": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "permalink"
+      ],
+      "type": "object"
+    }
+  },
+  "recent_activity": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": null,
+      "readOnlyHint": true,
+      "title": null
+    },
+    "description": "A palaia memory vault.\n\nThe most recently modified notes, most recent first.",
+    "input_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "limit": {
+          "default": 10,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "search": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": null
+    },
+    "description": "A palaia memory vault.\n\nSearch this vault's notes. Returns best matches first.",
+    "input_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "limit": {
+          "default": 10,
+          "type": "integer"
+        },
+        "query": {
+          "description": "Search text.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "query"
+      ],
+      "type": "object"
+    }
+  },
+  "write": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": null,
+      "readOnlyHint": false,
+      "title": null
+    },
+    "description": "A palaia memory vault.\n\nCreate a new note in this vault.",
+    "input_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "folder": {
+          "default": "",
+          "description": "Folder to scope to. Empty means the whole vault.",
+          "type": "string"
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "default": "note",
+          "type": "string"
+        }
+      },
+      "required": [
+        "title",
+        "body"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/v3/server/tests/e2e/query_battery.py
+++ b/v3/server/tests/e2e/query_battery.py
@@ -1,0 +1,55 @@
+"""The golden vault's query battery (SPEC-113 deliverable #1).
+
+Two flavors, both against the ``work`` vault unless noted:
+
+- :data:`MUST_INCLUDE` — spot checks: a query paired with permalinks that
+  MUST appear among its results. Used where a scenario only needs to prove
+  "this is findable", not "these are exactly the results".
+- :data:`CANONICAL_QUERIES` — the fixed query list SPEC-113's rebuild
+  scenario (S4) runs before and after reindexing and asserts byte-for-byte
+  identical permalink sets against (format spec §10: "reindex MUST
+  reproduce identical query results from files alone").
+
+Every query here is deliberately chosen to also exercise a specific corpus
+feature: a forward reference (``"Q3 Roadmap"``), a personal-vault-only hit,
+and a query with no matches at all (the empty case is a result too).
+"""
+
+from __future__ import annotations
+
+#: query -> permalinks that MUST be present in that query's results
+#: (against the golden ``work`` vault, except where marked "(personal)").
+MUST_INCLUDE: dict[str, list[str]] = {
+    "API Gateway": ["projects/api-gateway"],
+    "Vault Engine": ["projects/vault-engine"],
+    "Alice Novak": ["people/alice-novak"],
+    "Rate limit decision": ["inbox/rate-limit-decision-from-pr-review"],
+    # Forward reference (vault-format.md §5.2): "Q3 Roadmap" names no entity
+    # that exists anywhere in the vault; the note that *references* it must
+    # still be findable by that text.
+    "Q3 Roadmap": ["projects/legacy-migration"],
+    "curator": ["projects/curator"],
+    # personal vault
+    "marathon": ["projects/marathon-training"],  # (personal)
+}
+
+#: A query with no matches anywhere in the golden ``work`` vault — the
+#: empty-result case is part of the contract too.
+NO_MATCH_QUERY = "xyzzy-nonexistent-term-42"
+
+#: Fixed query set for the S4 rebuild-identity check. Deliberately a mix of
+#: title hits, body-only hits, and a forward reference.
+CANONICAL_QUERIES: list[str] = [
+    "API Gateway",
+    "Vault Engine",
+    "Recall Engine",
+    "Dashboard",
+    "Alice Novak",
+    "curator",
+    "rate limit",
+    "Q3 Roadmap",
+    "commit messages",
+    NO_MATCH_QUERY,
+]
+
+__all__ = ["CANONICAL_QUERIES", "MUST_INCLUDE", "NO_MATCH_QUERY"]

--- a/v3/server/tests/e2e/simulator.py
+++ b/v3/server/tests/e2e/simulator.py
@@ -1,0 +1,118 @@
+"""Thin async MCP client simulator for the e2e scenarios.
+
+SPEC-113 deliverable #2. Deliberately does not reimplement any MCP wire
+protocol details — :class:`fastmcp.Client` already speaks streamable HTTP
+against a real server URL, including the 2026-07-28 protocol-version
+handshake nuance ``_e2e_server.py`` (SPEC-105) documented. This module wraps
+it down to exactly the operations the scenarios need: connect, list tools,
+call a tool and get back both the human-readable text and the structured
+payload, and take a name+schema snapshot for drift detection.
+
+Each :class:`SimulatedClient` carries its own MCP ``client_info`` (name +
+version), so two simulated clients hitting the same gateway profile (or two
+different profiles mounting the same vault) show up as genuinely distinct
+MCP sessions — the mechanism S1 (SPEC-113) uses to play "client A" and
+"client B" against one shared vault.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from fastmcp import Client
+from mcp.types import Implementation, Tool
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCallResult:
+    """One tool call's outcome: human text, structured payload, error flag."""
+
+    text: str
+    structured: Any | None
+    is_error: bool
+
+
+def tool_schema_snapshot(tools: list[Tool]) -> dict[str, Any]:
+    """A comparable, order-independent snapshot of a tool list's names+schemas.
+
+    Used by the golden ``tools/list`` snapshot test (SPEC-113 acceptance:
+    "harness fails loudly on tool-schema drift") and reusable by any SPEC
+    that wants the same drift check against its own tool surface.
+    """
+    return {
+        tool.name: {
+            "description": tool.description,
+            "input_schema": tool.inputSchema,
+            "annotations": tool.annotations.model_dump() if tool.annotations else None,
+        }
+        for tool in tools
+    }
+
+
+class SimulatedClient:
+    """One simulated MCP client session against a gateway profile URL.
+
+    Usage::
+
+        async with SimulatedClient(url, client_name="claude-code") as client:
+            tools = await client.list_tools()
+            result = await client.call_tool_ok("work_memory_write", {...})
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        client_name: str = "simulated-client",
+        client_version: str = "0.0.0",
+    ) -> None:
+        self._url = url
+        self._client_info = Implementation(name=client_name, version=client_version)
+        self._client: Client[Any] | None = None
+
+    async def __aenter__(self) -> SimulatedClient:
+        client: Client[Any] = Client(self._url, client_info=self._client_info)
+        await client.__aenter__()
+        self._client = client
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        client = self._client
+        self._client = None
+        if client is not None:
+            await client.__aexit__(*exc_info)
+
+    def _require_client(self) -> Client[Any]:
+        if self._client is None:
+            raise RuntimeError("SimulatedClient used outside 'async with'")
+        return self._client
+
+    async def list_tools(self) -> list[Tool]:
+        return await self._require_client().list_tools()
+
+    async def tool_names(self) -> set[str]:
+        return {tool.name for tool in await self.list_tools()}
+
+    async def call_tool(self, name: str, arguments: dict[str, Any] | None = None) -> ToolCallResult:
+        """Call a tool, never raising on a tool-level (``isError``) failure."""
+        result = await self._require_client().call_tool(
+            name, arguments or {}, raise_on_error=False
+        )
+        text = "".join(getattr(block, "text", "") for block in result.content)
+        return ToolCallResult(
+            text=text,
+            structured=result.structured_content,
+            is_error=bool(result.is_error),
+        )
+
+    async def call_tool_ok(
+        self, name: str, arguments: dict[str, Any] | None = None
+    ) -> ToolCallResult:
+        """Call a tool and assert it did not return a tool-level error."""
+        result = await self.call_tool(name, arguments)
+        assert not result.is_error, f"{name} call failed: {result.text}"
+        return result
+
+
+__all__ = ["SimulatedClient", "ToolCallResult", "tool_schema_snapshot"]

--- a/v3/server/tests/e2e/support/hub_server.py
+++ b/v3/server/tests/e2e/support/hub_server.py
@@ -1,0 +1,99 @@
+"""Standalone hub process for the SPEC-113 e2e scenarios.
+
+A plain script invoked as a subprocess (``sys.executable hub_server.py
+...``), run in the same interpreter/venv as pytest — the same pattern
+SPEC-105's ``tests/gateway/_e2e_server.py`` uses, and for the same reason:
+killing this process's PID must kill the real server, not a wrapper (the
+SPEC-003/SPEC-102 kill-test finding).
+
+Mounts exactly one vault, backed by a real :class:`~palaia_hub.vault.VaultEngine`
+through :class:`~palaia_hub.gateway.wiring.EngineVaultService` (SPEC-113's
+adapter — no ``FakeVaultService`` anywhere in this module), under one or
+more profile paths. A :class:`~palaia_hub.vault.VaultWatcher` is always
+started alongside the engine so external edits (S2) become visible to the
+gateway's tools without a manual refresh.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from pathlib import Path
+
+import uvicorn
+
+from palaia_hub.app import create_app
+from palaia_hub.config import HubConfig
+from palaia_hub.gateway.build import build_gateway
+from palaia_hub.gateway.config import GatewayConfig, ProfileConfig, VaultMountConfig
+from palaia_hub.gateway.wiring import EngineVaultService
+from palaia_hub.vault import VaultEngine, VaultWatcher
+
+logger = logging.getLogger("e2e.hub_server")
+
+
+async def _run(
+    *, host: str, port: int, vault_dir: Path, vault_key: str, vault_name: str, profiles: list[str]
+) -> None:
+    engine = VaultEngine(vault_dir, vault_name)
+    await engine.open(purpose=f"SPEC-113 e2e vault {vault_name!r}", create=True)
+    watcher = VaultWatcher(engine)
+    await watcher.start()
+
+    gateway_config = GatewayConfig(
+        vaults=[
+            VaultMountConfig(
+                key=vault_key,
+                name=vault_name,
+                purpose=f"SPEC-113 e2e vault {vault_name!r}.",
+            )
+        ],
+        profiles=[ProfileConfig(path=p, vaults=[vault_key]) for p in profiles],
+    )
+    gateway = build_gateway(gateway_config, {vault_key: EngineVaultService(engine)})
+    app = create_app(HubConfig(log_level="info"), gateway=gateway)
+
+    server = uvicorn.Server(uvicorn.Config(app, host=host, port=port, log_level="info"))
+    try:
+        await server.serve()
+    finally:
+        await watcher.stop()
+        await engine.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--vault-dir", required=True)
+    parser.add_argument("--vault-key", default="work")
+    parser.add_argument("--vault-name", default="work")
+    parser.add_argument(
+        "--profile",
+        action="append",
+        dest="profiles",
+        default=None,
+        help="profile path to mount the vault under; may repeat. Default: 'default'.",
+    )
+    args = parser.parse_args()
+    profiles = args.profiles or ["default"]
+
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+    )
+
+    asyncio.run(
+        _run(
+            host=args.host,
+            port=args.port,
+            vault_dir=Path(args.vault_dir),
+            vault_key=args.vault_key,
+            vault_name=args.vault_name,
+            profiles=profiles,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/v3/server/tests/e2e/support/mcp_write_burst.py
+++ b/v3/server/tests/e2e/support/mcp_write_burst.py
@@ -1,0 +1,74 @@
+"""MCP write-burst worker for the S3 kill/recover scenario (SPEC-113).
+
+Same pattern as SPEC-102's ``tests/vault/support/write_burst.py``, one layer
+up the stack: instead of writing through the engine directly, this writes
+through the *running hub's* gateway over real streamable HTTP, so the kill
+test exercises the whole process, not just the engine. Every acknowledged
+tool call (the ``await`` for ``call_tool`` returned, non-error) is logged as
+one JSON line to a progress file outside the vault — exactly the promise
+the checker verifies afterwards: an acknowledged write is on disk, intact,
+and (once the hub is healthy again) readable through the gateway.
+
+Run directly with a Python interpreter — never through a wrapper — so
+killing this process's PID kills the real writer (see
+``support/hub_server.py``'s docstring for why that matters).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))  # for `simulator`
+
+from simulator import SimulatedClient  # noqa: E402 - path insert must come first
+
+
+async def burst(url: str, progress_path: Path, count: int) -> None:
+    async with SimulatedClient(url, client_name="s3-write-burst") as client:
+        with progress_path.open("a", encoding="utf-8") as progress:
+            for index in range(count):
+                try:
+                    result = await client.call_tool(
+                        "work_memory_write",
+                        {
+                            "title": f"Kill Test Note {index:05d}",
+                            "body": f"- [index] {index}",
+                            "folder": "killtest",
+                        },
+                    )
+                except Exception:  # noqa: BLE001 - the hub may already be dead
+                    break
+                if result.is_error:
+                    # The hub may already be gone by the time this call
+                    # lands — that write was never acknowledged, so it is
+                    # correctly absent from the progress log.
+                    break
+                assert result.structured is not None
+                progress.write(
+                    json.dumps(
+                        {
+                            "index": index,
+                            "permalink": result.structured["permalink"],
+                            "title": result.structured["title"],
+                        }
+                    )
+                    + "\n"
+                )
+                progress.flush()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", required=True)
+    parser.add_argument("--progress", required=True)
+    parser.add_argument("--count", type=int, default=10_000)
+    args = parser.parse_args()
+    asyncio.run(burst(args.url, Path(args.progress), args.count))
+
+
+if __name__ == "__main__":
+    main()

--- a/v3/server/tests/e2e/test_s1_two_providers_one_memory.py
+++ b/v3/server/tests/e2e/test_s1_two_providers_one_memory.py
@@ -1,0 +1,58 @@
+"""S1 "two providers, one memory" (SPEC-113).
+
+Client A (a simulated Claude Code) writes a note; client B (a simulated
+Codex, connecting through a different profile with a distinct MCP client
+identity) finds and reads it — through the real gateway, over real
+streamable HTTP, backed by the real vault engine (SPEC-102) over the golden
+vault's ``work`` copy. Nothing here is faked: the only stand-in is the
+"different token/profile" requirement, realized as two profile paths
+mounting the *same* vault key (SPEC-105's actual multi-profile mechanism,
+not an invented one) plus distinct MCP ``client_info`` per simulated client.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from simulator import SimulatedClient
+
+if TYPE_CHECKING:
+    from conftest import HubFactory
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_client_a_writes_client_b_finds_it_through_a_different_profile(
+    golden_work_vault: Path, hub_factory: HubFactory
+) -> None:
+    hub = hub_factory(vault_dir=golden_work_vault, profiles=["claude-code", "codex"])
+
+    async with SimulatedClient(
+        hub.profile_url("claude-code"), client_name="claude-code", client_version="1.0.0"
+    ) as client_a:
+        write_result = await client_a.call_tool_ok(
+            "work_memory_write",
+            {
+                "title": "S1 Round Trip",
+                "body": "written by simulated client A (claude-code profile)",
+            },
+        )
+        assert "S1 Round Trip" in write_result.text
+        assert write_result.structured is not None
+        permalink = write_result.structured["permalink"]
+
+    # A brand new session, a different profile path, a different MCP
+    # client identity — the "second provider" — never having talked to
+    # client A directly.
+    async with SimulatedClient(
+        hub.profile_url("codex"), client_name="codex", client_version="1.0.0"
+    ) as client_b:
+        search_result = await client_b.call_tool_ok(
+            "work_memory_search", {"query": "S1 Round Trip"}
+        )
+        assert "S1 Round Trip" in search_result.text
+
+        read_result = await client_b.call_tool_ok("work_memory_read", {"permalink": permalink})
+        assert "written by simulated client A" in read_result.text

--- a/v3/server/tests/e2e/test_s2_external_edit.py
+++ b/v3/server/tests/e2e/test_s2_external_edit.py
@@ -1,0 +1,64 @@
+"""S2 "external edit: file edited on disk -> searchable within budget"
+(SPEC-113).
+
+A note is written straight to disk — bypassing the engine, exactly like a
+human editing the file in Obsidian — while the real hub (with its
+:class:`~palaia_hub.vault.VaultWatcher` running, per
+``support/hub_server.py``) has the vault open. The budget is the watcher's
+own documented one: a 200ms debounce plus the SPEC-003-measured ~2s
+watchfiles observation budget (see ``palaia_hub/vault/watcher.py``'s module
+docstring) — this test polls up to a generous multiple of that rather than
+asserting an exact latency, since CI runners are not real-time systems.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from simulator import SimulatedClient
+
+if TYPE_CHECKING:
+    from conftest import HubFactory
+
+pytestmark = pytest.mark.anyio
+
+_POLL_BUDGET_SECONDS = 10.0
+_POLL_INTERVAL_SECONDS = 0.25
+
+
+async def test_externally_written_note_becomes_searchable_within_budget(
+    golden_work_vault: Path, hub_factory: HubFactory
+) -> None:
+    hub = hub_factory(vault_dir=golden_work_vault)
+
+    external_note = golden_work_vault / "notes" / "written-by-an-external-editor.md"
+    external_note.parent.mkdir(parents=True, exist_ok=True)
+    external_note.write_text(
+        "---\n"
+        "title: Written By An External Editor\n"
+        "permalink: notes/written-by-an-external-editor\n"
+        "type: note\n"
+        "---\n\n"
+        "This note was written straight to disk, like an Obsidian save.\n",
+        encoding="utf-8",
+    )
+
+    async with SimulatedClient(hub.profile_url(), client_name="poller") as client:
+        deadline = asyncio.get_event_loop().time() + _POLL_BUDGET_SECONDS
+        found = False
+        while asyncio.get_event_loop().time() < deadline:
+            result = await client.call_tool_ok(
+                "work_memory_search", {"query": "external editor"}
+            )
+            if "Written By An External Editor" in result.text:
+                found = True
+                break
+            await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+
+    assert found, (
+        f"externally written note was not searchable within "
+        f"{_POLL_BUDGET_SECONDS}s (hub log: {hub.log_path})"
+    )

--- a/v3/server/tests/e2e/test_s3_kill_recover.py
+++ b/v3/server/tests/e2e/test_s3_kill_recover.py
@@ -1,0 +1,93 @@
+"""S3 "hub killed mid-writes -> restart -> doctor verify clean" (SPEC-113).
+
+One layer above SPEC-102's own engine-level kill test
+(``tests/vault/test_kill_safety.py``): here the *hub process* is SIGKILLed
+while a burst of writes is arriving over real streamable HTTP through the
+gateway, then a fresh hub is started against the same vault directory.
+Afterwards: every acknowledged write is present and readable through the
+new hub, and a doctor pass directly against the vault reports no fatal
+findings (the same tolerances the engine-level test uses — a still-held
+git lock alone is not fatal, crash recovery on open clears it).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from simulator import SimulatedClient
+
+if TYPE_CHECKING:
+    from conftest import HubFactory
+
+pytestmark = pytest.mark.anyio
+
+_BURST_WORKER = Path(__file__).parent / "support" / "mcp_write_burst.py"
+_BURST_DURATION_SECONDS = 3.0
+
+
+async def test_kill_mid_write_burst_then_restart_recovers_cleanly(
+    golden_work_vault: Path, hub_factory: HubFactory, tmp_path: Path
+) -> None:
+    from palaia_hub.vault import VaultDoctor, VaultEngine
+
+    hub1 = hub_factory(vault_dir=golden_work_vault, log_name="hub1.log")
+
+    progress_path = tmp_path / "progress.jsonl"
+    progress_path.touch()
+    worker = subprocess.Popen(  # noqa: S603 - fixed argv, no shell
+        [
+            sys.executable,
+            str(_BURST_WORKER),
+            "--url",
+            hub1.profile_url(),
+            "--progress",
+            str(progress_path),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        time.sleep(_BURST_DURATION_SECONDS)
+        hub1.kill()
+    finally:
+        try:
+            worker.wait(timeout=10)
+        except subprocess.TimeoutExpired:  # pragma: no cover - defensive
+            worker.kill()
+            worker.wait(timeout=5)
+
+    acknowledged = [
+        json.loads(line) for line in progress_path.read_text(encoding="utf-8").splitlines() if line
+    ]
+    assert acknowledged, "worker produced no acknowledged writes before the kill"
+
+    # Restart a fresh hub against the SAME vault directory.
+    hub2 = hub_factory(vault_dir=golden_work_vault, log_name="hub2.log")
+
+    async with SimulatedClient(hub2.profile_url(), client_name="recover-check") as client:
+        for record in acknowledged:
+            result = await client.call_tool_ok(
+                "work_memory_read", {"permalink": record["permalink"]}
+            )
+            assert result.structured is not None
+            assert result.structured["title"] == record["title"], (
+                f"acknowledged write {record['permalink']!r} did not survive the kill"
+            )
+
+    hub2.stop()
+
+    # Doctor pass directly against the vault: no fatal findings, same
+    # tolerance the engine-level kill test uses (a held git lock alone is
+    # not fatal — crash recovery on open already cleared it by this point).
+    engine = VaultEngine(golden_work_vault, "work")
+    await engine.open()
+    findings = await VaultDoctor(engine).verify()
+    fatal = [f for f in findings if f.severity == "error" and f.code != "git-lock-held"]
+    assert fatal == [], fatal
+    await engine.close()

--- a/v3/server/tests/e2e/test_s4_rebuild.py
+++ b/v3/server/tests/e2e/test_s4_rebuild.py
@@ -1,0 +1,77 @@
+"""S4 "delete index -> reindex -> query battery identical" (SPEC-113).
+
+Format spec §10: "the index is disposable: reindex MUST reproduce identical
+query results from files alone". This SPEC's search adapter has no
+persistent index of its own yet (SPEC-104 is not merged) — its "index" is
+the engine's in-memory identity catalog plus a linear scan, so this
+scenario's rebuild step is ``engine.close()`` (drops the catalog) followed
+by a fresh ``engine.open()`` (rebuilds it from files, and runs
+:meth:`~palaia_hub.vault.VaultDoctor.reindex` too, so the doctor's own
+rebuild hook is exercised, not only the catalog refresh). The assertion
+that matters is untouched by which index implementation is behind it: the
+same query battery, run through the same :class:`EngineVaultService`
+adapter the gateway uses, must return byte-for-byte identical permalink
+sets before and after.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from query_battery import CANONICAL_QUERIES
+
+from palaia_hub.gateway.wiring import EngineVaultService
+from palaia_hub.vault import VaultDoctor, VaultEngine
+
+pytestmark = pytest.mark.anyio
+
+
+class _RecordingSink:
+    """Minimal :class:`~palaia_hub.vault.ReindexSink` — just counts notes."""
+
+    def __init__(self) -> None:
+        self.paths: list[str] = []
+
+    def begin(self, vault: str) -> None:
+        self.paths = []
+
+    def emit(self, note: object) -> None:  # noqa: ANN001 - matches ReindexSink.emit(Note)
+        self.paths.append(getattr(note, "path", ""))
+
+    def finish(self) -> None:
+        pass
+
+
+async def test_reindex_reproduces_identical_query_results(golden_work_vault: Path) -> None:
+    engine = VaultEngine(golden_work_vault, "work")
+    await engine.open()
+    service = EngineVaultService(engine)
+
+    before: dict[str, set[str]] = {}
+    for query in CANONICAL_QUERIES:
+        hits = await service.search(query, limit=100)
+        before[query] = {hit.permalink for hit in hits}
+    note_count_before = len(engine.catalog)
+
+    # Simulate "delete the index": drop the in-memory catalog and the
+    # doctor's own rebuild hook, then rebuild everything from files alone.
+    await engine.close()
+    engine = VaultEngine(golden_work_vault, "work")
+    await engine.open()
+    reindexed = await engine.reindex(_RecordingSink())
+    assert reindexed == note_count_before
+
+    rebuilt_service = EngineVaultService(engine)
+    after: dict[str, set[str]] = {}
+    for query in CANONICAL_QUERIES:
+        hits = await rebuilt_service.search(query, limit=100)
+        after[query] = {hit.permalink for hit in hits}
+
+    assert after == before
+
+    findings = await VaultDoctor(engine).verify()
+    fatal = [f for f in findings if f.severity == "error"]
+    assert fatal == [], fatal
+
+    await engine.close()

--- a/v3/server/tests/e2e/test_s5_fresh_install.py
+++ b/v3/server/tests/e2e/test_s5_fresh_install.py
@@ -1,0 +1,71 @@
+"""S5 "fresh-install flow: container up -> wizard API -> first note"
+(SPEC-113).
+
+**Honest scope note:** the dashboard wizard and its HTTP config API are
+SPEC-109/SPEC-110 — not merged as of this SPEC. There is no
+"POST /api/wizard/vaults" or similar to drive yet. What this test exercises
+is everything that IS real and merged today, wired exactly the way the
+eventual wizard would have to wire it:
+
+1. A completely empty directory (no vault, no ``.git``, no notes) —
+   "container up" for someone who has never run palaia before.
+2. The hub process starts and opens that directory as a brand-new vault
+   (``VaultEngine.open(create=True)``, run inside ``support/hub_server.py``
+   exactly like every other scenario here) — the same call a future wizard
+   endpoint would make on "create my first vault", just not reachable over
+   HTTP as a config API yet.
+3. ``/api/health`` reports ready.
+4. The first note goes in through the real gateway, over real streamable
+   HTTP — the actual headline moment ("first note") the fresh-install story
+   is about.
+
+When SPEC-110 lands a real wizard API, this test is the natural place to
+extend step 2 into an actual HTTP call instead of a fresh directory handed
+straight to the hub.
+"""
+
+from __future__ import annotations
+
+import urllib.request
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from simulator import SimulatedClient
+
+if TYPE_CHECKING:
+    from conftest import HubFactory
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_fresh_install_creates_first_vault_and_takes_first_note(
+    tmp_path: Path, hub_factory: HubFactory
+) -> None:
+    fresh_vault_dir = tmp_path / "brand-new-vault"
+    assert not fresh_vault_dir.exists(), "this must start as a truly empty install"
+
+    hub = hub_factory(vault_dir=fresh_vault_dir, vault_key="work", vault_name="work")
+
+    # /api/health and /api/info are real, merged (SPEC-101) surfaces a
+    # wizard's landing page would poll before offering "create your first
+    # vault".
+    with urllib.request.urlopen(f"http://127.0.0.1:{hub.port}/api/info", timeout=2) as resp:
+        assert resp.status == 200
+
+    # The vault now exists on disk, git-initialized, with its manifest —
+    # VaultEngine.open(create=True) did the "wizard's" job.
+    assert (fresh_vault_dir / ".git").is_dir()
+    assert (fresh_vault_dir / "meta" / "vault.md").is_file()
+
+    async with SimulatedClient(hub.profile_url(), client_name="fresh-install-check") as client:
+        write_result = await client.call_tool_ok(
+            "work_memory_write",
+            {"title": "My First Note", "body": "the fresh-install headline moment"},
+        )
+        assert "My First Note" in write_result.text
+
+        read_result = await client.call_tool_ok(
+            "work_memory_read", {"permalink": "my-first-note"}
+        )
+        assert "the fresh-install headline moment" in read_result.text

--- a/v3/server/tests/e2e/test_tool_schema_drift.py
+++ b/v3/server/tests/e2e/test_tool_schema_drift.py
@@ -1,0 +1,67 @@
+"""Golden ``tools/list`` snapshot — SPEC-113 acceptance criterion: "harness
+fails loudly on tool-schema drift".
+
+Compares the memory tool family's live names, descriptions, input schemas
+and behavior annotations against a committed snapshot
+(``golden_tools_snapshot.json``). A deliberate tool-surface change (a
+renamed parameter, a dropped annotation, a reworded description) MUST show
+up here as a failing assertion with the exact diff, not as a silent
+behavior change discovered later by some other SPEC's tests.
+
+Regenerate the snapshot after an intentional change with::
+
+    uv run python -c "
+    import asyncio, json
+    from fastmcp import Client
+    from palaia_hub.gateway.config import VaultMountConfig
+    from palaia_hub.gateway.fake_vault import FakeVaultService
+    from palaia_hub.gateway.memory_tools import build_vault_server
+    from simulator import tool_schema_snapshot
+
+    async def main():
+        server = build_vault_server(
+            VaultMountConfig(key='work', name='work', purpose='A palaia memory vault.'),
+            FakeVaultService(),
+        )
+        async with Client(server) as client:
+            tools = await client.list_tools()
+        print(json.dumps(tool_schema_snapshot(tools), indent=2, sort_keys=True))
+    "
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastmcp import Client
+from simulator import tool_schema_snapshot
+
+from palaia_hub.gateway.config import VaultMountConfig
+from palaia_hub.gateway.fake_vault import FakeVaultService
+from palaia_hub.gateway.memory_tools import build_vault_server
+
+SNAPSHOT_PATH = Path(__file__).parent / "golden_tools_snapshot.json"
+
+
+@pytest.mark.anyio
+async def test_memory_tool_family_matches_golden_schema_snapshot() -> None:
+    config = VaultMountConfig(key="work", name="work", purpose="A palaia memory vault.")
+    server = build_vault_server(config, FakeVaultService())
+    async with Client(server) as client:
+        tools = await client.list_tools()
+
+    live = tool_schema_snapshot(tools)
+    golden = json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
+
+    assert set(live) == set(golden), (
+        f"tool surface drifted: added {set(live) - set(golden)}, "
+        f"removed {set(golden) - set(live)}. If intentional, regenerate "
+        f"{SNAPSHOT_PATH.name} (see this test module's docstring)."
+    )
+    for name in golden:
+        assert live[name] == golden[name], (
+            f"tool {name!r} schema/description/annotations drifted from the "
+            f"golden snapshot. If intentional, regenerate {SNAPSHOT_PATH.name}."
+        )

--- a/v3/server/tests/e2e/test_wiring.py
+++ b/v3/server/tests/e2e/test_wiring.py
@@ -1,0 +1,106 @@
+"""Unit tests for :class:`~palaia_hub.gateway.wiring.EngineVaultService`.
+
+Not a scenario — a focused check that the adapter's translation of every
+:class:`~palaia_hub.gateway.vault_protocol.VaultService` method onto a real
+:class:`~palaia_hub.vault.VaultEngine` behaves like the fake one the memory
+tool family was originally tested against, so SPEC-105's existing
+``test_memory_tools.py``-style expectations still hold once the real vault
+is behind the tools.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from palaia_hub.gateway.vault_protocol import VaultServiceError
+from palaia_hub.gateway.wiring import EngineVaultService
+from palaia_hub.vault import VaultEngine
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture
+async def service(tmp_path: Path) -> EngineVaultService:
+    engine = VaultEngine(tmp_path / "work", "work")
+    await engine.open(purpose="test vault")
+    return EngineVaultService(engine)
+
+
+async def test_write_then_read_round_trips(service: EngineVaultService) -> None:
+    note = await service.write("My First Note", "hello world", folder="notes", tags=["a", "b"])
+    assert note.permalink == "notes/my-first-note"
+    assert note.folder == "notes"
+    assert note.tags == ["a", "b"]
+
+    read_back = await service.read(note.permalink)
+    assert read_back.body.strip() == "hello world"
+    assert read_back.title == "My First Note"
+
+
+async def test_write_duplicate_title_in_same_folder_raises_service_error(
+    service: EngineVaultService,
+) -> None:
+    await service.write("Dup", "one")
+    with pytest.raises(VaultServiceError):
+        await service.write("Dup", "two")
+
+
+async def test_edit_replace_and_append(service: EngineVaultService) -> None:
+    note = await service.write("Editable", "line one")
+    replaced = await service.edit(note.permalink, body="new body")
+    assert replaced.body.strip() == "new body"
+    appended = await service.edit(note.permalink, append="line two")
+    assert appended.body.strip() == "new body\nline two"
+
+
+async def test_edit_updates_tags(service: EngineVaultService) -> None:
+    note = await service.write("Tagged", "body", tags=["x"])
+    updated = await service.edit(note.permalink, tags=["y", "z"])
+    assert updated.tags == ["y", "z"]
+
+
+async def test_move_preserves_permalink(service: EngineVaultService) -> None:
+    note = await service.write("Movable", "body", folder="a")
+    moved = await service.move(note.permalink, "b")
+    assert moved.permalink == note.permalink
+    assert moved.folder == "b"
+
+
+async def test_delete_returns_true_then_false(service: EngineVaultService) -> None:
+    note = await service.write("Deletable", "body")
+    assert await service.delete(note.permalink) is True
+    assert await service.delete(note.permalink) is False
+
+
+async def test_list_notes_scoped_to_folder(service: EngineVaultService) -> None:
+    await service.write("In A", "body", folder="a")
+    await service.write("In B", "body", folder="b")
+    only_a = await service.list_notes(folder="a")
+    assert [n.permalink for n in only_a] == ["a/in-a"]
+    everything = await service.list_notes()
+    assert {n.permalink for n in everything} == {"a/in-a", "b/in-b"}
+
+
+async def test_recent_activity_orders_most_recent_first(service: EngineVaultService) -> None:
+    await service.write("Older", "body")
+    await service.write("Newer", "body")
+    recent = await service.recent_activity(limit=2)
+    assert [n.title for n in recent] == ["Newer", "Older"]
+
+
+async def test_read_missing_permalink_raises_service_error(service: EngineVaultService) -> None:
+    with pytest.raises(VaultServiceError):
+        await service.read("does/not-exist")
+
+
+async def test_search_finds_body_text(service: EngineVaultService) -> None:
+    await service.write("Findable", "a distinctive phrase lives here")
+    hits = await service.search("distinctive phrase")
+    assert [h.permalink for h in hits] == ["findable"]

--- a/v3/server/tests/fixtures/golden-vault/personal/inbox/book-club-pick-for-next-month.md
+++ b/v3/server/tests/fixtures/golden-vault/personal/inbox/book-club-pick-for-next-month.md
@@ -1,0 +1,16 @@
+---
+title: Book club pick for next month
+permalink: inbox/book-club-pick-for-next-month
+type: capture
+tags: [inbox]
+status: uncurated
+capture_id: cap-4a89e01f76
+origin: { provider: anthropic, client: claude-code, session: s-4471 }
+created: 2026-08-21T09:15:00Z
+---
+
+One sentence: what this capture is about.
+
+- [entity] Reading List 2026
+- [why] Ines is hosting and wants a shorter book this time.
+- [raw] Ines proposed a shorter novel for next month's meeting.

--- a/v3/server/tests/fixtures/golden-vault/personal/inbox/contractor-quote-for-kitchen.md
+++ b/v3/server/tests/fixtures/golden-vault/personal/inbox/contractor-quote-for-kitchen.md
@@ -1,0 +1,16 @@
+---
+title: Contractor quote for kitchen
+permalink: inbox/contractor-quote-for-kitchen
+type: capture
+tags: [inbox]
+status: uncurated
+capture_id: cap-c02de817a3
+origin: { provider: anthropic, client: claude-code, session: s-4471 }
+created: 2026-08-21T09:15:00Z
+---
+
+One sentence: what this capture is about.
+
+- [entity] Home Renovation
+- [why] Jonah needs the quote before approving the renovation.
+- [raw] Contractor quoted six weeks for the kitchen, pending permit approval.

--- a/v3/server/tests/fixtures/golden-vault/personal/inbox/marathon-shoe-recommendation.md
+++ b/v3/server/tests/fixtures/golden-vault/personal/inbox/marathon-shoe-recommendation.md
@@ -1,0 +1,16 @@
+---
+title: Marathon shoe recommendation
+permalink: inbox/marathon-shoe-recommendation
+type: capture
+tags: [inbox]
+status: uncurated
+capture_id: cap-6f13ad2c90
+origin: { provider: anthropic, client: claude-code, session: s-4471 }
+created: 2026-08-21T09:15:00Z
+---
+
+One sentence: what this capture is about.
+
+- [entity] Marathon Training
+- [why] Hassan's recommendation matched two reviews I trust.
+- [raw] Hassan recommended the same trail shoe model I saw reviewed twice this month.

--- a/v3/server/tests/fixtures/golden-vault/personal/meta/vault.md
+++ b/v3/server/tests/fixtures/golden-vault/personal/meta/vault.md
@@ -1,0 +1,12 @@
+---
+title: Vault
+permalink: meta/vault
+type: meta
+vault_format: 1
+name: personal
+purpose: One person's own notes — private by default.
+---
+
+One person's own notes.
+
+This file is the vault manifest.

--- a/v3/server/tests/fixtures/golden-vault/personal/notes/apartment-wifi-password-location.md
+++ b/v3/server/tests/fixtures/golden-vault/personal/notes/apartment-wifi-password-location.md
@@ -1,0 +1,8 @@
+---
+title: Apartment Wifi Password Location
+permalink: notes/apartment-wifi-password-location
+type: note
+tags: [personal]
+---
+
+Written on the router, not here.

--- a/v3/server/tests/fixtures/golden-vault/personal/notes/car-maintenance-log.md
+++ b/v3/server/tests/fixtures/golden-vault/personal/notes/car-maintenance-log.md
@@ -1,0 +1,9 @@
+---
+title: Car Maintenance Log
+permalink: notes/car-maintenance-log
+type: note
+tags: [personal]
+---
+
+- [service] Oil change every 8,000 km
+- [service] Tire rotation with each oil change

--- a/v3/server/tests/fixtures/golden-vault/personal/notes/favorite-recipes.md
+++ b/v3/server/tests/fixtures/golden-vault/personal/notes/favorite-recipes.md
@@ -1,0 +1,10 @@
+---
+title: Favorite Recipes
+permalink: notes/favorite-recipes
+type: note
+tags: [personal]
+---
+
+A running list, nothing fancy.
+
+- [dish] Weeknight pasta

--- a/v3/server/tests/fixtures/golden-vault/personal/notes/gift-ideas.md
+++ b/v3/server/tests/fixtures/golden-vault/personal/notes/gift-ideas.md
@@ -1,0 +1,9 @@
+---
+title: Gift Ideas
+permalink: notes/gift-ideas
+type: note
+tags: [personal]
+---
+
+- [idea] Hassan — trail running socks
+- [idea] Ines — a book from her list

--- a/v3/server/tests/fixtures/golden-vault/personal/people/grace-kim.md
+++ b/v3/server/tests/fixtures/golden-vault/personal/people/grace-kim.md
@@ -1,0 +1,8 @@
+---
+title: Grace Kim
+permalink: people/grace-kim
+type: person
+tags: [personal]
+---
+
+Former manager, now a mentor.

--- a/v3/server/tests/fixtures/golden-vault/personal/people/hassan-malik.md
+++ b/v3/server/tests/fixtures/golden-vault/personal/people/hassan-malik.md
@@ -1,0 +1,8 @@
+---
+title: Hassan Malik
+permalink: people/hassan-malik
+type: person
+tags: [personal]
+---
+
+Running buddy.

--- a/v3/server/tests/fixtures/golden-vault/personal/people/ines-duarte.md
+++ b/v3/server/tests/fixtures/golden-vault/personal/people/ines-duarte.md
@@ -1,0 +1,8 @@
+---
+title: Ines Duarte
+permalink: people/ines-duarte
+type: person
+tags: [personal]
+---
+
+Book club organizer.

--- a/v3/server/tests/fixtures/golden-vault/personal/people/jonah-weiss.md
+++ b/v3/server/tests/fixtures/golden-vault/personal/people/jonah-weiss.md
@@ -1,0 +1,8 @@
+---
+title: Jonah Weiss
+permalink: people/jonah-weiss
+type: person
+tags: [personal]
+---
+
+Landlord.

--- a/v3/server/tests/fixtures/golden-vault/personal/projects/home-renovation.md
+++ b/v3/server/tests/fixtures/golden-vault/personal/projects/home-renovation.md
@@ -1,0 +1,10 @@
+---
+title: Home Renovation
+permalink: projects/home-renovation
+type: project
+tags: [personal]
+---
+
+Kitchen and bathroom, spring 2027.
+
+- relates_to [[Jonah Weiss]]

--- a/v3/server/tests/fixtures/golden-vault/personal/projects/marathon-training.md
+++ b/v3/server/tests/fixtures/golden-vault/personal/projects/marathon-training.md
@@ -1,0 +1,10 @@
+---
+title: Marathon Training
+permalink: projects/marathon-training
+type: project
+tags: [personal]
+---
+
+Training for the fall marathon.
+
+- relates_to [[Hassan Malik]]

--- a/v3/server/tests/fixtures/golden-vault/personal/projects/reading-list-2026.md
+++ b/v3/server/tests/fixtures/golden-vault/personal/projects/reading-list-2026.md
@@ -1,0 +1,10 @@
+---
+title: Reading List 2026
+permalink: projects/reading-list-2026
+type: project
+tags: [personal]
+---
+
+Books to read this year.
+
+- relates_to [[Ines Duarte]]

--- a/v3/server/tests/fixtures/golden-vault/personal/projects/side-project-notes.md
+++ b/v3/server/tests/fixtures/golden-vault/personal/projects/side-project-notes.md
@@ -1,0 +1,10 @@
+---
+title: Side Project Notes
+permalink: projects/side-project-notes
+type: project
+tags: [personal]
+---
+
+A small app idea, evenings only.
+
+- relates_to [[Grace Kim]]

--- a/v3/server/tests/fixtures/golden-vault/personal/rules/budget-rule.md
+++ b/v3/server/tests/fixtures/golden-vault/personal/rules/budget-rule.md
@@ -1,0 +1,8 @@
+---
+title: Budget Rule
+permalink: rules/budget-rule
+type: rule
+tags: [personal]
+---
+
+- [rule] Review the budget on the first of the month.

--- a/v3/server/tests/fixtures/golden-vault/personal/rules/weeknight-cooking-rule.md
+++ b/v3/server/tests/fixtures/golden-vault/personal/rules/weeknight-cooking-rule.md
@@ -1,0 +1,8 @@
+---
+title: Weeknight Cooking Rule
+permalink: rules/weeknight-cooking-rule
+type: rule
+tags: [personal]
+---
+
+- [rule] Nothing that takes longer than 30 minutes on a weeknight.

--- a/v3/server/tests/fixtures/golden-vault/work/decisions/adopt-fastmcp.md
+++ b/v3/server/tests/fixtures/golden-vault/work/decisions/adopt-fastmcp.md
@@ -1,0 +1,10 @@
+---
+title: Adopt FastMCP
+permalink: decisions/adopt-fastmcp
+type: decision
+tags: [adr]
+---
+
+The gateway is built on FastMCP 3.x rather than a hand-rolled streamable-HTTP server.
+
+- decided_in [[API Gateway]]

--- a/v3/server/tests/fixtures/golden-vault/work/decisions/files-are-truth.md
+++ b/v3/server/tests/fixtures/golden-vault/work/decisions/files-are-truth.md
@@ -1,0 +1,10 @@
+---
+title: Files Are Truth
+permalink: decisions/files-are-truth
+type: decision
+tags: [adr]
+---
+
+Everything not derivable from the vault's plain Markdown files is not vault state — no hidden database of record.
+
+- decided_in [[Vault Engine]]

--- a/v3/server/tests/fixtures/golden-vault/work/decisions/mit-license.md
+++ b/v3/server/tests/fixtures/golden-vault/work/decisions/mit-license.md
@@ -1,0 +1,8 @@
+---
+title: MIT License
+permalink: decisions/mit-license
+type: decision
+tags: [adr]
+---
+
+palaia v3 ships under the MIT license.

--- a/v3/server/tests/fixtures/golden-vault/work/decisions/physical-vault-isolation.md
+++ b/v3/server/tests/fixtures/golden-vault/work/decisions/physical-vault-isolation.md
@@ -1,0 +1,10 @@
+---
+title: Physical Vault Isolation
+permalink: decisions/physical-vault-isolation
+type: decision
+tags: [adr]
+---
+
+Two vaults never share storage: no nested roots, no shared index.
+
+- decided_in [[Vault Engine]]

--- a/v3/server/tests/fixtures/golden-vault/work/decisions/use-sqlite-for-index.md
+++ b/v3/server/tests/fixtures/golden-vault/work/decisions/use-sqlite-for-index.md
@@ -1,0 +1,10 @@
+---
+title: Use SQLite For Index
+permalink: decisions/use-sqlite-for-index
+type: decision
+tags: [adr]
+---
+
+The hybrid search index is SQLite (FTS5 + a small vector table), not a separate service — it is disposable and rebuilt from files.
+
+- decided_in [[Vault Engine]]

--- a/v3/server/tests/fixtures/golden-vault/work/decisions/warn-first-parsing.md
+++ b/v3/server/tests/fixtures/golden-vault/work/decisions/warn-first-parsing.md
@@ -1,0 +1,10 @@
+---
+title: Warn First Parsing
+permalink: decisions/warn-first-parsing
+type: decision
+tags: [adr]
+---
+
+The parser never rejects user content; anything that fails a rule degrades to plain Markdown plus a machine-readable warning.
+
+- relates_to [[Vault Engine]]

--- a/v3/server/tests/fixtures/golden-vault/work/embeds/cycle-a.md
+++ b/v3/server/tests/fixtures/golden-vault/work/embeds/cycle-a.md
@@ -1,0 +1,10 @@
+---
+title: Cycle A
+permalink: embeds/cycle-a
+type: note
+tags: [embed-test]
+---
+
+Embeds its own cycle partner, deliberately.
+
+![[Cycle B]]

--- a/v3/server/tests/fixtures/golden-vault/work/embeds/cycle-b.md
+++ b/v3/server/tests/fixtures/golden-vault/work/embeds/cycle-b.md
@@ -1,0 +1,10 @@
+---
+title: Cycle B
+permalink: embeds/cycle-b
+type: note
+tags: [embed-test]
+---
+
+Embeds its own cycle partner, deliberately.
+
+![[Cycle A]]

--- a/v3/server/tests/fixtures/golden-vault/work/glossary/base-rate.md
+++ b/v3/server/tests/fixtures/golden-vault/work/glossary/base-rate.md
@@ -1,0 +1,8 @@
+---
+title: Base Rate
+permalink: glossary/base-rate
+type: note
+tags: [glossary]
+---
+
+- [rate-limit] 100 req/min ^rate-limit

--- a/v3/server/tests/fixtures/golden-vault/work/glossary/pricing-summary.md
+++ b/v3/server/tests/fixtures/golden-vault/work/glossary/pricing-summary.md
@@ -1,0 +1,10 @@
+---
+title: Pricing Summary
+permalink: glossary/pricing-summary
+type: note
+tags: [glossary]
+---
+
+One level further out, still resolves at read time.
+
+![[Pricing]]

--- a/v3/server/tests/fixtures/golden-vault/work/glossary/pricing.md
+++ b/v3/server/tests/fixtures/golden-vault/work/glossary/pricing.md
@@ -1,0 +1,10 @@
+---
+title: Pricing
+permalink: glossary/pricing
+type: note
+tags: [glossary]
+---
+
+Current pricing embeds the shared rate.
+
+![[Base Rate#^rate-limit]]

--- a/v3/server/tests/fixtures/golden-vault/work/inbox/curator-retry-budget.md
+++ b/v3/server/tests/fixtures/golden-vault/work/inbox/curator-retry-budget.md
@@ -1,0 +1,16 @@
+---
+title: Curator retry budget
+permalink: inbox/curator-retry-budget
+type: capture
+tags: [inbox]
+status: uncurated
+capture_id: cap-7b21d94ee1
+origin: { provider: anthropic, client: claude-code, session: s-9021 }
+created: 2026-08-20T14:30:00Z
+---
+
+One sentence: what this capture is about.
+
+- [entity] Curator
+- [why] Three retries balances noisy transient failures against runaway apply loops.
+- [raw] Curator apply attempts cap at 3 before status flips to curation-failed.

--- a/v3/server/tests/fixtures/golden-vault/work/inbox/dashboard-color-contrast-note.md
+++ b/v3/server/tests/fixtures/golden-vault/work/inbox/dashboard-color-contrast-note.md
@@ -1,0 +1,16 @@
+---
+title: Dashboard color contrast note
+permalink: inbox/dashboard-color-contrast-note
+type: capture
+tags: [inbox]
+status: uncurated
+capture_id: cap-0a4f6e9b12
+origin: { provider: anthropic, client: claude-code, session: s-9021 }
+created: 2026-08-20T14:30:00Z
+---
+
+One sentence: what this capture is about.
+
+- [entity] Dashboard
+- [why] AA contrast is the accessibility bar for the wizard.
+- [raw] Body text must hit 4.5:1 contrast against its background.

--- a/v3/server/tests/fixtures/golden-vault/work/inbox/mit-license-file-location.md
+++ b/v3/server/tests/fixtures/golden-vault/work/inbox/mit-license-file-location.md
@@ -1,0 +1,16 @@
+---
+title: MIT license file location
+permalink: inbox/mit-license-file-location
+type: capture
+tags: [inbox]
+status: uncurated
+capture_id: cap-2e77f0a9d3
+origin: { provider: anthropic, client: claude-code, session: s-9021 }
+created: 2026-08-20T14:30:00Z
+---
+
+One sentence: what this capture is about.
+
+- [entity] MIT License
+- [why] Tooling that scans for LICENSE at the repo root should find v3's too.
+- [raw] v3 carries its own LICENSE pointer alongside the root one.

--- a/v3/server/tests/fixtures/golden-vault/work/inbox/rate-limit-decision-from-pr-review.md
+++ b/v3/server/tests/fixtures/golden-vault/work/inbox/rate-limit-decision-from-pr-review.md
@@ -1,0 +1,17 @@
+---
+title: Rate limit decision from PR review
+permalink: inbox/rate-limit-decision-from-pr-review
+type: capture
+tags: [inbox]
+status: uncurated
+capture_id: cap-3f9a1c02d4
+origin: { provider: anthropic, client: claude-code, session: s-9021 }
+created: 2026-08-20T14:30:00Z
+---
+
+One sentence: what this capture is about.
+
+- [entity] API Gateway
+- [why] The limit was chosen deliberately; future work will trip over it otherwise.
+- [raw] We capped ingest at 100 req/min because the embed queue saturates above that; raising it requires batching first.
+- [source] PR #88 review, cwendler, 2026-08-22

--- a/v3/server/tests/fixtures/golden-vault/work/inbox/recall-context-budget.md
+++ b/v3/server/tests/fixtures/golden-vault/work/inbox/recall-context-budget.md
@@ -1,0 +1,16 @@
+---
+title: Recall context budget
+permalink: inbox/recall-context-budget
+type: capture
+tags: [inbox]
+status: uncurated
+capture_id: cap-91be4a2c58
+origin: { provider: anthropic, client: claude-code, session: s-9021 }
+created: 2026-08-20T14:30:00Z
+---
+
+One sentence: what this capture is about.
+
+- [entity] Recall Engine
+- [why] A fixed token budget keeps assembled context predictable across clients.
+- [raw] Context assembly stops once the configured token budget is spent, ranked results first.

--- a/v3/server/tests/fixtures/golden-vault/work/inbox/watcher-debounce-window.md
+++ b/v3/server/tests/fixtures/golden-vault/work/inbox/watcher-debounce-window.md
@@ -1,0 +1,16 @@
+---
+title: Watcher debounce window
+permalink: inbox/watcher-debounce-window
+type: capture
+tags: [inbox]
+status: uncurated
+capture_id: cap-5d8c31a704
+origin: { provider: anthropic, client: claude-code, session: s-9021 }
+created: 2026-08-20T14:30:00Z
+---
+
+One sentence: what this capture is about.
+
+- [entity] Vault Engine
+- [why] Editors write in bursts; a fixed debounce avoids reindexing mid-save.
+- [raw] The watcher debounces external-change batches by 300ms by default.

--- a/v3/server/tests/fixtures/golden-vault/work/meta/vault.md
+++ b/v3/server/tests/fixtures/golden-vault/work/meta/vault.md
@@ -1,0 +1,12 @@
+---
+title: Vault
+permalink: meta/vault
+type: meta
+vault_format: 1
+name: work
+purpose: Team knowledge for the palaia project — decisions, conventions, gotchas.
+---
+
+Team knowledge for the palaia project.
+
+This file is the vault manifest. `name` and `purpose` are what clients see when they connect.

--- a/v3/server/tests/fixtures/golden-vault/work/people/alice-novak.md
+++ b/v3/server/tests/fixtures/golden-vault/work/people/alice-novak.md
@@ -1,0 +1,11 @@
+---
+title: Alice Novak
+permalink: people/alice-novak
+type: person
+tags: [team]
+---
+
+Vault engine lead. Owns SPEC-102 and the doctor.
+
+- [role] Vault engine lead
+- works_on [[API Gateway]]

--- a/v3/server/tests/fixtures/golden-vault/work/people/bob-chen.md
+++ b/v3/server/tests/fixtures/golden-vault/work/people/bob-chen.md
@@ -1,0 +1,11 @@
+---
+title: Bob Chen
+permalink: people/bob-chen
+type: person
+tags: [team]
+---
+
+Gateway maintainer. Owns SPEC-105 and the MCP tool family.
+
+- [role] Gateway maintainer
+- works_on [[API Gateway]]

--- a/v3/server/tests/fixtures/golden-vault/work/people/carla-reyes.md
+++ b/v3/server/tests/fixtures/golden-vault/work/people/carla-reyes.md
@@ -1,0 +1,11 @@
+---
+title: Carla Reyes
+permalink: people/carla-reyes
+type: person
+tags: [team]
+---
+
+Dashboard designer. Owns the UX north star.
+
+- [role] Dashboard designer
+- works_on [[API Gateway]]

--- a/v3/server/tests/fixtures/golden-vault/work/people/deepa-iyer.md
+++ b/v3/server/tests/fixtures/golden-vault/work/people/deepa-iyer.md
@@ -1,0 +1,11 @@
+---
+title: Deepa Iyer
+permalink: people/deepa-iyer
+type: person
+tags: [team]
+---
+
+Curator author. Owns Phase-2 policy design.
+
+- [role] Curator author
+- works_on [[API Gateway]]

--- a/v3/server/tests/fixtures/golden-vault/work/people/evan-brooks.md
+++ b/v3/server/tests/fixtures/golden-vault/work/people/evan-brooks.md
@@ -1,0 +1,11 @@
+---
+title: Evan Brooks
+permalink: people/evan-brooks
+type: person
+tags: [team]
+---
+
+Release manager. Owns packaging and CI.
+
+- [role] Release manager
+- works_on [[API Gateway]]

--- a/v3/server/tests/fixtures/golden-vault/work/people/farah-al-sayed.md
+++ b/v3/server/tests/fixtures/golden-vault/work/people/farah-al-sayed.md
@@ -1,0 +1,11 @@
+---
+title: Farah Al-Sayed
+permalink: people/farah-al-sayed
+type: person
+tags: [team]
+---
+
+Recall engine lead. Owns SPEC-106.
+
+- [role] Recall engine lead
+- works_on [[API Gateway]]

--- a/v3/server/tests/fixtures/golden-vault/work/processes/incident-response.md
+++ b/v3/server/tests/fixtures/golden-vault/work/processes/incident-response.md
@@ -1,0 +1,12 @@
+---
+title: Incident Response
+permalink: processes/incident-response
+type: process
+tags: [runbook]
+---
+
+1. Kill the hub if it is corrupting data.
+2. Restart it.
+3. Run the doctor before trusting the vault again.
+
+- depends_on [[Vault Doctor Runbook]]

--- a/v3/server/tests/fixtures/golden-vault/work/processes/onboarding-a-new-client.md
+++ b/v3/server/tests/fixtures/golden-vault/work/processes/onboarding-a-new-client.md
@@ -1,0 +1,12 @@
+---
+title: Onboarding A New Client
+permalink: processes/onboarding-a-new-client
+type: process
+tags: [runbook]
+---
+
+1. Pick a profile.
+2. Add the MCP endpoint URL.
+3. Round-trip a write and a search.
+
+- depends_on [[API Gateway]]

--- a/v3/server/tests/fixtures/golden-vault/work/processes/release-process.md
+++ b/v3/server/tests/fixtures/golden-vault/work/processes/release-process.md
@@ -1,0 +1,12 @@
+---
+title: Release Process
+permalink: processes/release-process
+type: process
+tags: [runbook]
+---
+
+1. Cut a branch.
+2. Run the full verification suite.
+3. Tag and publish.
+
+- part_of [[Event Bus]]

--- a/v3/server/tests/fixtures/golden-vault/work/processes/vault-doctor-runbook.md
+++ b/v3/server/tests/fixtures/golden-vault/work/processes/vault-doctor-runbook.md
@@ -1,0 +1,12 @@
+---
+title: Vault Doctor Runbook
+permalink: processes/vault-doctor-runbook
+type: process
+tags: [runbook]
+---
+
+1. Run `verify()`.
+2. Review findings.
+3. Run `repair()` for the safe ones.
+
+- depends_on [[Vault Engine]]

--- a/v3/server/tests/fixtures/golden-vault/work/projects/api-gateway.md
+++ b/v3/server/tests/fixtures/golden-vault/work/projects/api-gateway.md
@@ -1,0 +1,11 @@
+---
+title: API Gateway
+permalink: projects/api-gateway
+type: project
+tags: [project]
+---
+
+The MCP gateway that mounts vault tool families per profile.
+
+- owned_by [[Bob Chen]]
+- depends_on [[Vault Engine]]

--- a/v3/server/tests/fixtures/golden-vault/work/projects/curator.md
+++ b/v3/server/tests/fixtures/golden-vault/work/projects/curator.md
@@ -1,0 +1,11 @@
+---
+title: Curator
+permalink: projects/curator
+type: project
+tags: [project]
+---
+
+Headless maintenance runs proposing fixes into review/.
+
+- owned_by [[Deepa Iyer]]
+- depends_on [[Recall Engine]]

--- a/v3/server/tests/fixtures/golden-vault/work/projects/dashboard.md
+++ b/v3/server/tests/fixtures/golden-vault/work/projects/dashboard.md
@@ -1,0 +1,10 @@
+---
+title: Dashboard
+permalink: projects/dashboard
+type: project
+tags: [project]
+---
+
+The web UI: wizard, vault explorer, connect-a-client page.
+
+- owned_by [[Carla Reyes]]

--- a/v3/server/tests/fixtures/golden-vault/work/projects/event-bus.md
+++ b/v3/server/tests/fixtures/golden-vault/work/projects/event-bus.md
@@ -1,0 +1,10 @@
+---
+title: Event Bus
+permalink: projects/event-bus
+type: project
+tags: [project]
+---
+
+Typed change events feeding the dashboard's live state.
+
+- part_of [[Dashboard]]

--- a/v3/server/tests/fixtures/golden-vault/work/projects/importer-suite.md
+++ b/v3/server/tests/fixtures/golden-vault/work/projects/importer-suite.md
@@ -1,0 +1,10 @@
+---
+title: Importer Suite
+permalink: projects/importer-suite
+type: project
+tags: [project]
+---
+
+Importers for palaia v2 and basic-memory vaults.
+
+- depends_on [[Vault Engine]]

--- a/v3/server/tests/fixtures/golden-vault/work/projects/legacy-migration.md
+++ b/v3/server/tests/fixtures/golden-vault/work/projects/legacy-migration.md
@@ -1,0 +1,14 @@
+---
+title: Legacy Migration
+permalink: projects/legacy-migration
+type: project
+tags: [project, migration]
+---
+
+Migrating palaia v2 vaults into v3 format.
+
+- depends_on [[Importer Suite]]
+- blocked_by [[Q3 Roadmap]]
+- part_of [[Future Initiative]]
+
+`Q3 Roadmap` and `Future Initiative` are forward references: no note with either title exists yet anywhere in this vault. The index is expected to resolve them later if such a note ever appears, never to error now.

--- a/v3/server/tests/fixtures/golden-vault/work/projects/mcp-gateway.md
+++ b/v3/server/tests/fixtures/golden-vault/work/projects/mcp-gateway.md
@@ -1,0 +1,10 @@
+---
+title: MCP Gateway
+permalink: projects/mcp-gateway
+type: project
+tags: [project]
+---
+
+Public name for the API Gateway project when talking to users.
+
+- relates_to [[API Gateway]]

--- a/v3/server/tests/fixtures/golden-vault/work/projects/recall-engine.md
+++ b/v3/server/tests/fixtures/golden-vault/work/projects/recall-engine.md
@@ -1,0 +1,11 @@
+---
+title: Recall Engine
+permalink: projects/recall-engine
+type: project
+tags: [project]
+---
+
+Traversal and context assembly over the knowledge graph.
+
+- owned_by [[Farah Al-Sayed]]
+- depends_on [[Vault Engine]]

--- a/v3/server/tests/fixtures/golden-vault/work/projects/vault-engine.md
+++ b/v3/server/tests/fixtures/golden-vault/work/projects/vault-engine.md
@@ -1,0 +1,10 @@
+---
+title: Vault Engine
+permalink: projects/vault-engine
+type: project
+tags: [project]
+---
+
+Files-are-truth CRUD, git history, identity, the watcher and doctor.
+
+- owned_by [[Alice Novak]]

--- a/v3/server/tests/fixtures/golden-vault/work/rules/coding-style.md
+++ b/v3/server/tests/fixtures/golden-vault/work/rules/coding-style.md
@@ -1,0 +1,9 @@
+---
+title: Coding Style
+permalink: rules/coding-style
+type: rule
+tags: [rule]
+---
+
+- [rule] Prefer explicit over clever.
+- [rule | anthropic] Keep functions under 40 lines where practical.

--- a/v3/server/tests/fixtures/golden-vault/work/rules/data-retention.md
+++ b/v3/server/tests/fixtures/golden-vault/work/rules/data-retention.md
@@ -1,0 +1,8 @@
+---
+title: Data Retention
+permalink: rules/data-retention
+type: rule
+tags: [rule]
+---
+
+- [rule] Keep git history; never force-push a vault's own repo.

--- a/v3/server/tests/fixtures/golden-vault/work/rules/escalation-policy.md
+++ b/v3/server/tests/fixtures/golden-vault/work/rules/escalation-policy.md
@@ -1,0 +1,8 @@
+---
+title: Escalation Policy
+permalink: rules/escalation-policy
+type: rule
+tags: [rule]
+---
+
+- [rule] Stop and report when a SPEC's acceptance criterion cannot be met as written.

--- a/v3/server/tests/fixtures/golden-vault/work/rules/how-to-write-commit-messages.md
+++ b/v3/server/tests/fixtures/golden-vault/work/rules/how-to-write-commit-messages.md
@@ -1,0 +1,10 @@
+---
+title: How To Write Commit Messages
+permalink: rules/how-to-write-commit-messages
+type: rule
+tags: [rule]
+---
+
+- [how-to-apply] Prefer the compact form: subject line only.
+- [how-to-apply | anthropic/opus-5] Use the extended form with a one-paragraph rationale.
+- [how-to-apply | openai] Use imperative phrasing throughout.

--- a/v3/server/tests/fixtures/golden-vault/work/rules/response-length.md
+++ b/v3/server/tests/fixtures/golden-vault/work/rules/response-length.md
@@ -1,0 +1,9 @@
+---
+title: Response Length
+permalink: rules/response-length
+type: rule
+tags: [rule]
+---
+
+- [rule] Default to concise answers.
+- [rule | anthropic/sonnet-5] Expand only when asked for detail.

--- a/v3/server/tests/fixtures/golden-vault/work/rules/secrets-handling.md
+++ b/v3/server/tests/fixtures/golden-vault/work/rules/secrets-handling.md
@@ -1,0 +1,8 @@
+---
+title: Secrets Handling
+permalink: rules/secrets-handling
+type: rule
+tags: [rule]
+---
+
+- [rule] Never write API keys or tokens into a note body.

--- a/v3/server/tests/fixtures/golden-vault/work/rules/testing-standards.md
+++ b/v3/server/tests/fixtures/golden-vault/work/rules/testing-standards.md
@@ -1,0 +1,9 @@
+---
+title: Testing Standards
+permalink: rules/testing-standards
+type: rule
+tags: [rule]
+---
+
+- [rule] Every acceptance criterion gets a test that fails without the change.
+- [rule | openai] Prefer table-driven tests where the language supports them.

--- a/v3/server/tests/fixtures/golden-vault/work/rules/tool-usage-etiquette.md
+++ b/v3/server/tests/fixtures/golden-vault/work/rules/tool-usage-etiquette.md
@@ -1,0 +1,9 @@
+---
+title: Tool Usage Etiquette
+permalink: rules/tool-usage-etiquette
+type: rule
+tags: [rule]
+---
+
+- [rule] Search before writing — check whether a note already exists.
+- [rule] Read a hit's full body before deciding to edit vs. write new.


### PR DESCRIPTION
## Summary

SPEC-113: the Phase-1 exit-criterion proof machinery, plus the real
`VaultService` wiring adapter SPEC-105 deferred to this wave.

- **`palaia_hub/gateway/wiring.py`** — `EngineVaultService`, a thin
  `VaultService` adapter over the SPEC-102 `VaultEngine`. Field names mirror
  vault-format.md on both sides, so it's a pass-through: `search` is a linear
  substring scan over open notes (SPEC-104's index isn't merged yet — not in
  this SPEC's `depends_on`); everything else talks straight to the engine.
  `meta`-type notes are excluded from `search`/`list_notes`/`recent_activity`
  per format spec §6 ("excluded from normal recall").
- **Golden vault fixture** (`server/tests/fixtures/golden-vault/`): 63 notes
  across two physically isolated vaults (`work`, `personal`) — people,
  projects, decisions, rules with per-model observation variants, processes,
  a glossary embed chain plus an embed cycle pair, inbox captures per the
  §7 contract, and a forward reference (`projects/legacy-migration.md` links
  to entities that exist nowhere in the vault, per §5.2).
- **MCP client simulator** (`server/tests/e2e/simulator.py`) — a thin wrapper
  over `fastmcp.Client`'s real streamable-HTTP transport: connect, list
  tools, call a tool, and a schema snapshot helper for drift detection.
- **Scenario suite** (`server/tests/e2e/test_s{1..5}_*.py`), each a real hub
  subprocess (`support/hub_server.py`) over a disposable golden-vault copy:
  - **S1** two providers, one memory — client A writes through one profile,
    client B (different MCP client identity, different profile path
    mounting the same vault) finds and reads it. Real vault, real gateway.
  - **S2** external edit — a note written straight to disk becomes
    searchable within budget, via the real `VaultWatcher`.
  - **S3** kill/recover — a write burst over real HTTP, hub SIGKILLed
    mid-burst, restarted against the same vault dir; every acknowledged
    write survives, and a doctor pass reports no fatal findings.
  - **S4** rebuild — catalog dropped and rebuilt from files
    (`engine.reindex`), the same canonical query battery run before/after,
    asserted byte-for-byte identical (format spec §10).
  - **S5** fresh-install — **honestly scoped**: SPEC-109/110 (the wizard +
    its HTTP config API) aren't merged, so there's no wizard endpoint to
    drive yet. This exercises everything that *is* real: an empty directory
    → hub opens it as a brand-new vault (`create=True`) → health check →
    first note through the real gateway. The docstring says exactly what's
    deferred and where to extend it once SPEC-110 lands.
  - Plus a golden `tools/list` schema snapshot test (drift detection) and a
    focused unit suite for the adapter itself.
- **CI**: a dedicated `e2e` job in `v3-ci.yml` (the one root file this SPEC
  may touch), amd64, with `--basetemp` capturing every scenario's hub logs +
  vault snapshot, uploaded as a failure artifact. The existing `python`
  job's `pytest` step now excludes `server/tests/e2e` to avoid double-running
  it.

Scope: `v3/server/**`, `v3/server/tests/**`, `.github/workflows/v3-ci.yml`.
(The SPEC names `v3/tests/`, but that directory doesn't exist yet — the repo
convention established by SPEC-101/105 is `v3/server/tests/`, which is where
`pytest`'s `testpaths` already point.)

## Acceptance checklist

- [x] all five scenarios green in CI on amd64 — new dedicated `e2e` job,
      verified locally (`uv run pytest server/tests/e2e`, twice in a row for
      stability)
- [x] harness fails loudly on tool-schema drift — golden
      `golden_tools_snapshot.json` + `test_tool_schema_drift.py`
- [x] any SPEC can import the simulator + golden vault as pytest fixtures —
      `simulator.SimulatedClient`, `conftest.golden_vault_copy` /
      `golden_work_vault` / `golden_personal_vault` / `hub_factory`,
      `query_battery.py`, all plain importable modules with no test-only
      coupling
- [x] a failing scenario dumps a reproducible bundle (logs + vault +
      config) — `--basetemp` in the CI job's e2e step, uploaded on failure;
      verified locally that a run's basetemp contains each scenario's hub
      log(s) and vault directory

## Verification evidence

```
cd v3
uv sync --all-packages
uv run ruff check server        # All checks passed!
uv run mypy server/src          # Success: no issues found in 29 source files
uv run pytest server/tests -q   # 226 passed, 1 skipped, 1 warning
uv run pytest server/tests/e2e -q   # 16 passed (run twice, stable)
```

## Notes (adjacent, not in this diff)

- `EngineVaultService.search` is a linear scan, not an index — correct for
  this SPEC's scope (SPEC-104 isn't merged) but the first thing a future
  SPEC should swap in once it lands; the module docstring flags this
  explicitly.
- S3/S5 use real subprocesses and real SIGKILLs; they're a little slower
  than pure-unit tests (whole e2e dir: ~26s) but that's the point — they're
  proving the actual process, not a mock of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790097482&installation_model_id=428086&pr_number=217&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F217&signature=7d393eaa6953e91fd0d2950878e050600f7e8b69cdfc06497659753a9b16b774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->