### PR TITLE
feat(v3): SPEC-104 index, hybrid search, async embeddings

### DIFF
--- a/v3/pyproject.toml
+++ b/v3/pyproject.toml
@@ -20,6 +20,13 @@ python_version = "3.12"
 strict = true
 files = ["server/src"]
 
+# fastembed and sqlite-vec ship no py.typed marker (SPEC-104's optional
+# embedding backend and the KNN extension loader). Their surfaces are used
+# behind our own typed wrappers in palaia_hub.index.
+[[tool.mypy.overrides]]
+module = ["sqlite_vec.*", "fastembed.*"]
+ignore_missing_imports = true
+
 [tool.uv]
 package = false
 
@@ -27,7 +34,7 @@ package = false
 palaia-hub = { workspace = true }
 
 [dependency-groups]
-dev = ["pytest>=8", "ruff>=0.6", "mypy>=1.11", "palaia-hub[dev]"]
+dev = ["pytest>=8", "ruff>=0.6", "mypy>=1.11", "palaia-hub[dev,embeddings]"]
 
 [tool.pytest.ini_options]
 testpaths = ["server/tests"]

--- a/v3/server/README.md
+++ b/v3/server/README.md
@@ -115,6 +115,45 @@ PALAIA_VAULT_SCALE_WRITES=10000 uv run pytest server/tests/vault/test_performanc
 ```
 >>>>>>> claude/palaia-major-rewrite-lj5v9x
 
+## Index & hybrid search (SPEC-104)
+
+`palaia_hub.index` — the disposable projection over one vault: SQLite (WAL)
+with FTS5 over notes, observations and relations, sqlite-vec KNN over chunk
+embeddings, and metadata filters (scope, type, tags, dates, custom
+frontmatter keys). Drop the file at any time; `reindex` rebuilds it from
+files and reproduces identical query results.
+
+```python
+from palaia_hub.index import VaultIndex
+from palaia_hub.vault import EventBus, VaultEngine
+
+engine = VaultEngine(path, "work", bus=EventBus())
+await engine.open()
+index = VaultIndex(engine)      # embeddings on by default
+await index.open()              # builds, subscribes to change events, starts the embed worker
+results = await index.search("who owns the gateway?", mode="hybrid", limit=5)
+index.status()                  # notes/observations/relations + embed backlog
+```
+
+- **Modes** `fts | vector | hybrid`. Hits are addressable below note
+  granularity: an observation hit carries its synthetic permalink
+  (`<permalink>/obs/<category>/<h8>`, format spec §9.2).
+- **Embeddings are always off the write path.** SPEC-003 measured 437 ms to
+  embed a note versus 0.6 ms to FTS-index it, so a write acks once chunks are
+  written as `pending` and a background worker drains them. Any query issued
+  meanwhile answers from FTS and says so (`SearchResults.degraded`).
+- **Default model** `sentence-transformers/all-MiniLM-L6-v2`, chosen by
+  benchmark (~10x faster than `bge-small-en-v1.5` at the same 384 dims on 4
+  vCPUs). Re-measure on your hardware:
+  `uv run python -m palaia_hub.index.bench --notes 200`.
+- **Incremental** from SPEC-102's change events, including forward references:
+  `- depends_on [[Q3 Roadmap]]` stays unresolved until a note answering to
+  that name appears, then resolves without a reindex.
+- **Doctor** — `index.verify()` runs SPEC-102's checks plus file↔index drift;
+  `index.reindex()` is the rebuild-from-files path.
+- Embeddings need the `embeddings` extra (`fastembed`); without it the index
+  is FTS-only and reports why.
+
 ## Running it
 
 ```bash

--- a/v3/server/pyproject.toml
+++ b/v3/server/pyproject.toml
@@ -14,12 +14,20 @@ dependencies = [
     "fastmcp==3.4.7",
     "watchfiles>=0.22",
     "argon2-cffi>=23.1",
+    "sqlite-vec>=0.1.6",
 ]
 
 [project.scripts]
 palaia-hub = "palaia_hub.cli:main"
 
 [project.optional-dependencies]
+# Local embeddings for the SPEC-104 vector/hybrid lane. Kept an extra rather
+# than a core dependency: fastembed pulls onnxruntime plus a ~130 MB model
+# download, and the index degrades cleanly to FTS-only without it (SPEC-104
+# acceptance: "queries degrade to FTS cleanly while vectors are pending").
+embeddings = [
+    "fastembed>=0.4",
+]
 dev = [
     "pytest>=8",
     "ruff>=0.6",
@@ -49,6 +57,13 @@ select = ["E", "F", "I", "UP", "B"]
 [tool.mypy]
 python_version = "3.12"
 strict = true
+
+# fastembed and sqlite-vec ship no py.typed marker (SPEC-104's optional
+# embedding backend and the KNN extension loader). Their surfaces are used
+# behind our own typed wrappers in palaia_hub.index.
+[[tool.mypy.overrides]]
+module = ["sqlite_vec.*", "fastembed.*"]
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/v3/server/src/palaia_hub/gateway/wiring.py
+++ b/v3/server/src/palaia_hub/gateway/wiring.py
@@ -10,12 +10,12 @@ pass-through: field names already mirror ``vault-format.md`` on both sides
 no translation layer is needed beyond unpacking frontmatter and mapping
 engine exceptions to :class:`~.vault_protocol.VaultServiceError`.
 
-**Search** here is a linear substring scan over already-open notes — the
-same trade-off :class:`~.fake_vault.FakeVaultService` made, now over real
-files and frontmatter instead of an in-memory dict. SPEC-104 (the hybrid
-index) is not in this SPEC's ``depends_on`` and is not merged yet; when it
-lands, ``search`` is the one method here a future SPEC should replace with
-an index-backed query, everything else already talks to the real vault.
+**Search** is index-backed when a :class:`~palaia_hub.index.VaultIndex` is
+passed in (SPEC-104): the tool's query runs as a hybrid FTS+vector query and
+degrades to FTS while the embed backlog drains. Without an index the adapter
+keeps its original linear substring scan — SPEC-105's trade-off — so every
+caller that has not been taught about the index (and every test that wants
+search with no SQLite file on disk) still works unchanged.
 """
 
 from __future__ import annotations
@@ -23,6 +23,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, cast
 
+from palaia_hub.index import SearchFilters, VaultIndex
 from palaia_hub.vault import (
     AmbiguousReferenceError,
     ChecksumConflictError,
@@ -125,12 +126,50 @@ class EngineVaultService:
 
     The engine must already be opened (``await engine.open(...)``) — this
     adapter does not manage the engine's lifecycle, only translates calls.
+    The same goes for ``index``: pass an already-opened
+    :class:`~palaia_hub.index.VaultIndex` to get indexed + hybrid search.
     """
 
-    def __init__(self, engine: VaultEngine) -> None:
+    def __init__(self, engine: VaultEngine, index: VaultIndex | None = None) -> None:
         self._engine = engine
+        self._index = index
 
     async def search(self, query: str, *, limit: int = 10) -> list[SearchHit]:
+        if self._index is not None:
+            return await self._indexed_search(query, limit=limit)
+        return await self._scan_search(query, limit=limit)
+
+    async def _indexed_search(self, query: str, *, limit: int) -> list[SearchHit]:
+        """Hybrid search through the SPEC-104 index.
+
+        ``meta`` notes are excluded here rather than filtered afterwards
+        (format spec §6: meta is "excluded from normal recall"), so the
+        requested ``limit`` is a limit on results the caller can use.
+
+        The index addresses hits below note granularity (an observation's
+        synthetic permalink, §9.2). The MCP-visible :class:`SearchHit` stays
+        note-level on purpose — that is the tool contract SPEC-105 froze and
+        SPEC-113 snapshots — so a sub-note hit reports its note's permalink
+        and lets its snippet carry the matched line.
+        """
+        assert self._index is not None
+        results = await self._index.search(
+            query,
+            mode="hybrid",
+            limit=limit,
+            filters=SearchFilters(exclude_types=("meta",)),
+        )
+        return [
+            SearchHit(
+                permalink=hit.permalink,
+                title=hit.title,
+                snippet=hit.snippet,
+                score=round(hit.score, 6),
+            )
+            for hit in results.hits
+        ]
+
+    async def _scan_search(self, query: str, *, limit: int) -> list[SearchHit]:
         needle = query.lower()
         hits: list[SearchHit] = []
         # Snapshot before iterating: every step below `await`s (read_note),

--- a/v3/server/src/palaia_hub/index/__init__.py
+++ b/v3/server/src/palaia_hub/index/__init__.py
@@ -1,0 +1,81 @@
+"""The disposable projection: SQLite full-text, vector and hybrid search.
+
+Files are the only truth (MASTERPLAN §5.1); everything in this package is
+derived from them and may be deleted at any time. ``reindex`` rebuilds it from
+files alone and must reproduce identical query results (format spec §10) —
+that invariant, not the schema, is what this package promises.
+
+Public surface (SPEC-104):
+
+* :class:`VaultIndex` — one vault's index: lifecycle, incremental updates from
+  SPEC-102 change events, hybrid search, embed backlog, status.
+* :class:`IndexWriter` — the write side; also the doctor's ``ReindexSink`` and
+  ``IndexView``, so ``reindex``/``verify`` plug straight into SPEC-102's
+  doctor primitives.
+* :class:`IndexSearch` — the three query modes and their rank fusion.
+* :class:`EmbeddingConfig` / :class:`Embedder` — local embeddings, always off
+  the write path (SPEC-003 measured 437 ms/note; see :mod:`.embeddings`).
+* :class:`SearchFilters`, :class:`SearchHit`, :class:`SearchResults`,
+  :class:`IndexStatus`, :class:`EmbedStatus` — the API's value types.
+"""
+
+from __future__ import annotations
+
+from .db import INDEX_RELATIVE_PATH, IndexDatabase
+from .embeddings import (
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_MODEL,
+    Chunk,
+    Embedder,
+    EmbedderUnavailableError,
+    EmbeddingConfig,
+    FastEmbedEmbedder,
+    chunk_text,
+    embeddable_text,
+)
+from .models import (
+    EmbedStatus,
+    HitKind,
+    IndexStatus,
+    SearchFilters,
+    SearchHit,
+    SearchMode,
+    SearchResults,
+    fingerprint,
+    observation_permalink,
+    relation_permalink,
+)
+from .schema import SCHEMA_VERSION
+from .search import RRF_K, IndexSearch, fts_match_expression
+from .service import VaultIndex
+from .writer import IndexWriter
+
+__all__ = [
+    "DEFAULT_BATCH_SIZE",
+    "DEFAULT_MODEL",
+    "INDEX_RELATIVE_PATH",
+    "RRF_K",
+    "SCHEMA_VERSION",
+    "Chunk",
+    "EmbedStatus",
+    "Embedder",
+    "EmbedderUnavailableError",
+    "EmbeddingConfig",
+    "FastEmbedEmbedder",
+    "HitKind",
+    "IndexDatabase",
+    "IndexSearch",
+    "IndexStatus",
+    "IndexWriter",
+    "SearchFilters",
+    "SearchHit",
+    "SearchMode",
+    "SearchResults",
+    "VaultIndex",
+    "chunk_text",
+    "embeddable_text",
+    "fingerprint",
+    "fts_match_expression",
+    "observation_permalink",
+    "relation_permalink",
+]

--- a/v3/server/src/palaia_hub/index/bench.py
+++ b/v3/server/src/palaia_hub/index/bench.py
@@ -1,0 +1,139 @@
+"""Embedding model / batch-size benchmark.
+
+SPEC-104 makes this a deliverable, not a nicety: the SPEC-003 spike measured
+**437 ms/note** with ``BAAI/bge-small-en-v1.5`` in a serial loop and closed
+with "investigate fastembed batch-size/thread tuning or a smaller/faster model
+before committing to it as *the* default". This module is that investigation,
+kept in-tree so the number can be re-measured on the hardware that matters
+instead of being quoted from a PR forever.
+
+Run it against the golden vault (or any vault):
+
+    uv run python -m palaia_hub.index.bench --notes 200
+    uv run python -m palaia_hub.index.bench --model BAAI/bge-small-en-v1.5 --batch 1,8,32
+
+It reports, per (model, batch size): model load time, total embed time,
+ms/note, and the embedding dimension — plus the FTS-only index build time on
+the same corpus, because the ratio between the two is the whole argument for
+embedding asynchronously.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from collections.abc import Sequence
+from pathlib import Path
+
+from .embeddings import EmbeddingConfig, chunk_text, embeddable_text
+
+#: Models worth comparing: the spike's default and the smaller/faster
+#: alternative, both 384-dimensional so the index schema is unaffected.
+CANDIDATE_MODELS: tuple[str, ...] = (
+    "sentence-transformers/all-MiniLM-L6-v2",
+    "BAAI/bge-small-en-v1.5",
+)
+
+DEFAULT_BATCHES: tuple[int, ...] = (1, 8, 32, 64)
+
+
+def collect_texts(vault: Path, limit: int) -> list[str]:
+    """Chunk up to ``limit`` notes of ``vault`` the way the index would."""
+    from palaia_hub.vault.parse import parse_note
+
+    texts: list[str] = []
+    for path in sorted(vault.rglob("*.md")):
+        if any(part in {".git", ".palaia", ".obsidian"} for part in path.parts):
+            continue
+        relative = str(path.relative_to(vault))
+        parsed = parse_note(path.read_text(encoding="utf-8"), relative)
+        note_text = embeddable_text(
+            parsed.title, parsed.body, [obs.text for obs in parsed.observations]
+        )
+        texts.extend(chunk.text for chunk in chunk_text(note_text))
+        if len(texts) >= limit:
+            break
+    return texts[:limit]
+
+
+def bench_model(model: str, texts: Sequence[str], batches: Sequence[int]) -> list[dict[str, float]]:
+    """Time ``model`` over ``texts`` at each batch size."""
+    from fastembed import TextEmbedding
+
+    rows: list[dict[str, float]] = []
+    started = time.perf_counter()
+    embedder = TextEmbedding(model_name=model)
+    load_seconds = time.perf_counter() - started
+    dim = len(next(iter(embedder.embed(["dimension probe"]))))
+
+    for batch in batches:
+        started = time.perf_counter()
+        vectors = list(embedder.embed(list(texts), batch_size=batch))
+        elapsed = time.perf_counter() - started
+        rows.append(
+            {
+                "batch_size": float(batch),
+                "chunks": float(len(vectors)),
+                "seconds": elapsed,
+                "ms_per_chunk": (elapsed / len(vectors)) * 1000 if vectors else 0.0,
+                "load_seconds": load_seconds,
+                "dim": float(dim),
+            }
+        )
+    return rows
+
+
+def bench_fts(texts: Sequence[str]) -> dict[str, float]:
+    """Time an FTS5 insert of the same texts — the async-mandate baseline."""
+    import sqlite3
+
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE VIRTUAL TABLE fts USING fts5(text)")
+    started = time.perf_counter()
+    conn.executemany("INSERT INTO fts(text) VALUES (?)", [(text,) for text in texts])
+    conn.commit()
+    elapsed = time.perf_counter() - started
+    conn.close()
+    return {
+        "chunks": float(len(texts)),
+        "seconds": elapsed,
+        "ms_per_chunk": (elapsed / len(texts)) * 1000 if texts else 0.0,
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    default_vault = (
+        Path(__file__).resolve().parents[3] / "tests" / "fixtures" / "golden-vault" / "work"
+    )
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--vault", type=Path, default=default_vault)
+    parser.add_argument("--notes", type=int, default=120, help="max chunks to embed")
+    parser.add_argument("--model", action="append", dest="models", default=None)
+    parser.add_argument("--batch", default=",".join(str(b) for b in DEFAULT_BATCHES))
+    args = parser.parse_args(argv)
+
+    models = args.models or list(CANDIDATE_MODELS)
+    batches = [int(part) for part in str(args.batch).split(",") if part.strip()]
+    texts = collect_texts(args.vault, args.notes)
+    if not texts:
+        parser.error(f"no notes found under {args.vault}")
+
+    report: dict[str, object] = {
+        "vault": str(args.vault),
+        "chunks": len(texts),
+        "mean_chunk_chars": round(statistics.mean(len(text) for text in texts), 1),
+        "default_config": {
+            "model": EmbeddingConfig().model,
+            "batch_size": EmbeddingConfig().batch_size,
+        },
+        "fts_baseline": bench_fts(texts),
+        "models": {model: bench_model(model, texts, batches) for model in models},
+    }
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/v3/server/src/palaia_hub/index/db.py
+++ b/v3/server/src/palaia_hub/index/db.py
@@ -1,0 +1,221 @@
+"""SQLite connection management for the per-vault index.
+
+Three things worth knowing before editing this module:
+
+* **WAL**, so a reader (a search) never blocks on the writer (an incremental
+  update), which is the whole point of an index that must answer queries
+  while an embed backlog drains behind it.
+* **One connection, one lock.** The index is touched from the event loop, from
+  ``asyncio.to_thread`` workers, and from the doctor's reindex thread. Rather
+  than a connection pool with per-thread affinity, there is a single
+  connection created with ``check_same_thread=False`` and every statement
+  runs under :attr:`IndexDatabase.lock`. SQLite serializes writes anyway, and
+  a vault index is not a contended OLTP database.
+* **Drop, don't migrate.** The index is disposable (format spec §10). A schema
+  version mismatch deletes the file and lets the caller reindex, which is
+  both simpler and better tested than an ALTER TABLE path nobody exercises.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import threading
+from pathlib import Path
+
+from .schema import (
+    META_SCHEMA_VERSION,
+    META_VAULT,
+    SCHEMA_SQL,
+    SCHEMA_VERSION,
+    VEC_TABLE_SQL,
+)
+
+logger = logging.getLogger("palaia_hub.index.db")
+
+#: Where a vault's index lives: inside the engine-private, gitignored,
+#: rebuildable ``.palaia/`` directory (format spec §1).
+INDEX_RELATIVE_PATH = ".palaia/index.sqlite3"
+
+
+class VectorSupport:
+    """Whether sqlite-vec could be loaded, and why not when it could not."""
+
+    __slots__ = ("available", "reason")
+
+    def __init__(self, available: bool, reason: str = "") -> None:
+        self.available = available
+        self.reason = reason
+
+
+def _load_sqlite_vec(conn: sqlite3.Connection) -> VectorSupport:
+    try:
+        import sqlite_vec
+    except ImportError as exc:  # pragma: no cover - dependency is declared
+        return VectorSupport(False, f"sqlite-vec is not installed ({exc})")
+    if not hasattr(conn, "enable_load_extension"):  # pragma: no cover - stdlib build
+        return VectorSupport(
+            False,
+            "this Python's sqlite3 was built without extension loading, so "
+            "sqlite-vec cannot be loaded; search stays FTS-only",
+        )
+    try:
+        conn.enable_load_extension(True)
+        sqlite_vec.load(conn)
+    except sqlite3.Error as exc:  # pragma: no cover - platform dependent
+        return VectorSupport(False, f"sqlite-vec failed to load ({exc})")
+    finally:
+        try:
+            conn.enable_load_extension(False)
+        except (AttributeError, sqlite3.Error):  # pragma: no cover
+            pass
+    return VectorSupport(True)
+
+
+class IndexDatabase:
+    """One vault's index file: connection, schema, and the guarding lock."""
+
+    def __init__(self, path: Path, vault: str) -> None:
+        self.path = Path(path)
+        self.vault = vault
+        self.lock = threading.RLock()
+        self._conn: sqlite3.Connection | None = None
+        self.vectors = VectorSupport(False, "not opened yet")
+
+    # ------------------------------------------------------------- lifecycle
+
+    @property
+    def conn(self) -> sqlite3.Connection:
+        if self._conn is None:
+            raise RuntimeError("index database is not open — call open() first")
+        return self._conn
+
+    @property
+    def opened(self) -> bool:
+        return self._conn is not None
+
+    def open(self) -> None:
+        """Open (creating or rebuilding) the index database."""
+        if self._conn is not None:
+            return
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        rebuilt = self._open_once()
+        if rebuilt is not None:
+            # Version mismatch or a corrupt file: the index is disposable, so
+            # throw it away rather than trying to salvage it.
+            logger.info("index at %s dropped and recreated: %s", self.path, rebuilt)
+            self._close_conn()
+            self.path.unlink(missing_ok=True)
+            for suffix in ("-wal", "-shm"):
+                self.path.with_name(self.path.name + suffix).unlink(missing_ok=True)
+            self._open_once(force_create=True)
+
+    def _open_once(self, *, force_create: bool = False) -> str | None:
+        conn = sqlite3.connect(self.path, check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.execute("PRAGMA busy_timeout=5000")
+        self._conn = conn
+        self.vectors = _load_sqlite_vec(conn)
+        if self.vectors.available:
+            logger.debug("sqlite-vec loaded for index %s", self.path)
+        else:
+            logger.info("vector search unavailable for %s: %s", self.path, self.vectors.reason)
+
+        try:
+            existing = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='meta'"
+            ).fetchone()
+        except sqlite3.DatabaseError as exc:
+            return f"unreadable database ({exc})"
+
+        if existing is None or force_create:
+            self._create_schema()
+            return None
+
+        version = self.meta_get(META_SCHEMA_VERSION)
+        if version != str(SCHEMA_VERSION):
+            return f"schema version {version!r} != {SCHEMA_VERSION}"
+        return None
+
+    def _create_schema(self) -> None:
+        with self.lock:
+            self.conn.executescript(SCHEMA_SQL)
+            self.conn.execute(
+                "INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)",
+                (META_SCHEMA_VERSION, str(SCHEMA_VERSION)),
+            )
+            self.conn.execute(
+                "INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)",
+                (META_VAULT, self.vault),
+            )
+            self.conn.commit()
+
+    def _close_conn(self) -> None:
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            except sqlite3.Error:  # pragma: no cover
+                pass
+            self._conn = None
+
+    def close(self) -> None:
+        """Close the connection (the file stays; it is rebuildable anyway)."""
+        with self.lock:
+            self._close_conn()
+
+    # ------------------------------------------------------------------- meta
+
+    def meta_get(self, key: str) -> str | None:
+        with self.lock:
+            row = self.conn.execute("SELECT value FROM meta WHERE key = ?", (key,)).fetchone()
+        return None if row is None else str(row["value"])
+
+    def meta_set(self, key: str, value: str) -> None:
+        """Set one metadata key, committing immediately.
+
+        Committing matters: an uncommitted write leaves sqlite3's implicit
+        transaction open, and the next ``BEGIN IMMEDIATE`` a rebuild issues
+        would then fail with "cannot start a transaction within a transaction".
+        """
+        with self.lock:
+            self.conn.execute(
+                "INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)", (key, value)
+            )
+            self.conn.commit()
+
+    # -------------------------------------------------------------- vec table
+
+    def has_vec_table(self) -> bool:
+        with self.lock:
+            row = self.conn.execute(
+                "SELECT name FROM sqlite_master WHERE name='vec_chunks'"
+            ).fetchone()
+        return row is not None
+
+    def ensure_vec_table(self, dim: int) -> bool:
+        """Create the KNN table for ``dim``-dimensional vectors if needed.
+
+        Returns ``True`` when a table exists afterwards. A dimension change
+        (a different embedding model) drops the old table — vectors from
+        another model are not comparable, and they are rebuildable.
+        """
+        if not self.vectors.available:
+            return False
+        with self.lock:
+            current = self.meta_get("vec_dim")
+            if self.has_vec_table() and current == str(dim):
+                return True
+            if self.has_vec_table():
+                logger.info("embedding dimension changed %s -> %s; dropping vectors", current, dim)
+                self.conn.execute("DROP TABLE vec_chunks")
+                self.conn.execute("UPDATE chunks SET state='pending', attempts=0")
+            self.conn.execute(VEC_TABLE_SQL.format(dim=dim))
+            self.meta_set("vec_dim", str(dim))
+            self.conn.commit()
+        return True
+
+
+__all__ = ["INDEX_RELATIVE_PATH", "IndexDatabase", "VectorSupport"]

--- a/v3/server/src/palaia_hub/index/embeddings.py
+++ b/v3/server/src/palaia_hub/index/embeddings.py
@@ -1,0 +1,233 @@
+"""Chunking and local embeddings.
+
+**Why everything here is off the write path.** SPEC-003 Q4 measured 437 ms to
+embed one note against 0.6 ms to FTS-index it — a factor of ~700. Embedding
+synchronously would turn a sub-10 ms note write into a half-second one, so
+the write path stops at "chunks written, state pending" and a background
+worker drains the backlog (see :class:`~.service.VaultIndex`). That is a
+hard constraint from the spike, not a preference.
+
+**Chunking.** Notes are split on blank lines into ~``max_chars`` windows with
+a small overlap, so an observation list and the paragraph introducing it tend
+to land in the same chunk. Each chunk carries a content fingerprint: on
+re-index, a chunk whose fingerprint is unchanged keeps its vector, so editing
+one paragraph of a long note re-embeds one chunk instead of the note.
+
+**Model choice** is config (:class:`EmbeddingConfig`). The default was picked
+by benchmark, not by reputation — run ``python -m palaia_hub.index.bench`` to
+reproduce the comparison.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+from .models import fingerprint
+
+logger = logging.getLogger("palaia_hub.index.embeddings")
+
+#: Default local model, chosen by measurement rather than reputation — the
+#: SPEC-003 follow-up the spike asked for ("investigate ... a smaller/faster
+#: model before committing to bge-small-en-v1.5 as *the* default").
+#: :mod:`palaia_hub.index.bench` on the golden vault, 4 vCPUs, 45 chunks:
+#:
+#: =================================== ======== ============
+#: model                               batch    ms/chunk
+#: =================================== ======== ============
+#: sentence-transformers/all-MiniLM-L6-v2   8    **15.6**
+#: sentence-transformers/all-MiniLM-L6-v2  32      17.7
+#: BAAI/bge-small-en-v1.5                   8     152.8
+#: BAAI/bge-small-en-v1.5                  32     224.0
+#: =================================== ======== ============
+#:
+#: ~10x faster at the same 384 dimensions, so the index schema is unaffected
+#: by the choice and a deployment that prefers bge-small only has to set
+#: ``model`` and re-embed. FTS on the same corpus: 0.013 ms/chunk — three
+#: orders of magnitude cheaper, which is why embedding is async, full stop.
+DEFAULT_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+#: Texts per ``embed()`` call, and chunks claimed per worker transaction. 8 was
+#: the measured optimum on 4 vCPUs (above); bigger batches lost ~12% there,
+#: probably to thread oversubscription, so re-run the benchmark before raising
+#: it on very different hardware.
+DEFAULT_BATCH_SIZE = 8
+
+#: Chunk sizing. ~1200 characters is roughly 250-300 tokens, comfortably
+#: inside the 512-token window of both candidate models.
+DEFAULT_MAX_CHARS = 1200
+DEFAULT_OVERLAP_CHARS = 120
+
+
+@dataclass(frozen=True, slots=True)
+class EmbeddingConfig:
+    """How this index embeds — or that it does not."""
+
+    enabled: bool = True
+    model: str = DEFAULT_MODEL
+    batch_size: int = DEFAULT_BATCH_SIZE
+    max_chars: int = DEFAULT_MAX_CHARS
+    overlap_chars: int = DEFAULT_OVERLAP_CHARS
+    threads: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Chunk:
+    """One embedding unit of a note."""
+
+    seq: int
+    text: str
+    fingerprint: str
+
+
+class Embedder(Protocol):
+    """Minimal embedding interface — a list of texts in, vectors out.
+
+    A protocol rather than a class so tests can substitute a deterministic
+    stub (embedding a real model in a unit test would dominate its runtime)
+    and so a future remote embedder is a drop-in.
+    """
+
+    @property
+    def dim(self) -> int:
+        """Vector dimension."""
+        ...
+
+    @property
+    def name(self) -> str:
+        """Model identifier, stored in the index's ``meta`` table."""
+        ...
+
+    def embed(self, texts: Sequence[str]) -> list[list[float]]:
+        """Embed ``texts``, returning one vector per input, in order."""
+        ...
+
+
+class FastEmbedEmbedder:
+    """:class:`Embedder` backed by fastembed's local ONNX models.
+
+    Construction loads the model (and downloads it on first use), which the
+    spike measured at ~0.6 s warm — so it happens on the background worker's
+    first batch, never on a query or a write.
+    """
+
+    def __init__(self, config: EmbeddingConfig | None = None) -> None:
+        self._config = config or EmbeddingConfig()
+        try:
+            from fastembed import TextEmbedding
+        except ImportError as exc:  # pragma: no cover - optional extra
+            raise EmbedderUnavailableError(
+                f"fastembed is not installed ({exc}). Fix: install the "
+                f"'embeddings' extra (uv sync installs it for this workspace), "
+                f"or run with embeddings disabled — search degrades to FTS."
+            ) from exc
+        kwargs: dict[str, object] = {"model_name": self._config.model}
+        if self._config.threads is not None:
+            kwargs["threads"] = self._config.threads
+        try:
+            self._model = TextEmbedding(**kwargs)  # type: ignore[arg-type]
+        except Exception as exc:  # noqa: BLE001 - fastembed raises broadly
+            raise EmbedderUnavailableError(
+                f"could not load embedding model {self._config.model!r}: {exc}. "
+                f"Fix: check the model name, or the network/cache for its "
+                f"first download. Search stays available as FTS-only."
+            ) from exc
+        self._dim = len(self.embed(["dimension probe"])[0])
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    @property
+    def name(self) -> str:
+        return self._config.model
+
+    def embed(self, texts: Sequence[str]) -> list[list[float]]:
+        if not texts:
+            return []
+        vectors = self._model.embed(list(texts), batch_size=self._config.batch_size)
+        return [[float(value) for value in vector] for vector in vectors]
+
+
+class EmbedderUnavailableError(RuntimeError):
+    """No embedder could be built — the index runs FTS-only and says so."""
+
+
+def build_embedder(config: EmbeddingConfig) -> Embedder:
+    """Construct the configured embedder (currently: fastembed only)."""
+    return FastEmbedEmbedder(config)
+
+
+# --------------------------------------------------------------------- chunking
+
+
+def embeddable_text(title: str, body: str, observations: Sequence[str]) -> str:
+    """The text an embedding sees for one note.
+
+    Title first (it is the strongest short signal), then the body, then the
+    observation lines — which the spike's ``entity_text`` did too, and which
+    matters because an observation's fact is often nowhere else in the prose.
+    """
+    parts = [title.strip(), body.strip()]
+    parts.extend(text.strip() for text in observations)
+    return "\n".join(part for part in parts if part)
+
+
+def chunk_text(
+    text: str, *, max_chars: int = DEFAULT_MAX_CHARS, overlap_chars: int = DEFAULT_OVERLAP_CHARS
+) -> list[Chunk]:
+    """Split ``text`` into chunks, preferring paragraph boundaries.
+
+    Paragraphs are packed greedily into ``max_chars`` windows. ``overlap_chars``
+    applies only where a *single* paragraph exceeds the window and has to be
+    hard-split mid-text: there the next piece repeats the tail of the previous
+    one, so a phrase straddling the cut survives in at least one chunk.
+    """
+    normalized = text.strip()
+    if not normalized:
+        return []
+    if len(normalized) <= max_chars:
+        return [Chunk(0, normalized, fingerprint(normalized))]
+
+    step = max(1, max_chars - max(0, overlap_chars))
+    units: list[str] = []
+    for raw in normalized.split("\n\n"):
+        para = raw.strip()
+        while len(para) > max_chars:
+            units.append(para[:max_chars])
+            para = para[step:].strip()
+        if para:
+            units.append(para)
+
+    windows: list[str] = []
+    current = ""
+    for unit in units:
+        candidate = f"{current}\n\n{unit}" if current else unit
+        if len(candidate) <= max_chars:
+            current = candidate
+            continue
+        if current:
+            windows.append(current)
+        current = unit
+    if current:
+        windows.append(current)
+
+    return [Chunk(seq, window, fingerprint(window)) for seq, window in enumerate(windows)]
+
+
+__all__ = [
+    "DEFAULT_BATCH_SIZE",
+    "DEFAULT_MAX_CHARS",
+    "DEFAULT_MODEL",
+    "DEFAULT_OVERLAP_CHARS",
+    "Chunk",
+    "EmbedderUnavailableError",
+    "EmbeddingConfig",
+    "Embedder",
+    "FastEmbedEmbedder",
+    "build_embedder",
+    "chunk_text",
+    "embeddable_text",
+]

--- a/v3/server/src/palaia_hub/index/models.py
+++ b/v3/server/src/palaia_hub/index/models.py
@@ -1,0 +1,187 @@
+"""Value types of the index and search API, plus the synthetic-permalink rules.
+
+Synthetic permalinks (format spec §9.2) are *derived, never stored in files*:
+``<permalink>/obs/<category-slug>/<h8>`` for an observation and
+``<permalink>/rel/<type-slug>/<target>`` for a relation. They are what makes
+a search hit addressable below note granularity — a result can point at the
+one observation line that matched instead of at a 300-line note.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from typing import Literal
+
+from palaia_hub.vault import permalink as pl
+
+#: The three search modes of the hybrid API (SPEC-104 deliverable #3).
+SearchMode = Literal["fts", "vector", "hybrid"]
+
+#: The addressable granularities a hit can have.
+HitKind = Literal["note", "observation", "relation"]
+
+#: Embedding lifecycle of one chunk.
+ChunkState = Literal["pending", "ready", "failed"]
+
+
+def text_hash8(text: str) -> str:
+    """First 8 hex of sha256 over ``text`` — the ``h8`` of §9.2."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:8]
+
+
+def fingerprint(text: str) -> str:
+    """Content fingerprint of a chunk (16 hex of sha256).
+
+    Longer than ``h8`` on purpose: this one gates whether an existing vector
+    may be reused, so an accidental collision would serve a wrong embedding.
+    """
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def observation_permalink(note_permalink: str, category: str, text: str) -> str:
+    """``<permalink>/obs/<category-slug>/<h8>`` (§9.2)."""
+    return f"{note_permalink}/obs/{pl.slugify(category) or 'obs'}/{text_hash8(text)}"
+
+
+def relation_permalink(
+    note_permalink: str, relation_type: str, target_permalink: str | None, target_raw: str
+) -> str:
+    """``<permalink>/rel/<type-slug>/<target-permalink>`` (§9.2).
+
+    An unresolved forward reference has no target permalink yet, so the
+    slugified raw target stands in — the synthetic permalink stays stable
+    when the target later appears *if* the target's permalink slug matches,
+    and changes otherwise. Either way it is derived, never persisted in a
+    file, so nothing on disk depends on it.
+    """
+    target = target_permalink or pl.slugify(target_raw) or "unresolved"
+    return f"{note_permalink}/rel/{pl.slugify(relation_type) or 'rel'}/{target}"
+
+
+@dataclass(frozen=True, slots=True)
+class SearchFilters:
+    """Metadata filters applied to any search mode.
+
+    ``scope`` is a folder prefix (``"projects"`` matches ``projects`` and
+    ``projects/api``), ``meta`` filters on flattened frontmatter keys — the
+    unknown-keys-are-searchable-metadata promise of §2.1.
+    """
+
+    scope: str | None = None
+    types: tuple[str, ...] = ()
+    tags: tuple[str, ...] = ()
+    since: str | None = None
+    until: str | None = None
+    meta: tuple[tuple[str, str], ...] = ()
+    kinds: tuple[HitKind, ...] = ()
+    exclude_types: tuple[str, ...] = ()
+
+    @property
+    def empty(self) -> bool:
+        return not (
+            self.scope
+            or self.types
+            or self.tags
+            or self.since
+            or self.until
+            or self.meta
+            or self.kinds
+            or self.exclude_types
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SearchHit:
+    """One search result, addressable at its own granularity."""
+
+    ref: str
+    """The synthetic (or note) permalink this hit points at (§9.2)."""
+
+    permalink: str
+    """The containing note's permalink."""
+
+    kind: HitKind
+    title: str
+    snippet: str
+    score: float
+    path: str = ""
+    type: str = "note"
+    tags: tuple[str, ...] = ()
+    modified: str = ""
+    fts_rank: int | None = None
+    vector_rank: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SearchResults:
+    """A result page plus how it was produced.
+
+    ``degraded`` is the honest signal SPEC-104's last acceptance criterion
+    asks for: a hybrid query answered from FTS alone because vectors are
+    still pending (or unavailable) says so instead of pretending.
+    """
+
+    hits: tuple[SearchHit, ...]
+    mode: SearchMode
+    effective_mode: SearchMode
+    degraded: bool = False
+    degraded_reason: str = ""
+
+    def __len__(self) -> int:
+        return len(self.hits)
+
+    def __iter__(self) -> Iterator[SearchHit]:
+        return iter(self.hits)
+
+
+@dataclass(frozen=True, slots=True)
+class EmbedStatus:
+    """Embedding backlog — SPEC-104's "embed backlog visible via status API"."""
+
+    enabled: bool
+    available: bool
+    model: str
+    dim: int
+    total: int = 0
+    ready: int = 0
+    pending: int = 0
+    failed: int = 0
+    reason: str = ""
+
+    @property
+    def usable(self) -> bool:
+        """True when a vector query can return anything at all."""
+        return self.enabled and self.available and self.ready > 0
+
+
+@dataclass(frozen=True, slots=True)
+class IndexStatus:
+    """Everything the dashboard/CLI needs to describe one vault's index."""
+
+    vault: str
+    path: str
+    schema_version: int
+    notes: int
+    observations: int
+    relations: int
+    unresolved_relations: int
+    embeds: EmbedStatus
+    counts_by_type: dict[str, int] = field(default_factory=dict)
+
+
+__all__ = [
+    "ChunkState",
+    "EmbedStatus",
+    "HitKind",
+    "IndexStatus",
+    "SearchFilters",
+    "SearchHit",
+    "SearchMode",
+    "SearchResults",
+    "fingerprint",
+    "observation_permalink",
+    "relation_permalink",
+    "text_hash8",
+]

--- a/v3/server/src/palaia_hub/index/schema.py
+++ b/v3/server/src/palaia_hub/index/schema.py
@@ -1,0 +1,186 @@
+"""The disposable projection's SQL schema.
+
+Nothing in here is a source of truth: every table is derivable from the
+notes on disk (format spec §10, "the index is disposable"), which is why the
+migration story is *drop and rebuild* rather than ALTER TABLE — a schema
+version bump wipes the file and reindexes from files.
+
+Two deliberate deviations from the obvious design:
+
+* ``notes.path`` is the UNIQUE key, ``notes.permalink`` only an index.
+  Duplicate permalinks are a doctor *finding* (``permalink-duplicate``), not
+  something the index may refuse to represent — warn-first applies here too.
+* full text lives in ``search_rows`` (one row per addressable thing: a note,
+  an observation, a relation) with an external-content FTS5 table kept in
+  sync by triggers. That is what gives sub-note addressability (§9.2): an
+  observation hit carries its own synthetic permalink, and deleting a note's
+  rows is a plain ``DELETE ... WHERE note_id = ?`` instead of the
+  re-supply-the-old-values dance contentless FTS5 deletes require.
+"""
+
+from __future__ import annotations
+
+#: Bumping this drops the database file and triggers a full reindex.
+SCHEMA_VERSION = 1
+
+#: Metadata keys stored in the ``meta`` table.
+META_SCHEMA_VERSION = "schema_version"
+META_EMBED_MODEL = "embed_model"
+META_EMBED_DIM = "embed_dim"
+META_VAULT = "vault"
+
+#: Row kinds in ``search_rows`` — the three addressable granularities.
+KIND_NOTE = "note"
+KIND_OBSERVATION = "observation"
+KIND_RELATION = "relation"
+
+#: FTS5 tokenizer: unicode61 with diacritic folding so "Farah Al-Sayed"
+#: matches "Farah Al Sayed", and with ``-``/``_``/``/`` kept as separators
+#: (the default) so permalink-ish queries split into their words.
+_TOKENIZER = "unicode61 remove_diacritics 2"
+
+SCHEMA_SQL = f"""
+CREATE TABLE meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+CREATE TABLE notes (
+    id          INTEGER PRIMARY KEY,
+    path        TEXT NOT NULL UNIQUE,
+    permalink   TEXT NOT NULL,
+    title       TEXT NOT NULL,
+    type        TEXT NOT NULL,
+    folder      TEXT NOT NULL,
+    tags        TEXT NOT NULL,          -- JSON array, lowercased
+    aliases     TEXT NOT NULL,          -- JSON array
+    created     TEXT,
+    modified    TEXT,
+    checksum    TEXT NOT NULL,
+    body        TEXT NOT NULL,
+    frontmatter TEXT NOT NULL           -- JSON object, verbatim (§2.1)
+);
+CREATE INDEX notes_permalink ON notes(permalink);
+CREATE INDEX notes_type ON notes(type);
+CREATE INDEX notes_folder ON notes(folder);
+CREATE INDEX notes_modified ON notes(modified);
+
+-- Every string a note answers to (permalink, title, aliases, and their
+-- slugs). Both directions of reference resolution join through this table.
+CREATE TABLE note_keys (
+    note_id INTEGER NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
+    key     TEXT NOT NULL
+);
+CREATE INDEX note_keys_key ON note_keys(key);
+CREATE INDEX note_keys_note ON note_keys(note_id);
+
+CREATE TABLE note_tags (
+    note_id INTEGER NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
+    tag     TEXT NOT NULL
+);
+CREATE INDEX note_tags_tag ON note_tags(tag);
+CREATE INDEX note_tags_note ON note_tags(note_id);
+
+-- Flattened frontmatter scalars, including unknown keys: format spec §2.1
+-- says unknown keys are "preserved verbatim and indexed as searchable
+-- metadata", so custom-key filters are a first-class deliverable.
+CREATE TABLE note_meta (
+    note_id INTEGER NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
+    key     TEXT NOT NULL,
+    value   TEXT NOT NULL
+);
+CREATE INDEX note_meta_key_value ON note_meta(key, value);
+CREATE INDEX note_meta_note ON note_meta(note_id);
+
+CREATE TABLE observations (
+    id        INTEGER PRIMARY KEY,
+    note_id   INTEGER NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
+    permalink TEXT NOT NULL,            -- synthetic (§9.2)
+    category  TEXT NOT NULL,
+    scope     TEXT,
+    text      TEXT NOT NULL,
+    tags      TEXT NOT NULL,            -- JSON array
+    context   TEXT,
+    block_id  TEXT,
+    line      INTEGER NOT NULL
+);
+CREATE INDEX observations_note ON observations(note_id);
+CREATE INDEX observations_category ON observations(category);
+
+CREATE TABLE relations (
+    id               INTEGER PRIMARY KEY,
+    note_id          INTEGER NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
+    permalink        TEXT NOT NULL,     -- synthetic (§9.2)
+    type             TEXT NOT NULL,
+    target_raw       TEXT NOT NULL,
+    target_key       TEXT NOT NULL,     -- lowercased target_raw
+    target_slug      TEXT NOT NULL,     -- slugified target_raw
+    target_permalink TEXT,              -- NULL = unresolved forward reference
+    implicit         INTEGER NOT NULL,
+    context          TEXT,
+    line             INTEGER NOT NULL
+);
+CREATE INDEX relations_note ON relations(note_id);
+CREATE INDEX relations_target_permalink ON relations(target_permalink);
+CREATE INDEX relations_target_key ON relations(target_key);
+CREATE INDEX relations_target_slug ON relations(target_slug);
+
+CREATE TABLE search_rows (
+    id      INTEGER PRIMARY KEY,
+    note_id INTEGER NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
+    kind    TEXT NOT NULL,
+    ref     TEXT NOT NULL,              -- addressable permalink of this row
+    title   TEXT NOT NULL,
+    text    TEXT NOT NULL
+);
+CREATE INDEX search_rows_note ON search_rows(note_id);
+
+CREATE VIRTUAL TABLE fts USING fts5(
+    title,
+    text,
+    content='search_rows',
+    content_rowid='id',
+    tokenize='{_TOKENIZER}'
+);
+
+CREATE TRIGGER search_rows_ai AFTER INSERT ON search_rows BEGIN
+    INSERT INTO fts(rowid, title, text) VALUES (new.id, new.title, new.text);
+END;
+CREATE TRIGGER search_rows_ad AFTER DELETE ON search_rows BEGIN
+    INSERT INTO fts(fts, rowid, title, text) VALUES ('delete', old.id, old.title, old.text);
+END;
+
+-- Embedding units. `fingerprint` is what makes an incremental update cheap:
+-- a chunk whose text is unchanged keeps its vector and its `ready` state, so
+-- editing a note's last paragraph re-embeds one chunk, not the whole note.
+CREATE TABLE chunks (
+    id          INTEGER PRIMARY KEY,
+    note_id     INTEGER NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
+    seq         INTEGER NOT NULL,
+    ref         TEXT NOT NULL,
+    fingerprint TEXT NOT NULL,
+    text        TEXT NOT NULL,
+    state       TEXT NOT NULL DEFAULT 'pending',   -- pending | ready | failed
+    attempts    INTEGER NOT NULL DEFAULT 0,
+    UNIQUE (note_id, seq)
+);
+CREATE INDEX chunks_state ON chunks(state);
+CREATE INDEX chunks_fingerprint ON chunks(fingerprint);
+"""
+
+#: sqlite-vec's KNN table, created lazily once the embedding dimension is
+#: known (it is part of the table declaration).
+VEC_TABLE_SQL = "CREATE VIRTUAL TABLE vec_chunks USING vec0(embedding float[{dim}])"
+
+__all__ = [
+    "KIND_NOTE",
+    "KIND_OBSERVATION",
+    "KIND_RELATION",
+    "META_EMBED_DIM",
+    "META_EMBED_MODEL",
+    "META_SCHEMA_VERSION",
+    "META_VAULT",
+    "SCHEMA_SQL",
+    "SCHEMA_VERSION",
+    "VEC_TABLE_SQL",
+]

--- a/v3/server/src/palaia_hub/index/search.py
+++ b/v3/server/src/palaia_hub/index/search.py
@@ -1,0 +1,494 @@
+"""FTS, vector and hybrid querying over one vault's index.
+
+**Query text is user input, not FTS5 syntax.** ``search("rate limit -42")``
+must not blow up on FTS5's operators, so the query is tokenized with the same
+character classes the ``unicode61`` tokenizer uses and rebuilt as
+``"rate" AND "limit" AND "42"``. Callers never need to know FTS5 exists; a
+query whose every token is punctuation matches nothing, which is a result too.
+
+**Fusion is reciprocal rank fusion**, not score addition. The spike's sketch
+summed ``1/(rank+1)`` per list, which is RRF with ``k=1`` — steep enough that
+the top FTS hit almost always wins outright. ``k=60`` (the value the RRF paper
+settles on) keeps a result that both lists rank *moderately* well ahead of one
+that only one list loves, which is the entire point of hybridizing: BM25 finds
+the exact words, vectors find the paraphrase, and agreement is the signal.
+
+**Degradation is explicit.** Vectors arrive asynchronously (see
+:mod:`.embeddings`), so a hybrid query issued while the backlog drains has no
+vector list to fuse. It answers from FTS and sets
+:attr:`~.models.SearchResults.degraded`, rather than silently pretending the
+vector half ran.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import sqlite3
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Any
+
+from .db import IndexDatabase
+from .models import (
+    SearchFilters,
+    SearchHit,
+    SearchMode,
+    SearchResults,
+)
+from .schema import KIND_NOTE
+
+logger = logging.getLogger("palaia_hub.index.search")
+
+#: RRF constant. 60 is the value from Cormack et al.'s original evaluation and
+#: the de-facto default in hybrid-search implementations.
+RRF_K = 60
+
+#: Column weights for bm25(): a title match is worth much more than a body
+#: match, matching the linear-scan adapter's 1.0-vs-0.5 intuition but ranked
+#: rather than bucketed.
+_BM25_TITLE_WEIGHT = 10.0
+_BM25_TEXT_WEIGHT = 1.0
+
+#: How many rows each half of a hybrid query fetches before fusion. Fusion can
+#: promote a result ranked ~30th by one list, so both lists must be deeper than
+#: the requested page.
+_FUSION_DEPTH_FACTOR = 5
+_FUSION_MIN_DEPTH = 30
+
+#: Score scale for lexical-only results when the lexical pass was disjunctive
+#: (``LEXICAL_TAIL`` fusion). Small enough that such a result always sorts
+#: below every vector result while keeping its own BM25 order.
+_TAIL_SCALE = 1e-3
+
+#: The two fusion policies (see :meth:`IndexSearch.fuse`).
+PEER = "peer"
+LEXICAL_TAIL = "lexical-tail"
+
+#: Tokens the ``unicode61`` tokenizer would produce: runs of alphanumerics,
+#: underscore excluded (unicode61 treats it as a separator).
+_TOKEN_RE = re.compile(r"[^\W_]+", re.UNICODE)
+
+
+def query_tokens(query: str) -> list[str]:
+    """Tokenize a user query the way the FTS tokenizer will."""
+    return _TOKEN_RE.findall(query.casefold())
+
+
+def fts_match_expression(query: str, *, operator: str = "AND") -> str | None:
+    """Build an FTS5 MATCH expression, or ``None`` if nothing is searchable."""
+    tokens = query_tokens(query)
+    if not tokens:
+        return None
+    return f" {operator} ".join(f'"{token}"' for token in tokens)
+
+
+@dataclass(frozen=True, slots=True)
+class _Clause:
+    sql: str
+    params: tuple[Any, ...]
+
+
+def _filter_clause(filters: SearchFilters, alias: str = "n") -> _Clause:
+    """Translate :class:`SearchFilters` into SQL over the ``notes`` alias."""
+    parts: list[str] = []
+    params: list[Any] = []
+    if filters.scope:
+        scope = filters.scope.strip("/")
+        parts.append(f"({alias}.folder = ? OR {alias}.folder LIKE ?)")
+        params.extend([scope, f"{scope}/%"])
+    if filters.types:
+        placeholders = ",".join("?" for _ in filters.types)
+        parts.append(f"{alias}.type IN ({placeholders})")
+        params.extend(filters.types)
+    if filters.exclude_types:
+        placeholders = ",".join("?" for _ in filters.exclude_types)
+        parts.append(f"{alias}.type NOT IN ({placeholders})")
+        params.extend(filters.exclude_types)
+    if filters.since:
+        parts.append(f"COALESCE({alias}.modified, {alias}.created, '') >= ?")
+        params.append(filters.since)
+    if filters.until:
+        parts.append(f"COALESCE({alias}.modified, {alias}.created, '') <= ?")
+        params.append(filters.until)
+    for tag in filters.tags:
+        parts.append(
+            f"EXISTS (SELECT 1 FROM note_tags t WHERE t.note_id = {alias}.id AND t.tag = ?)"
+        )
+        params.append(tag.lower())
+    for key, value in filters.meta:
+        parts.append(
+            f"EXISTS (SELECT 1 FROM note_meta m WHERE m.note_id = {alias}.id "
+            f"AND m.key = ? AND m.value = ?)"
+        )
+        params.extend([key, value])
+    if not parts:
+        return _Clause("", ())
+    return _Clause(" AND " + " AND ".join(parts), tuple(params))
+
+
+def _kind_clause(filters: SearchFilters, alias: str = "sr") -> _Clause:
+    if not filters.kinds:
+        return _Clause("", ())
+    placeholders = ",".join("?" for _ in filters.kinds)
+    return _Clause(f" AND {alias}.kind IN ({placeholders})", tuple(filters.kinds))
+
+
+def _row_to_hit(
+    row: sqlite3.Row,
+    *,
+    kind: str,
+    snippet: str,
+    score: float,
+    fts_rank: int | None = None,
+    vector_rank: int | None = None,
+) -> SearchHit:
+    return SearchHit(
+        ref=str(row["ref"]),
+        permalink=str(row["permalink"]),
+        kind=kind,  # type: ignore[arg-type]
+        title=str(row["title"]),
+        snippet=snippet,
+        score=score,
+        path=str(row["path"]),
+        type=str(row["type"]),
+        tags=tuple(json.loads(str(row["tags"] or "[]"))),
+        modified=str(row["modified"] or ""),
+        fts_rank=fts_rank,
+        vector_rank=vector_rank,
+    )
+
+
+class IndexSearch:
+    """Read-side of the index: the three modes and their fusion."""
+
+    def __init__(self, db: IndexDatabase) -> None:
+        self._db = db
+
+    # ------------------------------------------------------------------- FTS
+
+    def fts(
+        self, query: str, *, limit: int = 10, filters: SearchFilters | None = None
+    ) -> list[SearchHit]:
+        """Rank rows by BM25 over the FTS5 index (see :meth:`fts_pass`)."""
+        return self.fts_pass(query, limit=limit, filters=filters)[0]
+
+    def fts_pass(
+        self, query: str, *, limit: int = 10, filters: SearchFilters | None = None
+    ) -> tuple[list[SearchHit], str]:
+        """Rank rows by BM25, reporting which pass produced them.
+
+        Two passes: every token required (precise — "rate limit" means both
+        words), and if that finds nothing, any token (recall — a
+        natural-language question like "what database backs the search layer"
+        shares only some words with the note that answers it).
+
+        The pass is returned because it is a statement about *evidence
+        strength*: an ``AND`` hit contains everything the caller typed, an
+        ``OR`` hit merely overlaps. Hybrid fusion weights the two differently
+        (see :meth:`search`), which is the difference between a paraphrased
+        question being answered and being buried under lexical near-misses.
+        """
+        for operator in ("AND", "OR"):
+            match = fts_match_expression(query, operator=operator)
+            if match is None:
+                return [], operator
+            hits = self._fts_match(match, limit=limit, filters=filters)
+            if hits:
+                return hits, operator
+            if len(query_tokens(query)) < 2:
+                break
+        return [], "OR"
+
+    def _fts_match(
+        self, match: str, *, limit: int, filters: SearchFilters | None
+    ) -> list[SearchHit]:
+        filters = filters or SearchFilters()
+        where = _filter_clause(filters)
+        kinds = _kind_clause(filters)
+        sql = (
+            "SELECT sr.kind AS kind, sr.ref AS ref, sr.note_id AS note_id, "
+            "n.permalink AS permalink, n.path AS path, n.type AS type, n.tags AS tags, "
+            "n.modified AS modified, sr.title AS title, "
+            "bm25(fts, ?, ?) AS bm25_score, "
+            "snippet(fts, 1, '', '', '…', 14) AS snip "
+            "FROM fts JOIN search_rows sr ON sr.id = fts.rowid "
+            "JOIN notes n ON n.id = sr.note_id "
+            "WHERE fts MATCH ?"
+            f"{kinds.sql}{where.sql} "
+            "ORDER BY bm25_score, sr.ref LIMIT ?"
+        )
+        params = (
+            _BM25_TITLE_WEIGHT,
+            _BM25_TEXT_WEIGHT,
+            match,
+            *kinds.params,
+            *where.params,
+            limit,
+        )
+        with self._db.lock:
+            try:
+                rows = self._db.conn.execute(sql, params).fetchall()
+            except sqlite3.OperationalError as exc:
+                # A MATCH expression the tokenizer rejects is a bad query, not
+                # a broken index: report nothing rather than raising at a
+                # caller who typed something odd.
+                logger.debug("FTS query rejected (%s): %r", exc, match)
+                return []
+        hits: list[SearchHit] = []
+        for rank, row in enumerate(rows):
+            hits.append(
+                _row_to_hit(
+                    row,
+                    kind=str(row["kind"]),
+                    snippet=str(row["snip"] or "").strip(),
+                    # bm25() returns a negative number, better = more negative.
+                    score=-float(row["bm25_score"]),
+                    fts_rank=rank,
+                )
+            )
+        return hits
+
+    # ---------------------------------------------------------------- vectors
+
+    def vector(
+        self,
+        embedding: Sequence[float],
+        *,
+        limit: int = 10,
+        filters: SearchFilters | None = None,
+    ) -> list[SearchHit]:
+        """KNN over ready chunk vectors, folded to one hit per note."""
+        if not self._db.vectors.available or not self._db.has_vec_table():
+            return []
+        import sqlite_vec
+
+        filters = filters or SearchFilters()
+        where = _filter_clause(filters)
+        # Over-fetch: several chunks of one note may crowd the top-k, and
+        # filters are applied after the KNN (sqlite-vec has no join-aware
+        # pre-filter), so the raw k must be generous.
+        knn = max(limit * 8, 40)
+        sql = (
+            "SELECT c.note_id AS note_id, c.ref AS ref, c.text AS chunk_text, v.distance AS dist, "
+            "n.permalink AS permalink, n.path AS path, n.type AS type, n.tags AS tags, "
+            "n.modified AS modified, n.title AS title "
+            "FROM (SELECT rowid, distance FROM vec_chunks "
+            "      WHERE embedding MATCH ? ORDER BY distance LIMIT ?) v "
+            "JOIN chunks c ON c.id = v.rowid "
+            "JOIN notes n ON n.id = c.note_id "
+            f"WHERE 1=1{where.sql} "
+            "ORDER BY v.distance, c.ref"
+        )
+        params = (sqlite_vec.serialize_float32(list(embedding)), knn, *where.params)
+        with self._db.lock:
+            try:
+                rows = self._db.conn.execute(sql, params).fetchall()
+            except sqlite3.Error as exc:  # pragma: no cover - vec table issues
+                logger.warning("vector query failed, degrading to FTS: %s", exc)
+                return []
+
+        hits: list[SearchHit] = []
+        seen: set[str] = set()
+        for row in rows:
+            permalink = str(row["permalink"])
+            if permalink in seen:
+                continue
+            seen.add(permalink)
+            distance = float(row["dist"])
+            hits.append(
+                _row_to_hit(
+                    row,
+                    kind=KIND_NOTE,
+                    snippet=_head(str(row["chunk_text"])),
+                    score=1.0 / (1.0 + distance),
+                    vector_rank=len(hits),
+                )
+            )
+            if len(hits) >= limit:
+                break
+        return hits
+
+    # ----------------------------------------------------------------- hybrid
+
+    def fuse(
+        self,
+        fts_hits: Sequence[SearchHit],
+        vector_hits: Sequence[SearchHit],
+        *,
+        limit: int = 10,
+        policy: str = PEER,
+    ) -> list[SearchHit]:
+        """Rank-fuse the two lists, keyed by note permalink.
+
+        Fusion is per *note*: a note whose observation matched textually and
+        whose body matched semantically is one result, not two. The surviving
+        ``ref`` is the best-ranked FTS row for that note — often an
+        observation's synthetic permalink, which is the addressable thing the
+        caller can act on — and falls back to the note-level vector hit when
+        only the vector list found it.
+
+        **Each list is collapsed to one entry per note before ranks are
+        taken.** The FTS side returns *rows*, and a note can easily contribute
+        six of them (its body plus five observations). Scoring each row
+        separately would hand that note six reciprocal-rank contributions and
+        let sheer row count outrank genuine agreement between the two
+        retrievers — measured on the golden vault, that alone dropped hybrid
+        recall@5 below plain FTS. Rank means "this note was the n-th best
+        answer according to this retriever", nothing else.
+
+        **Two policies.** ``PEER`` is symmetric RRF: both retrievers are
+        credible judges, and agreement between them wins. That is right when
+        the lexical list came from the conjunctive pass — those documents
+        contain everything the caller typed.
+
+        ``LEXICAL_TAIL`` applies when no document contained all the query
+        terms and the lexical list is the disjunctive fallback. Then lexical
+        search has no real evidence, only word overlap, and symmetric RRF
+        actively hurts: a note both lists rank *mediocrely* outscores the note
+        the vector retriever ranks first, because under RRF (k=60) mere
+        agreement beats any single-list rank. Measured on the golden vault's
+        relevance battery, that is exactly how a paraphrased question's correct
+        answer fell from vector rank 1 to hybrid rank 6. So under this policy
+        the vector ranking leads and lexical-only hits are appended below it —
+        candidates, not competitors.
+        """
+        fts_ranked = _collapse(fts_hits)
+        vector_ranked = _collapse(vector_hits)
+        scores: dict[str, float] = {}
+        best: dict[str, SearchHit] = {}
+        fts_weight = 1.0 if policy == PEER else _TAIL_SCALE
+        fts_rank_of: dict[str, int] = {}
+        vector_rank_of: dict[str, int] = {}
+        for rank, hit in enumerate(fts_ranked):
+            scores[hit.permalink] = scores.get(hit.permalink, 0.0) + fts_weight / (RRF_K + rank + 1)
+            best[hit.permalink] = hit
+            fts_rank_of[hit.permalink] = rank
+        for rank, hit in enumerate(vector_ranked):
+            scores[hit.permalink] = scores.get(hit.permalink, 0.0) + 1.0 / (RRF_K + rank + 1)
+            vector_rank_of[hit.permalink] = rank
+            if hit.permalink not in best:
+                best[hit.permalink] = hit
+            elif not best[hit.permalink].snippet:
+                best[hit.permalink] = replace(best[hit.permalink], snippet=hit.snippet)
+        ordered = sorted(
+            best.values(),
+            key=lambda hit: (-scores[hit.permalink], hit.ref),
+        )
+        return [
+            replace(
+                hit,
+                score=scores[hit.permalink],
+                fts_rank=fts_rank_of.get(hit.permalink),
+                vector_rank=vector_rank_of.get(hit.permalink),
+            )
+            for hit in ordered[:limit]
+        ]
+
+    def search(
+        self,
+        query: str,
+        *,
+        mode: SearchMode = "hybrid",
+        limit: int = 10,
+        filters: SearchFilters | None = None,
+        query_embedding: Sequence[float] | None = None,
+        vectors_reason: str = "",
+    ) -> SearchResults:
+        """Run ``query`` in ``mode``, degrading to FTS when vectors cannot run."""
+        filters = filters or SearchFilters()
+        depth = max(limit * _FUSION_DEPTH_FACTOR, _FUSION_MIN_DEPTH)
+
+        if mode == "fts":
+            return SearchResults(
+                hits=tuple(self.fts(query, limit=limit, filters=filters)),
+                mode=mode,
+                effective_mode="fts",
+            )
+
+        vector_hits: list[SearchHit] = []
+        if query_embedding is not None:
+            vector_hits = self.vector(query_embedding, limit=depth, filters=filters)
+
+        if mode == "vector":
+            if query_embedding is None or not vector_hits:
+                reason = vectors_reason or (
+                    "no vectors are ready yet — the embed backlog is still draining"
+                )
+                return SearchResults(
+                    hits=tuple(self._degraded_fts(query, limit=limit, filters=filters)),
+                    mode=mode,
+                    effective_mode="fts",
+                    degraded=True,
+                    degraded_reason=reason,
+                )
+            return SearchResults(
+                hits=tuple(vector_hits[:limit]), mode=mode, effective_mode="vector"
+            )
+
+        fts_hits, fts_operator = self.fts_pass(query, limit=depth, filters=filters)
+        if not vector_hits:
+            return SearchResults(
+                hits=tuple(_collapse(fts_hits)[:limit]),
+                mode=mode,
+                effective_mode="fts",
+                degraded=True,
+                degraded_reason=vectors_reason
+                or "no vectors are ready yet — the embed backlog is still draining",
+            )
+        return SearchResults(
+            hits=tuple(
+                self.fuse(
+                    fts_hits,
+                    vector_hits,
+                    limit=limit,
+                    policy=PEER if fts_operator == "AND" else LEXICAL_TAIL,
+                )
+            ),
+            mode=mode,
+            effective_mode="hybrid",
+        )
+
+
+    def _degraded_fts(
+        self, query: str, *, limit: int, filters: SearchFilters | None
+    ) -> list[SearchHit]:
+        """FTS results at *note* granularity, for a degraded hybrid/vector query.
+
+        A hybrid query's results are one-per-note (that is what fusion
+        produces), so its FTS fallback must be too — otherwise ``limit=5``
+        silently means "five matching lines, possibly all from one note".
+        Explicit ``mode="fts"`` keeps sub-note rows: there the caller asked for
+        the addressable granularity.
+        """
+        depth = max(limit * _FUSION_DEPTH_FACTOR, _FUSION_MIN_DEPTH)
+        return _collapse(self.fts(query, limit=depth, filters=filters))[:limit]
+
+
+def _collapse(hits: Sequence[SearchHit]) -> list[SearchHit]:
+    """One entry per note, keeping each note's best-ranked hit and order."""
+    seen: set[str] = set()
+    collapsed: list[SearchHit] = []
+    for hit in hits:
+        if hit.permalink in seen:
+            continue
+        seen.add(hit.permalink)
+        collapsed.append(hit)
+    return collapsed
+
+
+def _head(text: str, width: int = 160) -> str:
+    """First ``width`` characters of a chunk, as a vector hit's snippet."""
+    flat = " ".join(text.split())
+    return flat if len(flat) <= width else flat[: width - 1].rstrip() + "…"
+
+
+__all__ = [
+    "LEXICAL_TAIL",
+    "PEER",
+    "RRF_K",
+    "IndexSearch",
+    "fts_match_expression",
+    "query_tokens",
+]

--- a/v3/server/src/palaia_hub/index/service.py
+++ b/v3/server/src/palaia_hub/index/service.py
@@ -1,0 +1,417 @@
+"""The per-vault index as one object: :class:`VaultIndex`.
+
+Everything the rest of the hub touches goes through here — the gateway's
+search tool, the dashboard's status panel, the doctor's reindex/verify.
+Three responsibilities:
+
+1. **Lifecycle.** Open the SQLite file, do the initial build, subscribe to the
+   vault's change events, and stop cleanly. The subscription is what makes the
+   index incremental: SPEC-102's :class:`~palaia_hub.vault.EventBus` already
+   emits exactly the vocabulary needed (created/modified/moved/deleted/renamed).
+2. **The embed backlog.** A background task drains pending chunks in batches.
+   It is deliberately the *only* thing that ever calls an embedder for
+   indexing, so no write path can accidentally take the 437 ms/note hit the
+   SPEC-003 spike measured.
+3. **Degrading honestly.** Every query reports the mode it actually ran in.
+   With no embedder, no sqlite-vec, or an undrained backlog, a hybrid query is
+   an FTS query that says so.
+
+An :class:`EntityRenamed` event triggers a full reindex rather than a
+single-note update: a rename rewrites *inbound wikilinks across the whole
+vault* in one commit (format spec §4.2) and emits one event for all of it, so
+the only correct response is to re-walk the vault. That is affordable because
+:meth:`VaultIndex.reindex` skips notes whose checksum is unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import time
+from collections.abc import Callable, Iterator, Sequence
+from pathlib import Path
+
+from palaia_hub.vault import (
+    ChangeEvent,
+    EntityRenamed,
+    Finding,
+    IndexEntry,
+    NoteCreated,
+    NoteDeleted,
+    NoteModified,
+    NoteMoved,
+    VaultDoctor,
+    VaultEngine,
+)
+
+from .db import INDEX_RELATIVE_PATH, IndexDatabase
+from .embeddings import Embedder, EmbedderUnavailableError, EmbeddingConfig, build_embedder
+from .models import (
+    EmbedStatus,
+    IndexStatus,
+    SearchFilters,
+    SearchMode,
+    SearchResults,
+)
+from .schema import META_EMBED_DIM, META_EMBED_MODEL, SCHEMA_VERSION
+from .search import IndexSearch
+from .writer import IndexWriter
+
+logger = logging.getLogger("palaia_hub.index.service")
+
+#: How long the embed worker waits for new work before re-checking. Only a
+#: safety net — every indexing write wakes it immediately.
+_WORKER_POLL_SECONDS = 2.0
+
+#: A chunk that fails this many times is parked as ``failed`` instead of
+#: spinning the worker forever on the same input.
+_MAX_EMBED_ATTEMPTS = 3
+
+
+class VaultIndex:
+    """One vault's searchable projection."""
+
+    def __init__(
+        self,
+        engine: VaultEngine,
+        *,
+        path: Path | None = None,
+        embedding: EmbeddingConfig | None = None,
+        embedder: Embedder | None = None,
+    ) -> None:
+        self._engine = engine
+        self._embedding = embedding or EmbeddingConfig()
+        self.db = IndexDatabase(path or engine.root / INDEX_RELATIVE_PATH, engine.name)
+        self.writer = IndexWriter(self.db, self._embedding)
+        self.searcher = IndexSearch(self.db)
+        self._doctor = VaultDoctor(engine)
+        self._embedder: Embedder | None = embedder
+        self._embedder_failed = ""
+        self._embedder_probed = embedder is not None
+        self._unsubscribe: Callable[[], None] | None = None
+        self._worker: asyncio.Task[None] | None = None
+        self._wake = asyncio.Event()
+        self._closing = False
+        self._last_indexed_at = 0.0
+
+    # ------------------------------------------------------------- lifecycle
+
+    async def open(self, *, build: bool = True, start_worker: bool = True) -> int:
+        """Open the index, optionally build it, and subscribe to change events.
+
+        Returns the number of notes indexed by the initial build (0 when
+        ``build=False``).
+        """
+        await asyncio.to_thread(self.db.open)
+        indexed = await self.reindex() if build else 0
+        if self._engine.bus is not None:
+            self._unsubscribe = self._engine.bus.subscribe(self._on_event)
+        if start_worker and self._embedding.enabled:
+            self.start_worker()
+        return indexed
+
+    def start_worker(self) -> None:
+        """Start the background embed worker (idempotent)."""
+        if self._worker is None or self._worker.done():
+            self._worker = asyncio.create_task(self._worker_loop())
+
+    async def close(self) -> None:
+        """Unsubscribe, stop the worker, close the database."""
+        self._closing = True
+        if self._unsubscribe is not None:
+            self._unsubscribe()
+        self._unsubscribe = None
+        if self._worker is not None:
+            self._wake.set()
+            self._worker.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._worker
+            self._worker = None
+        await asyncio.to_thread(self.db.close)
+
+    # -------------------------------------------------------- doctor plumbing
+
+    def index_entries(self) -> Iterator[IndexEntry]:
+        """:class:`~palaia_hub.vault.IndexView` implementation (drift check)."""
+        return self.writer.index_entries()
+
+    async def reindex(self) -> int:
+        """Full rebuild from files via the doctor's reindex hook.
+
+        The whole walk is one transaction (see :class:`~.writer.IndexWriter`),
+        and notes whose checksum already matches the index are skipped, so a
+        no-op reindex is cheap enough to use as the response to any event the
+        index cannot interpret precisely.
+        """
+        count = await self._engine.reindex(self.writer)
+        self._last_indexed_at = time.monotonic()
+        self._wake.set()
+        logger.debug("reindexed %d note(s) of vault %s", count, self._engine.name)
+        return count
+
+    async def verify(self) -> list[Finding]:
+        """Doctor verification *including* file↔index drift for this index."""
+        return await self._doctor.verify(self)
+
+    # ------------------------------------------------------------ event intake
+
+    async def _on_event(self, event: ChangeEvent) -> None:
+        """Apply one vault change event to the index."""
+        try:
+            await self.apply_event(event)
+        except Exception:  # noqa: BLE001 - an index update must not break a write
+            logger.exception("index update failed", extra={"event": type(event).__name__})
+
+    async def apply_event(self, event: ChangeEvent) -> None:
+        """Apply one change event (public so tests can drive it directly)."""
+        if isinstance(event, NoteDeleted):
+            await asyncio.to_thread(self.writer.delete_note, event.path)
+        elif isinstance(event, NoteMoved):
+            note = await self._engine.read_note(event.path)
+            await asyncio.to_thread(self.writer.move_note, event.previous_path, note)
+        elif isinstance(event, (NoteCreated, NoteModified)):
+            note = await self._engine.read_note(event.path)
+            await asyncio.to_thread(self.writer.upsert_note, note)
+        elif isinstance(event, EntityRenamed):
+            # A rename rewrote inbound links vault-wide under a single event.
+            await self.reindex()
+        else:  # pragma: no cover - the union is closed today
+            logger.debug("ignoring unknown event %s", type(event).__name__)
+            return
+        self._last_indexed_at = time.monotonic()
+        self._wake.set()
+
+    # ----------------------------------------------------------------- search
+
+    async def search(
+        self,
+        query: str,
+        *,
+        mode: SearchMode = "hybrid",
+        limit: int = 10,
+        filters: SearchFilters | None = None,
+    ) -> SearchResults:
+        """Search this vault. Never raises on odd query text."""
+        embedding: Sequence[float] | None = None
+        reason = ""
+        if mode in ("vector", "hybrid"):
+            embedding, reason = await self._embed_query(query)
+        return await asyncio.to_thread(
+            lambda: self.searcher.search(
+                query,
+                mode=mode,
+                limit=limit,
+                filters=filters,
+                query_embedding=embedding,
+                vectors_reason=reason,
+            )
+        )
+
+    async def _embed_query(self, query: str) -> tuple[Sequence[float] | None, str]:
+        """Embed the query, or explain why the vector half cannot run.
+
+        Deliberately checks the backlog *before* paying for a query embedding
+        (~108 ms in the spike): with nothing ready to match against, the
+        embedding would be wasted work on the answer path.
+        """
+        status = self.embed_status()
+        if not status.enabled:
+            return None, "embeddings are disabled for this vault"
+        if not status.available:
+            return None, status.reason or "no embedding backend is available"
+        if status.ready == 0:
+            return None, (
+                f"no vectors are ready yet ({status.pending} chunk(s) pending) — "
+                f"answering from full-text search"
+            )
+        embedder = await self._ensure_embedder()
+        if embedder is None:
+            return None, self._embedder_failed or "no embedding backend is available"
+        try:
+            vectors = await asyncio.to_thread(embedder.embed, [query])
+        except Exception as exc:  # noqa: BLE001 - backend-specific failures
+            logger.warning("query embedding failed, degrading to FTS: %s", exc)
+            return None, f"query embedding failed ({exc})"
+        return vectors[0], ""
+
+    # ------------------------------------------------------------- embeddings
+
+    async def _ensure_embedder(self) -> Embedder | None:
+        if self._embedder is not None:
+            return self._embedder
+        if self._embedder_probed:
+            return None
+        self._embedder_probed = True
+        try:
+            embedder = await asyncio.to_thread(build_embedder, self._embedding)
+        except EmbedderUnavailableError as exc:
+            self._embedder_failed = str(exc)
+            logger.warning("embeddings unavailable: %s", exc)
+            return None
+        self._embedder = embedder
+        self.db.meta_set(META_EMBED_MODEL, embedder.name)
+        self.db.meta_set(META_EMBED_DIM, str(embedder.dim))
+        return embedder
+
+    async def _worker_loop(self) -> None:
+        """Drain the embed backlog in batches, forever."""
+        while not self._closing:
+            try:
+                await asyncio.wait_for(self._wake.wait(), timeout=_WORKER_POLL_SECONDS)
+            except TimeoutError:
+                pass
+            self._wake.clear()
+            try:
+                while await self.embed_next_batch():
+                    pass
+            except asyncio.CancelledError:  # pragma: no cover - shutdown
+                raise
+            except Exception:  # noqa: BLE001 - the worker must survive anything
+                logger.exception("embed worker batch failed")
+                await asyncio.sleep(_WORKER_POLL_SECONDS)
+
+    async def embed_next_batch(self) -> int:
+        """Embed one batch of pending chunks; returns how many were embedded.
+
+        Public because it is also how tests (and a future CLI ``palaia-hub
+        index embed``) drain the backlog deterministically instead of racing
+        the worker.
+        """
+        if not self._embedding.enabled:
+            return 0
+        rows = await asyncio.to_thread(self._claim_batch)
+        if not rows:
+            return 0
+        embedder = await self._ensure_embedder()
+        if embedder is None:
+            return 0
+        if not await asyncio.to_thread(self.db.ensure_vec_table, embedder.dim):
+            logger.info(
+                "vector table unavailable (%s); backlog left pending", self.db.vectors.reason
+            )
+            return 0
+        texts = [text for _, text in rows]
+        try:
+            vectors = await asyncio.to_thread(embedder.embed, texts)
+        except Exception as exc:  # noqa: BLE001 - backend-specific failures
+            logger.warning("embedding batch failed: %s", exc)
+            await asyncio.to_thread(self._record_failures, [chunk_id for chunk_id, _ in rows])
+            return 0
+        await asyncio.to_thread(
+            self._store_vectors, [chunk_id for chunk_id, _ in rows], vectors
+        )
+        return len(rows)
+
+    async def drain_embeddings(self, *, timeout: float = 120.0) -> int:
+        """Embed everything pending (test/CLI helper); returns chunks embedded."""
+        deadline = time.monotonic() + timeout
+        total = 0
+        while time.monotonic() < deadline:
+            done = await self.embed_next_batch()
+            if done == 0:
+                break
+            total += done
+        return total
+
+    def _claim_batch(self) -> list[tuple[int, str]]:
+        with self.db.lock:
+            rows = self.db.conn.execute(
+                "SELECT id, text FROM chunks WHERE state = 'pending' "
+                "ORDER BY id LIMIT ?",
+                (self._embedding.batch_size,),
+            ).fetchall()
+        return [(int(row["id"]), str(row["text"])) for row in rows]
+
+    def _store_vectors(self, chunk_ids: Sequence[int], vectors: Sequence[Sequence[float]]) -> None:
+        import sqlite_vec
+
+        with self.db.lock:
+            conn = self.db.conn
+            for chunk_id, vector in zip(chunk_ids, vectors, strict=True):
+                conn.execute("DELETE FROM vec_chunks WHERE rowid = ?", (chunk_id,))
+                conn.execute(
+                    "INSERT INTO vec_chunks(rowid, embedding) VALUES (?, ?)",
+                    (chunk_id, sqlite_vec.serialize_float32(list(vector))),
+                )
+                conn.execute(
+                    "UPDATE chunks SET state = 'ready', attempts = 0 WHERE id = ?", (chunk_id,)
+                )
+            conn.commit()
+
+    def _record_failures(self, chunk_ids: Sequence[int]) -> None:
+        with self.db.lock:
+            conn = self.db.conn
+            for chunk_id in chunk_ids:
+                conn.execute(
+                    "UPDATE chunks SET attempts = attempts + 1, "
+                    "state = CASE WHEN attempts + 1 >= ? THEN 'failed' ELSE 'pending' END "
+                    "WHERE id = ?",
+                    (_MAX_EMBED_ATTEMPTS, chunk_id),
+                )
+            conn.commit()
+
+    # ----------------------------------------------------------------- status
+
+    def embed_status(self) -> EmbedStatus:
+        """The embed backlog, as the status API reports it."""
+        counts = {"pending": 0, "ready": 0, "failed": 0}
+        if self.db.opened:
+            with self.db.lock:
+                for row in self.db.conn.execute(
+                    "SELECT state, COUNT(*) AS n FROM chunks GROUP BY state"
+                ).fetchall():
+                    counts[str(row["state"])] = int(row["n"])
+        available = self.db.vectors.available
+        reason = "" if available else self.db.vectors.reason
+        if available and self._embedder_failed:
+            available = False
+            reason = self._embedder_failed
+        model = self.db.meta_get(META_EMBED_MODEL) or self._embedding.model
+        dim = self.db.meta_get(META_EMBED_DIM)
+        return EmbedStatus(
+            enabled=self._embedding.enabled,
+            available=available,
+            model=model,
+            dim=int(dim) if dim else 0,
+            total=sum(counts.values()),
+            ready=counts["ready"],
+            pending=counts["pending"],
+            failed=counts["failed"],
+            reason=reason,
+        )
+
+    def status(self) -> IndexStatus:
+        """Everything the dashboard/CLI needs about this vault's index."""
+        with self.db.lock:
+            conn = self.db.conn
+            notes = int(conn.execute("SELECT COUNT(*) AS n FROM notes").fetchone()["n"])
+            observations = int(
+                conn.execute("SELECT COUNT(*) AS n FROM observations").fetchone()["n"]
+            )
+            relations = int(conn.execute("SELECT COUNT(*) AS n FROM relations").fetchone()["n"])
+            unresolved = int(
+                conn.execute(
+                    "SELECT COUNT(*) AS n FROM relations WHERE target_permalink IS NULL"
+                ).fetchone()["n"]
+            )
+            by_type = {
+                str(row["type"]): int(row["n"])
+                for row in conn.execute(
+                    "SELECT type, COUNT(*) AS n FROM notes GROUP BY type ORDER BY type"
+                ).fetchall()
+            }
+        return IndexStatus(
+            vault=self._engine.name,
+            path=str(self.db.path),
+            schema_version=SCHEMA_VERSION,
+            notes=notes,
+            observations=observations,
+            relations=relations,
+            unresolved_relations=unresolved,
+            embeds=self.embed_status(),
+            counts_by_type=by_type,
+        )
+
+
+__all__ = ["VaultIndex"]

--- a/v3/server/src/palaia_hub/index/writer.py
+++ b/v3/server/src/palaia_hub/index/writer.py
@@ -1,0 +1,485 @@
+"""Turning notes into index rows — and keeping references resolved.
+
+This module is the only writer of the index tables. Three behaviors carry
+most of the SPEC's weight:
+
+**Batched builds.** :class:`IndexWriter` implements the vault doctor's
+``ReindexSink`` protocol, and a whole rebuild runs inside **one** transaction
+(``begin`` → ``emit``\\ × n → ``finish``). The spike measured an easy 5-10×
+from that alone; committing per note also makes a crashed rebuild leave a
+half-index behind, which a single transaction cannot.
+
+**Forward references resolve in both directions.** ``- depends_on [[Q3
+Roadmap]]`` is legal when no such note exists (format spec §5.2): the
+relation is stored with ``target_permalink = NULL``. When a note that answers
+to "Q3 Roadmap" later appears, :meth:`IndexWriter.upsert_note` back-resolves
+every waiting relation — no full reindex, per the SPEC's acceptance
+criterion. Deleting the target puts them back to NULL.
+
+**Reindex preserves embedding work.** A rebuild does not blindly delete and
+reinsert: notes are matched by path and chunks by ``(seq, fingerprint)``, so a
+reindex of an unchanged vault leaves every vector in place. Editing one
+paragraph re-embeds one chunk.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from collections.abc import Iterator, Sequence
+from typing import Any
+
+from palaia_hub.vault import IndexEntry, Note
+from palaia_hub.vault import permalink as pl
+from palaia_hub.vault.parse import ParsedNote, parse_note
+
+from .db import IndexDatabase
+from .embeddings import Chunk, EmbeddingConfig, chunk_text, embeddable_text
+from .models import observation_permalink, relation_permalink
+from .schema import KIND_NOTE, KIND_OBSERVATION, KIND_RELATION
+
+logger = logging.getLogger("palaia_hub.index.writer")
+
+#: Frontmatter keys with their own columns/tables — not duplicated into
+#: ``note_meta``, which exists for everything else (§2.1's unknown keys).
+_META_SKIP = frozenset({"title", "permalink", "type", "tags", "aliases"})
+
+
+def _folder_of(path: str) -> str:
+    return path.rsplit("/", 1)[0] if "/" in path else ""
+
+
+def _permalink_for(note: Note, parsed: ParsedNote) -> str:
+    """The identity this note is indexed under.
+
+    A note may legitimately have no permalink yet (the engine mints one on
+    first index via a write-back commit, §3.1) — until it does, the path
+    without its suffix stands in, which is exactly what the gateway adapter
+    already reports to callers.
+    """
+    return parsed.permalink or note.permalink or note.path.removesuffix(".md")
+
+
+def _resolution_keys(permalink: str, title: str, aliases: Sequence[str]) -> list[str]:
+    """Every lowercase string this note answers to (§3.2 resolution order)."""
+    keys = {permalink.lower(), title.strip().lower(), pl.slugify(title)}
+    for alias in aliases:
+        alias = str(alias).strip()
+        if alias:
+            keys.add(alias.lower())
+            keys.add(pl.slugify(alias))
+    # A permalink's last segment ("projects/api-gateway" -> "api-gateway") is
+    # how a wikilink usually names it.
+    keys.add(permalink.rsplit("/", 1)[-1].lower())
+    return sorted(key for key in keys if key)
+
+
+def _flatten_meta(frontmatter: dict[str, Any]) -> list[tuple[str, str]]:
+    """Flatten frontmatter into ``(key, value)`` filter rows."""
+    rows: list[tuple[str, str]] = []
+    for key, value in frontmatter.items():
+        name = str(key)
+        if name in _META_SKIP:
+            continue
+        if isinstance(value, dict):
+            for sub_key, sub_value in value.items():
+                if not isinstance(sub_value, (dict, list)):
+                    rows.append((f"{name}.{sub_key}", str(sub_value)))
+            continue
+        if isinstance(value, (list, tuple)):
+            rows.extend((name, str(item)) for item in value if not isinstance(item, (dict, list)))
+            continue
+        rows.append((name, str(value)))
+    return rows
+
+
+class IndexWriter:
+    """Writes one vault's index. Implements the doctor's ``ReindexSink``."""
+
+    def __init__(self, db: IndexDatabase, embedding: EmbeddingConfig | None = None) -> None:
+        self._db = db
+        self._embedding = embedding or EmbeddingConfig()
+        self._rebuild_seen: set[str] | None = None
+
+    # ------------------------------------------------------- ReindexSink API
+
+    def begin(self, vault: str) -> None:
+        """Start a full rebuild: one transaction for the whole vault."""
+        with self._db.lock:
+            self._rebuild_seen = set()
+            if self._db.conn.in_transaction:  # pragma: no cover - defensive
+                self._db.conn.commit()
+            self._db.conn.execute("BEGIN IMMEDIATE")
+
+    def emit(self, note: Note) -> None:
+        """Index one note as part of the in-flight rebuild."""
+        if self._rebuild_seen is None:  # pragma: no cover - misuse
+            raise RuntimeError("emit() called outside a begin()/finish() rebuild")
+        with self._db.lock:
+            self._rebuild_seen.add(note.path)
+            self._index_note(note)
+
+    def finish(self) -> None:
+        """Drop notes that vanished, then commit the rebuild atomically."""
+        with self._db.lock:
+            seen = self._rebuild_seen or set()
+            stale = [
+                str(row["path"])
+                for row in self._db.conn.execute("SELECT path FROM notes").fetchall()
+                if str(row["path"]) not in seen
+            ]
+            for path in stale:
+                self._delete_note(path)
+            self._db.conn.commit()
+            self._rebuild_seen = None
+            if stale:
+                logger.debug("rebuild dropped %d stale note(s)", len(stale))
+
+    def abort(self) -> None:
+        """Roll back an in-flight rebuild (a half-index is never committed)."""
+        with self._db.lock:
+            if self._rebuild_seen is not None:
+                self._db.conn.rollback()
+                self._rebuild_seen = None
+
+    # -------------------------------------------------------- incremental API
+
+    def upsert_note(self, note: Note) -> None:
+        """Index (or re-index) one note and commit."""
+        with self._db.lock:
+            self._index_note(note)
+            self._db.conn.commit()
+
+    def delete_note(self, path: str) -> bool:
+        """Remove one note from the index; returns whether it was present."""
+        with self._db.lock:
+            removed = self._delete_note(path)
+            self._db.conn.commit()
+        return removed
+
+    def move_note(self, previous_path: str, note: Note) -> None:
+        """Handle a move: drop the old path's rows, index the new ones."""
+        with self._db.lock:
+            if previous_path != note.path:
+                self._delete_note(previous_path)
+            self._index_note(note)
+            self._db.conn.commit()
+
+    # ------------------------------------------------------------- IndexView
+
+    def index_entries(self) -> Iterator[IndexEntry]:
+        """Yield one :class:`~palaia_hub.vault.IndexEntry` per indexed note.
+
+        This is the doctor's file↔index drift check (SPEC-102 wrote its
+        ``_check_index`` against this protocol before an index existed).
+        """
+        with self._db.lock:
+            rows = self._db.conn.execute(
+                "SELECT permalink, path, checksum FROM notes ORDER BY path"
+            ).fetchall()
+        for row in rows:
+            yield IndexEntry(
+                permalink=str(row["permalink"]),
+                path=str(row["path"]),
+                checksum=str(row["checksum"]),
+            )
+
+    # ---------------------------------------------------------------- internals
+
+    def _index_note(self, note: Note) -> None:
+        conn = self._db.conn
+        row = conn.execute(
+            "SELECT id, permalink, checksum FROM notes WHERE path = ?", (note.path,)
+        ).fetchone()
+        if row is not None and str(row["checksum"]) == note.checksum:
+            # Byte-identical content produces byte-identical rows, so a
+            # reindex of an unchanged vault (and any event that re-emits a note
+            # that did not really change) costs one SELECT per note — no parse,
+            # no chunking, no writes. This is what makes "reindex on anything
+            # ambiguous" an affordable strategy in the service layer.
+            return
+        parsed = parse_note(note.text, note.path)
+        permalink = _permalink_for(note, parsed)
+        aliases = list(note.aliases) or [
+            str(alias) for alias in parsed.frontmatter.get("aliases", []) or []
+        ]
+        frontmatter = dict(parsed.frontmatter)
+        values = (
+            permalink,
+            parsed.title,
+            parsed.type,
+            _folder_of(note.path),
+            json.dumps(list(parsed.tags)),
+            json.dumps(aliases),
+            str(frontmatter.get("created") or "") or None,
+            str(frontmatter.get("modified") or "") or None,
+            note.checksum,
+            parsed.body,
+            json.dumps(frontmatter, sort_keys=True, default=str),
+        )
+        if row is None:
+            cursor = conn.execute(
+                "INSERT INTO notes(path, permalink, title, type, folder, tags, aliases, "
+                "created, modified, checksum, body, frontmatter) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (note.path, *values),
+            )
+            note_id = int(cursor.lastrowid or 0)
+        else:
+            note_id = int(row["id"])
+            previous_permalink = str(row["permalink"])
+            conn.execute(
+                "UPDATE notes SET permalink=?, title=?, type=?, folder=?, tags=?, aliases=?, "
+                "created=?, modified=?, checksum=?, body=?, frontmatter=? WHERE id=?",
+                (*values, note_id),
+            )
+            if previous_permalink != permalink:
+                # The identity moved: anything pointing at the old permalink
+                # is no longer resolved by it (the back-resolution below
+                # re-links whatever the new identity answers to).
+                self._unresolve_target(previous_permalink)
+            for table in ("note_keys", "note_tags", "note_meta", "observations", "relations"):
+                conn.execute(f"DELETE FROM {table} WHERE note_id = ?", (note_id,))
+            conn.execute("DELETE FROM search_rows WHERE note_id = ?", (note_id,))
+
+        keys = _resolution_keys(permalink, parsed.title, aliases)
+        conn.executemany(
+            "INSERT INTO note_keys(note_id, key) VALUES (?, ?)",
+            [(note_id, key) for key in keys],
+        )
+        conn.executemany(
+            "INSERT INTO note_tags(note_id, tag) VALUES (?, ?)",
+            [(note_id, tag.lower()) for tag in parsed.tags],
+        )
+        conn.executemany(
+            "INSERT INTO note_meta(note_id, key, value) VALUES (?, ?, ?)",
+            [(note_id, key, value) for key, value in _flatten_meta(frontmatter)],
+        )
+
+        self._insert_note_row(note_id, permalink, parsed, aliases)
+        self._insert_observations(note_id, permalink, parsed)
+        self._insert_relations(note_id, permalink, parsed)
+        self._sync_chunks(note_id, permalink, parsed)
+        # Back-resolution: this note may be the target other notes were
+        # waiting for (acceptance criterion: "forward reference resolves when
+        # target note appears (no full reindex)").
+        self._resolve_pending(permalink, keys)
+
+    def _insert_note_row(
+        self, note_id: int, permalink: str, parsed: ParsedNote, aliases: Sequence[str]
+    ) -> None:
+        # Aliases and tags join the note's searchable text so a query naming
+        # an old title or a tag word still finds the note.
+        extra = " ".join([*aliases, *(f"#{tag}" for tag in parsed.tags)])
+        text = f"{parsed.body}\n{extra}".strip() if extra else parsed.body
+        self._db.conn.execute(
+            "INSERT INTO search_rows(note_id, kind, ref, title, text) VALUES (?, ?, ?, ?, ?)",
+            (note_id, KIND_NOTE, permalink, parsed.title, text),
+        )
+
+    def _insert_observations(self, note_id: int, permalink: str, parsed: ParsedNote) -> None:
+        conn = self._db.conn
+        for obs in parsed.observations:
+            synthetic = observation_permalink(permalink, obs.category, obs.text)
+            conn.execute(
+                "INSERT INTO observations(note_id, permalink, category, scope, text, tags, "
+                "context, block_id, line) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    note_id,
+                    synthetic,
+                    obs.category,
+                    obs.scope,
+                    obs.text,
+                    json.dumps(list(obs.tags)),
+                    obs.context,
+                    obs.block_id,
+                    obs.line,
+                ),
+            )
+            parts = [f"[{obs.category}]", obs.text]
+            if obs.context:
+                parts.append(f"({obs.context})")
+            parts.extend(f"#{tag}" for tag in obs.tags)
+            conn.execute(
+                "INSERT INTO search_rows(note_id, kind, ref, title, text) VALUES (?, ?, ?, ?, ?)",
+                (note_id, KIND_OBSERVATION, synthetic, parsed.title, " ".join(parts)),
+            )
+
+    def _insert_relations(self, note_id: int, permalink: str, parsed: ParsedNote) -> None:
+        conn = self._db.conn
+        for rel in parsed.relations:
+            target_key = rel.target.strip().lower()
+            target_slug = pl.slugify(rel.target)
+            resolved = self._resolve_target(target_key, target_slug)
+            synthetic = relation_permalink(permalink, rel.type, resolved, rel.target)
+            conn.execute(
+                "INSERT INTO relations(note_id, permalink, type, target_raw, target_key, "
+                "target_slug, target_permalink, implicit, context, line) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    note_id,
+                    synthetic,
+                    rel.type,
+                    rel.target,
+                    target_key,
+                    target_slug,
+                    resolved,
+                    int(rel.implicit),
+                    rel.context,
+                    rel.line,
+                ),
+            )
+            text = f"{rel.type} {rel.target}"
+            if rel.context:
+                text = f"{text} ({rel.context})"
+            conn.execute(
+                "INSERT INTO search_rows(note_id, kind, ref, title, text) VALUES (?, ?, ?, ?, ?)",
+                (note_id, KIND_RELATION, synthetic, parsed.title, text),
+            )
+
+    # ------------------------------------------------------------- resolution
+
+    def _resolve_target(self, target_key: str, target_slug: str) -> str | None:
+        """Resolve one relation target to a permalink, deterministically.
+
+        Ambiguity is not an error here (that is the engine's resolver's job
+        for user-facing lookups); the index picks the lowest permalink so a
+        rebuild reproduces byte-identical results.
+        """
+        conn = self._db.conn
+        for key in (target_key, target_slug):
+            if not key:
+                continue
+            row = conn.execute(
+                "SELECT n.permalink FROM note_keys k JOIN notes n ON n.id = k.note_id "
+                "WHERE k.key = ? ORDER BY n.permalink, n.path LIMIT 1",
+                (key,),
+            ).fetchone()
+            if row is not None:
+                return str(row["permalink"])
+        return None
+
+    def _resolve_pending(self, permalink: str, keys: Sequence[str]) -> None:
+        """Point every waiting forward reference at this note's permalink."""
+        if not keys:
+            return
+        conn = self._db.conn
+        placeholders = ",".join("?" for _ in keys)
+        rows = conn.execute(
+            "SELECT r.id, r.note_id, r.permalink, r.type, r.target_raw, n.permalink AS source "
+            "FROM relations r JOIN notes n ON n.id = r.note_id "
+            "WHERE r.target_permalink IS NULL "
+            f"AND (r.target_key IN ({placeholders}) OR r.target_slug IN ({placeholders}))",
+            [*keys, *keys],
+        ).fetchall()
+        for row in rows:
+            new_ref = relation_permalink(
+                str(row["source"]), str(row["type"]), permalink, str(row["target_raw"])
+            )
+            conn.execute(
+                "UPDATE relations SET target_permalink = ?, permalink = ? WHERE id = ?",
+                (permalink, new_ref, int(row["id"])),
+            )
+            self._retarget_search_row(int(row["note_id"]), str(row["permalink"]), new_ref)
+        if rows:
+            logger.debug("resolved %d forward reference(s) to %s", len(rows), permalink)
+
+    def _unresolve_target(self, permalink: str) -> None:
+        """A target disappeared: its inbound relations become forward refs again."""
+        conn = self._db.conn
+        rows = conn.execute(
+            "SELECT r.id, r.note_id, r.permalink, r.type, r.target_raw, n.permalink AS source "
+            "FROM relations r JOIN notes n ON n.id = r.note_id "
+            "WHERE r.target_permalink = ?",
+            (permalink,),
+        ).fetchall()
+        for row in rows:
+            new_ref = relation_permalink(
+                str(row["source"]), str(row["type"]), None, str(row["target_raw"])
+            )
+            conn.execute(
+                "UPDATE relations SET target_permalink = NULL, permalink = ? WHERE id = ?",
+                (new_ref, int(row["id"])),
+            )
+            self._retarget_search_row(int(row["note_id"]), str(row["permalink"]), new_ref)
+
+    def _retarget_search_row(self, note_id: int, old_ref: str, new_ref: str) -> None:
+        if old_ref == new_ref:
+            return
+        self._db.conn.execute(
+            "UPDATE search_rows SET ref = ? WHERE note_id = ? AND kind = ? AND ref = ?",
+            (new_ref, note_id, KIND_RELATION, old_ref),
+        )
+
+    # ----------------------------------------------------------------- chunks
+
+    def _sync_chunks(self, note_id: int, permalink: str, parsed: ParsedNote) -> None:
+        """Reconcile this note's embedding units, reusing unchanged vectors."""
+        conn = self._db.conn
+        text = embeddable_text(parsed.title, parsed.body, [obs.text for obs in parsed.observations])
+        chunks = chunk_text(
+            text,
+            max_chars=self._embedding.max_chars,
+            overlap_chars=self._embedding.overlap_chars,
+        )
+        existing = {
+            int(row["seq"]): row
+            for row in conn.execute(
+                "SELECT id, seq, fingerprint FROM chunks WHERE note_id = ?", (note_id,)
+            ).fetchall()
+        }
+        for chunk in chunks:
+            row = existing.pop(chunk.seq, None)
+            if row is not None and str(row["fingerprint"]) == chunk.fingerprint:
+                conn.execute("UPDATE chunks SET ref = ? WHERE id = ?", (permalink, row["id"]))
+                continue
+            if row is not None:
+                self._drop_vector(int(row["id"]))
+                conn.execute(
+                    "UPDATE chunks SET ref=?, fingerprint=?, text=?, state='pending', attempts=0 "
+                    "WHERE id=?",
+                    (permalink, chunk.fingerprint, chunk.text, int(row["id"])),
+                )
+                continue
+            self._insert_chunk(note_id, permalink, chunk)
+        for row in existing.values():
+            self._drop_vector(int(row["id"]))
+            conn.execute("DELETE FROM chunks WHERE id = ?", (int(row["id"]),))
+
+    def _insert_chunk(self, note_id: int, permalink: str, chunk: Chunk) -> None:
+        self._db.conn.execute(
+            "INSERT INTO chunks(note_id, seq, ref, fingerprint, text, state) "
+            "VALUES (?, ?, ?, ?, ?, 'pending')",
+            (note_id, chunk.seq, permalink, chunk.fingerprint, chunk.text),
+        )
+
+    def _drop_vector(self, chunk_id: int) -> None:
+        if not self._db.has_vec_table():
+            return
+        try:
+            self._db.conn.execute("DELETE FROM vec_chunks WHERE rowid = ?", (chunk_id,))
+        except sqlite3.Error:  # pragma: no cover - vec table vanished
+            logger.debug("could not drop vector for chunk %s", chunk_id, exc_info=True)
+
+    # ----------------------------------------------------------------- delete
+
+    def _delete_note(self, path: str) -> bool:
+        conn = self._db.conn
+        row = conn.execute("SELECT id, permalink FROM notes WHERE path = ?", (path,)).fetchone()
+        if row is None:
+            return False
+        note_id = int(row["id"])
+        for chunk_row in conn.execute(
+            "SELECT id FROM chunks WHERE note_id = ?", (note_id,)
+        ).fetchall():
+            self._drop_vector(int(chunk_row["id"]))
+        # search_rows explicitly (its delete trigger keeps FTS in sync);
+        # the rest goes by ON DELETE CASCADE.
+        conn.execute("DELETE FROM search_rows WHERE note_id = ?", (note_id,))
+        conn.execute("DELETE FROM notes WHERE id = ?", (note_id,))
+        self._unresolve_target(str(row["permalink"]))
+        return True
+
+
+__all__ = ["IndexWriter"]

--- a/v3/server/tests/e2e/support/hub_server.py
+++ b/v3/server/tests/e2e/support/hub_server.py
@@ -12,6 +12,13 @@ adapter — no ``FakeVaultService`` anywhere in this module), under one or
 more profile paths. A :class:`~palaia_hub.vault.VaultWatcher` is always
 started alongside the engine so external edits (S2) become visible to the
 gateway's tools without a manual refresh.
+
+Search runs through the real SPEC-104 index (:class:`~palaia_hub.index.VaultIndex`),
+subscribed to the same event bus the watcher publishes on — which is what
+makes S2's "searchable within budget" a statement about the index, not about
+a linear scan. Embeddings are switched **off** here: they would download a
+model into every e2e run and add nothing to what these scenarios assert, and
+FTS-only degradation is itself a SPEC-104 acceptance criterion.
 """
 
 from __future__ import annotations
@@ -28,7 +35,8 @@ from palaia_hub.config import HubConfig
 from palaia_hub.gateway.build import build_gateway
 from palaia_hub.gateway.config import GatewayConfig, ProfileConfig, VaultMountConfig
 from palaia_hub.gateway.wiring import EngineVaultService
-from palaia_hub.vault import VaultEngine, VaultWatcher
+from palaia_hub.index import EmbeddingConfig, VaultIndex
+from palaia_hub.vault import EventBus, VaultEngine, VaultWatcher
 
 logger = logging.getLogger("e2e.hub_server")
 
@@ -36,8 +44,10 @@ logger = logging.getLogger("e2e.hub_server")
 async def _run(
     *, host: str, port: int, vault_dir: Path, vault_key: str, vault_name: str, profiles: list[str]
 ) -> None:
-    engine = VaultEngine(vault_dir, vault_name)
+    engine = VaultEngine(vault_dir, vault_name, bus=EventBus())
     await engine.open(purpose=f"SPEC-113 e2e vault {vault_name!r}", create=True)
+    index = VaultIndex(engine, embedding=EmbeddingConfig(enabled=False))
+    await index.open()
     watcher = VaultWatcher(engine)
     await watcher.start()
 
@@ -51,7 +61,7 @@ async def _run(
         ],
         profiles=[ProfileConfig(path=p, vaults=[vault_key]) for p in profiles],
     )
-    gateway = build_gateway(gateway_config, {vault_key: EngineVaultService(engine)})
+    gateway = build_gateway(gateway_config, {vault_key: EngineVaultService(engine, index)})
     app = create_app(HubConfig(log_level="info"), gateway=gateway)
 
     server = uvicorn.Server(uvicorn.Config(app, host=host, port=port, log_level="info"))
@@ -59,6 +69,7 @@ async def _run(
         await server.serve()
     finally:
         await watcher.stop()
+        await index.close()
         await engine.close()
 
 

--- a/v3/server/tests/index/conftest.py
+++ b/v3/server/tests/index/conftest.py
@@ -1,0 +1,75 @@
+"""Fixtures for the SPEC-104 index tests.
+
+The golden vault (SPEC-113 deliverable #1) is the corpus here too — its
+acceptance criterion says any SPEC may import it — so the rebuild-identity
+and relevance checks run against the same notes the e2e scenarios do, rather
+than against a fixture invented for this SPEC alone.
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import AsyncIterator, Callable
+from pathlib import Path
+
+import pytest
+
+from palaia_hub.index import EmbeddingConfig, VaultIndex
+from palaia_hub.vault import EventBus, VaultEngine
+
+GOLDEN_VAULT_ROOT = Path(__file__).parent.parent / "fixtures" / "golden-vault"
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture
+def golden_work_vault(tmp_path: Path) -> Path:
+    """A disposable copy of the golden vault's ``work`` vault."""
+    target = tmp_path / "work"
+    shutil.copytree(GOLDEN_VAULT_ROOT / "work", target)
+    return target
+
+
+IndexFactory = Callable[..., "AsyncIterator[tuple[VaultEngine, VaultIndex]]"]
+
+
+@pytest.fixture
+async def open_index() -> AsyncIterator[Callable[..., object]]:
+    """Factory yielding opened ``(engine, index)`` pairs, closed on teardown.
+
+    Embeddings default to *off*: the FTS/incremental/rebuild behavior is
+    independent of them, and a unit test must not download a model. Tests that
+    care about vectors pass their own ``embedder`` (a deterministic stub) or
+    switch embeddings on explicitly.
+    """
+    opened: list[tuple[VaultEngine, VaultIndex]] = []
+
+    async def factory(
+        root: Path,
+        name: str = "work",
+        *,
+        embedding: EmbeddingConfig | None = None,
+        embedder: object | None = None,
+        build: bool = True,
+        index_path: Path | None = None,
+    ) -> tuple[VaultEngine, VaultIndex]:
+        engine = VaultEngine(root, name, bus=EventBus())
+        await engine.open(purpose=f"index test vault {name}", create=True)
+        index = VaultIndex(
+            engine,
+            path=index_path,
+            embedding=embedding or EmbeddingConfig(enabled=False),
+            embedder=embedder,  # type: ignore[arg-type]
+        )
+        await index.open(build=build, start_worker=False)
+        opened.append((engine, index))
+        return engine, index
+
+    yield factory
+
+    for engine, index in reversed(opened):
+        await index.close()
+        await engine.close()

--- a/v3/server/tests/index/stub_embedder.py
+++ b/v3/server/tests/index/stub_embedder.py
@@ -1,0 +1,52 @@
+"""A deterministic embedder for tests that need vectors but not a model.
+
+Hashed bag-of-words: each token increments one dimension, the vector is L2
+normalized. That makes cosine similarity a lexical-overlap measure — enough to
+prove the plumbing (pending → ready, KNN returns the right note, fusion runs,
+vectors survive a reindex) without downloading 130 MB and burning 437 ms per
+note. Semantic quality is measured separately, against the real model, in
+``test_hybrid_relevance.py``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+from collections.abc import Sequence
+
+_TOKEN_RE = re.compile(r"[^\W_]+", re.UNICODE)
+
+
+class StubEmbedder:
+    """:class:`~palaia_hub.index.Embedder` with no model behind it."""
+
+    def __init__(self, dim: int = 64, name: str = "stub/hashed-bow") -> None:
+        self._dim = dim
+        self._name = name
+        self.calls = 0
+        self.embedded: list[str] = []
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def embed(self, texts: Sequence[str]) -> list[list[float]]:
+        self.calls += 1
+        self.embedded.extend(texts)
+        return [self._vector(text) for text in texts]
+
+    def _vector(self, text: str) -> list[float]:
+        vector = [0.0] * self._dim
+        for token in _TOKEN_RE.findall(text.casefold()):
+            digest = hashlib.sha256(token.encode("utf-8")).digest()
+            vector[digest[0] % self._dim] += 1.0
+        norm = math.sqrt(sum(value * value for value in vector))
+        if norm == 0.0:
+            vector[0] = 1.0
+            return vector
+        return [value / norm for value in vector]

--- a/v3/server/tests/index/test_embeddings.py
+++ b/v3/server/tests/index/test_embeddings.py
@@ -1,0 +1,256 @@
+"""Chunking, the embed backlog, and clean degradation while it drains.
+
+Uses the deterministic :class:`~stub_embedder.StubEmbedder`: the point here is
+the *mechanism* — write ack never waits on an embed, status reports the
+backlog, queries degrade to FTS while vectors are pending, and unchanged
+chunks keep their vectors. Semantic quality is measured against the real model
+in ``test_hybrid_relevance.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from stub_embedder import StubEmbedder
+
+from palaia_hub.index import EmbeddingConfig, chunk_text, embeddable_text, fingerprint
+
+pytestmark = pytest.mark.anyio
+
+
+def _stub_config(**kwargs: Any) -> EmbeddingConfig:
+    return EmbeddingConfig(enabled=True, model="stub/hashed-bow", **kwargs)
+
+
+# ------------------------------------------------------------------- chunking
+
+
+def test_short_text_is_one_chunk() -> None:
+    chunks = chunk_text("a short note body")
+    assert len(chunks) == 1
+    assert chunks[0].seq == 0
+    assert chunks[0].fingerprint == fingerprint("a short note body")
+
+
+def test_empty_text_produces_no_chunks() -> None:
+    assert chunk_text("   \n\n  ") == []
+
+
+def test_long_text_splits_on_paragraph_boundaries() -> None:
+    paragraph = "sentence about vaults. " * 12  # ~276 chars
+    text = "\n\n".join(paragraph for _ in range(10))
+    chunks = chunk_text(text, max_chars=600, overlap_chars=60)
+    assert len(chunks) > 1
+    assert all(len(chunk.text) <= 600 for chunk in chunks)
+    assert [chunk.seq for chunk in chunks] == list(range(len(chunks)))
+
+
+def test_oversized_single_paragraph_is_hard_split_with_overlap() -> None:
+    text = "x" * 2500
+    chunks = chunk_text(text, max_chars=1000, overlap_chars=100)
+    assert len(chunks) >= 3
+    assert all(len(chunk.text) <= 1000 for chunk in chunks)
+
+
+def test_fingerprints_are_stable_and_content_addressed() -> None:
+    first = chunk_text("stable text")[0]
+    second = chunk_text("stable text")[0]
+    assert first.fingerprint == second.fingerprint
+    assert chunk_text("other text")[0].fingerprint != first.fingerprint
+
+
+def test_embeddable_text_includes_title_body_and_observations() -> None:
+    text = embeddable_text("Title", "Body prose.", ["an observed fact"])
+    assert text.splitlines()[0] == "Title"
+    assert "Body prose." in text
+    assert "an observed fact" in text
+
+
+# ------------------------------------------------------------------- backlog
+
+
+async def test_build_leaves_chunks_pending_and_status_reports_the_backlog(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    _, index = await open_index(
+        golden_work_vault, embedding=_stub_config(), embedder=StubEmbedder()
+    )
+    status = index.status()
+    assert status.embeds.enabled
+    assert status.embeds.pending == status.embeds.total > 0
+    assert status.embeds.ready == 0
+
+
+async def test_hybrid_degrades_to_fts_while_vectors_are_pending(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    _, index = await open_index(
+        golden_work_vault, embedding=_stub_config(), embedder=StubEmbedder()
+    )
+    results = await index.search("API Gateway", mode="hybrid", limit=5)
+    assert results.mode == "hybrid"
+    assert results.effective_mode == "fts"
+    assert results.degraded
+    assert "pending" in results.degraded_reason
+    assert "projects/api-gateway" in {hit.permalink for hit in results.hits}
+
+
+async def test_vector_mode_also_degrades_rather_than_returning_nothing(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    _, index = await open_index(
+        golden_work_vault, embedding=_stub_config(), embedder=StubEmbedder()
+    )
+    results = await index.search("API Gateway", mode="vector", limit=5)
+    assert results.effective_mode == "fts"
+    assert results.degraded
+    assert results.hits
+
+
+async def test_draining_the_backlog_enables_vector_and_hybrid_modes(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    embedder = StubEmbedder()
+    _, index = await open_index(
+        golden_work_vault, embedding=_stub_config(batch_size=16), embedder=embedder
+    )
+    pending = index.status().embeds.pending
+    embedded = await index.drain_embeddings()
+    assert embedded == pending
+    status = index.status()
+    assert status.embeds.pending == 0
+    assert status.embeds.ready == pending
+    assert status.embeds.usable
+    assert embedder.calls >= pending / 16
+
+    vector = await index.search("gateway tool families per profile", mode="vector", limit=5)
+    assert not vector.degraded
+    assert vector.effective_mode == "vector"
+    assert vector.hits
+
+    hybrid = await index.search("API Gateway", mode="hybrid", limit=5)
+    assert hybrid.effective_mode == "hybrid"
+    assert not hybrid.degraded
+    assert "projects/api-gateway" in {hit.permalink for hit in hybrid.hits}
+
+
+async def test_background_worker_drains_the_backlog_without_being_asked(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    """The write path never embeds; the worker does, on its own."""
+    import asyncio
+
+    _, index = await open_index(
+        golden_work_vault, embedding=_stub_config(), embedder=StubEmbedder()
+    )
+    assert index.status().embeds.pending > 0
+    index.start_worker()
+    deadline = asyncio.get_event_loop().time() + 10.0
+    while asyncio.get_event_loop().time() < deadline:
+        if index.status().embeds.pending == 0:
+            break
+        await asyncio.sleep(0.05)
+    status = index.status()
+    assert status.embeds.pending == 0
+    assert status.embeds.ready > 0
+
+
+async def test_editing_a_note_only_re_embeds_its_changed_chunks(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    embedder = StubEmbedder()
+    engine, index = await open_index(
+        golden_work_vault, embedding=_stub_config(), embedder=embedder
+    )
+    long_body = "\n\n".join(f"Paragraph {n} about the vault engine. " * 20 for n in range(6))
+    await engine.write_note(
+        "notes/long.md", body=long_body + "\n", title="Long", frontmatter={"type": "note"}
+    )
+    await index.drain_embeddings()
+    chunks_before = _chunk_rows(index, "notes/long")
+    assert len(chunks_before) > 2
+
+    current = await engine.read_note("notes/long")
+    await engine.edit_note(
+        "notes/long",
+        body=long_body + "\n\nOne appended paragraph at the very end.\n",
+        expected_checksum=current.checksum,
+    )
+    pending = [row for row in _chunk_rows(index, "notes/long") if row["state"] == "pending"]
+    ready = [row for row in _chunk_rows(index, "notes/long") if row["state"] == "ready"]
+    assert pending, "the changed tail must be re-embedded"
+    assert ready, "unchanged chunks must keep their vectors"
+    assert len(pending) < len(chunks_before)
+
+
+async def test_reindex_preserves_ready_vectors(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    embedder = StubEmbedder()
+    _, index = await open_index(
+        golden_work_vault, embedding=_stub_config(), embedder=embedder
+    )
+    await index.drain_embeddings()
+    ready_before = index.status().embeds.ready
+    calls_before = embedder.calls
+    await index.reindex()
+    assert index.status().embeds.ready == ready_before
+    assert await index.drain_embeddings() == 0
+    assert embedder.calls == calls_before
+
+
+async def test_deleting_a_note_removes_its_chunks(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    engine, index = await open_index(
+        golden_work_vault, embedding=_stub_config(), embedder=StubEmbedder()
+    )
+    await index.drain_embeddings()
+    before = index.status().embeds.total
+    removed = len(_chunk_rows(index, "projects/curator"))
+    assert removed > 0
+    await engine.delete_note("projects/curator")
+    assert index.status().embeds.total == before - removed
+
+
+async def test_disabled_embeddings_report_why_and_still_search(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    _, index = await open_index(
+        golden_work_vault, embedding=EmbeddingConfig(enabled=False)
+    )
+    status = index.status()
+    assert not status.embeds.enabled
+    results = await index.search("API Gateway", mode="hybrid", limit=5)
+    assert results.degraded
+    assert "disabled" in results.degraded_reason
+    assert results.hits
+
+
+async def test_unavailable_embedder_degrades_without_raising(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    """A missing/broken model is an FTS-only index, not a broken hub."""
+    _, index = await open_index(
+        golden_work_vault,
+        embedding=EmbeddingConfig(enabled=True, model="does-not-exist/nope"),
+    )
+    assert await index.embed_next_batch() == 0
+    status = index.status()
+    assert status.embeds.pending > 0
+    assert not status.embeds.available
+    assert status.embeds.reason
+    results = await index.search("API Gateway", mode="hybrid", limit=5)
+    assert results.effective_mode == "fts"
+    assert results.hits
+
+
+def _chunk_rows(index: Any, permalink: str) -> list[Any]:
+    with index.db.lock:
+        return index.db.conn.execute(
+            "SELECT c.id, c.seq, c.state, c.fingerprint FROM chunks c "
+            "JOIN notes n ON n.id = c.note_id WHERE n.permalink = ? ORDER BY c.seq",
+            (permalink,),
+        ).fetchall()

--- a/v3/server/tests/index/test_fusion.py
+++ b/v3/server/tests/index/test_fusion.py
@@ -1,0 +1,71 @@
+"""Rank fusion, pinned as a unit — no database, no model.
+
+The two properties that took measurement to get right (see
+``test_hybrid_relevance.py``): a note is ranked once no matter how many rows
+it matched, and a disjunctive lexical list never outranks the vector list.
+"""
+
+from __future__ import annotations
+
+from palaia_hub.index import IndexSearch, SearchHit
+from palaia_hub.index.search import LEXICAL_TAIL, PEER
+
+
+def _hit(permalink: str, ref: str | None = None, kind: str = "note") -> SearchHit:
+    return SearchHit(
+        ref=ref or permalink,
+        permalink=permalink,
+        kind=kind,  # type: ignore[arg-type]
+        title=permalink,
+        snippet="",
+        score=0.0,
+    )
+
+
+def _fuse(fts: list[SearchHit], vector: list[SearchHit], **kwargs: object) -> list[str]:
+    searcher = IndexSearch.__new__(IndexSearch)  # no DB needed for pure fusion
+    hits = searcher.fuse(fts, vector, limit=10, **kwargs)  # type: ignore[arg-type]
+    return [hit.permalink for hit in hits]
+
+
+def test_agreement_between_retrievers_wins_under_peer_policy() -> None:
+    fts = [_hit("a"), _hit("b"), _hit("c")]
+    vector = [_hit("c"), _hit("d")]
+    # "c" is the only note both retrievers found: it leads even though each
+    # list ranks something else higher.
+    assert _fuse(fts, vector, policy=PEER)[0] == "c"
+
+
+def test_many_matching_rows_do_not_stack_a_notes_score() -> None:
+    """A note with six matching observations is still one ranked answer."""
+    fts = [_hit("noisy", f"noisy/obs/cat/{n:08x}", "observation") for n in range(6)]
+    fts.append(_hit("precise"))
+    vector = [_hit("precise")]
+    assert _fuse(fts, vector, policy=PEER)[0] == "precise"
+
+
+def test_lexical_tail_policy_lets_the_vector_ranking_lead() -> None:
+    fts = [_hit("overlap-noise"), _hit("more-noise"), _hit("agreed")]
+    vector = [_hit("semantic-answer"), _hit("agreed")]
+    ranked = _fuse(fts, vector, policy=LEXICAL_TAIL)
+    assert ranked[0] == "semantic-answer"
+    assert ranked[1] == "agreed"
+    # Lexical-only hits keep their BM25 order, below every vector result.
+    assert ranked[2:] == ["overlap-noise", "more-noise"]
+
+
+def test_fusion_keeps_the_more_specific_ref_from_the_lexical_list() -> None:
+    fts = [_hit("note", "note/obs/decision/deadbeef", "observation")]
+    vector = [_hit("note")]
+    searcher = IndexSearch.__new__(IndexSearch)
+    fused = searcher.fuse(fts, vector, limit=5)
+    assert fused[0].ref == "note/obs/decision/deadbeef"
+    assert fused[0].kind == "observation"
+    # Both retrievers' ranks survive on the result, for debugging a ranking.
+    assert fused[0].vector_rank == 0
+
+
+def test_empty_lists_fuse_to_nothing() -> None:
+    assert _fuse([], []) == []
+    assert _fuse([_hit("a")], []) == ["a"]
+    assert _fuse([], [_hit("b")]) == ["b"]

--- a/v3/server/tests/index/test_gateway_search.py
+++ b/v3/server/tests/index/test_gateway_search.py
@@ -1,0 +1,80 @@
+"""The gateway's ``search`` tool, served by the index instead of a linear scan.
+
+SPEC-104 wires :class:`~palaia_hub.gateway.wiring.EngineVaultService` to the
+index — the spot that adapter's docstring marked. The tool contract itself does
+not change (SPEC-113 snapshots it), so these tests assert the *contract* holds
+while the results get better.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from palaia_hub.gateway.wiring import EngineVaultService
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_indexed_search_returns_ranked_hits(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    engine, index = await open_index(golden_work_vault)
+    service = EngineVaultService(engine, index)
+    hits = await service.search("API Gateway", limit=5)
+    assert hits
+    assert hits[0].permalink == "projects/api-gateway"
+    assert hits[0].title == "API Gateway"
+    assert all(hit.score > 0 for hit in hits)
+    assert len(hits) <= 5
+
+
+async def test_indexed_search_excludes_meta_notes(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    """Format spec §6: ``meta`` stays out of normal recall."""
+    engine, index = await open_index(golden_work_vault)
+    service = EngineVaultService(engine, index)
+    hits = await service.search("vault", limit=50)
+    assert hits
+    assert "meta/vault" not in {hit.permalink for hit in hits}
+
+
+async def test_indexed_search_reports_one_result_per_note(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    engine, index = await open_index(golden_work_vault)
+    service = EngineVaultService(engine, index)
+    hits = await service.search("how-to-apply", limit=20)
+    permalinks = [hit.permalink for hit in hits]
+    assert len(permalinks) == len(set(permalinks))
+
+
+async def test_indexed_search_has_no_results_for_an_absent_term(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    engine, index = await open_index(golden_work_vault)
+    service = EngineVaultService(engine, index)
+    assert await service.search("xyzzy-nonexistent-term-42") == []
+
+
+async def test_search_without_an_index_still_scans(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    """The SPEC-105 fallback stays: no index passed, no SQLite needed."""
+    engine, _ = await open_index(golden_work_vault, build=False)
+    service = EngineVaultService(engine)
+    hits = await service.search("gateway", limit=5)
+    assert any(hit.permalink == "projects/api-gateway" for hit in hits)
+
+
+async def test_new_writes_are_searchable_through_the_tool_immediately(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    engine, index = await open_index(golden_work_vault)
+    service = EngineVaultService(engine, index)
+    record = await service.write("Tool Written Note", "a body with lycanthropy in it")
+    hits = await service.search("lycanthropy", limit=5)
+    assert [hit.permalink for hit in hits] == [record.permalink]

--- a/v3/server/tests/index/test_hybrid_relevance.py
+++ b/v3/server/tests/index/test_hybrid_relevance.py
@@ -1,0 +1,129 @@
+"""Does hybrid actually beat pure FTS? Measured, not assumed.
+
+SPEC-104 acceptance criterion: "hybrid beats pure FTS on the SPEC-003 toy-vault
+relevance battery (recall@5 measured, documented in PR)". The battery below is
+written *against the golden vault* and deliberately phrased the way a person
+asks a question rather than the way the note is written — which is exactly the
+case lexical search cannot serve and a paraphrase-aware embedding can.
+
+This is the only test that loads a real embedding model. It is skipped when
+fastembed or the model cache is unavailable (offline CI), so the numbers in
+the PR come from a run where it did execute; run it explicitly with::
+
+    uv run pytest server/tests/index/test_hybrid_relevance.py -s
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from palaia_hub.index import EmbeddingConfig
+from palaia_hub.index.embeddings import EmbedderUnavailableError, build_embedder
+
+pytestmark = pytest.mark.anyio
+
+#: query -> the permalink that should be in the top 5. Every query avoids the
+#: target note's distinctive words where possible.
+RELEVANCE_BATTERY: dict[str, str] = {
+    "who leads work on the vault and owns its doctor": "people/alice-novak",
+    "how should I phrase the subject of a git commit": "rules/how-to-write-commit-messages",
+    "which database stores the searchable projection": "decisions/use-sqlite-for-index",
+    "what do I do first when the hub is destroying data": "processes/incident-response",
+    "never put credentials or secret tokens in a note": "rules/secrets-handling",
+    "assembling context by traversing the knowledge graph": "projects/recall-engine",
+    "keeping each customer's notes physically apart": "decisions/physical-vault-isolation",
+    "how long do we keep old data around": "rules/data-retention",
+    "steps for bringing a new customer on board": "processes/onboarding-a-new-client",
+    "what licence did we settle on": "decisions/mit-license",
+}
+
+_TOP_K = 5
+
+
+def _rank(ranked: list[str], expected: str) -> str:
+    """1-based position of ``expected`` in ``ranked``, or ``-`` if absent."""
+    return str(ranked.index(expected) + 1) if expected in ranked else "-"
+
+
+def _recall_at_k(found: dict[str, list[str]], k: int = _TOP_K) -> float:
+    hits = sum(
+        1 for query, expected in RELEVANCE_BATTERY.items() if expected in found[query][:k]
+    )
+    return hits / len(RELEVANCE_BATTERY)
+
+
+@pytest.fixture(scope="module")
+def real_embedder() -> Any:
+    pytest.importorskip("fastembed", reason="the embeddings extra is not installed")
+    try:
+        return build_embedder(EmbeddingConfig())
+    except EmbedderUnavailableError as exc:  # pragma: no cover - offline CI
+        pytest.skip(f"embedding model unavailable: {exc}")
+
+
+async def test_hybrid_beats_pure_fts_on_recall_at_5(
+    golden_work_vault: Path, open_index: Any, real_embedder: Any, capsys: Any
+) -> None:
+    _, index = await open_index(
+        golden_work_vault,
+        embedding=EmbeddingConfig(enabled=True),
+        embedder=real_embedder,
+    )
+    embedded = await index.drain_embeddings(timeout=600.0)
+    assert embedded > 0
+    assert index.status().embeds.pending == 0
+
+    fts: dict[str, list[str]] = {}
+    hybrid: dict[str, list[str]] = {}
+    vector: dict[str, list[str]] = {}
+    for query in RELEVANCE_BATTERY:
+        fts[query] = [hit.permalink for hit in (await index.search(query, mode="fts")).hits]
+        vector_results = await index.search(query, mode="vector")
+        assert not vector_results.degraded
+        vector[query] = [hit.permalink for hit in vector_results.hits]
+        hybrid_results = await index.search(query, mode="hybrid")
+        assert hybrid_results.effective_mode == "hybrid"
+        hybrid[query] = [hit.permalink for hit in hybrid_results.hits]
+
+    fts_recall = _recall_at_k(fts)
+    vector_recall = _recall_at_k(vector)
+    hybrid_recall = _recall_at_k(hybrid)
+
+    with capsys.disabled():
+        print(
+            f"\nrecall@{_TOP_K} over {len(RELEVANCE_BATTERY)} queries "
+            f"(model {real_embedder.name}, dim {real_embedder.dim}): "
+            f"fts={fts_recall:.2f} vector={vector_recall:.2f} hybrid={hybrid_recall:.2f}"
+        )
+        for query, expected in RELEVANCE_BATTERY.items():
+            print(
+                f"  fts={_rank(fts[query], expected):>3} "
+                f"vec={_rank(vector[query], expected):>3} "
+                f"hyb={_rank(hybrid[query], expected):>3}  {query}"
+            )
+
+    assert hybrid_recall > fts_recall, (
+        f"hybrid recall@{_TOP_K} {hybrid_recall:.2f} did not beat FTS {fts_recall:.2f}"
+    )
+
+
+async def test_hybrid_keeps_the_exact_lexical_hits_fts_finds(
+    golden_work_vault: Path, open_index: Any, real_embedder: Any
+) -> None:
+    """Fusion must not *lose* the precise hits — the other half of "hybrid"."""
+    _, index = await open_index(
+        golden_work_vault,
+        embedding=EmbeddingConfig(enabled=True),
+        embedder=real_embedder,
+    )
+    await index.drain_embeddings(timeout=600.0)
+    for query, expected in (
+        ("API Gateway", "projects/api-gateway"),
+        ("Alice Novak", "people/alice-novak"),
+        ("rate limit", "inbox/rate-limit-decision-from-pr-review"),
+    ):
+        results = await index.search(query, mode="hybrid", limit=5)
+        assert expected in {hit.permalink for hit in results.hits}, query

--- a/v3/server/tests/index/test_incremental.py
+++ b/v3/server/tests/index/test_incremental.py
@@ -1,0 +1,214 @@
+"""Incremental updates from SPEC-102 change events.
+
+The two behaviors this SPEC's model note calls out as "where the judgment
+lives": incremental-update correctness, and forward-reference resolution
+happening *without* a full reindex.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from palaia_hub.vault import VaultWatcher
+
+pytestmark = pytest.mark.anyio
+
+#: SPEC-104 acceptance criterion: index lag after a change event < 2 s.
+_LAG_BUDGET_SECONDS = 2.0
+
+
+def _unresolved_targets(index: Any) -> set[str]:
+    with index.db.lock:
+        rows = index.db.conn.execute(
+            "SELECT target_raw FROM relations WHERE target_permalink IS NULL"
+        ).fetchall()
+    return {str(row["target_raw"]) for row in rows}
+
+
+def _relation_row(index: Any, target_raw: str) -> Any:
+    with index.db.lock:
+        return index.db.conn.execute(
+            "SELECT permalink, target_permalink FROM relations WHERE target_raw = ?",
+            (target_raw,),
+        ).fetchone()
+
+
+async def test_write_through_engine_updates_index_via_event(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    engine, index = await open_index(golden_work_vault)
+    before = index.status().notes
+    await engine.write_note(
+        "notes/incremental.md",
+        body="A note written through the engine, indexed by its event.\n",
+        title="Incremental",
+        frontmatter={"type": "note"},
+    )
+    assert index.status().notes == before + 1
+    results = await index.search("indexed by its event", mode="fts", limit=5)
+    assert [hit.permalink for hit in results.hits] == ["notes/incremental"]
+
+
+async def test_edit_replaces_stale_text(golden_work_vault: Path, open_index: Any) -> None:
+    engine, index = await open_index(golden_work_vault)
+    await engine.write_note(
+        "notes/mutable.md",
+        body="original haystack sentinel\n",
+        title="Mutable",
+        frontmatter={"type": "note"},
+    )
+    assert (await index.search("sentinel", mode="fts")).hits
+    current = await engine.read_note("notes/mutable")
+    await engine.edit_note(
+        "notes/mutable", body="replaced entirely\n", expected_checksum=current.checksum
+    )
+    assert list(await index.search("sentinel", mode="fts")) == []
+    assert (await index.search("replaced entirely", mode="fts")).hits
+
+
+async def test_delete_removes_the_note_and_its_subrows(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    engine, index = await open_index(golden_work_vault)
+    before = index.status()
+    await engine.delete_note("rules/how-to-write-commit-messages")
+    after = index.status()
+    assert after.notes == before.notes - 1
+    assert after.observations < before.observations
+    assert list(await index.search("imperative phrasing", mode="fts")) == []
+
+
+async def test_move_keeps_identity_and_updates_the_folder(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    engine, index = await open_index(golden_work_vault)
+    await engine.move_note("projects/curator", "archive/curator.md")
+    hits = (await index.search("curator", mode="fts", limit=20)).hits
+    moved = [hit for hit in hits if hit.permalink == "projects/curator"]
+    assert moved, "a move keeps the permalink (§3.1)"
+    assert moved[0].path == "archive/curator.md"
+    assert index.status().notes == len(list(golden_work_vault.rglob("*.md")))
+
+
+async def test_forward_reference_resolves_when_target_appears_without_reindex(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    engine, index = await open_index(golden_work_vault)
+    await engine.write_note(
+        "projects/waiting.md",
+        body="Depends on something that does not exist yet.\n\n- depends_on [[Ghost Project]]\n",
+        title="Waiting",
+        frontmatter={"type": "project"},
+    )
+    assert "Ghost Project" in _unresolved_targets(index)
+    unresolved_before = index.status().unresolved_relations
+
+    # The target appears. No reindex is called anywhere in this test — only
+    # the note-created event path runs.
+    await engine.write_note(
+        "projects/ghost-project.md",
+        body="Here at last.\n",
+        title="Ghost Project",
+        frontmatter={"type": "project"},
+    )
+
+    assert "Ghost Project" not in _unresolved_targets(index)
+    assert index.status().unresolved_relations == unresolved_before - 1
+    row = _relation_row(index, "Ghost Project")
+    assert row["target_permalink"] == "projects/ghost-project"
+    # The synthetic relation permalink now addresses the resolved target (§9.2).
+    assert str(row["permalink"]) == "projects/waiting/rel/depends-on/projects/ghost-project"
+    refs = {
+        hit.ref
+        for hit in (await index.search("depends_on Ghost Project", mode="fts", limit=20)).hits
+    }
+    assert "projects/waiting/rel/depends-on/projects/ghost-project" in refs
+
+
+async def test_forward_reference_resolves_through_an_alias(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    engine, index = await open_index(golden_work_vault)
+    await engine.write_note(
+        "projects/needs-alias.md",
+        body="- depends_on [[Legacy Name]]\n",
+        title="Needs Alias",
+        frontmatter={"type": "project"},
+    )
+    assert "Legacy Name" in _unresolved_targets(index)
+    await engine.write_note(
+        "projects/current-name.md",
+        body="Renamed long ago.\n",
+        title="Current Name",
+        frontmatter={"type": "project", "aliases": ["Legacy Name"]},
+    )
+    assert _relation_row(index, "Legacy Name")["target_permalink"] == "projects/current-name"
+
+
+async def test_deleting_a_target_turns_relations_back_into_forward_references(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    engine, index = await open_index(golden_work_vault)
+    assert _relation_row(index, "Vault Engine")["target_permalink"] == "projects/vault-engine"
+    await engine.delete_note("projects/vault-engine")
+    assert _relation_row(index, "Vault Engine")["target_permalink"] is None
+    assert "Vault Engine" in _unresolved_targets(index)
+
+
+async def test_rename_reindexes_and_keeps_backlinks_resolved(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    engine, index = await open_index(golden_work_vault)
+    result = await engine.rename_entity("projects/vault-engine", "Vault Core")
+    assert result.rewritten_links > 0
+    # The rename rewrote inbound links vault-wide; every one of them still
+    # points at a resolved target afterwards.
+    with index.db.lock:
+        stale = index.db.conn.execute(
+            "SELECT COUNT(*) AS n FROM relations WHERE target_raw = 'Vault Engine'"
+        ).fetchone()["n"]
+    assert int(stale) == 0
+    assert _relation_row(index, "Vault Core")["target_permalink"] == "projects/vault-core"
+    hits = await index.search("Vault Core", mode="fts", limit=10)
+    assert "projects/vault-core" in {hit.permalink for hit in hits.hits}
+
+
+async def test_external_edit_is_indexed_within_the_lag_budget(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    """A file written straight to disk becomes searchable in under 2 s."""
+    engine, index = await open_index(golden_work_vault)
+    watcher = VaultWatcher(engine)
+    await watcher.start()
+    try:
+        # watchfiles has no "watch established" signal; settle briefly first.
+        await _sleep(0.3)
+        target = golden_work_vault / "notes" / "written-outside.md"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        started = time.monotonic()
+        target.write_text(
+            "---\ntitle: Written Outside\npermalink: notes/written-outside\ntype: note\n---\n\n"
+            "This body arrived from an external editor.\n",
+            encoding="utf-8",
+        )
+        lag = None
+        while time.monotonic() - started < 10.0:
+            hits = await index.search("arrived from an external editor", mode="fts", limit=5)
+            if any(hit.permalink == "notes/written-outside" for hit in hits.hits):
+                lag = time.monotonic() - started
+                break
+            await _sleep(0.05)
+        assert lag is not None, "external edit never reached the index"
+        assert lag < _LAG_BUDGET_SECONDS, f"index lag {lag:.2f}s exceeds {_LAG_BUDGET_SECONDS}s"
+    finally:
+        await watcher.stop()
+
+
+async def _sleep(seconds: float) -> None:
+    import asyncio
+
+    await asyncio.sleep(seconds)

--- a/v3/server/tests/index/test_rebuild.py
+++ b/v3/server/tests/index/test_rebuild.py
@@ -1,0 +1,165 @@
+"""The index is disposable: drop it, rebuild it, get the same answers.
+
+Format spec §10 and SPEC-104's first acceptance criterion. The query battery
+is SPEC-113's (``tests/e2e/query_battery.py``) so this check and the e2e
+rebuild scenario are asking the same question of the same corpus.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from palaia_hub.index import SearchFilters, VaultIndex
+from palaia_hub.vault import VaultDoctor
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "e2e"))
+
+from query_battery import CANONICAL_QUERIES, MUST_INCLUDE, NO_MATCH_QUERY  # noqa: E402
+
+pytestmark = pytest.mark.anyio
+
+
+async def _battery(index: VaultIndex) -> dict[str, list[tuple[str, str]]]:
+    """Run the battery, keeping ranked order and the addressed ref per hit."""
+    out: dict[str, list[tuple[str, str]]] = {}
+    for query in CANONICAL_QUERIES:
+        results = await index.search(query, mode="fts", limit=100)
+        out[query] = [(hit.permalink, hit.ref) for hit in results.hits]
+    return out
+
+
+async def test_drop_database_then_reindex_reproduces_identical_results(
+    golden_work_vault: Path, open_index: Any, tmp_path: Path
+) -> None:
+    db_path = tmp_path / "index.sqlite3"
+    engine, index = await open_index(golden_work_vault, index_path=db_path)
+    before = await _battery(index)
+    assert any(before[query] for query in CANONICAL_QUERIES), "battery must not be all-empty"
+    assert before[NO_MATCH_QUERY] == []
+    await index.close()
+
+    # "Delete the DB": the file and its WAL sidecars, exactly as a user
+    # clearing a broken index would.
+    db_path.unlink()
+    for suffix in ("-wal", "-shm"):
+        db_path.with_name(db_path.name + suffix).unlink(missing_ok=True)
+    assert not db_path.exists()
+
+    rebuilt = VaultIndex(engine, path=db_path)
+    await rebuilt.open(start_worker=False)
+    try:
+        after = await _battery(rebuilt)
+        assert after == before
+    finally:
+        await rebuilt.close()
+
+
+async def test_must_include_queries_find_their_notes(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    _, index = await open_index(golden_work_vault)
+    for query, expected in MUST_INCLUDE.items():
+        if query == "marathon":  # personal vault, not this one
+            continue
+        results = await index.search(query, mode="fts", limit=20)
+        found = {hit.permalink for hit in results.hits}
+        assert set(expected) <= found, f"{query!r} lost {set(expected) - found}"
+
+
+async def test_forward_reference_query_finds_the_referencing_note(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    """"Q3 Roadmap" names no entity — the note referencing it is still findable."""
+    _, index = await open_index(golden_work_vault)
+    results = await index.search("Q3 Roadmap", mode="fts", limit=20)
+    assert "projects/legacy-migration" in {hit.permalink for hit in results.hits}
+    status = index.status()
+    assert status.unresolved_relations > 0
+
+
+async def test_reindex_of_unchanged_vault_is_a_no_op(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    _, index = await open_index(golden_work_vault)
+    before = index.status()
+    reindexed = await index.reindex()
+    after = index.status()
+    assert reindexed == before.notes
+    assert (after.notes, after.observations, after.relations) == (
+        before.notes,
+        before.observations,
+        before.relations,
+    )
+
+
+async def test_reindex_drops_notes_that_vanished_from_disk(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    _, index = await open_index(golden_work_vault)
+    before = index.status().notes
+    (golden_work_vault / "projects" / "curator.md").unlink()
+    assert await index.reindex() == before - 1
+    results = await index.search("curator", mode="fts", limit=20)
+    assert "projects/curator" not in {hit.permalink for hit in results.hits}
+
+
+async def test_doctor_verify_sees_no_index_drift_after_build(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    engine, index = await open_index(golden_work_vault)
+    findings = await index.verify()
+    codes = {finding.code for finding in findings}
+    assert not codes & {"index-orphan-entry", "index-stale-entry", "index-missing-entry"}
+    # And the doctor reached the index at all (it was handed an IndexView).
+    assert list(index.index_entries())
+
+
+async def test_doctor_verify_reports_stale_and_missing_index_entries(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    engine, index = await open_index(golden_work_vault)
+    (golden_work_vault / "projects" / "curator.md").write_text(
+        "---\ntitle: Curator\npermalink: projects/curator\ntype: project\n---\n\nedited\n",
+        encoding="utf-8",
+    )
+    (golden_work_vault / "notes").mkdir(exist_ok=True)
+    (golden_work_vault / "notes" / "brand-new.md").write_text(
+        "---\ntitle: Brand New\npermalink: notes/brand-new\ntype: note\n---\n\nnew\n",
+        encoding="utf-8",
+    )
+    engine.refresh_now()
+    findings = await VaultDoctor(engine).verify(index)
+    codes = {finding.code for finding in findings}
+    assert "index-stale-entry" in codes
+    assert "index-missing-entry" in codes
+    # ... and reindexing clears both, because files are the only truth.
+    await index.reindex()
+    codes_after = {finding.code for finding in await index.verify()}
+    assert not codes_after & {"index-stale-entry", "index-missing-entry"}
+
+
+async def test_rebuild_after_filter_query_keeps_filters_working(
+    golden_work_vault: Path, open_index: Any, tmp_path: Path
+) -> None:
+    db_path = tmp_path / "filters.sqlite3"
+    engine, index = await open_index(golden_work_vault, index_path=db_path)
+    query = "vault"
+    filters = SearchFilters(types=("decision",), tags=("adr",))
+    before = [hit.ref for hit in (await index.search(query, mode="fts", filters=filters)).hits]
+    assert before
+    await index.close()
+    db_path.unlink()
+
+    rebuilt = VaultIndex(engine, path=db_path)
+    await rebuilt.open(start_worker=False)
+    try:
+        after = [
+            hit.ref for hit in (await rebuilt.search(query, mode="fts", filters=filters)).hits
+        ]
+        assert after == before
+    finally:
+        await rebuilt.close()

--- a/v3/server/tests/index/test_search.py
+++ b/v3/server/tests/index/test_search.py
@@ -1,0 +1,187 @@
+"""FTS ranking, metadata filters and sub-note addressability."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from palaia_hub.index import SearchFilters, fts_match_expression
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_build_indexes_notes_observations_and_relations(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    _, index = await open_index(golden_work_vault)
+    status = index.status()
+    assert status.notes == len(list(golden_work_vault.rglob("*.md")))
+    assert status.observations > 0
+    assert status.relations > 0
+    assert status.counts_by_type["project"] == 9
+
+
+async def test_title_match_outranks_body_match(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    _, index = await open_index(golden_work_vault)
+    results = await index.search("API Gateway", mode="fts", limit=5)
+    assert results.hits
+    assert results.hits[0].permalink == "projects/api-gateway"
+
+
+async def test_observation_hit_carries_its_synthetic_permalink(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    _, index = await open_index(golden_work_vault)
+    results = await index.search(
+        "imperative phrasing",
+        mode="fts",
+        limit=10,
+        filters=SearchFilters(kinds=("observation",)),
+    )
+    assert results.hits, "the observation line should be findable on its own"
+    hit = results.hits[0]
+    assert hit.kind == "observation"
+    assert hit.permalink == "rules/how-to-write-commit-messages"
+    # <permalink>/obs/<category-slug>/<h8> — format spec §9.2
+    assert hit.ref.startswith("rules/how-to-write-commit-messages/obs/how-to-apply/")
+    assert len(hit.ref.rsplit("/", 1)[-1]) == 8
+
+
+async def test_relation_hit_carries_its_synthetic_permalink(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    _, index = await open_index(golden_work_vault)
+    results = await index.search(
+        "owned_by Bob Chen",
+        mode="fts",
+        limit=10,
+        filters=SearchFilters(kinds=("relation",)),
+    )
+    refs = {hit.ref for hit in results.hits}
+    assert "projects/api-gateway/rel/owned-by/people/bob-chen" in refs
+
+
+async def test_no_match_query_returns_nothing(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    _, index = await open_index(golden_work_vault)
+    results = await index.search("xyzzy-nonexistent-term-42", mode="fts", limit=10)
+    assert list(results) == []
+
+
+async def test_punctuation_only_query_is_a_result_not_a_crash(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    _, index = await open_index(golden_work_vault)
+    for query in ("", "   ", "*", '"', "NOT AND OR ( )".replace("A", "")):
+        results = await index.search(query, mode="fts", limit=5)
+        assert isinstance(results.hits, tuple)
+
+
+async def test_fts_operators_in_user_query_are_not_fts_syntax(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    _, index = await open_index(golden_work_vault)
+    # A user typing FTS5 operators must get a normal search, not an error.
+    results = await index.search('gateway OR "unbalanced', mode="fts", limit=5)
+    assert any(hit.permalink == "projects/api-gateway" for hit in results.hits)
+
+
+async def test_scope_filter_restricts_to_folder_subtree(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    _, index = await open_index(golden_work_vault)
+    results = await index.search(
+        "vault", mode="fts", limit=50, filters=SearchFilters(scope="decisions")
+    )
+    assert results.hits
+    assert {hit.path.split("/")[0] for hit in results.hits} == {"decisions"}
+
+
+async def test_type_and_tag_filters(golden_work_vault: Path, open_index: Any) -> None:
+    _, index = await open_index(golden_work_vault)
+    typed = await index.search(
+        "vault", mode="fts", limit=50, filters=SearchFilters(types=("decision",))
+    )
+    assert typed.hits
+    assert {hit.type for hit in typed.hits} == {"decision"}
+
+    tagged = await index.search(
+        "vault", mode="fts", limit=50, filters=SearchFilters(tags=("adr",))
+    )
+    assert tagged.hits
+    assert all("adr" in hit.tags for hit in tagged.hits)
+
+
+async def test_exclude_types_hides_meta_notes(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    _, index = await open_index(golden_work_vault)
+    unfiltered = await index.search("vault", mode="fts", limit=50)
+    filtered = await index.search(
+        "vault", mode="fts", limit=50, filters=SearchFilters(exclude_types=("meta",))
+    )
+    assert any(hit.type == "meta" for hit in unfiltered.hits)
+    assert all(hit.type != "meta" for hit in filtered.hits)
+
+
+async def test_custom_frontmatter_key_is_a_filter(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    """Format spec §2.1: unknown keys are indexed as searchable metadata."""
+    engine, index = await open_index(golden_work_vault)
+    await engine.write_note(
+        "notes/quarterly-plan.md",
+        body="Everything about the quarter.\n",
+        title="Quarterly Plan",
+        frontmatter={"type": "note", "quarter": "Q3", "owner": "alice"},
+    )
+    await index.reindex()
+    hits = await index.search(
+        "quarter", mode="fts", limit=10, filters=SearchFilters(meta=(("quarter", "Q3"),))
+    )
+    assert [hit.permalink for hit in hits.hits] == ["notes/quarterly-plan"]
+    misses = await index.search(
+        "quarter", mode="fts", limit=10, filters=SearchFilters(meta=(("quarter", "Q4"),))
+    )
+    assert list(misses) == []
+
+
+async def test_date_filters_use_modified_then_created(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    engine, index = await open_index(golden_work_vault)
+    await engine.write_note(
+        "notes/dated.md",
+        body="A dated note.\n",
+        title="Dated",
+        frontmatter={"type": "note", "created": "2026-01-01", "modified": "2026-06-15"},
+    )
+    await index.reindex()
+    inside = await index.search(
+        "dated", mode="fts", limit=10, filters=SearchFilters(since="2026-06-01")
+    )
+    outside = await index.search(
+        "dated", mode="fts", limit=10, filters=SearchFilters(until="2026-06-01")
+    )
+    assert "notes/dated" in {hit.permalink for hit in inside.hits}
+    assert "notes/dated" not in {hit.permalink for hit in outside.hits}
+
+
+def test_match_expression_is_conjunctive_by_default() -> None:
+    assert fts_match_expression("rate limit") == '"rate" AND "limit"'
+    assert fts_match_expression("rate limit", operator="OR") == '"rate" OR "limit"'
+    assert fts_match_expression("- / *") is None
+
+
+async def test_snippet_points_at_the_matching_text(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    _, index = await open_index(golden_work_vault)
+    results = await index.search("disposable", mode="fts", limit=5)
+    assert results.hits
+    assert "disposable" in " ".join(hit.snippet.lower() for hit in results.hits)

--- a/v3/uv.lock
+++ b/v3/uv.lock
@@ -5,8 +5,10 @@ resolution-markers = [
     "python_full_version >= '3.15'",
     "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version == '3.14.*' and sys_platform != 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform != 'win32'",
 ]
 
 [manifest]
@@ -342,6 +344,137 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/3f/143b048436775b0f76ac3eec145c019e8173ccc2885c8f20319b996d5e83/charset_normalizer-3.5.1.tar.gz", hash = "sha256:6117b84ea48435e5356dc737f5121485c30920ba43375fa7b434fd753df0eac3", size = 171764, upload-time = "2026-08-15T08:20:44.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/27/78873dc8b6a56357517b74b6bb9568b80450e7bb4f6ef7e3fa9d22aa0bd7/charset_normalizer-3.5.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5b6d1386bf0096d26d3a863dc0a487a5b4eb9aa93cf5ba69683d29dde6b9d60f", size = 344456, upload-time = "2026-08-15T08:17:10.072Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/4c/be49ada26b1f0232d57aa89bbebf997a5cc2332a5616b6eca26ff680044d/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4582c27e8c889d64811987b5967fbd3ae0c823fe1fd933b543d55ac20bb475fa", size = 238530, upload-time = "2026-08-15T08:17:11.563Z" },
+    { url = "https://files.pythonhosted.org/packages/76/84/6f1290fa07ae6978d3960caa3eb1b8019bf9284ab7c2297b00c099ef4250/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:1d1c7a53a6c2103925cdd6d7229f8c567379f211c869793df679f2e9f738c369", size = 230200, upload-time = "2026-08-15T08:17:12.919Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/a0/47b18adeed31c8f16ba9700f32c1b18594cfa09f47eb672a488c273c22bf/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e6621fb2a4988d6e53eedc455e5903e2679f3967b8acb3d639f1b63c14a2e893", size = 262222, upload-time = "2026-08-15T08:17:14.571Z" },
+    { url = "https://files.pythonhosted.org/packages/38/fe/341861ac118dae06f3ec0eb487488af52128f2ef2faf0b11003944d22259/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7c0c10730342b0c9b35dd1d619beb8214e520bd96a1f870f452680b238aab3e0", size = 258951, upload-time = "2026-08-15T08:17:16.158Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/89/bb5108dc6c3651dca963f2b0a3ba19bbcb370c94e1b6d3e0e844a58e6dca/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b9af956078716df40d985fb0dfeb2c2120c5ca92ba4ff4b388acfd01cdc14d08", size = 248801, upload-time = "2026-08-15T08:17:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ba/ef83ae3aca816393decfa3530976f38a79812d707b80b580ac33b83f9877/charset_normalizer-3.5.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f9f8405c2c758532c74fed975dbee57be1f31a6e865c031870c79a6ed3212ada", size = 244070, upload-time = "2026-08-15T08:17:19.191Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/0b/c5292a2462d69b7378ea89793bbb5b2b6fcf6f7dd6d1667f9619094ad553/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:96fef3e886d6a9874b14f27fc193fbdc69d5d8035783d86aa4e1cea594e695f9", size = 240110, upload-time = "2026-08-15T08:17:20.547Z" },
+    { url = "https://files.pythonhosted.org/packages/46/22/111e5be3b740d5c2a5bfcedb3d237b6591e5c2e82ae9d6ffcb121fe0909c/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5d8531a6569d025f68e2321e7638fb7978f23db58e5f69f56913837aae03816e", size = 232836, upload-time = "2026-08-15T08:17:21.895Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/d2/d2aad6fe0dbb44b194bf3becb60f5a0ac48446ade999a47fe7bb41eb09a7/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:aae2ee51122d3ae968a3837d97dc24a0aeebb0dea23694422cd172bd30017cd6", size = 262712, upload-time = "2026-08-15T08:17:23.727Z" },
+    { url = "https://files.pythonhosted.org/packages/35/5a/337e4663a5eae6de99db940ee8066d4145caafb61327db62deda15313cce/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7235dc28fc6dd9d832ac7c7bce95367dedb85929f17368a0c2bee1e080b9acbf", size = 242977, upload-time = "2026-08-15T08:17:25.157Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/85/f82f8a92e31c7519410e2e1afdc630f28ec47490ce2c09a11c1a43cbb459/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4abdc5f9ad448c1ecbfae2974b820535d6bc6e7eef63babbab3d81cf46968c71", size = 260207, upload-time = "2026-08-15T08:17:26.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/52/643d11ffd60e9ac2fd1fb87e167a19285b9eefeff4a40e63c87cbfbeab36/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ba501e667c17d8411f98e67a022d9604ef179aff0e459b7e292c796837c13573", size = 250562, upload-time = "2026-08-15T08:17:27.971Z" },
+    { url = "https://files.pythonhosted.org/packages/62/16/46556278c2168d12df9da7fede5dc6fc70e60301b26a82bbeec238c9cfe3/charset_normalizer-3.5.1-cp312-cp312-win32.whl", hash = "sha256:cfa1c0cc3a8f9f53f1243a5a99ac36fd003880199383b37672e86ddda9cb07e2", size = 178507, upload-time = "2026-08-15T08:17:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/4c6c298171e6b3e745633180ff59350fc0ca0db1ffd28df1e369e0579f71/charset_normalizer-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3617ac3cfd8b9888f145ad89dd6e692285834b0201c6074a5eeaad3fd4d668c2", size = 200551, upload-time = "2026-08-15T08:17:30.668Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d7/eb95a042f0dd22e304b0b6472b154f3546a1a039a9ee89ccb2a7f61591fc/charset_normalizer-3.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:88e85ab89cb822c1e635f51d6d32e488f94e002e70e2f492bdb8b945543f345a", size = 180700, upload-time = "2026-08-15T08:17:32.028Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/61/2cb6ad133dbbb449fa2d37ccae973232f4827e799af258d15e589a3d1e9e/charset_normalizer-3.5.1-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:4f298bdadb8f0b9e5672877f647d1be9373ef5320c9e2f049795e26cad28b6a9", size = 211584, upload-time = "2026-08-15T08:17:33.597Z" },
+    { url = "https://files.pythonhosted.org/packages/18/57/a305c968be1ca13f3dd1b32f445877e97addf55d80b65c7cb35fac82b777/charset_normalizer-3.5.1-cp313-cp313-android_24_x86_64.whl", hash = "sha256:88ca277405c2d3b71c4e1c2ee0e7966e807bcba86a69d11e19ba199d18ae4491", size = 223359, upload-time = "2026-08-15T08:17:35.022Z" },
+    { url = "https://files.pythonhosted.org/packages/09/0a/d3646670292ce8d8f8cc11ac067d44885e697a5591f57a9221128da5e7b3/charset_normalizer-3.5.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:9362dd90aa7dab48c0054a21187791ccf05473f7dba5d92b8033ae62164675e7", size = 194464, upload-time = "2026-08-15T08:17:36.452Z" },
+    { url = "https://files.pythonhosted.org/packages/de/93/d51ec556e01042fed6f993ea859311bc7917b466684182fbbceb6ca24762/charset_normalizer-3.5.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:977cdbd483a9cff38179bea4fd754289a6f2195c7abd414aba85410b3e66cc5e", size = 197676, upload-time = "2026-08-15T08:17:37.819Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/a0/562247944386f7d4ef94467e84876600cc1e0f1b93239aaa9213d2bc3cbd/charset_normalizer-3.5.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e90251c0c7bdd54a100a0dce3c07b7e637278c93af29dbf78ebb89a58c4bac7d", size = 340473, upload-time = "2026-08-15T08:17:39.303Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e7/1d994be1b93d41e9502b8b0460eaa88a1dd8df335df415db87d6c3e91ab2/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94d78ecec2605a8d0398b0f365d5f12a63248438516f5dac536a5eff7337df4a", size = 240156, upload-time = "2026-08-15T08:17:40.66Z" },
+    { url = "https://files.pythonhosted.org/packages/09/53/27923ce5cc6cbccb832037b27dca98882d9c53e9b69e866bbbef4aae7fc8/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d59b75732e9b6f27388e10c14b0259cc5f2e48c78627d185e6a177b58ad3cffe", size = 228246, upload-time = "2026-08-15T08:17:42.003Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/5a97e84d63af1d55c07439cb80e56d99a8efb4295700eb4e18c0d1615d2c/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0d929fc574b4d6fd9e7c0f5c2ede8716a41911923aa7fa5fce38e0818aa4a1ac", size = 263660, upload-time = "2026-08-15T08:17:43.627Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c2/071575791dcc88316c0a9a65ce38897a82e4cfe4a325f0f7fe1b1ac47bcf/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:394fea06235c8543390050ed5f529187074b029fb027213f6c46ac11ab5d950e", size = 260354, upload-time = "2026-08-15T08:17:45.094Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/af/63240b0c0248c075c2535a1f1bd992821d8251b9f173abc13329661d09e4/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62b55f6722735a6c472f88361cde6640608773d9443cebdbb51abf436a1fcdd3", size = 250638, upload-time = "2026-08-15T08:17:46.496Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/66/70dfad64f15be09c15ccfee81330a7e515895dbe296dd23114e9a231268a/charset_normalizer-3.5.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa48b1b63d639f9483e0633e092f5851e2348c352f1f9bb6c8182f87884ef876", size = 244583, upload-time = "2026-08-15T08:17:47.963Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/24/ef36367d38b9ddd4bccbf72888c342e8de1f5ae506fa0b2dcf970e2732a1/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c71fb0d56c920c269cd3e2e3fe7c610e3f1fdb21a6ce60efa6430ff63676cea6", size = 242038, upload-time = "2026-08-15T08:17:49.481Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ab/55e683ba0fff2e43adafc10daa3001eac90fdaa419a97227d5a7067eedde/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:485a0d363cafefcd2538a73c7c838daa2035f09b2c9f9b5e3133f80c6aeb84c2", size = 233677, upload-time = "2026-08-15T08:17:50.845Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/67/0f40eaf8d1b6e7cf15e82382a2965efaca787fc1c2794b7021d37aaf5036/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c0ea61a470e070686aa30892fed79e297d2c8d0ab46b8bcdf027d38c51da591", size = 264491, upload-time = "2026-08-15T08:17:52.61Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/64/12b4c2a11ee8df4fcc518c78b0d93e3a92bd3d5253d1617ce74ff0e8c7ef/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:90b7481fb62fbe172c558bc6fd1c4c98d82004a54a7551f20e11ac9bf0b8708c", size = 245196, upload-time = "2026-08-15T08:17:54.023Z" },
+    { url = "https://files.pythonhosted.org/packages/37/2e/651d910af6d0fba325eee1cda37ec5443462ed25360e666c144166eb6091/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:35fe081843b35aad20ffeccec3eeffbe637b15d14f3fb22cc1b59cd8ec17e93c", size = 261660, upload-time = "2026-08-15T08:17:55.491Z" },
+    { url = "https://files.pythonhosted.org/packages/90/c6/b09e05e6db7f64338e0dc067c79577b1138da86c1e38369096851d96be88/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fd0350afdc3aabd5576f60ea109228bd5538139713c7b094c5cd27c73a98bc6f", size = 252618, upload-time = "2026-08-15T08:17:57.025Z" },
+    { url = "https://files.pythonhosted.org/packages/76/4e/362d4f9fdcdf5556fb2aa3ce7d4a58ebce03ed1ff03aa1d9aca8d02f13f3/charset_normalizer-3.5.1-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:9d9a0dc7cbe9bec24c3f767c9122c41fe5a1bc43f47cd099d00d393e09769de4", size = 140362, upload-time = "2026-08-15T08:17:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/d4/703be739b26acce318bd29eb3b25b7209e1b1f527f9eae3d1f1f01fdde2b/charset_normalizer-3.5.1-cp313-cp313-win32.whl", hash = "sha256:d63600d620ad0064c3a748b950ac5ea38a80190e5498532efefa4b7b3f1da1f3", size = 177755, upload-time = "2026-08-15T08:18:00.037Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/33/56d97ade41c8db611e727168c52ae46c9224c362ec28d4b65d7e9869e8da/charset_normalizer-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:aea996a6aba25260827c9ea511d1addfde2da9eb686ac961838509086188b7e6", size = 199295, upload-time = "2026-08-15T08:18:01.506Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/75/5b20dd1e6573a01a08158fe104104fa2c8abf941745596954185726cd46c/charset_normalizer-3.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:fd0a274c0e5f9a21565cd9d3dd749b61f96b7aa1e20a93aa1ba4029518f2e5c0", size = 179856, upload-time = "2026-08-15T08:18:02.929Z" },
+    { url = "https://files.pythonhosted.org/packages/29/cd/2b812ce5e888f1ce69a5350281e58aab07ae64a958ecae8912f30865718e/charset_normalizer-3.5.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:774d157f112367ff4abd29019f38f023c24e00e56edc7829c20e358a5a913ad8", size = 212318, upload-time = "2026-08-15T08:18:04.403Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4a/a6ee107430768a5334e6d63f31f148a04a1a491ef161a1ac9415a73f2fa8/charset_normalizer-3.5.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:26422d45fd13551cf564c58932f7d72b4f58b93b0fcf18c35ba6be12b46bb102", size = 224897, upload-time = "2026-08-15T08:18:05.997Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/d9/35ae3f64f29d0179c35c3baefe575904df2913dde519129c7f75995a2b1d/charset_normalizer-3.5.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:09a7bba9f739468c8e78c36a75c33768e53cb1959fc638f510454c14683f00d5", size = 194848, upload-time = "2026-08-15T08:18:07.397Z" },
+    { url = "https://files.pythonhosted.org/packages/74/76/f2fc7380f056cc273a53af37f50d08ad54b2c59f61078f31432edcf1c2bd/charset_normalizer-3.5.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4c9548dc78002099910abaebc0a72ac58b7d30931869e0351c09b507dff4ece3", size = 198163, upload-time = "2026-08-15T08:18:08.989Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/40/095ce62fa078483cccc1fa2b36e6bc9580b85422a20ee9f925341c50e44f/charset_normalizer-3.5.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c428c6c31eb5f4277d7f8eccaf767fbd548ddd5ce3c8b4f4cbbfab3d96b5904c", size = 341823, upload-time = "2026-08-15T08:18:10.458Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/5a/0e58b1c04a1596e0256f407274a92d5fb2ee21324409d1fab1da48a65b5b/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2f06b7eae9dbe77fe1d644ca244dad508de8d302870a43f3c559b521270938a0", size = 242458, upload-time = "2026-08-15T08:18:11.989Z" },
+    { url = "https://files.pythonhosted.org/packages/22/95/b4618ce912e6db0b1aae89ba788e38e8a7eba0f3025cc66e8c0699f977b2/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6b7430cf5728e68f6c462254009a6ef4086e1bea43cf2f57aa9c55fb4f50ff96", size = 226717, upload-time = "2026-08-15T08:18:13.401Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/76/c681192bbda3d55356db5dadd64381d5202b37c6b598fcda5282e88b5d3d/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ab743e9bc90c1f73552ec33e10e3331315acd2c397b36065b591b0181de533cc", size = 266111, upload-time = "2026-08-15T08:18:14.961Z" },
+    { url = "https://files.pythonhosted.org/packages/88/be/55127bfca72c0cff6c022488d140d7c5b04c771e3b72e9bdb4836d54979d/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f6f7deae3feb4edfa2efaf7c574fe88cbf055038a6abdb40188e4fff66d5699f", size = 263128, upload-time = "2026-08-15T08:18:16.515Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/91/39c3af510b0aa32bbda03374259200f28430febfd1bf5e511fe765282ce5/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15f024313246a4ed976c60f440bb8d257815513a681d212ff74fd46f7d715a90", size = 251240, upload-time = "2026-08-15T08:18:18.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a5/cbe418bbc6ecdfc3e05a0116002897c4b403a5e838d697e64c78e9f0190d/charset_normalizer-3.5.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:823f82903d189af463d7df250ef1f7f696f3cee08cc8d91deb565e8d425f6506", size = 245282, upload-time = "2026-08-15T08:18:19.625Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a4/689bb42e8e7cd492f3cb64907c6bc00ad247ec9a3628cd3f8eed126e8ae1/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:01e93745f7f219b703b60ba7afead36cfc4242782be5af484673fc500df12da5", size = 244597, upload-time = "2026-08-15T08:18:21.121Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ce/9962938e179cf9f699d3f1e7b3114b5d7642dee6a893745229f9dd04f274/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:329fc3ccb63ad22d867d84c2adea759a64079a37ba4a343433b02c7a2816871e", size = 231376, upload-time = "2026-08-15T08:18:22.57Z" },
+    { url = "https://files.pythonhosted.org/packages/85/54/46000450ada53bd9eac5429a2c8c54cd2d9b39c0c255f229aea9af0948a5/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:bb57753e36e4855b8ca375069482250a6246372331a3e4f3407eaebb007443f5", size = 266715, upload-time = "2026-08-15T08:18:24.235Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/bb/618749d70f792b44252a777bf89bfb86823b9bbc1ea13fe8ce759b07f38a/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fce8cbd4997efeb450bd298b54f755dcdff18d496f7a5ddbb4867c6d7c88fdc3", size = 245848, upload-time = "2026-08-15T08:18:25.726Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3f/ffb64458527c7668031d5eb095d978de561958dc9f5b53f8e488a533e603/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:6c9cdde8becb25a7fde49924511aa2644d6f8081cc8df8e9452724303348d8e3", size = 264521, upload-time = "2026-08-15T08:18:27.193Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ab/74a55fd803916a35ac461daf002708191aac19b546b80dc8cabfedc63d98/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9ac4444d8d4fd4c4bd08bf451ed3167aa9e7ec6cdb41b648794f1d1103652e36", size = 253054, upload-time = "2026-08-15T08:18:28.568Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2a/6a9034b7d3c60b17499afb482df5878bf9fa20b50cc3887d5ef017a833db/charset_normalizer-3.5.1-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:f03ac127268b43ef4fe9e6ab6794a6794b49485a0cc0c1db79876d2f33f75bc7", size = 140580, upload-time = "2026-08-15T08:18:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/46/1d362e1a00d035d66b9869e1281eee115907f7e390a16a07824ab5737360/charset_normalizer-3.5.1-cp314-cp314-win32.whl", hash = "sha256:1f5883d77fd409a261abb5dc8ccbe335720d798b1de4abb3b1d47ccbbc76b53b", size = 180325, upload-time = "2026-08-15T08:18:31.877Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/7c/4938c329b6a9d446f6a59aa2092ff7118f274209b5ed0e26893d1d30a63c/charset_normalizer-3.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:c658c50ac0c98cd755a2dd50b7977d3bca7df401dcc47fbdfa87db53ef7d4e8b", size = 204175, upload-time = "2026-08-15T08:18:33.466Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/33/eeb384dbd8dec570661354592f4f2e1b2fcc92585624d146a000caf53841/charset_normalizer-3.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:4bea7f8ebe90bbd7f0e4a2de42ca6924ba23e3e76418c408ff82f1d46fabd687", size = 184123, upload-time = "2026-08-15T08:18:34.913Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/6c/c73fa9d5a85f6ab05395de61c5f6984e0a9ff40bb5ff888d46dff02526c6/charset_normalizer-3.5.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:fbc597639158fd7c14d55e808718848319540f51b0e6746e3eefa59723a4a348", size = 381682, upload-time = "2026-08-15T08:18:36.349Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c7/63565f860921457feba93bae6c86fb7746deb4cffeed2f375cb845318146/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e71c909f353863b2b89c83de2ebed71ea6d0df8a6ef65a128193c5e650766bef", size = 240826, upload-time = "2026-08-15T08:18:37.887Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ae/7ae8807410dfa33f8e6f1715740adeaafa8a816cc4cb33508f54b1f7c896/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7ac76cf9afd34929d76eb7fcb63be476a4853d8a96f0dcf2d0db68a0cbdf9885", size = 227861, upload-time = "2026-08-15T08:18:39.315Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a3/887c1642f0da26000b0e0652d91071113c0e72cea33952e225cf589f49a9/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a3a370082ce34d0612f421e15fe011c53bb1feff21a26d06ad4fb244dab5a375", size = 260758, upload-time = "2026-08-15T08:18:40.88Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/11/e6f5b9a3d0e55b0ef7505cd3765cdd48f22db89994c947b316f52f801fd8/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:256dd4d85d9e4dc595e2bc983c980e73f62ddeb3165c58b4c3dfe78c5c8548c1", size = 259950, upload-time = "2026-08-15T08:18:42.351Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ee/e4e10a94d51cd1ee638aa7e00b65399e6b2a4e8376ab6d2eac9f95586671/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:58d4aa13a59c969dbfdf9e6a9560e242cbfd9e8a8f50c2747714df1a423adf65", size = 249329, upload-time = "2026-08-15T08:18:43.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/25/d5f4198819e6059735a84e8d0bfb72dc33976da67b97adcd3fb5a5e07ec6/charset_normalizer-3.5.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0c6dfb5ca6723eeed15aa8e564a014d69fcb8812f94eef11fe3631e0508199f5", size = 243137, upload-time = "2026-08-15T08:18:45.368Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/e9/e925ca7569cf9fb9701fd82503fee73eea5268fdb856bdd64947092d3daa/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c010f5581d9c612804cc59fcf7b524b707fbcb72828551237ab545bb5c7034af", size = 242820, upload-time = "2026-08-15T08:18:46.842Z" },
+    { url = "https://files.pythonhosted.org/packages/34/17/672c251a888ed2aebcdd2fe830ad0104e25ff83c43f5c4f9c15e9fc6853c/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:52ec005752a56ae79547a05c0139ca2501a0c866390b6115008456b9f0e7cde1", size = 230504, upload-time = "2026-08-15T08:18:48.353Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/fc/f6a85abebd42ce4da2f1db0aa56cc6a0df1995e318b3875d14401b8381d1/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2bced4061f000f7187254a02ad3433ae17eaf991747ceea2f478422590a5bba9", size = 263087, upload-time = "2026-08-15T08:18:49.859Z" },
+    { url = "https://files.pythonhosted.org/packages/98/66/7c42677e739ba66746b297e2046918d793078094dc239e1e72768cffccc6/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:9eea3ab2597a5e65fe65296e2d6a84570845a6b55532d90333d740d48bbc850a", size = 243269, upload-time = "2026-08-15T08:18:51.601Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d8/a50b79237f417af10f8c2a501ce8d1ca87829a22e69117891ca4ba20a69e/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:496846868fea80e479324862fa877f02411f2fd0f83b79ccee2607aa68b2a032", size = 258766, upload-time = "2026-08-15T08:18:53.23Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1d/0fc91aeaeb3c83b748f532399ce67cf84604b48297405d740000f7a9e786/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:85d5855daafc240cc045c026d7a15fd198a09b0fc8ff6f5ecbb5297b509cb11e", size = 250814, upload-time = "2026-08-15T08:18:54.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/10/3d8c777cf9024615295aa1b808324ad5b4a77855869c00824bad74ffaf8a/charset_normalizer-3.5.1-cp314-cp314t-win32.whl", hash = "sha256:58d3e12c88e0950bca850ae1f7c256055c097639c2edb9eb123af9807d8b15e4", size = 191074, upload-time = "2026-08-15T08:18:56.305Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/81/ae557d3c44d1a1d688696d60563413a0866a91b7ebc50f20df838be3d8c8/charset_normalizer-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:acaf604462bf330b0d07e7a07c1d6e4adac79e5fb13e9c5140590542cafacc00", size = 216476, upload-time = "2026-08-15T08:18:57.889Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e9/61c01fb8b804692569c036b3fc50495814502dcf13a60649c6055390b02c/charset_normalizer-3.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:fdb8a068947befafba9952162645dc2fecaeb400e64584829ed5e9b2fbe21a7f", size = 194115, upload-time = "2026-08-15T08:18:59.418Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/4e/8544831ef59d8f27ce92c80871380fdacc8076a8a56ed62f82e54f991333/charset_normalizer-3.5.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:9085f87b0e38a2b92b8923059b4e8789fe40d9279712d15dcc670048d77079af", size = 342048, upload-time = "2026-08-15T08:19:01.054Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a6/e3b46852424246065355644f4fb6dbccc0239a42a2eee27ecfc8957f0bcd/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2679de311c7946dde5d3b6f44941844133ff5c7cb86099c0061ab1e8901c20a8", size = 242997, upload-time = "2026-08-15T08:19:02.492Z" },
+    { url = "https://files.pythonhosted.org/packages/03/3b/0cc9a26777334ab2f2e3089b948bbf4e4fe72ea70b897715ef6415043ec8/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:baf3775a2635e5a11fbd5e4e64ee69c7e86875d224a5c72aca4c141064589a90", size = 237014, upload-time = "2026-08-15T08:19:03.943Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c2/027335f0aa337a2a2e121bac1ad88c4f02ba6053ea0926802784f3db11af/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8ac8c94b6539074e0f40899301273ac8402b9b3e01c7b7ba269ff30340aaaf20", size = 266174, upload-time = "2026-08-15T08:19:05.598Z" },
+    { url = "https://files.pythonhosted.org/packages/86/d3/e367787febe4e74769dec0f406f2c3c8d1b955fce5aee1fd0f94e8367a45/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8fe532b3c966d1fb794e0698e4589d0444017ae77fc0b31edea13c0e35bcc449", size = 263361, upload-time = "2026-08-15T08:19:07.251Z" },
+    { url = "https://files.pythonhosted.org/packages/af/3d/391b193eb9f3e84b02f9314088c386debdc0debee843535aaea2e2c6715d/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5c84bec0ab5ae0c64bfe73a7d2adcb5ce73b467523fc27fd6a28ab2aa6cbe35a", size = 252143, upload-time = "2026-08-15T08:19:08.816Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/57/de221f1745a90d418199761967e2776bfe2c275a1194220985e8c1d37833/charset_normalizer-3.5.1-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:854066be00447fa8de2ccbbe893e2ffc4b123ef16d897af794c1e18bd4a714b0", size = 252086, upload-time = "2026-08-15T08:19:10.255Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e3/d119f86a01f9331e8186175f24873b1d74a7ee9e2e4b4d68f9947dae5afd/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:21b82d8082f6f5e7f456ef0bd16323d08de1266efbfeb476e64b2a91d1471a4e", size = 245231, upload-time = "2026-08-15T08:19:11.807Z" },
+    { url = "https://files.pythonhosted.org/packages/26/de/d8e48c135ae480879539cdb179c8d3b50c7879497d75dd899b5763b69cee/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_armv7l.whl", hash = "sha256:838648accb3a7fd9803fd45c87bce8509648eb0c11bc34e216141300977244f2", size = 241546, upload-time = "2026-08-15T08:19:13.416Z" },
+    { url = "https://files.pythonhosted.org/packages/67/c4/217755fd1abc50d326c252922cd642002758095a81ff45010337b8b3ef65/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_ppc64le.whl", hash = "sha256:195ce897c6153c0700078142cf8efe3e6454ca4cf4357499e4078dfd83396626", size = 267033, upload-time = "2026-08-15T08:19:14.981Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d7/34d8e404e358d2adcc5a228c2134643af00104c8fb0bf525f3688d756f05/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:978eab16f55b4ab2c2a745be9a0a840bf8f09a7f227d9c76eb30214d078865a5", size = 252045, upload-time = "2026-08-15T08:19:16.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/fa/40414471acf0aa0692ca77305aa00e434fcd8288f0941c93c30e9a5f8f2f/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_s390x.whl", hash = "sha256:cc0329df4caaceb950d2f580b5ac716a377f7059624a0bafaeaf8a218c6ed774", size = 264866, upload-time = "2026-08-15T08:19:18.101Z" },
+    { url = "https://files.pythonhosted.org/packages/32/90/fcc850bae791abd2e0c041847f13e270aa08692a79f3e00de6d2dce1cb50/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:687c9ca3035544b113bea2055e180af96fb63c0c476e22a9180f51925186e7b7", size = 253932, upload-time = "2026-08-15T08:19:19.734Z" },
+    { url = "https://files.pythonhosted.org/packages/af/af/53afe99068b3c10b4cbae592a52ef72a7c92c0188440e83ee3a078fd8f75/charset_normalizer-3.5.1-cp315-cp315-win32.whl", hash = "sha256:706bfd38730a5ac7a365793269a00f4e988178cec121391f4248d84ad8c972e9", size = 180320, upload-time = "2026-08-15T08:19:21.37Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/bc/f46a132041b29e4a8779ed712d3df1bf112e94ca8de58b66d7ec2c0cf8b9/charset_normalizer-3.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:92caef967d287a407085d61176fce4012b1dd62daed4eb6d5ceb26d3d2538712", size = 204174, upload-time = "2026-08-15T08:19:23.088Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5d/9ed554480eda8e447b673648628fdc29574d23dbad01fe11837adedd1cae/charset_normalizer-3.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:5fc45d653ea8c9a20479167e11d4a0f8cb2fa3470737ab6f9c827532313187b7", size = 184126, upload-time = "2026-08-15T08:19:24.471Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/32/9b8929bf384061ee1fe5d9c27c6f9776d3d824039ad4e14c88ec00c7808e/charset_normalizer-3.5.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:59171c6e45bf07d0d5cab3b0bf81d945035530f6873398b3b531c31184d46663", size = 381441, upload-time = "2026-08-15T08:19:26.038Z" },
+    { url = "https://files.pythonhosted.org/packages/96/10/e9aa7923d3ddac652c99a1c5f7be494e737e151566a44abe018daf757f2c/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9dbdd9205662134957cf0c324f639bdc5031c0ca056e2369e238db75187c0f11", size = 241742, upload-time = "2026-08-15T08:19:27.532Z" },
+    { url = "https://files.pythonhosted.org/packages/28/53/a2d249ebddf47b889a100c0bdcb61a2f9dbb8bc24ef325cc062e4f476877/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e4b018dc5a0eee4676e38fe84a47a427816c590b93b55d9025274ec4d6ffc2dc", size = 235298, upload-time = "2026-08-15T08:19:29.274Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/07/469f78af590f7d5cd48e20d8dbfa3d66deeff9ba37768c04d886b5afd45c/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ced3fdd71aaa83ce593746c2edb42b7a59cb4c19c8b5c407781c72e493aae55a", size = 262500, upload-time = "2026-08-15T08:19:30.955Z" },
+    { url = "https://files.pythonhosted.org/packages/55/66/3bb56a47f7dcba014055b1a1d33c6f08bbe9c1e74dba154cfa25f90ae885/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:19a3dd5aa73cef1c99687c4fc57db016a9c17104ae1185da88ba566a5d3bebe4", size = 258888, upload-time = "2026-08-15T08:19:32.458Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c1/2adc2800903fb013210349313b710a5376856578d9e33e6b9a1d8b36714a/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cc5d36d96478aa9c60654bd932525bf32964c62a7281eafdf16d85003a8d6004", size = 250243, upload-time = "2026-08-15T08:19:33.94Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b5/a18d0dd1157ab655cc2cb14a545f4a4784bbad70ab3502412e36097502d9/charset_normalizer-3.5.1-cp315-cp315t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:04368edf83514385ffc3e1cfd4546e595f4f1272dd23ba437a93a9cc3741d47b", size = 249871, upload-time = "2026-08-15T08:19:35.413Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c3/525f508cd1e58d0450ac55ed40ac75bc3a97482c59def5278456a5fbf03c/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:9b5db6052055d34d41230fb78d7c439c23dc536a9896f6cb039e8dd92cfc1263", size = 243580, upload-time = "2026-08-15T08:19:36.886Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/c1/49a91fe7e97c8140094ca5c64161ab623a70d9f636bf834eace14048acb5/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_armv7l.whl", hash = "sha256:252d099029bcbea642f2a06c4ed5046bdf8b5a8150b64afa5e027e88b106e5ee", size = 239807, upload-time = "2026-08-15T08:19:38.392Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/58/56a48c296601274c4689b864a8e2dfb209b81dfcb39472753ce95eea662b/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_ppc64le.whl", hash = "sha256:6199d5606e2bbf2b096cf64d03f8b6790c91081d5ac866b8e7bb6422738cc60c", size = 264083, upload-time = "2026-08-15T08:19:39.856Z" },
+    { url = "https://files.pythonhosted.org/packages/10/4c/dc48409274a1817ff349711d26c62aa0c597df865d4d69ef79160c859193/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:77efcff2b23071c349402ac1066667a3d011f62398d81408c9b88ad991747c9e", size = 250317, upload-time = "2026-08-15T08:19:41.53Z" },
+    { url = "https://files.pythonhosted.org/packages/81/58/d325912115caec62d6bdd77bbab5e0b7da5d234a9f20affdffcbcb530d0b/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_s390x.whl", hash = "sha256:a5cbd90ecf0fc62e64726917ad083b73001f0563657a87ec3c0b504e277dc90d", size = 258173, upload-time = "2026-08-15T08:19:43.07Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f7/b13b1ccae2c8ec63980d13be1890eb73f8aeabbfce02a24aabc0908788f5/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:4d26f14f041e83dd8edfd61f4cd4fa7285d31798b5bf1f28e70c367ba6c41d61", size = 251960, upload-time = "2026-08-15T08:19:44.587Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/25/ed3f9919c5aef8cc818be1f972f565f7610d7b2076b8ebb98839516ffc3c/charset_normalizer-3.5.1-cp315-cp315t-win32.whl", hash = "sha256:ac13b004224fb341e1e25a1ed5e19d32f57cdb2a403e01f003b46f051a550f6f", size = 191186, upload-time = "2026-08-15T08:19:46.293Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/43c2b3e9d8267092b913eb8b0603f0f71993c395632886bd37a7223f96cf/charset_normalizer-3.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:35aea775dc2bd5f54cd84a1cd2696cc3207c479cb9cf0bd346f0d343e4300ddb", size = 215947, upload-time = "2026-08-15T08:19:47.853Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/76/9aad3e9c8865e5e0efa9a7f6f81c37a67635a985145ecd44528a81e088ee/charset_normalizer-3.5.1-cp315-cp315t-win_arm64.whl", hash = "sha256:fb78f6e7fcd8ad785d28cd577168bc1aaee827b25bb8755638f694794ea98f0a", size = 193909, upload-time = "2026-08-15T08:19:49.383Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/97/fb4e82231aba271ffd775a1b4993b0defc4e3059f286ae41d9433409fe85/charset_normalizer-3.5.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:41876ee62a3dddf48ff1121ad8f0798032aa03f2fd35f21f34a4cab14f18d8d2", size = 331467, upload-time = "2026-08-15T08:19:50.959Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2f/fe3f187327aac18e2d54e9d2b08e15d27bf9b642d9e51c219f130fc34d1a/charset_normalizer-3.5.1-cp37-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6dac12ff6b846103483683f60c5f8fee205121adc58ffd87e90a90a3af69e99", size = 253057, upload-time = "2026-08-15T08:19:52.654Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/c7/9e48cee5c161fe24da823b61bf381921d77cb994a0a4de148e95018c1984/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cee5dd7c6fb5dd52a0fe2a740f9bc6e3593f5f8b1788bde49de02086f30182b2", size = 240930, upload-time = "2026-08-15T08:19:54.163Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e0/716601f3cc69be7b198951150c75ead1ece33c3c8036ff6ffa46029659a0/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:343fb4f2821043bd87095f7b08a1a181febc8e36ac64212143bbfd0a0e1bc235", size = 230822, upload-time = "2026-08-15T08:19:55.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/05/71bfc5caa0abcc45aea1f6a4d50ac68e59605ddc7666fe8494f4cd229665/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ae4a097991662cd4fff0ddc74e0fe7874f82e00042fa0ea00855645ed0c79598", size = 260037, upload-time = "2026-08-15T08:19:57.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/92/de7e32ed05341e7a9c4c877c318418197b7f2d66a3b68d561bf2ac57ca3e/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b599739b93b2cbeded49645ae3c8d1405c29ddfbceac1545c87a3f9580a9e96", size = 255097, upload-time = "2026-08-15T08:19:59.056Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/7b/ade0a122600319dfa0b1000ab0f9731c94a817904cf3c5de408c73a4ede7/charset_normalizer-3.5.1-cp37-abi3-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b39b69b347e5e47a3b5b8cfc005c68c1ba347474e3960236c4944a8ecd174962", size = 250166, upload-time = "2026-08-15T08:20:00.612Z" },
+    { url = "https://files.pythonhosted.org/packages/75/9c/019fbb9f4834491a160951349b1a3714439376f66e5f7cf18b4f18f0c7aa/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a2028475ba855475b8b4d3cfeb4994269c967aea8b9892dfba907f4263a863a3", size = 241821, upload-time = "2026-08-15T08:20:02.321Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/11d4840bfc99330cc7fbcc2681ee5a044553a6e77655508d8f9b2bff7b34/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:36047af20e17097c3bb9476c2b7655f2f7aa51322c0ba58c07695bedf755a950", size = 232529, upload-time = "2026-08-15T08:20:04.008Z" },
+    { url = "https://files.pythonhosted.org/packages/18/96/2b3a21492d9f65171ac75d872f5018260013d00bfa0ff70ec9f179148cbd/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:4c4fb141a727957c93edfe5c32a26ceb6b5f6461d67146e2d39f51e16170bea8", size = 260348, upload-time = "2026-08-15T08:20:05.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/aa/a69a2028e8bd052476c245460ab19d7de595de084dd968f2d75cd50c3e25/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:2f293479cce755c75f1697e87c409b7ae4c555c7dfecb6e988ad13abba943031", size = 247234, upload-time = "2026-08-15T08:20:07.487Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8a/3d130aeabcaf3d2466af76b7b141c08d9e89c9016ab4b7cdd0f7dc2d1c62/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_s390x.whl", hash = "sha256:3588e376b3ea2eea84976f67273d679f229e24c66dce7b82ae45aef04ff6e072", size = 256917, upload-time = "2026-08-15T08:20:09.142Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c2/a7379b840292d0c1ab9fbd17d1f3967aa81794dc95bc74be8999d7fedcf7/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e199fb99720074809a7720f1c0b4d919eea8b87e88713e0f8f602f7bef543d9d", size = 254846, upload-time = "2026-08-15T08:20:10.727Z" },
+    { url = "https://files.pythonhosted.org/packages/01/65/d43b714731bb2f40d4053dfa00ecfc1c5a301f8e3316c5db3a09af59fe94/charset_normalizer-3.5.1-cp37-abi3-win32.whl", hash = "sha256:dd732602a7009217f658d5863d12d79d373a4de0eebc111094bcdd3bb8e0a6cc", size = 174216, upload-time = "2026-08-15T08:20:12.334Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4f/b911ed898b26a09789eba9c9200c999aff6c61b4bafaf4838e56d1a1e1a3/charset_normalizer-3.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:70055ff39b97c99e7ae40ea3e393fb62aa2e44dbd9b29f8d14f42fb0025c3959", size = 199764, upload-time = "2026-08-15T08:20:13.908Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a7/920baf467bfd9bf689f3b318340f37aee4572a71f162bd8db51da55ba4fa/charset_normalizer-3.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:87e4f41d375c0b9be2fb5251aee4b8a689169e134535aed81bf085c3b647451e", size = 287318, upload-time = "2026-08-15T08:20:15.551Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/61/d01fc49b8dea277640b55a9e15960dbca9fdc8c9fde18e572d39c59f4019/charset_normalizer-3.5.1-py3-none-any.whl", hash = "sha256:6df0ec430f9a831772c23ca5a224cba36517a58a84bb32c32bb59a9fa67c47f6", size = 68658, upload-time = "2026-08-15T08:20:43.306Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -487,6 +620,27 @@ wheels = [
 ]
 
 [[package]]
+name = "fastembed"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "loguru" },
+    { name = "mmh3" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "pillow" },
+    { name = "py-rust-stemmers" },
+    { name = "requests" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/25/58865e36b6e8a9a0d0ff905b5601aa30db97956327c0df42ec4ed6accc21/fastembed-0.8.0.tar.gz", hash = "sha256:75966edfa8b006ee78514c726bd7f6a50721dadc89305279052be9db72fd53e8", size = 75115, upload-time = "2026-03-23T16:34:41.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/e8/26b7d78bb8972498c467ca34cb12ee2e60d26ba5eae6d8443189a1af37a5/fastembed-0.8.0-py3-none-any.whl", hash = "sha256:40bee672657574a1009e35ec50030a55f2b426842cb011845379817641bbbbd0", size = 116572, upload-time = "2026-03-23T16:34:40.69Z" },
+]
+
+[[package]]
 name = "fastmcp"
 version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -550,6 +704,32 @@ server = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.32.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/30/03b03951873a1a0ffc7e8ca0e10c15597b59e8d0e39260704cd2ea087bc4/filelock-3.32.4.tar.gz", hash = "sha256:2bde2e4cf732e0153406d8a7bc80620ecf5e621fe0d25e41143c4e3b4733ff30", size = 222126, upload-time = "2026-08-23T17:37:55.363Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/a4/9b63d595d748e3aff8812b65eacc1a2c4bd90b7c2012e08e72373b4835eb/filelock-3.32.4-py3-none-any.whl", hash = "sha256:22e58ca3b1ae3b98993b762d7338367ae64fe50252bf78d59da3bfebcdf1cedd", size = 99864, upload-time = "2026-08-23T17:37:53.913Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/78/f34251dadb8f3921264a1d9b8946f5e542014ee2614b285261b4e40e6775/fsspec-2026.7.0.tar.gz", hash = "sha256:c803c40f4cf860b49dea58ee3e1c33cb9c790520e233537e1340049f89b82a88", size = 317040, upload-time = "2026-07-28T16:34:51.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl", hash = "sha256:b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279", size = 206583, upload-time = "2026-07-28T16:34:49.538Z" },
+]
+
+[[package]]
 name = "griffelib"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -565,6 +745,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/ab/522a2ab67f27971a9d48ca666d4fca85ef7d5282d142e31fd087e27b1bbe/hf_xet-1.6.0.tar.gz", hash = "sha256:2e58454a340b3556dfa4972d5451aff4fba8dd42a236600ba1a1d2b1514f0fef", size = 920527, upload-time = "2026-08-03T22:33:13.243Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/62/3c062f593bd92ef4e77a0ef39541e3d82a0a1d3947c8a777a02a13a27828/hf_xet-1.6.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:70cbb9c896901600128cb9b6f06e132954fbede1db30f31f7c6c63f84cb7c31d", size = 4074584, upload-time = "2026-08-03T22:32:47.364Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1e/c0ad437dd267a8e435bef594acf781bbc3874ff0b6435b4962d03ecf7cc4/hf_xet-1.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:23379c2f9ec8696d952b16414a2bae72cad86a52df869b050698ba60f538c675", size = 3867381, upload-time = "2026-08-03T22:32:49.049Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ee/7c0d7b6ab336167531b1c30af2af003f054af4c749becbd7209ae33a77c3/hf_xet-1.6.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f2f7278c05c22fd60cb436cda1269649b3e81db65ecdc8496e5e164aa4143e7b", size = 4453982, upload-time = "2026-08-03T22:32:50.568Z" },
+    { url = "https://files.pythonhosted.org/packages/63/06/ad8eab1c9525246650cbaa821caa3cdbaca734ab1a5b8c91bea09cbd8d69/hf_xet-1.6.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:948f15d3a9545cfe5932f6bd8b440f6ae630aee108f14b7bd6c561f7c2dcc522", size = 4249445, upload-time = "2026-08-03T22:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/26/1eee8aedb0dafc1ab9717dc9ac602cde33361b232dc06803f1f6ed18b58c/hf_xet-1.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5153e6bb103ad49d6ea9f1b2e230db5a2ea32551ad09a706d2f61d7c7c80d80e", size = 4451099, upload-time = "2026-08-03T22:32:54.114Z" },
+    { url = "https://files.pythonhosted.org/packages/67/57/0b88af1f194ab6c9c650547d9cc06bfeaab836ae4dcdb331676bfb8be95a/hf_xet-1.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:35cec30d75c6f9eb9c16a77cef68e85a103b72e24d4b473714ec9ff06428bab9", size = 4664712, upload-time = "2026-08-03T22:32:55.547Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a0/26b717a9d1840e8abf48dcec64b5ed8fbe472671d38ad28d30e147132b33/hf_xet-1.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5789835d7c6bc9436962853192082374297fb72d7eff7e7762ec25ceb7e25338", size = 4025906, upload-time = "2026-08-03T22:32:57.391Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f6/4a9966633c6fef83af997e2cff68ec1963676d412bdfd096df2a93b8e185/hf_xet-1.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:75765820ce4700db3750c94acc8fe27c5fae4c9ec000a0dbac3ca082acf97765", size = 3849221, upload-time = "2026-08-03T22:32:59.123Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/50/7afa2c9c787405864fc47a0d1bbc02c62e9101947ed43c1f43899fc7d91d/hf_xet-1.6.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:633dc0cd71d32da58ab8c03ad38e2fac452c15c2b0a2866ebf6ededfe0a5061d", size = 4071729, upload-time = "2026-08-03T22:33:00.721Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/69/55b8dcf636142ae660fec1869fcac14c4da2e8412e14d6eee1523be77e9f/hf_xet-1.6.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:f0906082d9932ae0c0057fa194041c22b4e2cdb46b2592ef3b91f020d62a081a", size = 3876287, upload-time = "2026-08-03T22:33:02.251Z" },
+    { url = "https://files.pythonhosted.org/packages/67/4e/a28359bf1c1ecf11eba22123168c138698f7cb576ac678f5a2e16cd5da08/hf_xet-1.6.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d62671bb130879cef0ee4c9ebe47a14af6c66ec53e6d84dc15936e5ffdfac82f", size = 4464663, upload-time = "2026-08-03T22:33:03.802Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/69/1f0cbc2fb22ae6082d094f743d1b8945a3f36f6089cb95f42b7ee348cda7/hf_xet-1.6.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0e6e21fa3cdfcdcd76748564bf593870a5e013f47d97cf10aed63aa222cff5b7", size = 4262538, upload-time = "2026-08-03T22:33:05.287Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3a/4f4f2301ade26e404462d3336fa11f7958d914cabbabdd6e03c3c5d5658c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4fc74352a17015bd0ee90038bc9efe38db894cde45f268b6712b04fce8cd0acb", size = 4460520, upload-time = "2026-08-03T22:33:06.81Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/311725e2a905534dfee2dcb5b08414f249147f1f12252bfc2bd24caa075c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8fb4f71cba6129110c3374a33f919001ff130488fc23553698e34cc1c2a1198c", size = 4675937, upload-time = "2026-08-03T22:33:08.616Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b7/8c59a66d15205024662f1d66968136f13893f96df1ddc5087e2e281fc95f/hf_xet-1.6.0-cp38-abi3-win_amd64.whl", hash = "sha256:fb4fadde1b2b70bf4c0c14a6dccbe7194b1c28947fefd5bbe3fed9d940676c3b", size = 4033128, upload-time = "2026-08-03T22:33:10.171Z" },
+    { url = "https://files.pythonhosted.org/packages/73/63/ca511b6f802f28cf3489b280fe77475bcca8de85e81a6299d7916b5b5555/hf_xet-1.6.0-cp38-abi3-win_arm64.whl", hash = "sha256:3dc3e35441ba395006af5aaacc40ef2e603c51ef46c3530b9156185f00935ea3", size = 3859359, upload-time = "2026-08-03T22:33:11.725Z" },
 ]
 
 [[package]]
@@ -602,6 +806,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/ae/222a91937ebee7f62c0ca8f5ee0afd97577caf24c0abb927d1f5c7e9f6d2/huggingface_hub-1.28.0.tar.gz", hash = "sha256:46a2e950c09234de54093d587d1675382f0d08dbd600d9fb599b5932f5b2c6cb", size = 959609, upload-time = "2026-08-18T12:27:15.101Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/0e/eafef18f1a75e125e68395db21131db0cf868a128ecd2fce69b4df6c584b/huggingface_hub-1.28.0-py3-none-any.whl", hash = "sha256:58a8bacb03072edfc38067065e9dc24bbb34805410fcd36a1632de0b329660bb", size = 793202, upload-time = "2026-08-18T12:27:12.719Z" },
 ]
 
 [[package]]
@@ -846,6 +1070,19 @@ wheels = [
 ]
 
 [[package]]
+name = "loguru"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -889,6 +1126,88 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mmh3"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/1a/edb23803a168f070ded7a3014c6d706f63b90c84ccc024f89d794a3b7a6d/mmh3-5.2.1.tar.gz", hash = "sha256:bbea5b775f0ac84945191fb83f845a6fd9a21a03ea7f2e187defac7e401616ad", size = 33775, upload-time = "2026-03-05T15:55:57.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/94/bc5c3b573b40a328c4d141c20e399039ada95e5e2a661df3425c5165fd84/mmh3-5.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0cc21533878e5586b80d74c281d7f8da7932bc8ace50b8d5f6dbf7e3935f63f1", size = 56087, upload-time = "2026-03-05T15:54:21.92Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/80/64a02cc3e95c3af0aaa2590849d9ed24a9f14bb93537addde688e039b7c3/mmh3-5.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4eda76074cfca2787c8cf1bec603eaebdddd8b061ad5502f85cddae998d54f00", size = 40500, upload-time = "2026-03-05T15:54:22.953Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/72/e6d6602ce18adf4ddcd0e48f2e13590cc92a536199e52109f46f259d3c46/mmh3-5.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:eee884572b06bbe8a2b54f424dbd996139442cf83c76478e1ec162512e0dd2c7", size = 40034, upload-time = "2026-03-05T15:54:23.943Z" },
+    { url = "https://files.pythonhosted.org/packages/59/c2/bf4537a8e58e21886ef16477041238cab5095c836496e19fafc34b7445d2/mmh3-5.2.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0d0b7e803191db5f714d264044e06189c8ccd3219e936cc184f07106bd17fd7b", size = 97292, upload-time = "2026-03-05T15:54:25.335Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e2/51ed62063b44d10b06d975ac87af287729eeb5e3ed9772f7584a17983e90/mmh3-5.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e6c219e375f6341d0959af814296372d265a8ca1af63825f65e2e87c618f006", size = 103274, upload-time = "2026-03-05T15:54:26.44Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ce/12a7524dca59eec92e5b31fdb13ede1e98eda277cf2b786cf73bfbc24e81/mmh3-5.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26fb5b9c3946bf7f1daed7b37e0c03898a6f062149127570f8ede346390a0825", size = 106158, upload-time = "2026-03-05T15:54:28.578Z" },
+    { url = "https://files.pythonhosted.org/packages/86/1f/d3ba6dd322d01ab5d44c46c8f0c38ab6bbbf9b5e20e666dfc05bf4a23604/mmh3-5.2.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3c38d142c706201db5b2345166eeef1e7740e3e2422b470b8ba5c8727a9b4c7a", size = 113005, upload-time = "2026-03-05T15:54:29.767Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/a9/15d6b6f913294ea41b44d901741298e3718e1cb89ee626b3694625826a43/mmh3-5.2.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:50885073e2909251d4718634a191c49ae5f527e5e1736d738e365c3e8be8f22b", size = 120744, upload-time = "2026-03-05T15:54:30.931Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b3/70b73923fd0284c439860ff5c871b20210dfdbe9a6b9dd0ee6496d77f174/mmh3-5.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b3f99e1756fc48ad507b95e5d86f2fb21b3d495012ff13e6592ebac14033f166", size = 99111, upload-time = "2026-03-05T15:54:32.353Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/38/99f7f75cd27d10d8b899a1caafb9d531f3903e4d54d572220e3d8ac35e89/mmh3-5.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62815d2c67f2dd1be76a253d88af4e1da19aeaa1820146dec52cf8bee2958b16", size = 98623, upload-time = "2026-03-05T15:54:33.801Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/68/6e292c0853e204c44d2f03ea5f090be3317a0e2d9417ecb62c9eb27687df/mmh3-5.2.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8f767ba0911602ddef289404e33835a61168314ebd3c729833db2ed685824211", size = 106437, upload-time = "2026-03-05T15:54:35.177Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c6/fedd7284c459cfb58721d461fcf5607a4c1f5d9ab195d113d51d10164d16/mmh3-5.2.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:67e41a497bac88cc1de96eeba56eeb933c39d54bc227352f8455aa87c4ca4000", size = 110002, upload-time = "2026-03-05T15:54:36.673Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ac/ca8e0c19a34f5b71390171d2ff0b9f7f187550d66801a731bb68925126a4/mmh3-5.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3d74a03fb57757ece25aa4b3c1c60157a1cece37a020542785f942e2f827eed5", size = 97507, upload-time = "2026-03-05T15:54:37.804Z" },
+    { url = "https://files.pythonhosted.org/packages/df/94/6ebb9094cfc7ac5e7950776b9d13a66bb4a34f83814f32ba2abc9494fc68/mmh3-5.2.1-cp312-cp312-win32.whl", hash = "sha256:7374d6e3ef72afe49697ecd683f3da12f4fc06af2d75433d0580c6746d2fa025", size = 40773, upload-time = "2026-03-05T15:54:40.077Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/cd3527198cf159495966551c84a5f36805a10ac17b294f41f67b83f6a4d6/mmh3-5.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:3a9fed49c6ce4ed7e73f13182760c65c816da006debe67f37635580dfb0fae00", size = 41560, upload-time = "2026-03-05T15:54:41.148Z" },
+    { url = "https://files.pythonhosted.org/packages/15/96/6fe5ebd0f970a076e3ed5512871ce7569447b962e96c125528a2f9724470/mmh3-5.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:bbfcb95d9a744e6e2827dfc66ad10e1020e0cac255eb7f85652832d5a264c2fc", size = 39313, upload-time = "2026-03-05T15:54:42.171Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a5/9daa0508a1569a54130f6198d5462a92deda870043624aa3ea72721aa765/mmh3-5.2.1-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:723b2681ed4cc07d3401bbea9c201ad4f2a4ca6ba8cddaff6789f715dd2b391e", size = 40832, upload-time = "2026-03-05T15:54:43.212Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/6b/3230c6d80c1f4b766dedf280a92c2241e99f87c1504ff74205ec8cebe451/mmh3-5.2.1-cp313-cp313-android_21_x86_64.whl", hash = "sha256:3619473a0e0d329fd4aec8075628f8f616be2da41605300696206d6f36920c3d", size = 41964, upload-time = "2026-03-05T15:54:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/62/fb/648bfddb74a872004b6ee751551bfdda783fe6d70d2e9723bad84dbe5311/mmh3-5.2.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:e48d4dbe0f88e53081da605ae68644e5182752803bbc2beb228cca7f1c4454d6", size = 39114, upload-time = "2026-03-05T15:54:45.205Z" },
+    { url = "https://files.pythonhosted.org/packages/95/c2/ab7901f87af438468b496728d11264cb397b3574d41506e71b92128e0373/mmh3-5.2.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a482ac121de6973897c92c2f31defc6bafb11c83825109275cffce54bb64933f", size = 39819, upload-time = "2026-03-05T15:54:46.509Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/ed/6f88dda0df67de1612f2e130ffea34cf84aaee5bff5b0aff4dbff2babe34/mmh3-5.2.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:17fbb47f0885ace8327ce1235d0416dc86a211dcd8cc1e703f41523be32cfec8", size = 40330, upload-time = "2026-03-05T15:54:47.864Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/66/7516d23f53cdf90f43fce24ab80c28f45e6851d78b46bef8c02084edf583/mmh3-5.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d51fde50a77f81330523562e3c2734ffdca9c4c9e9d355478117905e1cfe16c6", size = 56078, upload-time = "2026-03-05T15:54:48.9Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/34/4d152fdf4a91a132cb226b671f11c6b796eada9ab78080fb5ce1e95adaab/mmh3-5.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:19bbd3b841174ae6ed588536ab5e1b1fe83d046e668602c20266547298d939a9", size = 40498, upload-time = "2026-03-05T15:54:49.942Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/4c/8e3af1b6d85a299767ec97bd923f12b06267089c1472c27c1696870d1175/mmh3-5.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:be77c402d5e882b6fbacfd90823f13da8e0a69658405a39a569c6b58fdb17b03", size = 40033, upload-time = "2026-03-05T15:54:50.994Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f2/966ea560e32578d453c9e9db53d602cbb1d0da27317e232afa7c38ceba11/mmh3-5.2.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:fd96476f04db5ceba1cfa0f21228f67c1f7402296f0e73fee3513aa680ad237b", size = 97320, upload-time = "2026-03-05T15:54:52.072Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/0d/2c5f9893b38aeb6b034d1a44ecd55a010148054f6a516abe53b5e4057297/mmh3-5.2.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:707151644085dd0f20fe4f4b573d28e5130c4aaa5f587e95b60989c5926653b5", size = 103299, upload-time = "2026-03-05T15:54:53.569Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fc/2ebaef4a4d4376f89761274dc274035ffd96006ab496b4ee5af9b08f21a9/mmh3-5.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3737303ca9ea0f7cb83028781148fcda4f1dac7821db0c47672971dabcf63593", size = 106222, upload-time = "2026-03-05T15:54:55.092Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/ea7ffe126d0ba0406622602a2d05e1e1a6841cc92fc322eb576c95b27fad/mmh3-5.2.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2778fed822d7db23ac5008b181441af0c869455b2e7d001f4019636ac31b6fe4", size = 113048, upload-time = "2026-03-05T15:54:56.305Z" },
+    { url = "https://files.pythonhosted.org/packages/85/57/9447032edf93a64aa9bef4d9aa596400b1756f40411890f77a284f6293ca/mmh3-5.2.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d57dea657357230cc780e13920d7fa7db059d58fe721c80020f94476da4ca0a1", size = 120742, upload-time = "2026-03-05T15:54:57.453Z" },
+    { url = "https://files.pythonhosted.org/packages/53/82/a86cc87cc88c92e9e1a598fee509f0409435b57879a6129bf3b3e40513c7/mmh3-5.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:169e0d178cb59314456ab30772429a802b25d13227088085b0d49b9fe1533104", size = 99132, upload-time = "2026-03-05T15:54:58.583Z" },
+    { url = "https://files.pythonhosted.org/packages/54/f7/6b16eb1b40ee89bb740698735574536bc20d6cdafc65ae702ea235578e05/mmh3-5.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7e4e1f580033335c6f76d1e0d6b56baf009d1a64d6a4816347e4271ba951f46d", size = 98686, upload-time = "2026-03-05T15:55:00.078Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/88/a601e9f32ad1410f438a6d0544298ea621f989bd34a0731a7190f7dec799/mmh3-5.2.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:2bd9f19f7f1fcebd74e830f4af0f28adad4975d40d80620be19ffb2b2af56c9f", size = 106479, upload-time = "2026-03-05T15:55:01.532Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/ce29ae3dfc4feec4007a437a1b7435fb9507532a25147602cd5b52be86db/mmh3-5.2.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:c88653877aeb514c089d1b3d473451677b8b9a6d1497dbddf1ae7934518b06d2", size = 110030, upload-time = "2026-03-05T15:55:02.934Z" },
+    { url = "https://files.pythonhosted.org/packages/13/30/ae444ef2ff87c805d525da4fa63d27cda4fe8a48e77003a036b8461cfd5c/mmh3-5.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fceef7fe67c81e1585198215e42ad3fdba3a25644beda8fbdaf85f4d7b93175a", size = 97536, upload-time = "2026-03-05T15:55:04.135Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f9/dc3787ee5c813cc27fe79f45ad4500d9b5437f23a7402435cc34e07c7718/mmh3-5.2.1-cp313-cp313-win32.whl", hash = "sha256:54b64fb2433bc71488e7a449603bf8bd31fbcf9cb56fbe1eb6d459e90b86c37b", size = 40769, upload-time = "2026-03-05T15:55:05.277Z" },
+    { url = "https://files.pythonhosted.org/packages/43/67/850e0b5a1e97799822ebfc4ca0e8c6ece3ed8baf7dcdf64de817dfdda2ca/mmh3-5.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:cae6383181f1e345317742d2ddd88f9e7d2682fa4c9432e3a74e47d92dce0229", size = 41563, upload-time = "2026-03-05T15:55:06.283Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/cc/98c90b28e1da5458e19fbfaf4adb5289208d3bfccd45dd14eab216a2f0bb/mmh3-5.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:022aa1a528604e6c83d0a7705fdef0b5355d897a9e0fa3a8d26709ceaa06965d", size = 39310, upload-time = "2026-03-05T15:55:07.323Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b4/65bc1fb2bb7f83e91c30865023b1847cf89a5f237165575e8c83aa536584/mmh3-5.2.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:d771f085fcdf4035786adfb1d8db026df1eb4b41dac1c3d070d1e49512843227", size = 40794, upload-time = "2026-03-05T15:55:09.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/86/7168b3d83be8eb553897b1fac9da8bbb06568e5cfe555ffc329ebb46f59d/mmh3-5.2.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:7f196cd7910d71e9d9860da0ff7a77f64d22c1ad931f1dd18559a06e03109fc0", size = 41923, upload-time = "2026-03-05T15:55:10.924Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/9b/b653ab611c9060ce8ff0ba25c0226757755725e789292f3ca138a58082cd/mmh3-5.2.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b1f12bd684887a0a5d55e6363ca87056f361e45451105012d329b86ec19dbe0b", size = 39131, upload-time = "2026-03-05T15:55:11.961Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b4/5a2e0d34ab4d33543f01121e832395ea510132ea8e52cdf63926d9d81754/mmh3-5.2.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:d106493a60dcb4aef35a0fac85105e150a11cf8bc2b0d388f5a33272d756c966", size = 39825, upload-time = "2026-03-05T15:55:13.013Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/69/81699a8f39a3f8d368bec6443435c0c392df0d200ad915bf0d222b588e03/mmh3-5.2.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:44983e45310ee5b9f73397350251cdf6e63a466406a105f1d16cb5baa659270b", size = 40344, upload-time = "2026-03-05T15:55:14.026Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b3/71c8c775807606e8fd8acc5c69016e1caf3200d50b50b6dd4b40ce10b76c/mmh3-5.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:368625fb01666655985391dbad3860dc0ba7c0d6b9125819f3121ee7292b4ac8", size = 56291, upload-time = "2026-03-05T15:55:15.137Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/75/2c24517d4b2ce9e4917362d24f274d3d541346af764430249ddcc4cb3a08/mmh3-5.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:72d1cc63bcc91e14933f77d51b3df899d6a07d184ec515ea7f56bff659e124d7", size = 40575, upload-time = "2026-03-05T15:55:16.518Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/b9/e4a360164365ac9f07a25f0f7928e3a66eb9ecc989384060747aa170e6aa/mmh3-5.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e8b4b5580280b9265af3e0409974fb79c64cf7523632d03fbf11df18f8b0181e", size = 40052, upload-time = "2026-03-05T15:55:17.735Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ca/120d92223a7546131bbbc31c9174168ee7a73b1366f5463ffe69d9e691fe/mmh3-5.2.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4cbbde66f1183db040daede83dd86c06d663c5bb2af6de1142b7c8c37923dd74", size = 97311, upload-time = "2026-03-05T15:55:18.959Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/71/c1a60c1652b8813ef9de6d289784847355417ee0f2980bca002fe87f4ae5/mmh3-5.2.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8ff038d52ef6aa0f309feeba00c5095c9118d0abf787e8e8454d6048db2037fc", size = 103279, upload-time = "2026-03-05T15:55:20.448Z" },
+    { url = "https://files.pythonhosted.org/packages/48/29/ad97f4be1509cdcb28ae32c15593ce7c415db47ace37f8fad35b493faa9a/mmh3-5.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4130d0b9ce5fad6af07421b1aecc7e079519f70d6c05729ab871794eded8617", size = 106290, upload-time = "2026-03-05T15:55:21.6Z" },
+    { url = "https://files.pythonhosted.org/packages/77/29/1f86d22e281bd8827ba373600a4a8b0c0eae5ca6aa55b9a8c26d2a34decc/mmh3-5.2.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f6e0bfe77d238308839699944164b96a2eeccaf55f2af400f54dc20669d8d5f2", size = 113116, upload-time = "2026-03-05T15:55:22.826Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7c/339971ea7ed4c12d98f421f13db3ea576a9114082ccb59d2d1a0f00ccac1/mmh3-5.2.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f963eafc0a77a6c0562397da004f5876a9bcf7265a7bcc3205e29636bc4a1312", size = 120740, upload-time = "2026-03-05T15:55:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/92/3c7c4bdb8e926bb3c972d1e2907d77960c1c4b250b41e8366cf20c6e4373/mmh3-5.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:92883836caf50d5255be03d988d75bc93e3f86ba247b7ca137347c323f731deb", size = 99143, upload-time = "2026-03-05T15:55:25.456Z" },
+    { url = "https://files.pythonhosted.org/packages/df/0a/33dd8706e732458c8375eae63c981292de07a406bad4ec03e5269654aa2c/mmh3-5.2.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:57b52603e89355ff318025dd55158f6e71396c0f1f609d548e9ea9c94cc6ce0a", size = 98703, upload-time = "2026-03-05T15:55:26.723Z" },
+    { url = "https://files.pythonhosted.org/packages/51/04/76bbce05df76cbc3d396f13b2ea5b1578ef02b6a5187e132c6c33f99d596/mmh3-5.2.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f40a95186a72fa0b67d15fef0f157bfcda00b4f59c8a07cbe5530d41ac35d105", size = 106484, upload-time = "2026-03-05T15:55:28.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8f/c6e204a2c70b719c1f62ffd9da27aef2dddcba875ea9c31ca0e87b975a46/mmh3-5.2.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:58370d05d033ee97224c81263af123dea3d931025030fd34b61227a768a8858a", size = 110012, upload-time = "2026-03-05T15:55:29.532Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/37/7181efd8e39db386c1ebc3e6b7d1f702a09d7c1197a6f2742ed6b5c16597/mmh3-5.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7be6dfb49e48fd0a7d91ff758a2b51336f1cd21f9d44b20f6801f072bd080cdd", size = 97508, upload-time = "2026-03-05T15:55:31.01Z" },
+    { url = "https://files.pythonhosted.org/packages/42/0f/afa7ca2615fd85e1469474bb860e381443d0b868c083b62b41cb1d7ca32f/mmh3-5.2.1-cp314-cp314-win32.whl", hash = "sha256:54fe8518abe06a4c3852754bfd498b30cc58e667f376c513eac89a244ce781a4", size = 41387, upload-time = "2026-03-05T15:55:32.403Z" },
+    { url = "https://files.pythonhosted.org/packages/71/0d/46d42a260ee1357db3d486e6c7a692e303c017968e14865e00efa10d09fc/mmh3-5.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:3f796b535008708846044c43302719c6956f39ca2d93f2edda5319e79a29efbb", size = 42101, upload-time = "2026-03-05T15:55:33.646Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/7b/848a8378059d96501a41159fca90d6a99e89736b0afbe8e8edffeac8c74b/mmh3-5.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:cd471ede0d802dd936b6fab28188302b2d497f68436025857ca72cd3810423fe", size = 39836, upload-time = "2026-03-05T15:55:35.026Z" },
+    { url = "https://files.pythonhosted.org/packages/27/61/1dabea76c011ba8547c25d30c91c0ec22544487a8750997a27a0c9e1180b/mmh3-5.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5174a697ce042fa77c407e05efe41e03aa56dae9ec67388055820fb48cf4c3ba", size = 57727, upload-time = "2026-03-05T15:55:36.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/32/731185950d1cf2d5e28979cc8593016ba1619a295faba10dda664a4931b5/mmh3-5.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0a3984146e414684a6be2862d84fcb1035f4984851cb81b26d933bab6119bf00", size = 41308, upload-time = "2026-03-05T15:55:37.254Z" },
+    { url = "https://files.pythonhosted.org/packages/76/aa/66c76801c24b8c9418b4edde9b5e57c75e72c94e29c48f707e3962534f18/mmh3-5.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:bd6e7d363aa93bd3421b30b6af97064daf47bc96005bddba67c5ffbc6df426b8", size = 40758, upload-time = "2026-03-05T15:55:38.61Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/bb/79a1f638a02f0ae389f706d13891e2fbf7d8c0a22ecde67ba828951bb60a/mmh3-5.2.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:113f78e7463a36dbbcea05bfe688efd7fa759d0f0c56e73c974d60dcfec3dfcc", size = 109670, upload-time = "2026-03-05T15:55:40.13Z" },
+    { url = "https://files.pythonhosted.org/packages/26/94/8cd0e187a288985bcfc79bf5144d1d712df9dee74365f59d26e3a1865be6/mmh3-5.2.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7e8ec5f606e0809426d2440e0683509fb605a8820a21ebd120dcdba61b74ef7f", size = 117399, upload-time = "2026-03-05T15:55:42.076Z" },
+    { url = "https://files.pythonhosted.org/packages/42/94/dfea6059bd5c5beda565f58a4096e43f4858fb6d2862806b8bbd12cbb284/mmh3-5.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22b0f9971ec4e07e8223f2beebe96a6cfc779d940b6f27d26604040dd74d3a44", size = 120386, upload-time = "2026-03-05T15:55:43.481Z" },
+    { url = "https://files.pythonhosted.org/packages/47/cb/f9c45e62aaa67220179f487772461d891bb582bb2f9783c944832c60efd9/mmh3-5.2.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:85ffc9920ffc39c5eee1e3ac9100c913a0973996fbad5111f939bbda49204bb7", size = 125924, upload-time = "2026-03-05T15:55:44.638Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/83/fe54a4a7c11bc9f623dfc1707decd034245602b076dfc1dcc771a4163170/mmh3-5.2.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7aec798c2b01aaa65a55f1124f3405804184373abb318a3091325aece235f67c", size = 135280, upload-time = "2026-03-05T15:55:45.866Z" },
+    { url = "https://files.pythonhosted.org/packages/97/67/fe7e9e9c143daddd210cd22aef89cbc425d58ecf238d2b7d9eb0da974105/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:55dbbd8ffbc40d1697d5e2d0375b08599dae8746b0b08dea05eee4ce81648fac", size = 110050, upload-time = "2026-03-05T15:55:47.074Z" },
+    { url = "https://files.pythonhosted.org/packages/43/c4/6d4b09fcbef80794de447c9378e39eefc047156b290fa3dd2d5257ca8227/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:6c85c38a279ca9295a69b9b088a2e48aa49737bb1b34e6a9dc6297c110e8d912", size = 111158, upload-time = "2026-03-05T15:55:48.239Z" },
+    { url = "https://files.pythonhosted.org/packages/81/a6/ca51c864bdb30524beb055a6d8826db3906af0834ec8c41d097a6e8573d5/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:6290289fa5fb4c70fd7f72016e03633d60388185483ff3b162912c81205ae2cf", size = 116890, upload-time = "2026-03-05T15:55:49.405Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/04/5a1fe2e2ad843d03e89af25238cbc4f6840a8bb6c4329a98ab694c71deda/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:4fc6cd65dc4d2fdb2625e288939a3566e36127a84811a4913f02f3d5931da52d", size = 123121, upload-time = "2026-03-05T15:55:50.61Z" },
+    { url = "https://files.pythonhosted.org/packages/af/4d/3c820c6f4897afd25905270a9f2330a23f77a207ea7356f7aadace7273c0/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:623f938f6a039536cc02b7582a07a080f13fdfd48f87e63201d92d7e34d09a18", size = 110187, upload-time = "2026-03-05T15:55:52.143Z" },
+    { url = "https://files.pythonhosted.org/packages/21/54/1d71cd143752361c0aebef16ad3f55926a6faf7b112d355745c1f8a25f7f/mmh3-5.2.1-cp314-cp314t-win32.whl", hash = "sha256:29bc3973676ae334412efdd367fcd11d036b7be3efc1ce2407ef8676dabfeb82", size = 41934, upload-time = "2026-03-05T15:55:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e4/63a2a88f31d93dea03947cccc2a076946857e799ea4f7acdecbf43b324aa/mmh3-5.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:28cfab66577000b9505a0d068c731aee7ca85cd26d4d63881fab17857e0fe1fb", size = 43036, upload-time = "2026-03-05T15:55:55.252Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0f/59204bf136d1201f8d7884cfbaf7498c5b4674e87a4c693f9bde63741ce1/mmh3-5.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:dfd51b4c56b673dfbc43d7d27ef857dd91124801e2806c69bb45585ce0fa019b", size = 40391, upload-time = "2026-03-05T15:55:56.697Z" },
 ]
 
 [[package]]
@@ -964,6 +1283,111 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/80/db0b4559e57ec36362bedbb05530a87fafbcb6067708c946967a41d449e7/numpy-2.5.2.tar.gz", hash = "sha256:d482d171c406ae88c5b19cad3b6a1c4c5209f886ab74bc44c2c865c23f52d860", size = 20773161, upload-time = "2026-08-09T13:48:27.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/72/dccb0aaf40972777283303919f613964227266d0c13adebb79ac124f1c3e/numpy-2.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:14e373cfc6387177e8409dac3c7159be8eb05cd77096cd7c950268b86f62831c", size = 16891693, upload-time = "2026-08-09T13:44:51.702Z" },
+    { url = "https://files.pythonhosted.org/packages/60/2e/b5aee50a1f74ac815cf8331812cb8251e29024025de462e0c047641c614c/numpy-2.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4bbd96c833ecc8cc069ce518078fc8c60cb9cbfb0fea5b7a803ad65035596d03", size = 11903109, upload-time = "2026-08-09T13:44:55.501Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f4/29e78102a80601cf034d4e9767022cffeca2c3b4c926e1754572ca95593d/numpy-2.5.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:6e8172ddfcf5cf74b811d372b570b83c60bd2de87a6fbfbebdadb4a9bd9c6cbb", size = 5350202, upload-time = "2026-08-09T13:44:58.401Z" },
+    { url = "https://files.pythonhosted.org/packages/11/4b/dcd3b7eadaf4035d2c7a4289d232523a6964f602598ef7674e4bd7291f93/numpy-2.5.2-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:65f188481f1669e26f62b701e8205d19e460fa4a9b52a1414ba382330e4a3414", size = 6687736, upload-time = "2026-08-09T13:45:00.813Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/21/4947e0e9d6c9fc2e2ff15b8949049ee44f63adb9cacc729ab8793f97e712/numpy-2.5.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8ee9c4eeb8454b3660a8b53493563c3e121c2fc94fbd72b848ef814ed7b676a9", size = 15612696, upload-time = "2026-08-09T13:45:04.151Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5f/62d28cf019460c7f1394105b4d49d9911a9c444cb77ab0bd95a204c5a6de/numpy-2.5.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3cdec01fa790a186d430433fdd4d4ffb70eed6f0eeb4bf05c8dbe2dce0a9bcb8", size = 16722264, upload-time = "2026-08-09T13:45:07.714Z" },
+    { url = "https://files.pythonhosted.org/packages/14/25/3f0be4c1b9fdf5dd5e708a6806978564d7c46a055c000496309ff2a2f8af/numpy-2.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7999d4ddb0c4025018373fd787510d46e04c769467af22869707b3c1cfd459ab", size = 16974396, upload-time = "2026-08-09T13:45:11.316Z" },
+    { url = "https://files.pythonhosted.org/packages/22/72/6262cbdeeb45da9d971e40715f579d791603ba8ec0b5e2db1ac55454421d/numpy-2.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c1f017dc0875c9209d219f97feceb7d54c2661bb243deb4114478e1295808af7", size = 18476044, upload-time = "2026-08-09T13:45:14.869Z" },
+    { url = "https://files.pythonhosted.org/packages/36/33/29208b8b075bde62d26a81d14b358c42b0f69b6cabd98d4ff97f37f22b05/numpy-2.5.2-cp312-cp312-win32.whl", hash = "sha256:d6a48072864e3324e194a8fbb3c657bcc5b5c869dbc64c9537b1d5c862572c0a", size = 6072817, upload-time = "2026-08-09T13:45:17.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b9/87fea2769fe1c47c1b5b01d8310772c9d1a85d485de7cf386ef7a3332b02/numpy-2.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:28ac63476ec7651484215ee7fa15a1f78b57c14621f01e392afe17b9a1390ce4", size = 12464674, upload-time = "2026-08-09T13:45:20.734Z" },
+    { url = "https://files.pythonhosted.org/packages/14/52/032b97e00461ab0809bbe4c588b035620e5a14b8cdee47ecddefc7b17d33/numpy-2.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:27650bb0e7140fa3d37b9923b4803645e0b125d190f326eecfd3f4dad8e8ade1", size = 10397131, upload-time = "2026-08-09T13:45:23.73Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d2/6b24738a0ef4557d189b150046cd07823c50e4273e8aebd651222e24306f/numpy-2.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8e4cb9a754c8a0c62eaa88273a5fba3391f4a610d1dee893c0755da31c083f15", size = 16886595, upload-time = "2026-08-09T13:45:27.323Z" },
+    { url = "https://files.pythonhosted.org/packages/65/60/f2d208d366f263f39c6e69ed309290717aab41078b6d04c9be2a84fa2a07/numpy-2.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:52c808f96484f5571a5cc863775ce50247c17dfb3b0361f8ed6b4b0456f80080", size = 11896845, upload-time = "2026-08-09T13:45:31.638Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/79/81e0bf24f4d020a2b1d5cd297a9f60c3f24eeb116f9bba5870443f7b6a4a/numpy-2.5.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:29d81e97f668489cba8ebfd796b9bdd453525d35dd9e162e2daec94bf3fc7740", size = 5343880, upload-time = "2026-08-09T13:45:34.373Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/cc/e3141cf06d1a8a2c7e107543fe1269c1d1af760d4d683c0794a4ee1127c2/numpy-2.5.2-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:afb3f0632d6b2e3ba04dbce8d1e48d321b369138b73830b5ca371a0e8d479d56", size = 6682264, upload-time = "2026-08-09T13:45:36.7Z" },
+    { url = "https://files.pythonhosted.org/packages/29/f1/2a64a307d92c5d98f5255a4014eb43bb6103ee477087b61ecae44a3aa9b9/numpy-2.5.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0aadf13b60048d501e05fa699efaf7734e2494f3498a4c2a5521d822640324f3", size = 15609566, upload-time = "2026-08-09T13:45:39.518Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/44/59a1eb68e773c4098d107ef34a0dbdeca501d72ffcfbff9a7707343921ce/numpy-2.5.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29b86ff8a6cc556b47ec6b64b194815cc80e6bf5eedcc6cddfd65318cb0b4eee", size = 16709995, upload-time = "2026-08-09T13:45:43.661Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/4c/3e54d4ddbc359a1295f8b633e8106bcd4d7d4a206e82df051bdfb3058755/numpy-2.5.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6950c4b7dd562453090548ba7f5da7e59f57f85663f15d5dcc60e249192f7e59", size = 16972511, upload-time = "2026-08-09T13:45:47.094Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9f/02e371638ebf19b66d46231e4be52999e87f32d1961b113bc45656608b22/numpy-2.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b9727f472d2f3888053b8a75ab0cb94745a9de224bb5846dbadc0092101bc71d", size = 18465609, upload-time = "2026-08-09T13:45:50.808Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ae/ad6645abc7a3510fe48e8ea1ab4598166f500057ef4ebf38bfad4f1577de/numpy-2.5.2-cp313-cp313-win32.whl", hash = "sha256:4f9744f9fbdcea0bc552e8f19e1f141f811a3f9bc2be2cc6e86d982cab23e3f4", size = 6070204, upload-time = "2026-08-09T13:45:54.111Z" },
+    { url = "https://files.pythonhosted.org/packages/15/20/f3489f86d81ea460b2bcdceaed094142ca6579f6be0ec527b781d39afe68/numpy-2.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:85aaccb24182c25df891ad0ec333585967e115269d5f1b17f2c9ae005bc96657", size = 12460532, upload-time = "2026-08-09T13:45:57.167Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/21/35b31dde1b283b79de828b80f876afd8c94e28fe1e9c375f89e261cc4c0d/numpy-2.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:bd68ece1553d2023c09a4226d9e41c586ad2d20594d1a456186c33513d2cb3f2", size = 10396725, upload-time = "2026-08-09T13:46:00.478Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f8/c3b222bf075b50afd8e949a07a15c4b312a4a84bd8102a332bcd953cbbb4/numpy-2.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d787cf769c3baeb5f6235e778edb52c08dfa923789b5958f28e6450f96107cb1", size = 16885180, upload-time = "2026-08-09T13:46:03.939Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e1/2c1d4b1987795a92b5bbf7c24fe249ab96aa2573ab0d7604802c189d7b86/numpy-2.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:24b9dc2e3d84aa58523798805194e23e736f3f6ce2d1a5b92583ae734e6dbda8", size = 11907878, upload-time = "2026-08-09T13:46:07.045Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ee/d08226fc858044355983a6e5b94f08ff6f3969e0a2b160a4a89f0ddb3445/numpy-2.5.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:9e9413326d726c2545bfa65d2c0876871e8d8386e77f992c1d426e180bbd4323", size = 5354922, upload-time = "2026-08-09T13:46:10.04Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/6d3d933056440ebbc5e6bad92065fc6c26a48a84a36b1208580e94eea76c/numpy-2.5.2-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:60e902ac295855348a5ca2ea4c89108989a9f5fddfad3dfc0a8f36b10358567e", size = 6679168, upload-time = "2026-08-09T13:46:12.275Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3b/ecd49dd90033cceb2704d88ca905d4d7d89b0e8c739608754ffd325fa820/numpy-2.5.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50e500dc868e9313530ce12ba470fe50ff3afe3d62993ed6eff652dacd555b65", size = 15624501, upload-time = "2026-08-09T13:46:15.322Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/99/461bd36dbdfac6c1c53efa370bd55a83227542d0d118f1677dbf1a3dacd5/numpy-2.5.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318b9a4c845dbea06708a29c84ee429cc3065048db34cdb799047643492050ee", size = 16713701, upload-time = "2026-08-09T13:46:18.949Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/9c/2b251df9e8a5d647b62b0cbc1b90a91850c1cf4859ecb532fd0b4eacff6c/numpy-2.5.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:34c319e2963be042673fb46570501b2f06c41924e17e3563d58646b4380dfb68", size = 16986065, upload-time = "2026-08-09T13:46:23.006Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/25/20de43f53ff1390534a124475055a19f01fe10c920a0fd11b8e18d6d6052/numpy-2.5.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f06571a052127dc1b4e8b83029b4d1b20daa2b64a31cdd181fc6bc774e9000eb", size = 18470031, upload-time = "2026-08-09T13:46:27.102Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5e/0c577ca308d6da5eb79b546ba10bbe5b60148192194e2da060913b1de4f1/numpy-2.5.2-cp314-cp314-win32.whl", hash = "sha256:2cc779226e476d1e1f08c74068c419e60f41a9e0e069c92f6671d31d5c985e98", size = 6121028, upload-time = "2026-08-09T13:46:30.046Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5c/7bcbd5b11f94199073320410cddcbb80cee62415bfeb540874b265c2d922/numpy-2.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:7587f53dfbd5edc0f7b87c6217b4c6d2d1f2ef9c3da70bc1315e7db5f8d7ec9d", size = 12597627, upload-time = "2026-08-09T13:46:32.886Z" },
+    { url = "https://files.pythonhosted.org/packages/87/bc/4d0b06fba0da90ccc75af62823cb9dcedb6c9ea0cffa058cb2c9ee773a77/numpy-2.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:3e4c367352d3747784248a227fbec218e193b56f7e6692e3b64fc805478ecfdf", size = 10680414, upload-time = "2026-08-09T13:46:36.036Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/17/f429aac9dc08833a0d0f188eba38c532a751b1a1f2ca6018a37b455cb321/numpy-2.5.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b879fb674276e331513fb136b78dbc6bd3c848309e0d841cfd63be3896c4cfc1", size = 12026967, upload-time = "2026-08-09T13:46:39.084Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/9f/d0849de96a2a4ceaa16662f18ee13eaa9c0aa418269fdc8c4857c56b11da/numpy-2.5.2-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:fd0d703772bba096843785bd38371e31bb4a0c1151497ad5739d182114a73f7f", size = 5473874, upload-time = "2026-08-09T13:46:42.075Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3c/8df216d4a4a5422a3de045301cf7df8ea47286d76f5cb7160b0128ac26b7/numpy-2.5.2-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:3a2f061cebd9e3d23bdcfaaded5e2293a4c6a5b60fa42df85d410a725ce621bf", size = 6789276, upload-time = "2026-08-09T13:46:44.387Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3a/20d7e9891c4ddfadd6ff8d95bf4b29f353d8e1770553de2099880551dfb9/numpy-2.5.2-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6df895598c0edcb41030126c89e0f353b07d93238116143b7405e937359736c4", size = 15659154, upload-time = "2026-08-09T13:46:47.538Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/d6/f3aa3d2688bf501b858835c6bd087ae9b51a56ae6fca8e2b0990abd177af/numpy-2.5.2-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1ab3d4a901f844ea836c3e80bf463c6a27d7f3c14e8e292fcf28d348b25b9bce", size = 16748909, upload-time = "2026-08-09T13:46:51.442Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8f/1c5cae8d2baf86ab802ae97a00be55bc7e21ebc11b12bbc33376c5f05342/numpy-2.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:cebc2d6dbb605a7703d59751dea4bd6b0ab127a5a4338a6f432df1936fef8b26", size = 17027685, upload-time = "2026-08-09T13:46:55.095Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/27/71d3467404aedc1c24ce79610f91b52b0b0f466c43a701aa56fc75c145ab/numpy-2.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eaca7ff36f0f52e2111ec71f169d8fd3e889e7ddc0d2592e0d703fd8d3ce8fac", size = 18501181, upload-time = "2026-08-09T13:46:59.09Z" },
+    { url = "https://files.pythonhosted.org/packages/14/2f/42921d27c40aea7e077f4a423ae509fd9220b028cd787bafefd8ab2b3a5f/numpy-2.5.2-cp314-cp314t-win32.whl", hash = "sha256:ddf47472af2e4280d79bac82304f5e80150211f1b9e614b760061d5fdfbb6eba", size = 6271085, upload-time = "2026-08-09T13:47:01.903Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e6/bad5f5d56de9b1971bac959963dda276d35c40f1854475005434bbe08692/numpy-2.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:44ef9675d908e65f9953063837c3277730f3f4437615a4cdab67b366cabaf884", size = 12787971, upload-time = "2026-08-09T13:47:04.963Z" },
+    { url = "https://files.pythonhosted.org/packages/df/05/f608795cb34391acd67e38d94a3c36abd8d8576293a3a80727d7595c372c/numpy-2.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:eaa088384c46f519dacb93b7ec483a6d6b19a4a2085ae4f25ab9b1c43d387d1e", size = 10750306, upload-time = "2026-08-09T13:47:07.976Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c6/28de0191c5f82b7d42a0a51390ba98587048aa93a39fafb05bdbe6e8d00c/numpy-2.5.2-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:078f9b027b478c9379b9677babbf0f8b8f1ecfada27636d7b9a93990c638739f", size = 16885274, upload-time = "2026-08-09T13:47:11.439Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/973ca116000d244897e468ea1aff30b589e5022e3c8744b71706fe33bd57/numpy-2.5.2-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:50a68f4bacd8a2b33d8da3d2269d0d78500f86ea582e4786dc10f5ef2c2c6842", size = 11907846, upload-time = "2026-08-09T13:47:15.128Z" },
+    { url = "https://files.pythonhosted.org/packages/78/d9/8c4b3937ef204cb2fd88d389ccd0f265a2ffb11f35a01d2064cf46714bd6/numpy-2.5.2-cp315-cp315-macosx_14_0_arm64.whl", hash = "sha256:e79aba74ffaf5f78a050d777c184cddf8fdffabab38acf5f3ef1fecbc17895d6", size = 5354892, upload-time = "2026-08-09T13:47:18.07Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/b6ee65ea2999fdb7023935e108e6fb776ee4082aa15f159acfa857e578c8/numpy-2.5.2-cp315-cp315-macosx_14_0_x86_64.whl", hash = "sha256:9a0731745a72a184490a582fb4af2533512bd071ace67785b5fdffc0ae58dce8", size = 6679309, upload-time = "2026-08-09T13:47:20.456Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f3/acb18d8b137a393c8e7803a8c994c9e64bde3930692a69d826993113a159/numpy-2.5.2-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4ec954036759bcee3aa484f8603bd9c14f3e776293b85578b8734c2d72777c69", size = 15625850, upload-time = "2026-08-09T13:47:24.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/bf/a8e9bb0db815a0e265b5744ebedd3af0bd5faad8604e5b50a1cd012f3c91/numpy-2.5.2-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc649493697006bc90614a5f0bbc8cb3cb1866715c474e473694968d7e6b99ab", size = 16713664, upload-time = "2026-08-09T13:47:27.965Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c3/6e913736b3dd6582344af32418b5fb9dab34282e8a8174ae1d54ceb0fc13/numpy-2.5.2-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:cf7de32f486e4ac9e2d93b810f9e9ac72a728dd46a32a0bb403222f27f653514", size = 16986749, upload-time = "2026-08-09T13:47:31.541Z" },
+    { url = "https://files.pythonhosted.org/packages/80/09/7d3b23eff5c7428ef6c01e6f7052bb60d504c4d33e317b36b8959c24ad97/numpy-2.5.2-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:2ffa7bacab3e2ee1b19ed31766bb60bb380b68c23f051e199c5cc598afd68710", size = 18470495, upload-time = "2026-08-09T13:47:35.364Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/a4/68a321d825374f6eb677ffe8ef8c6b9a328304e6fd2e39d9530822776607/numpy-2.5.2-cp315-cp315-win32.whl", hash = "sha256:6b588cc8f902d6bff201c19fd00c43ab8545671e3554d014e12e14139e5e8617", size = 6120696, upload-time = "2026-08-09T13:47:38.561Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/23/deafbb1700f79fae9cd1e91220f133d124cc267de1b584da3fbf6db2f6cd/numpy-2.5.2-cp315-cp315-win_amd64.whl", hash = "sha256:07d4e89f3a9ab0a9ba24264ccdb642b3dd951b2281e8883a5481a4aa79cc31a7", size = 12597324, upload-time = "2026-08-09T13:47:41.401Z" },
+    { url = "https://files.pythonhosted.org/packages/33/cd/3272ba105e3bbbdaeb11357eda31e7a6825ffe159e8171665660299a948f/numpy-2.5.2-cp315-cp315-win_arm64.whl", hash = "sha256:a610dc7e3c52edd39c2bc2375ff9c3fd59cb3ad00e4472d36f83bc1457145788", size = 10680466, upload-time = "2026-08-09T13:47:44.873Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/58370637b1bb70a5c9ce2b43f4b521ccb224e36ccb76a6596b17ae4b447c/numpy-2.5.2-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:40f4d451aed46a8046a1aae41c4e55fb3612273df9c502480135e1501576a34b", size = 16993947, upload-time = "2026-08-09T13:47:48.97Z" },
+    { url = "https://files.pythonhosted.org/packages/10/93/2abcb807712b289d6d60fe4cf30532f98974a8396d885650f3ba5a13026e/numpy-2.5.2-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:c081cbe16ba1ab53078e5ff29013621e33c509eedab055775d956427712c236e", size = 12025331, upload-time = "2026-08-09T13:47:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/3a/2898e003a5fbaf87e76c039b4ee1f5eb390471b4ffe74887c1f34c4e791e/numpy-2.5.2-cp315-cp315t-macosx_14_0_arm64.whl", hash = "sha256:0090ccdd57ec2703e9b49d0bf554767370581c1dd0a6b2bb2b2d9def317d042a", size = 5472336, upload-time = "2026-08-09T13:47:55.403Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a5/23f69d07c544597b29758b31b55c27dc9d541012a2c1496189fef702aec2/numpy-2.5.2-cp315-cp315t-macosx_14_0_x86_64.whl", hash = "sha256:6a9bb119fb8dd21ba30b3f0e555b7e2b081bd9883af21ec9c1c633d161cda3a8", size = 6788387, upload-time = "2026-08-09T13:47:58.192Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ea/c0dbdbcf22f43782510a3e492dd3da73c6112b69cac8929d16d127536fc4/numpy-2.5.2-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a839318485284a6fb31be4f8f2c91c8f2cb22f4543c4a8903f12b0671ffe07cc", size = 15667096, upload-time = "2026-08-09T13:48:01.562Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5e/29c73c31748cdb0f7566642125ba17fd5b56780cddf891b085dab27e4466/numpy-2.5.2-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba0a474801b8dc67b66bf465548abc90e82b44d2611b5770f33008dcabffe8ec", size = 16751730, upload-time = "2026-08-09T13:48:05.706Z" },
+    { url = "https://files.pythonhosted.org/packages/47/95/02501e8454796bb58dadf7a99d3181e0b464bf264e1003039572f9779fac/numpy-2.5.2-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:0a4035ae1129ff8777f08bfbd44f1e5d8e9c049ce0c2dd78fc0d92c13e7251c0", size = 17038686, upload-time = "2026-08-09T13:48:09.627Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b5/53a681d91b5c82687067d8ea5035e02d917b5509d6f334cb06484a954714/numpy-2.5.2-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:77843ca236b777e67f8d6b3660ea116e499612703a0ecd7093f316201eb9d8e2", size = 18507727, upload-time = "2026-08-09T13:48:13.744Z" },
+    { url = "https://files.pythonhosted.org/packages/42/06/6e11443f7b64ee376c860506091103bf68f92d2cab9e8d96d4501babf07c/numpy-2.5.2-cp315-cp315t-win32.whl", hash = "sha256:7354826bc6f8f69402e9b7fe28d15fcd34feebd74f856f111585c5b0c9fb0251", size = 6269775, upload-time = "2026-08-09T13:48:17.543Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/18/195d6b86cd72dbbc501edfa778005fa6b87afd34c153e46028cd3a0938f4/numpy-2.5.2-cp315-cp315t-win_amd64.whl", hash = "sha256:e5651f3f87add730ee6608d915009e19c911fba0cb000c7e3ea994b7d768eb12", size = 12782559, upload-time = "2026-08-09T13:48:21.023Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/07/458c344f0f0c178f4481dad5cca790626ffe4c34eabf9467069d06ee4999/numpy-2.5.2-cp315-cp315t-win_arm64.whl", hash = "sha256:5f8e00be2ec6f45f4e8a41a527f68d44a7d96fee92a650e4d8b1326f77f61e6e", size = 10748103, upload-time = "2026-08-09T13:48:24.21Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/80/381c1e9efed9cc32d00aa7cab0547dc84116cec906c3ffe3613686d6963a/onnxruntime-1.29.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3a3814c041251d6a77fdf513fb282056538ee826d2f1178a0df3c549d3fff6ba", size = 21430049, upload-time = "2026-08-17T22:53:48.286Z" },
+    { url = "https://files.pythonhosted.org/packages/30/12/4be0e345d38fe707a701ca07e8f63c05b152a2e6285d1e43a7faf63fedd2/onnxruntime-1.29.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d2fb19e848f7c33ed8d3182b52504aaa11c5e8da438bbb47296f85b133cbcf6b", size = 20816870, upload-time = "2026-08-17T22:53:51.169Z" },
+    { url = "https://files.pythonhosted.org/packages/96/eb/e6968f5e41aac3125f2ff5708855f09cb0b70d85ed3115b625b0b58305ba/onnxruntime-1.29.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:2b80d8c7ec2cc7438e4da3760b88c24568cba72c9ace96d668800a6c79419acb", size = 23136745, upload-time = "2026-08-17T22:53:53.92Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/80/5b28f1f1111210fc4a336ddbc6950f468ebf9a6a265420568f4f43fa33ce/onnxruntime-1.29.0-cp312-cp312-win_amd64.whl", hash = "sha256:4acf2b4948b7ede87221ca6332344b8facdc8059d6ac751a7d367d04532b02dd", size = 14001407, upload-time = "2026-08-17T22:53:56.486Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d6/6883f89ea4b044e6e8447ebfaf9bcecdf457b7d80a683635e130b25498e0/onnxruntime-1.29.0-cp312-cp312-win_arm64.whl", hash = "sha256:dc61a79cb39afd66ab3f01fd2c23591a7f01de89c1668e1fb6315067fc279164", size = 13746981, upload-time = "2026-08-17T22:53:58.977Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f8/d375facf60edaf41f5732f9f689c98a800fcc52df5cf6ddfb406703eb5a1/onnxruntime-1.29.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:be0f8ed688cfb1d4d5765a137193b7bfab0c8ea214eed99260b380bb525a3a7f", size = 21429708, upload-time = "2026-08-17T22:54:01.44Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/17/b9ad04051a8c4f504852ce0e8e10f9a6b2f1a331eedcdcc503df776dd0ea/onnxruntime-1.29.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:d67673c5367727860922c5262d724472f1b5539fb7ccf4c81a638f9b71719803", size = 20816263, upload-time = "2026-08-17T22:54:04.088Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2c/d8eb945d2a372149df9705a8d5c8d7c6c46c987c5446dbcea9e1ea7f6556/onnxruntime-1.29.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e2128f31f449e922c62dbe5d8b6b7b079f0bcaf2d56a102fa203cb6e5bb5ab19", size = 23136817, upload-time = "2026-08-17T22:54:06.714Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/3b/66b424c63fa92dfaa48d1719efaae66fc8c256b9426a832eda51d8dfe1e9/onnxruntime-1.29.0-cp313-cp313-win_amd64.whl", hash = "sha256:2945e1f82f81f27e88decea88c7861f45baea23818950d467bf3909aa303119e", size = 14001310, upload-time = "2026-08-17T22:54:09.13Z" },
+    { url = "https://files.pythonhosted.org/packages/83/22/d6a700e3a6322fa3d56fbe7cee9ffc53f35e77ffcd6b7e97f4b7722a27ab/onnxruntime-1.29.0-cp313-cp313-win_arm64.whl", hash = "sha256:4b940b0d777590c7e20bf298f5c16af1ea6ad1b400a1c822a6be192f64f4d954", size = 13747112, upload-time = "2026-08-17T22:54:11.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/89/c4af146de3d60a32c89fea48d5d34bfd044faaf8957270043a03bd1b462b/onnxruntime-1.29.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:533f8370ce124304e5cb08ab961836cf755631e3dd77adc5f3bbdab70c2b7d99", size = 20826136, upload-time = "2026-08-17T22:54:14.315Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f2/e6bbacd11dfe8d070613261a758795ea128b9fc9bea391a2a7da2e4c7a08/onnxruntime-1.29.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:c1ad3f437153fe77f9d01a08fbaac0beb030e09b8a80ace1603bcf69b6c95481", size = 23138951, upload-time = "2026-08-17T22:54:17.154Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/a3/718e1b83096a1bc7b0fc8014c23d4cf795559fe666961cfac4fc038a4871/onnxruntime-1.29.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e74b278af1d949876f5d91d1268fd6c680e79f2bac194967394eaba9fdf69e7e", size = 21431104, upload-time = "2026-08-17T22:54:20.118Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/17/c75e78ddc1fe69b6ebaef7fe88ac83f29bfe10955e3a0d2436d93473c91c/onnxruntime-1.29.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:939e5d65f332e6d399774b2bd0d3559fd8fa629c1e77833db29d968d2384f23d", size = 20818488, upload-time = "2026-08-17T22:54:23.147Z" },
+    { url = "https://files.pythonhosted.org/packages/65/54/9f197c578d3d3d7bea16971e233e5483981228eec73748585cf7b5933403/onnxruntime-1.29.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:6c0c37b92f67ed68dd36221ce0403e1d9bd4f7efce724439978a2597848530e5", size = 23136994, upload-time = "2026-08-17T22:54:26.321Z" },
+    { url = "https://files.pythonhosted.org/packages/24/53/4616a55d2495679cfd0195f968feb3d74fe30e26467d168ee243ac97c089/onnxruntime-1.29.0-cp314-cp314-win_amd64.whl", hash = "sha256:4a3129ae56e70d2618ff773920166916310370a7e3cacb60b9e0e8910092725f", size = 14350643, upload-time = "2026-08-17T22:54:28.794Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0f/c338cb5500a522c7e671a3bb1276f4562404fbecce8a0e274565aa968484/onnxruntime-1.29.0-cp314-cp314-win_arm64.whl", hash = "sha256:e417ef8628dcce310d2d53023e750ea298ec14d4341ae6dc3a572bfd9bc7fa97", size = 14124294, upload-time = "2026-08-17T22:54:31.015Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/e7/61064289a9a1301b25c1f0f574fe98aba31c2d388db3c1dbec664f78621f/onnxruntime-1.29.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:11264bb58f7b7cf6af835ab10d36838d73680580820fd6f51d90124a1ca8f449", size = 20826174, upload-time = "2026-08-17T22:54:34.283Z" },
+    { url = "https://files.pythonhosted.org/packages/60/21/d0c04b561b46e9bff89b5f500fb7415b8ca0669f7902204f76ab06bb0c7e/onnxruntime-1.29.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1ea91cef3b971506e51ae9c37c16d027774ec64994a524ec1bdfb027d68a9832", size = 23138547, upload-time = "2026-08-17T22:54:37.491Z" },
+]
+
+[[package]]
 name = "openapi-pydantic"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1006,6 +1430,7 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "sqlite-vec" },
     { name = "uvicorn" },
     { name = "watchfiles" },
 ]
@@ -1019,12 +1444,16 @@ dev = [
     { name = "ruff" },
     { name = "types-pyyaml" },
 ]
+embeddings = [
+    { name = "fastembed" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "anyio", marker = "extra == 'dev'", specifier = ">=4" },
     { name = "argon2-cffi", specifier = ">=23.1" },
     { name = "fastapi", specifier = ">=0.115" },
+    { name = "fastembed", marker = "extra == 'embeddings'", specifier = ">=0.4" },
     { name = "fastmcp", specifier = "==3.4.7" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
@@ -1033,11 +1462,12 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
+    { name = "sqlite-vec", specifier = ">=0.1.6" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "uvicorn", specifier = ">=0.30" },
     { name = "watchfiles", specifier = ">=0.22" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "embeddings"]
 
 [[package]]
 name = "palaia-v3-workspace"
@@ -1047,7 +1477,7 @@ source = { virtual = "." }
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
-    { name = "palaia-hub", extra = ["dev"] },
+    { name = "palaia-hub", extra = ["dev", "embeddings"] },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -1057,7 +1487,7 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.11" },
-    { name = "palaia-hub", extras = ["dev"], editable = "server" },
+    { name = "palaia-hub", extras = ["dev", "embeddings"], editable = "server" },
     { name = "pytest", specifier = ">=8" },
     { name = "ruff", specifier = ">=0.6" },
 ]
@@ -1081,6 +1511,77 @@ wheels = [
 ]
 
 [[package]]
+name = "pillow"
+version = "12.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload-time = "2026-07-01T11:56:38.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/bf/fb3ebff8ddcb76aac5a01389251bbbb9519922a9b520d8247c1ca864a25d/pillow-12.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ba09209fbe443b4acccebe845d8a138b89a8f4fbaeedd44953490b5315d5e965", size = 5345969, upload-time = "2026-07-01T11:54:06.397Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/66/9a386a92561f402389a4fc70c18838bf6d35eb5eb5c6850b4b2dc64f5048/pillow-12.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffd0c5368496f41b0944be820fcb7a838aa6e623d250b01acf2643939c3f99d7", size = 4780323, upload-time = "2026-07-01T11:54:09.351Z" },
+    { url = "https://files.pythonhosted.org/packages/25/27/ac8f99618ffd3dde21db0f4d4b1d2ab00c0880595bfd17df103f7f39fd0c/pillow-12.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9c7f76c0673154f044e9d78c8655fb4213f6ca31a836df48b40fe5d187717b9", size = 6266838, upload-time = "2026-07-01T11:54:11.71Z" },
+    { url = "https://files.pythonhosted.org/packages/84/21/a35af28dcc61f37ed850a2d64c65c701321dfbf25085e469d5559360cbbf/pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78cb2c6865a35ab8ff8b75fd122f6033b92a62c82801110e48ddd6c936a45d91", size = 6940830, upload-time = "2026-07-01T11:54:13.732Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/51/8b08617af3ad95e33ce6d7dd2c99ed6c8298f7fb131636303956be022e25/pillow-12.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e491916b378fba47242221bb9ead245211b70d504f495d105d17b14a24b4907c", size = 6344383, upload-time = "2026-07-01T11:54:15.756Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/72/cf78ac9780bb93c28328f408973845a309d4d145041665f734572ced1b52/pillow-12.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0dd2064cbc55aaec028ef5fbb60fa47bb6c3e7918e07ff17935284b227a9d2df", size = 7052934, upload-time = "2026-07-01T11:54:17.721Z" },
+    { url = "https://files.pythonhosted.org/packages/20/20/25e0f4dc178a6bc0696793720055519a0de89e7661dae886992decbd2f81/pillow-12.3.0-cp312-cp312-win32.whl", hash = "sha256:dbce0b29841537a2fa4a214c2bbf14de3587c9680caa9b4e217568472490b28f", size = 6472684, upload-time = "2026-07-01T11:54:19.839Z" },
+    { url = "https://files.pythonhosted.org/packages/45/89/da2f7971a317f83d807fdd4065c0af40208e59e692cc43d315a71a0e96d1/pillow-12.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2b55dd6b2a4c4b7d87ffa56bdb33fdc5fdb9a462173861a7bc097f17d91cb09", size = 7227137, upload-time = "2026-07-01T11:54:22.025Z" },
+    { url = "https://files.pythonhosted.org/packages/de/47/4845a0a6c0dbf1db8456bd9fc791f13c5ced7ced20606d08a0aacfd25b49/pillow-12.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:331b624368d4f1d069149002f25f44bc61c8919ce8ddb3c45bdad8f6e2d89510", size = 2568267, upload-time = "2026-07-01T11:54:24.051Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ac/31fb64e1e7efb5a4b50cd3d92049ba89ac6e4d8d3bb6a74e15048ca3353e/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:21900ce7ba264168cd50defae43cd75d25c833ad4ad6e73ffc5596d12e25ac89", size = 4161684, upload-time = "2026-07-01T11:54:25.934Z" },
+    { url = "https://files.pythonhosted.org/packages/87/b4/9805e23d2b4d77842b468513841fda254ee42f0289d25088340e4ff46e2d/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4e8c2a84d977f50b9daed6eeaf3baef67d00d5d74d932288f02cb94518ee3ace", size = 4255487, upload-time = "2026-07-01T11:54:27.935Z" },
+    { url = "https://files.pythonhosted.org/packages/df/39/ecf519435a200c693fe053a6ee4d835b41cf963a4dfc2551c4e637cb2a71/pillow-12.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:ae26d61dfa7a47befdc7572b521024e8745f3d809bd95ca9505a7bba9ef849ec", size = 3696433, upload-time = "2026-07-01T11:54:29.813Z" },
+    { url = "https://files.pythonhosted.org/packages/42/92/2fc3ffad878ae8dd5469ec1bc8eb83b71f48e13efdf68f02709003982a32/pillow-12.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7a743ff716f746fc19a9557f60dab1600d4613255f8a7aeb3cdde4db7eb15a66", size = 5345889, upload-time = "2026-07-01T11:54:31.97Z" },
+    { url = "https://files.pythonhosted.org/packages/10/76/8803c13605b763d33d156c4678fc77f8443389c0c51c8aef707bb02015f4/pillow-12.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d69141514cc30b774ceea5e3ed3a6635c8d8a96edf664689b890f4089111fb35", size = 4780109, upload-time = "2026-07-01T11:54:34.026Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/e18aff37cb0b4aac47ac90f016d347a49aca667ef97f190b06ac2aabc928/pillow-12.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7401aebd7f581d7f83a439d87d474999317ee099218e5ad25d125290990ba65", size = 6263736, upload-time = "2026-07-01T11:54:36.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/62/de5bdd77d935331f4f802edc11e4d82950f642caad6cb2f949837b8560e2/pillow-12.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0847a763afefb695bc912d7c131e7e0632d4edc1d8698f58ddabec8e46b8b6d3", size = 6937129, upload-time = "2026-07-01T11:54:38.216Z" },
+    { url = "https://files.pythonhosted.org/packages/70/4d/105627a13300c5e0df1d174230b32fd1273062c96f7745fd552b945d1e1d/pillow-12.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:571b9fcb07b97ef3a492028fb3d2dc0993ca23a06138b0315286566d29ef718a", size = 6339562, upload-time = "2026-07-01T11:54:40.354Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/1d/f13de01a553988ab895ba1c722e06cf3144d4f57656fd5b81b6d881f1179/pillow-12.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:756c768d0c9c2955feb7a56c37ea24aea2e369f8d36a88da270b6a9f19e62b5e", size = 7049439, upload-time = "2026-07-01T11:54:42.489Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f9/066794cca041b969964f779ee5fa66a9498bbf34248ac39c5d7954e4198f/pillow-12.3.0-cp313-cp313-win32.whl", hash = "sha256:a876864214e136f0eb367788dbd7df045f4806801518e2cfe9e13229cfe06d8f", size = 6473287, upload-time = "2026-07-01T11:54:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9b/7a58e61d62be561da3a356fe2384d4059a6345fc130e23ef1c36a5b81d24/pillow-12.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:1cca606cd25738df4ed873d5ad46bbdb3d83b5cbca291f6b4ff13a4df6b0bbe8", size = 7239691, upload-time = "2026-07-01T11:54:47.141Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b0/c4ed4f0ef8f8fa5ee8351537db6650bb8189f7e118842978dd6589065692/pillow-12.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:b629de27fda84b42cde7edef0d85f13b958b47f6e9bbcbba9b673c562a89bd8b", size = 2568185, upload-time = "2026-07-01T11:54:49.137Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/01/001f65b68192f0228cc1dbbc8d2530ab5d58b61037ba0587f946fea607cd/pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:9cf95fe4d0f84c82d282745d9bb08ad9f926efa00be4697e767b814ce40d4330", size = 4161736, upload-time = "2026-07-01T11:54:51.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d2/0219746d0fd16fc8a84498e79452375be3797d3ce4044596ce565164b84f/pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:8728f216dcdb6e6d555cf971cb34076139ad74b31fc2c14da4fafc741c5f6217", size = 4255435, upload-time = "2026-07-01T11:54:53.414Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/02/8d0bc62ef0302318c46ff2a512822d2610e81c7aa46c9b3abe6cbaca5ad0/pillow-12.3.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:a45650e8ce7fafffd731db8550230db6b0d306d181a90b67d3e6bca2f1990930", size = 3696262, upload-time = "2026-07-01T11:54:55.739Z" },
+    { url = "https://files.pythonhosted.org/packages/85/e2/73c77d218410b14f5f2d565e8a998d5317b7b9c75368d29985139f7a46f0/pillow-12.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ba54cfebe86920a559a7c4d6b9050791c20513650a1952ebe3368c7dc70306f8", size = 5350344, upload-time = "2026-07-01T11:54:57.657Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/da/32c752228ae345f489e3a42499d817b6c3996da7e8a3bc7a04fc806b243b/pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e158cb00350dc278f3b91551101aa7d12415a66ebf2c91d8d5ac14e56ddd3ad0", size = 4780131, upload-time = "2026-07-01T11:54:59.713Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/9d/8b2c807dbef61a5197c047afe99823787eb66f63daf9fb2432f91d6f0462/pillow-12.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9aeb04d6aef139de265b29683e119b638208f88cf73cdd1658aa07221165321", size = 6263757, upload-time = "2026-07-01T11:55:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/44/c85361f65dbe00eea8576ee467c768d25129989efb76e94f205e9ca9bb46/pillow-12.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:251bf95b67017e27b13d82f5b326234ca62d70f9cf4c2b9032de2358a3b12c7b", size = 6936962, upload-time = "2026-07-01T11:55:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/18/7e/e483414b35800b86b6f08dbbc7803fb5cd52c4d6f897f47d53ea2c7e6f65/pillow-12.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fe3cca2e4e8a592be0f269a1ca4835c25199d9f3ce815c8491048f785b0a0198", size = 6339171, upload-time = "2026-07-01T11:55:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f4/68c491844841ede6bed70189546b3ee9731cf9f2cbad396faff5e1ccba45/pillow-12.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:23aceaa007d6172b02c277f0cd359c79492bbb14f7072b4ede9fbcaf20648130", size = 7048116, upload-time = "2026-07-01T11:55:08.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/34/77f3f793fed8efc7d243f21b33c5a3f0d1c97ee70346d3db855587e155ff/pillow-12.3.0-cp314-cp314-win32.whl", hash = "sha256:af8d94b0db561cf68b88a267c5c44b49e134f525d0dc2cb7ed413a66bc23559a", size = 6467209, upload-time = "2026-07-01T11:55:10.408Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e0/492879f69d94f91f60fc8cd05ba03650e9520afebb2fb7aa12777d7c7f38/pillow-12.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:fdafc9cce40277e0f7a0feabce0ee50dd2fa1800f3b38015e51296b5e814048d", size = 7237707, upload-time = "2026-07-01T11:55:12.745Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ac/6b11f2875f1c2ac040d84e1bbf9cf22a88038f901ca1037898b280b38365/pillow-12.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:e91206ee562682b51b98ef4b26a6ef48fd84e15fd4c4bc5ec768eb641d206838", size = 2565995, upload-time = "2026-07-01T11:55:14.736Z" },
+    { url = "https://files.pythonhosted.org/packages/52/69/c2208e56af9bfc1913afb24020297a691eb1d4ef688474c8a04913f65e04/pillow-12.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:164b31cd1a0490ab6efae01aa5df49da7061be0af1b30e035b6e9a1bfe34ee6e", size = 5352503, upload-time = "2026-07-01T11:55:17.076Z" },
+    { url = "https://files.pythonhosted.org/packages/07/70/e5686d753e898a45d778ff1718dba8516ead6ab6b95d85fc8c4b70650cf2/pillow-12.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5afb51d599ea772b8365ae807ae557f18bccfe46ab261fd1c2a9ed700fc6eb17", size = 4782956, upload-time = "2026-07-01T11:55:19.448Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/37/25c6692f06927ee973ff18c8d9ee98ad0b4d84ee67a09610c2dd1447958e/pillow-12.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3edce1d53195db527e0191f84b71d02022de0540bf43a16ed734ed7537b07385", size = 6322855, upload-time = "2026-07-01T11:55:21.613Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/91/420637fcb8f1bc11029e403b4538e6694744428d8246118e45719f944556/pillow-12.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf16ba1b4d0b6b7c8e534936632270cf70eb00dbe09005bc345b2677b726855c", size = 6989642, upload-time = "2026-07-01T11:55:24.006Z" },
+    { url = "https://files.pythonhosted.org/packages/10/08/b94d7811281ccf0d143a1cf768d1c49e1e54af63e7b708ab2ee3eb87face/pillow-12.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:24870b09b224f7ae3c39ed07d10e819d06f8720bc551847b1d623832b5b0e28d", size = 6391281, upload-time = "2026-07-01T11:55:26.252Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/87/24233f785f55474dc02ce3e739c5528a77e3a862e9333d1dd7a25cc31f70/pillow-12.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:30f2aa603c41533cc25c05acd0da21636e84a315768feb631c937177db558931", size = 7096716, upload-time = "2026-07-01T11:55:28.318Z" },
+    { url = "https://files.pythonhosted.org/packages/23/26/fcb2f6e37175b04f53570b59937867e2b80ee1685e744023153028fc14f9/pillow-12.3.0-cp314-cp314t-win32.whl", hash = "sha256:4b0a7fe987b14c31ebda6083f74f22b561fd3739bc0ac51e019622e3d72668c7", size = 6474125, upload-time = "2026-07-01T11:55:30.956Z" },
+    { url = "https://files.pythonhosted.org/packages/90/de/3634abee5f1c9e13c56787b7d5517b0ba8d6de51700b95578cf338349c9f/pillow-12.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:962864dc93511324d51ddbb5b9f8731bf71675b93ca612a07441896f4688fb8c", size = 7242939, upload-time = "2026-07-01T11:55:34.044Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/2a/fd13f8eb24de5714a6eb444a3d67e2842c6c576e159a43793adf23051351/pillow-12.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0740a512dc522224c77d9aa5a8d70d8b7d73fb91f2c21125d8d025d3b8990e45", size = 2567506, upload-time = "2026-07-01T11:55:35.988Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/dc/8fdce34ec725a33c81c6ba122b904d6b9024e50ea9ac7bede62fab54506c/pillow-12.3.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:0feb2e9d6ad6c9e3c06effe9d00f3f1e618a6643273576b016f591e9315a7139", size = 4162063, upload-time = "2026-07-01T11:55:37.941Z" },
+    { url = "https://files.pythonhosted.org/packages/76/66/2044b9a63d3b84ff048228dfcb7cd9bf0df983e8470971bf7d4c57b693de/pillow-12.3.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:9e881fca225083806662a5c43d627d215f258ff43c890f831966c7d7ba9c7402", size = 4255549, upload-time = "2026-07-01T11:55:40.022Z" },
+    { url = "https://files.pythonhosted.org/packages/52/7e/1f67e6f4ece6b582ee4b539decbcc9f848dc245a93ed8cd7338bafef72f1/pillow-12.3.0-cp315-cp315-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:4998562bf62a445225f22e07c896bb04b35b1b1f2eb6d760584c9c51d7a5f78c", size = 3696331, upload-time = "2026-07-01T11:55:41.98Z" },
+    { url = "https://files.pythonhosted.org/packages/12/40/d306fc2c8e4d45d7f175c77edca7063be7b86fe7fe6e68f4353bf71d808c/pillow-12.3.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:dc624f6bc473dacdf7ef7eb8678d0d08edf15cd94fad6ae5c7d6cc67a4e4902f", size = 5350370, upload-time = "2026-07-01T11:55:44.028Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/44/668fb1437e8ce420f62d6106eb66e44a5971602a4d794615bdf79315d82d/pillow-12.3.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:71d6097b330eea8fd15097780c8e89cb1a8ce7838669f48c5bacd6f663dd4701", size = 4780147, upload-time = "2026-07-01T11:55:46.073Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/08/93fa2e70e30a2d81547e481b6ee2bb9522117221fb1e0ce4b5df70967677/pillow-12.3.0-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:28ce87c5ab450a9dd970b52e5aca5fe63ed432d18a2eaddd1979a00a1ba24ace", size = 6273659, upload-time = "2026-07-01T11:55:48.264Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/6d/043e96ff814fc31a33077e4cba86082167db520c93632afdf2042febbb0c/pillow-12.3.0-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b02afb9b97f65fbca5f31db6a2a3ba21aa93030225f150fa3f249717e938fb4", size = 6947439, upload-time = "2026-07-01T11:55:50.503Z" },
+    { url = "https://files.pythonhosted.org/packages/af/92/ba71d2ee2ac0edf3fa33bd9d5ee9ee080da70b1766f3ca3934f9938ddac9/pillow-12.3.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:1182d52bc2d5e5d7d0949503aa7e36d12f42205dc287e4883f407b1988820d39", size = 6353577, upload-time = "2026-07-01T11:55:52.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ce/e63064e2122923ff687c8ad792d0d736a7b3920a56a46982e81a7fdd25d6/pillow-12.3.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e795b7eb908249c4e43c7c99fac7c2c75dab0c43566e37db472a355f63693d71", size = 7060394, upload-time = "2026-07-01T11:55:55.149Z" },
+    { url = "https://files.pythonhosted.org/packages/54/76/a09cc3ccc8d773a7283d34c38bec1708f9e3cc932093cbc4c5e71ac4060b/pillow-12.3.0-cp315-cp315-win32.whl", hash = "sha256:57b3d78c95ba9059768b10e28b813002261d3f3dfc55cc48b0c988f625175827", size = 6467375, upload-time = "2026-07-01T11:55:57.769Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/03/1846c49ba3b1d5550392a4bbd06d6fb4578e1cd91a803198b5c90f5f7d53/pillow-12.3.0-cp315-cp315-win_amd64.whl", hash = "sha256:fa4ecea169a355be7a3ade2c783e2ed12f0e40d2c5621cda8b3297faf7fbb9f5", size = 7237048, upload-time = "2026-07-01T11:55:59.975Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/bb/89f35dcc79610423f9f195504d7def7f0d1416a711541b42867e25fe3412/pillow-12.3.0-cp315-cp315-win_arm64.whl", hash = "sha256:877c3f311ff35410f690861c4409e7ccbf0cd2f878e50628a28e5a0bb689e658", size = 2566006, upload-time = "2026-07-01T11:56:02.143Z" },
+    { url = "https://files.pythonhosted.org/packages/30/88/707027ba09942dfa2c28759b5c222d769290a41c6d20ea60ec250801941f/pillow-12.3.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:e9871b1ffbfa9656b60aeee92ed5136a5742696006fa322b29ea3d8da0ecc9cf", size = 5352509, upload-time = "2026-07-01T11:56:04.2Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6d/00352fa25332c2569cd387851f568cc5a4b75a9adbfb37ac4fbce4c02eec/pillow-12.3.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:53aa02d20d10c3d814d536aa4e5ac9b84ca0ff5a88377963b085ad6822f93e64", size = 4783167, upload-time = "2026-07-01T11:56:06.631Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4f/9e049dfa21af7c22427275720e2490267ba8138120add5c4c574deb69782/pillow-12.3.0-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:446c34dcc4324b084a53b705127dc15717b22c5e140ae0a3c38349d4efec071e", size = 6329237, upload-time = "2026-07-01T11:56:08.868Z" },
+    { url = "https://files.pythonhosted.org/packages/36/16/cf6eeaae8d0fce8dd390a33437cf68c5d5bd73834a2bc6e2f14efda0ab45/pillow-12.3.0-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf1845d02ad822a369a49f2bb9345b1614744267682e7a03527dc3bf6eea1777", size = 6997047, upload-time = "2026-07-01T11:56:11.379Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/69/dbf769bdd55f48bf5733cac28edc6364ffaa072ec9ba336266e4fe66be55/pillow-12.3.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:186941b6aef820ad110fb01fb06eb925374dc3a21b17e37ec9a53b250c6fe2d1", size = 6400440, upload-time = "2026-07-01T11:56:13.908Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e1/ffc9cfc2eea0d178da8018e18e959301ad9d6bc9f3edb7181e748a474b97/pillow-12.3.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:f13c32a3abd6079a66d9526e18dad9b6d280384d49d7c54040cd57b6424041d9", size = 7105895, upload-time = "2026-07-01T11:56:16.575Z" },
+    { url = "https://files.pythonhosted.org/packages/18/f0/a5595c1e8c3ae44b9828cb2f0fa8155e5095ef04d6327b8f61cf44a3df85/pillow-12.3.0-cp315-cp315t-win32.whl", hash = "sha256:1657923d2d45afb66526e5b933e5b3052e6bdea196c90d3abb2424e18c77dae8", size = 6474384, upload-time = "2026-07-01T11:56:18.855Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/04/62bcd9f844984c5938d3b05264a61d797a29d3e0812341a8204af70bbdee/pillow-12.3.0-cp315-cp315t-win_amd64.whl", hash = "sha256:8cd2f7bdda092d99c9fc2fb7391354f306d01443d22785d0cbfafa2e2c8bb418", size = 7243537, upload-time = "2026-07-01T11:56:21.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/68/1f3066acedf37673694a7141381d8f811ae97f30d34413d236abe7d489f1/pillow-12.3.0-cp315-cp315t-win_arm64.whl", hash = "sha256:06ff022112bc9cbf83b60f8e028d94ad87b60621706487e65f673de61610ab59", size = 2567491, upload-time = "2026-07-01T11:56:23.506Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.11.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1096,6 +1597,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.36.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/e7/0553e21d25ca4d9f573135775348a372c3ec34a93a71d5f297c3bac38341/protobuf-7.36.0.tar.gz", hash = "sha256:e8e09cb0d794c6687926fa558a8a6e72aa10edb997d5ca61da0765f12a3e00ea", size = 510034, upload-time = "2026-08-20T16:34:01.071Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/ae/58e3ca96cb2e118cc546b677359b3c6659f79a140935c08dec94c7998585/protobuf-7.36.0-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:9103532dffd80c6fab7e50c65a31007680a06eb57537d437bb1b35812c138a37", size = 453256, upload-time = "2026-08-20T16:33:53.945Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/15/5162230af4912697f0fe406f6800f80760945babcff0e2c2fe6c84ef2d5d/protobuf-7.36.0-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:bf94a5917c71058262de683669bc0a797a7669d3de71f0b36d058e3194f47b44", size = 341436, upload-time = "2026-08-20T16:33:55.134Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/09/1670b2bfc9a45e807e520c3e9be36524db9ccc7dc05ea17af7681cabdc61/protobuf-7.36.0-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:3297e60abdff301e5f74393d87f6cc59dacab5f024a89548a6e8de1d26576b16", size = 354440, upload-time = "2026-08-20T16:33:56.077Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f8/bd5804695ba400e423c33fd4d9f58c28d86633d5ba1945c36ff3967d98cb/protobuf-7.36.0-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:70f5ec8eb0da81a44360c0dc0beac99a0d78071d21956a7076bae8bd2051841b", size = 340439, upload-time = "2026-08-20T16:33:56.992Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/9f/acd02338235a3e7d03168c4303478347b7624fc8189ff4e7f0d2654bbe86/protobuf-7.36.0-cp310-abi3-win32.whl", hash = "sha256:7326fd717bdc419162a735938d89d4032332bcc3408804012b24ff3a37086071", size = 440216, upload-time = "2026-08-20T16:33:57.99Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4e/12cb93270967a2affff5b3f720694700d4d87712a67afd05c8cb3f6fa52c/protobuf-7.36.0-cp310-abi3-win_amd64.whl", hash = "sha256:1781cc1de61249b750848029bca452c0a8b7e990080316b9bbc2518b2117b488", size = 453731, upload-time = "2026-08-20T16:33:58.951Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c3/629999e78d46c1115c11886d51c6bd68c17ce4a944f1ea3e153a91316a33/protobuf-7.36.0-py3-none-any.whl", hash = "sha256:53374d53fc29a67f7dbbf0ade47d7526a0f0137bf0f9c90e48d8a60790ef748c", size = 177024, upload-time = "2026-08-20T16:34:00.053Z" },
 ]
 
 [[package]]
@@ -1121,6 +1637,44 @@ keyring = [
 ]
 memory = [
     { name = "cachetools" },
+]
+
+[[package]]
+name = "py-rust-stemmers"
+version = "0.1.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/c1/9763f9fb1cd73f9c317a83feeed6e0d4af320c6bbddab47b4a94f3a47d0c/py_rust_stemmers-0.1.8.tar.gz", hash = "sha256:6b0f6f48bc54d607aed802de872fcd5a71bae969a6760976dc78ce55e8eaf3da", size = 9732, upload-time = "2026-05-22T11:00:24.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/6a/39080bc8f4a441a35378c0faeeb834fb27974997f40d51342574e70f9662/py_rust_stemmers-0.1.8-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:6a9a4b8733d0b307bd0879ab7e321aa8a0bfd054a75a5cb23c647df5ca7d17c3", size = 290230, upload-time = "2026-05-22T10:59:44.551Z" },
+    { url = "https://files.pythonhosted.org/packages/73/15/ae60b9010924adac465f418822d9c514690aba6846edd67b6e2b5c227745/py_rust_stemmers-0.1.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:51d0042d2a92ef0f7048bfc06b6c2a02306af31ea47f09d24b34e4b7e63c4e80", size = 275449, upload-time = "2026-05-22T10:59:45.547Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/7c/94be8b932179823d66e0d2be03a94706132a7d16a640d5e5710de1cb1b8f/py_rust_stemmers-0.1.8-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89d3d34094b9b6078a8ea6fe1c7044e5fd32f14e76c94818c5008f49ae075f08", size = 316676, upload-time = "2026-05-22T10:59:46.522Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a4/8bd5c9f31207136830457d819e3f98bb21c54c0cdc40d6f1845ce4efdf7c/py_rust_stemmers-0.1.8-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:40c86be90cee4a709ad84fde4db7f11ca44d65630a56b77ec86fe84c23adfc09", size = 319458, upload-time = "2026-05-22T10:59:47.914Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/95/95da2b353b164a3a2b8a1c799866a58060693be4f1dc21065663dc67dc17/py_rust_stemmers-0.1.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:515884bcfb47b10335146648f276930d0c1201ae5e8b7b400fb46d8ea05c0ec2", size = 323541, upload-time = "2026-05-22T10:59:48.894Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ce/f34403b68808519dfa3220e1d94a40f26d5025f27e28893e2388ab9cfde5/py_rust_stemmers-0.1.8-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:fa42f5f8feb694aaaa869eedf477fcaf66f67a192cd64d94302d06920c33864a", size = 323873, upload-time = "2026-05-22T10:59:49.872Z" },
+    { url = "https://files.pythonhosted.org/packages/57/01/fb8527f6474d576975415405c985a97260e0403829e062103d334230b7d2/py_rust_stemmers-0.1.8-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2e86ad68fe297a6652f0f0390625ea81858b6f27862fd4c5ee1214bf5af29b9d", size = 494761, upload-time = "2026-05-22T10:59:51.021Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ac/73816237dbec20a7299abf901e2f7b6061d238754e033b48e423603f5336/py_rust_stemmers-0.1.8-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:4b90fc81411943b114e8eb4988a876ba3b12bd2d20741559803eddc4131575dc", size = 596141, upload-time = "2026-05-22T10:59:52.122Z" },
+    { url = "https://files.pythonhosted.org/packages/52/0a/dd48debf386a206ee1c6ad75a0827eac89428441291c90d98bc3803fccf1/py_rust_stemmers-0.1.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:56cc2c2df742fa6529285b7d204720f34b7da789ed78eb578442f93c6de97d89", size = 541633, upload-time = "2026-05-22T10:59:53.18Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ca/ebb707ab280636b8f46d040ccb051d1a9ddbc1f1ca2d90cdba626872f405/py_rust_stemmers-0.1.8-cp312-cp312-win_amd64.whl", hash = "sha256:dd967eea2f808a1e73aa71ecccef0f4925a4cca4eb02ced94057afe3303153ef", size = 212134, upload-time = "2026-05-22T10:59:54.245Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/98/f078f3930311e7b6154ccdf9166c4e30a416c7d199e136b5f09265d58a35/py_rust_stemmers-0.1.8-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5bd15b89203ecd886960e237124d1aa6e55498d76418c36c967d3b12168d43dc", size = 290427, upload-time = "2026-05-22T10:59:55.316Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/46/21d784a3f1db6a23051ffd5826d8ee667d26a64587c1cfbda0443ed87fff/py_rust_stemmers-0.1.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6c92733b020534470ca5a0d7fe8b85c85622ff383d4f37fec75a1c677aa84921", size = 275628, upload-time = "2026-05-22T10:59:56.687Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d5/701c73a4f6a7fecfd96a6588f0cafe98d6b0acde93adf8a2e45535f3d1d5/py_rust_stemmers-0.1.8-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9ab605a86c950ba7e8ab1392cf91296c0bec3084babb897a4aecf90a10c82395", size = 316656, upload-time = "2026-05-22T10:59:57.67Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0d/c58fe98153cfdb6abf4dfb6ac335c923000d4af4e736080c3a3045b7aea7/py_rust_stemmers-0.1.8-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:21ed8055cec1f78d666afad8ffd7a51775ba419d2c615b8a1df7b32ca7f33e2b", size = 319377, upload-time = "2026-05-22T10:59:58.664Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/d7/e60d04849e90aa3ad457211cc4999c30401f433341f9a5588c12b81f9877/py_rust_stemmers-0.1.8-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae773e1d01e9aa328d175f461475d0cd7074a82bfcc71de6dc5765e51f1cc9f7", size = 323719, upload-time = "2026-05-22T10:59:59.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/48/c0e4fb955db784cc354e0756354602f7043ff4c10fcbd9d901a2f8fe3239/py_rust_stemmers-0.1.8-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5cc8fab9d0f1b274a26935a632362b8278f03e81b65e8b8644d5ca3f62a5a1a4", size = 324110, upload-time = "2026-05-22T11:00:01.26Z" },
+    { url = "https://files.pythonhosted.org/packages/48/eb/981b26baff37cf7a26ee206763cc4d2fb3e1db8f0f86ec030074431fae05/py_rust_stemmers-0.1.8-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:35570098da02eb439afcd7270a12bf850bbe874b85cb912e0fb2d87a6e703920", size = 494645, upload-time = "2026-05-22T11:00:02.737Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/af/f16e805b7aefc2257b192b83a89300c8360b0fdffd3dfefa92dee4ec9b15/py_rust_stemmers-0.1.8-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:0a68745d4b3c7f5abc778ca967e8711df6154873abcfe4e62a6631fa2363cc32", size = 596124, upload-time = "2026-05-22T11:00:04.499Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8c/e7a2c940ba00e0792ae346aed5e755d51d37cf6d6853f6b141e5380e285d/py_rust_stemmers-0.1.8-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7cc0cc0b8eb45d2158c28ea43e2f338c110aad63052ad3bd00bc7446a595e12f", size = 541771, upload-time = "2026-05-22T11:00:06.081Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a0/dd7c5fc6ade6d2a2a49e49937f06f2d488511454e8ab1b313d277ee8c3b1/py_rust_stemmers-0.1.8-cp313-cp313-win_amd64.whl", hash = "sha256:15af4e12e1288de2e5241eec375afc6ad6be4c125a28ca010599d9f92db23f01", size = 212438, upload-time = "2026-05-22T11:00:07.244Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/7e/f4346adfd44acbd7eaedcbd7d21b7f40ec9712e6c699e71fddad8dae6f8d/py_rust_stemmers-0.1.8-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:526b58958c6ffa36c4a805326cfb624ecbd665d16ba435027dbed0bcbcaa09d2", size = 290379, upload-time = "2026-05-22T11:00:08.192Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d8/988fc3f5dc0dbbd4bf5909f50ff953ab55ee8b5f79a835d00e57847d3123/py_rust_stemmers-0.1.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2b607f0b270951fb66479baf4b68716cc63a981585cbd898b0b6b5c359efde7e", size = 275458, upload-time = "2026-05-22T11:00:09.522Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/94/e04c8b6a8364bca1b368785cef143755dd2d1ffe74df8f8b47b075bb1043/py_rust_stemmers-0.1.8-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b0327b151ab8a338fb54fdac114ba34394327fc1e2c4c425ad1caf2013e5de3", size = 314711, upload-time = "2026-05-22T11:00:10.878Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/cb/f59f9a80caa099cb6625a46c9a8e6e7e80bb3ed284f17e80245c8240a66e/py_rust_stemmers-0.1.8-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:dadd0e369703817fc7026987b3093f461f9f58d8dde74e689d546184bc8f3451", size = 319370, upload-time = "2026-05-22T11:00:11.961Z" },
+    { url = "https://files.pythonhosted.org/packages/06/59/8211cd0f56e53f7770debd9a78de37985fb5662ae66e3b7b380f4c79888b/py_rust_stemmers-0.1.8-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:245e2c61c52e073341893a9682cd1396b61047154548aee30bb1af3d8ed4b4cc", size = 321373, upload-time = "2026-05-22T11:00:13.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/72/fe33e614c114264d1ba54d39da4b5a4abeb6aedd0d26e5a8fd0637d6ddba/py_rust_stemmers-0.1.8-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:451ee1c02a3f5cf1e161b46ba9032cdda4ba10a8b03ff9ee61c1d34d42a0bc81", size = 321707, upload-time = "2026-05-22T11:00:14.177Z" },
+    { url = "https://files.pythonhosted.org/packages/91/f9/3cd18902fe2fa54557d3fe9132552256372d381c7aca71346163055d78b1/py_rust_stemmers-0.1.8-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d396dd25c473c1bc4248c79cd223f4b36356b55a124652f015c6a001547f81ac", size = 492457, upload-time = "2026-05-22T11:00:15.245Z" },
+    { url = "https://files.pythonhosted.org/packages/90/d7/32c6d3995e7036b73683389de2771f4dbbf40de192b7efe73c2528ee1eb5/py_rust_stemmers-0.1.8-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:479c77c32d8be692f3cfcde7e19273f02ac81d6f45c6aef49887ef95cab7abbb", size = 596085, upload-time = "2026-05-22T11:00:16.404Z" },
+    { url = "https://files.pythonhosted.org/packages/00/8c/e68fa5d862ea6a27fced3535c25ea4eaa26ba1ce00dfef5841924c74b167/py_rust_stemmers-0.1.8-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c786235275c5c2abb7f206b8236aee3ca0bc53c7497daf7fb7b01d3491469547", size = 539747, upload-time = "2026-05-22T11:00:17.414Z" },
+    { url = "https://files.pythonhosted.org/packages/44/48/aa584cf3772e01231641c95dc1aa73327a7d986c562639d78d0013733acf/py_rust_stemmers-0.1.8-cp314-cp314-win_amd64.whl", hash = "sha256:931d13570962b093417e5443a9d1bd63d73fa239ebb81e5b1d346663571403e4", size = 209636, upload-time = "2026-05-22T11:00:18.662Z" },
 ]
 
 [[package]]
@@ -1396,6 +1950,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
 name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1556,6 +2125,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlite-vec"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/85/9fad0045d8e7c8df3e0fa5a56c630e8e15ad6e5ca2e6106fceb666aa6638/sqlite_vec-0.1.9-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:1b62a7f0a060d9475575d4e599bbf94a13d85af896bc1ce86ee80d1b5b48e5fb", size = 131171, upload-time = "2026-03-31T08:02:31.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/3d/3677e0cd2f92e5ebc43cd29fbf565b75582bff1ccfa0b8327c7508e1084f/sqlite_vec-0.1.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d52e30513bae4cc9778ddbf6145610434081be4c3afe57cd877893bad9f6b6c", size = 165434, upload-time = "2026-03-31T08:02:32.712Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d4/f2b936d3bdc38eadcbd2a87875815db36430fab0363182ba5d12cd8e0b51/sqlite_vec-0.1.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e921e592f24a5f9a18f590b6ddd530eb637e2d474e3b1972f9bbeb773aa3cb9", size = 160076, upload-time = "2026-03-31T08:02:33.796Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ad/6afd073b0f817b3e03f9e37ad626ae341805891f23c74b5292818f49ac63/sqlite_vec-0.1.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:1515727990b49e79bcaf75fdee2ffc7d461f8b66905013231251f1c8938e7786", size = 163388, upload-time = "2026-03-31T08:02:34.888Z" },
+    { url = "https://files.pythonhosted.org/packages/42/89/81b2907cda14e566b9bf215e2ad82fc9b349edf07d2010756ffdb902f328/sqlite_vec-0.1.9-py3-none-win_amd64.whl", hash = "sha256:4a28dc12fa4b53d7b1dced22da2488fade444e96b5d16fd2d698cd670675cf32", size = 292804, upload-time = "2026-03-31T08:02:36.035Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.4.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1579,6 +2160,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/39/b87a87d5bb9470610b80a2d31df42fcffeaf35118b8b97952b2aff598cc7/tokenizers-0.23.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e03d6ffcbe0d56ee9c1ccd070e70a13fa750727c0277e138152acbc0252c2224", size = 3146732, upload-time = "2026-04-27T14:43:15.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6a/068ed9f6e444c9d7e9d55ce134181325700f3d7f30410721bdc8f848d727/tokenizers-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0948bbb1ac1d7cdfc9fb6d62c596e3b7550036ad60ecd654a66ad273326324e", size = 3054954, upload-time = "2026-04-27T14:43:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/36/e006edf031154cba92b8416057d92c3abe3635e4c4b0aa0b5b9bb39dde70/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf13402aff9bc533c89cb849ec3b412dc3fbeacc9744840e423d7bf3f7dc0e3", size = 3374081, upload-time = "2026-04-27T14:43:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ef/7735d226f9c7f874a6bee5e3f27fb25ecabdf207d37b8cf45286d0795893/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f836ca703b89ae07919a309f9651f7a88fd5a33d5f718ba5ad0870ec0256bad6", size = 3247641, upload-time = "2026-04-27T14:43:03.856Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d9/24827036f6e21297bfffda0768e58eb6096a4f411e932964a01707857931/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae848657742035523fdf261773630cb819a26995fcd3d9ecae0c1daf6e5a4959", size = 3585624, upload-time = "2026-04-27T14:43:10.664Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/22f3582b3a4f49358293a5206e25317621ee4526bfe9cdaa0f07a12e770e/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53b09e85775d5187941e7bab30e941b4134ab4a7dd8c68e783d231fb7ca27c51", size = 3844062, upload-time = "2026-04-27T14:43:05.643Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/65/b8f8814eef95800f20721384136d9a1d22241d50b2874357cb70542c392f/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea5a0ce170074329faaa8ea3f6400ecde604b6678192688533af80980daae71a", size = 3460098, upload-time = "2026-04-27T14:43:08.854Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d5/1353e5f677ec27c2494fb6a6725e82d56c985f53e90ec511369e7e4f02c6/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5075b405006415ea148a992d093699c66eb01952bf59f4d5727089a98bda45a4", size = 3346235, upload-time = "2026-04-27T14:43:12.377Z" },
+    { url = "https://files.pythonhosted.org/packages/71/89/39b6b8fc073fb6d413d0147aa333dc7eff7be65639ac9d19930a0b21bf33/tokenizers-0.23.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:56f3a77de629917652f876294dc9fe6bad4a0c43bc229dc72e59bb23a0f4729a", size = 3426398, upload-time = "2026-04-27T14:43:07.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/80/127c854da64827e5b79264ce524993a90dddcb320e5cd42412c5c02f9e8a/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d10a6d957ef01896dc274e890eee27d41bd0e74ef31e60616f0fc311345184e", size = 9823279, upload-time = "2026-04-27T14:43:17.222Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ba/44c2502feb1a058f096ddfb4e0996ef3225a01a388e1a9b094e91689fe93/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1974288a609c343774f1b897c8b482c791ab17b75ab5c8c2b1737565c1d82288", size = 9644986, upload-time = "2026-04-27T14:43:19.45Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c1/464019a9fb059870bfe4eebb4ba12208f3042035e258bf5e782906bd3847/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:120468fb4c24faf0543c835a4fabafa4deb3f20a035c9b6e83d0b553a97615d4", size = 9976181, upload-time = "2026-04-27T14:43:21.463Z" },
+    { url = "https://files.pythonhosted.org/packages/79/94/3ac1432bda31626071e9b6a12709b97ae05131c804b94c8f3ac622c5da32/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e3d8f40ea6268047de7046906326abed5134f27d4e8447b23763afe5808c8a96", size = 10113853, upload-time = "2026-04-27T14:43:23.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263, upload-time = "2026-04-27T14:43:29.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223, upload-time = "2026-04-27T14:43:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127, upload-time = "2026-04-27T14:43:26.949Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
 ]
 
 [[package]]
@@ -1618,6 +2238,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6b/5a/92ce0b3ea5481915f55da994c2c2c5f7a3c09949afde196ee89f8ab961aa/uncalled_for-0.4.0.tar.gz", hash = "sha256:335b95bd2422332ec210d518f314a16e4c640921c39fc8bf2ad095bd3538f4af", size = 56979, upload-time = "2026-08-10T14:51:46.247Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/40/97cec87c077eb3291fc7905e6633e08b7ca593c57d30238444bcb6bb3d53/uncalled_for-0.4.0-py3-none-any.whl", hash = "sha256:16c4bb3337532e4bd5569adc192285976f3ad5305402256d34c67a12b5c968bd", size = 15502, upload-time = "2026-08-10T14:51:45.068Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]
@@ -1806,4 +2435,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/2c/9d9c1da5a7ea9af307b386d25f64d1dead4729644198d2b92e36db5dfd41/websockets-17.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:bb31f42ea095ea826463c770829aa188a86c9a5c976b1467cbbf583c811de833", size = 213094, upload-time = "2026-07-31T11:31:15.367Z" },
     { url = "https://files.pythonhosted.org/packages/5b/24/a585e7573e128070605d003b5544729bcd58d9756c7e99d550818ca4b916/websockets-17.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:dbfae8e75b342e31fc6fd1a8bbb393b7cbb91d6cfd581650300a94381e7b7e2b", size = 213009, upload-time = "2026-07-31T11:31:16.776Z" },
     { url = "https://files.pythonhosted.org/packages/09/ce/3929538b2b9918f5eee623fbf3346893973191f6df93f19bbda097bd7bb7/websockets-17.0.1-py3-none-any.whl", hash = "sha256:c6be9cba65c65cc76dfa3d4619e359ff02a4476c74e179b215236c11a0b32345", size = 206718, upload-time = "2026-07-31T11:31:26.037Z" },
+]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
 ]


### PR DESCRIPTION
## Summary

`palaia_hub.index` — the disposable projection over one vault. Per-vault SQLite (WAL) with FTS5 over **notes, observations and relations**, sqlite-vec KNN over chunk embeddings, metadata filters (scope, type, tags, dates, custom frontmatter keys), and three search modes `fts | vector | hybrid`. Files stay the only truth: drop the file, `reindex`, get identical answers.

Modules: `schema.py` (DDL + why the shape is what it is), `db.py` (WAL, sqlite-vec loading, drop-don't-migrate), `writer.py` (the only writer; also the doctor's `ReindexSink`/`IndexView`), `search.py` (the three modes + rank fusion), `service.py` (`VaultIndex`: lifecycle, event subscription, embed worker, status), `embeddings.py` (chunking + fingerprints + fastembed), `bench.py` (the model/batch benchmark).

**Design decisions worth reviewing:**

1. **Embedding is structurally off the write path.** SPEC-003 measured 437 ms/note to embed vs 0.6 ms to FTS-index. A write acks once chunks are written as `pending`; a background asyncio worker drains them in batches. The worker is the *only* caller of an embedder for indexing, so no future write path can accidentally take that hit.
2. **One transaction per rebuild**, and chunk-level fingerprints: a reindex of an unchanged vault costs one `SELECT` per note (checksum fast path) and leaves every vector in place. Editing one paragraph of a long note re-embeds one chunk.
3. **Forward references resolve both ways.** A relation to a note that does not exist is stored with `target_permalink = NULL`; when a note answering to that name (permalink, title, alias, or slug) appears, its upsert back-resolves every waiting relation — no reindex. Deleting the target puts them back to NULL. The synthetic relation permalink (§9.2) is rewritten with it, in `relations` and in the FTS rows.
4. **Fusion had two bugs worth naming, both found by measuring rather than reasoning** (see `test_hybrid_relevance.py`, and `test_fusion.py` which pins both):
   - The FTS side returns *rows*, so a note with six matching observations got six reciprocal-rank contributions and outranked genuine agreement. Each list is now collapsed to one entry per note before ranks are taken.
   - When no document contains every query term, the FTS pass falls back to disjunctive matching — lexical *near-misses*, not evidence. Fusing that as a peer under RRF (k=60) meant "in both lists mediocrely" beat "vector rank 1", which is exactly how a paraphrased question's correct answer fell from vector rank 1 to hybrid rank 6. Hybrid now uses symmetric RRF when the conjunctive pass produced the lexical list, and lets the vector ranking lead with lexical-only hits appended below it when it did not.
5. **Degradation is explicit, never silent.** `SearchResults.degraded` + `degraded_reason` distinguish "hybrid ran" from "hybrid was asked for and FTS answered". Missing fastembed, missing sqlite-vec, an undrained backlog and a failed query embedding all land there.
6. **Gateway wiring**: `EngineVaultService(engine, index)` — the spot that adapter's docstring marked. `search` is now an indexed hybrid query with `meta` notes excluded at the SQL level. **The MCP tool contract is unchanged** (the golden `tools/list` snapshot is untouched and its drift test passes): sub-note addressability lives on the index API's `SearchHit.ref`, while the tool keeps note-level results, one per note. Passing no index keeps SPEC-105's linear scan, so nothing that has not been taught about the index breaks.
7. **Deps**: `sqlite-vec` is a core dependency; `fastembed` is an `embeddings` extra pulled into the workspace dev group (it drags onnxruntime plus a ~130 MB model download, and FTS-only is a supported mode). Two `[[tool.mypy.overrides]]` blocks for their missing `py.typed`.

## Model / batch benchmark (SPEC-003's requested follow-up, before locking the default)

`uv run python -m palaia_hub.index.bench --notes 200 --batch 8,32`, golden vault (45 chunks, mean 182 chars), 4 vCPUs, two consecutive runs consistent:

| model | batch | ms/chunk |
|---|---|---|
| `sentence-transformers/all-MiniLM-L6-v2` | 8 | **15.6** |
| `sentence-transformers/all-MiniLM-L6-v2` | 32 | 17.7 |
| `BAAI/bge-small-en-v1.5` | 8 | 152.8 |
| `BAAI/bge-small-en-v1.5` | 32 | 224.0 |
| FTS5 insert, same corpus | — | 0.013 |

**Default locked to `all-MiniLM-L6-v2`, batch 8** — ~10x faster at the same 384 dimensions, so the schema is indifferent to the choice and a deployment preferring bge-small only sets `model` and re-embeds. Bigger batches lost ~12% here (likely thread oversubscription on 4 vCPUs), which is why the default is 8 and the benchmark stays in-tree. The embed:FTS ratio of ~1200:1 is the async mandate restated on this hardware.

## Relevance battery: recall@5, hybrid vs pure FTS

10 paraphrased questions over the golden vault (`test_hybrid_relevance.py`, real model, `-s` prints the per-query table):

| mode | recall@5 |
|---|---|
| fts | 0.70 |
| vector | 0.90 |
| **hybrid** | **0.90** |

Hybrid recovers both queries FTS misses entirely ("which database stores the searchable projection" → `decisions/use-sqlite-for-index`, "what licence did we settle on" → `decisions/mit-license`) **without losing the exact lexical hits** — a second test asserts "API Gateway", "Alice Novak" and "rate limit" still land. One query is missed by every mode (`physical-vault-isolation`, no lexical or semantic overlap in a 3-line note); it is left in the battery rather than tuned away.

## Acceptance checklist

- [x] **drop DB → `reindex` → identical results for a fixed query battery (golden-vault test)** — `test_rebuild.py::test_drop_database_then_reindex_reproduces_identical_results` deletes the sqlite file + WAL sidecars and compares SPEC-113's `CANONICAL_QUERIES` results including ranked order *and* each hit's addressed ref; a second test does the same with filters applied.
- [x] **forward reference resolves when target note appears (no full reindex)** — `test_incremental.py::test_forward_reference_resolves_when_target_appears_without_reindex` (plus alias resolution, and un-resolution on target delete). Only the note-created event path runs in those tests.
- [x] **index lag after a change event < 2s in integration test** — `test_incremental.py::test_external_edit_is_indexed_within_the_lag_budget` writes straight to disk behind a live `VaultWatcher` and asserts searchability inside 2 s. The SPEC-113 S2 scenario now exercises the same path end-to-end: `hub_server.py` mounts the real index.
- [x] **hybrid beats pure FTS on the relevance battery (recall@5 measured, documented in PR)** — 0.90 vs 0.70, table above; the test asserts strict improvement.
- [x] **embed backlog visible via status API; queries degrade to FTS cleanly while vectors are pending** — `IndexStatus.embeds` (`total/ready/pending/failed`, model, dim, reason); `test_embeddings.py` covers pending→ready, hybrid and vector degradation with the reason text, a missing model degrading instead of raising, and the background worker draining unasked.

## Verification

```
cd v3
uv sync                    # ok
uv run ruff check server   # All checks passed!
uv run mypy server/src     # Success: no issues found in 50 source files
uv run pytest server/tests # 505 passed, 1 skipped in 140s
```

The golden `tools/list` snapshot was **not** regenerated and its drift test passes — this change does not alter the gateway tool surface.

## Notes for a follow-up, not in this diff

- `v3/server/README.md` carries committed merge-conflict markers (`<<<<<<< HEAD` … `>>>>>>>`) from before this branch point. Left alone; the SPEC-104 section is appended cleanly after them.
- Vector filters are applied *after* the KNN (sqlite-vec has no join-aware pre-filter), so a heavily filtered vector query over-fetches. Fine at Phase-1 vault sizes; worth revisiting if it shows up.
- A note whose title changes without an engine `rename_entity` can leave an inbound relation pointing at the old identity until the next `reindex`. The doctor's `partial-rename` finding already reports the user-facing half.
- No HTTP route or CLI surface for `IndexStatus` yet — it is a Python API, since SPEC-104 has no dashboard consumer. Wiring it into `/api/*` belongs with SPEC-110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790100909&installation_model_id=428086&pr_number=218&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F218&signature=2ee1055cc1975f044980e6d4cfca1f6f7e88f17084b564afc8c30d5e07e369ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->