### PR TITLE
feat(v3): GitHub / generic-OIDC sign-in (SPEC-204)

### DIFF
--- a/v3/server/src/palaia_hub/app.py
+++ b/v3/server/src/palaia_hub/app.py
@@ -286,11 +286,25 @@ def create_app(
 
     @app.get("/api/info")
     async def info() -> dict[str, Any]:
-        """Version, operating mode, uptime."""
+        """Version, operating mode, uptime, and how the owner signs in.
+
+        ``sign_in`` is non-secret (no client id, no allow-list) and is what
+        the dashboard's settings section (SPEC-204 deliverable #4) reads to
+        show "Sign in with GitHub" / a configured provider's name / the
+        local password, in plain language.
+        """
+        sign_in: dict[str, str | None]
+        if oauth_server is not None and oauth_server.idp_configured:
+            sign_in = {"method": "idp", "provider_name": oauth_server.idp_display_name}
+        elif oauth_server is not None:
+            sign_in = {"method": "password", "provider_name": None}
+        else:
+            sign_in = {"method": "none", "provider_name": None}
         return {
             "version": __version__,
             "mode": config.mode,
             "uptime_seconds": round(time.monotonic() - start_time, 3),
+            "sign_in": sign_in,
         }
 
     # SPEC-107: inbox visibility outside the MCP surface (deliverable #3).

--- a/v3/server/src/palaia_hub/config.py
+++ b/v3/server/src/palaia_hub/config.py
@@ -126,6 +126,26 @@ oauth:
   # MCP profile paths this server issues audience-scoped tokens for. Must
   # match the gateway's profile paths.
   profiles: []
+  # Sign in with an identity provider instead of the local password
+  # (SPEC-204). Uncomment ONE of the blocks below. Setting this removes the
+  # password sign-in route entirely — "one door only" (MASTERPLAN §5.5):
+  # two doors into the same room mean the weaker one decides how strong the
+  # room is. The provider's token is used once, to read the signed-in
+  # username, and is never stored.
+  # idp:
+  #   provider: github
+  #   github:
+  #     client_id: "..."
+  #     client_secret: "..."
+  #     allowed_users: ["your-github-username"]
+  # idp:
+  #   provider: oidc
+  #   oidc:
+  #     discovery_url: "https://accounts.example.com/.well-known/openid-configuration"
+  #     client_id: "..."
+  #     client_secret: "..."
+  #     allowed_users: ["you@example.com"]
+  #     display_name: "Example Workspace"
 """
 
 
@@ -189,6 +209,91 @@ class RecallSettings(BaseModel):
     unknown_recency: float = Field(default=0.5, ge=0.0, le=1.0)
 
 
+class GitHubIdpSettings(BaseModel):
+    """"Sign in with GitHub" (SPEC-204). Zero scopes are ever requested —
+    the token is used once to read the signed-in username, then discarded.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    client_id: str
+    client_secret: str
+    #: Usernames allowed to sign in, compared case-folded (GitHub usernames
+    #: are themselves case-insensitive, so this matches the provider's own
+    #: notion of identity rather than a stricter one of ours).
+    allowed_users: list[str] = Field(min_length=1)
+
+
+class OidcIdpSettings(BaseModel):
+    """A generic OpenID Connect provider (SPEC-204), discovery-configured.
+
+    Only the discovery URL, a client id/secret and an allow-list are asked
+    for — every endpoint the flow needs comes from the provider's own
+    ``/.well-known/openid-configuration`` document, fetched once and reused
+    for the life of the process.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    discovery_url: str
+    client_id: str
+    client_secret: str
+    allowed_users: list[str] = Field(min_length=1)
+    #: The claim in the provider's user-info response that carries the
+    #: username to check against ``allowed_users``. ``preferred_username``
+    #: is the OIDC-standard field for this; some providers only populate
+    #: ``email``, so it is configurable.
+    username_claim: str = "preferred_username"
+    #: The provider's plain-language name, e.g. ``"Acme Workspace"``. Shown
+    #: on the sign-in button as "Sign in with {display_name}" — the jargon
+    #: rule (no protocol acronyms user-facing) means this hub cannot invent
+    #: a generic label on the operator's behalf.
+    display_name: str = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _check_discovery_url(self) -> OidcIdpSettings:
+        if not self.discovery_url.lower().startswith("https://"):
+            raise ValueError(
+                "oauth.idp.oidc.discovery_url must be an https URL. Fix: use the "
+                "provider's `.well-known/openid-configuration` https URL."
+            )
+        return self
+
+
+class IdpSettings(BaseModel):
+    """Which identity provider (if any) fronts sign-in, and its settings.
+
+    **One door only** (MASTERPLAN §5.5): when this is set, the local owner
+    password route is not registered at all — see
+    :mod:`palaia_hub.oauth.routes`. Exactly one of ``github``/``oidc`` must
+    be present, matching ``provider``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    provider: Literal["github", "oidc"]
+    github: GitHubIdpSettings | None = None
+    oidc: OidcIdpSettings | None = None
+
+    @model_validator(mode="after")
+    def _check_matching_block(self) -> IdpSettings:
+        block = self.github if self.provider == "github" else self.oidc
+        if block is None:
+            raise ValueError(
+                f"oauth.idp.provider is {self.provider!r} but oauth.idp.{self.provider} "
+                f"is not set. Fix: add an `oauth.idp.{self.provider}:` block with its "
+                f"settings, or change `provider`."
+            )
+        other = "oidc" if self.provider == "github" else "github"
+        if getattr(self, other) is not None:
+            raise ValueError(
+                f"oauth.idp.provider is {self.provider!r} but oauth.idp.{other} is also "
+                f"set. Fix: remove the `oauth.idp.{other}:` block — only one identity "
+                f"provider may be configured at a time."
+            )
+        return self
+
+
 class OAuthSettings(BaseModel):
     """The OAuth 2.1 authorization server's settings (SPEC-203).
 
@@ -242,6 +347,11 @@ class OAuthSettings(BaseModel):
     #: profile set to :meth:`palaia_hub.oauth.AuthorizationServer.build` and
     #: ignores this list.
     profiles: list[str] = Field(default_factory=list)
+    #: An identity provider fronting sign-in (SPEC-204). ``None`` (default)
+    #: keeps the local owner password as the only door; setting this removes
+    #: the password route entirely rather than adding a second door next to
+    #: it (MASTERPLAN §5.5's "one door only" rule).
+    idp: IdpSettings | None = None
 
 
 class HubConfig(BaseModel):

--- a/v3/server/src/palaia_hub/oauth/__init__.py
+++ b/v3/server/src/palaia_hub/oauth/__init__.py
@@ -52,11 +52,21 @@ from __future__ import annotations
 from .cimd import CimdFetcher, StaticCimdFetcher
 from .clients import provision_machine_client, register_dcr_client
 from .errors import OAuthError
+from .idp import (
+    GitHubIdpProvider,
+    HttpxIdpHttp,
+    IdpHttp,
+    IdpProvider,
+    OidcIdpProvider,
+    StaticIdpHttp,
+    build_idp_provider,
+)
 from .keys import ALGORITHM, SigningKey, now_seconds
 from .login import LoginThrottle, set_owner_password
 from .models import (
     ClientInfo,
     ClientRow,
+    IdpStateRow,
     IssuedTokens,
     ProvisionedMachineClient,
     PruneReport,
@@ -64,7 +74,13 @@ from .models import (
 )
 from .resources import ResourceRegistry, normalize_issuer
 from .routes import build_oauth_router
-from .service import AuthorizationServer, AuthorizeRedirect, LoginRequired
+from .service import (
+    IDP_CALLBACK_PATH,
+    IDP_START_PATH,
+    AuthorizationServer,
+    AuthorizeRedirect,
+    LoginRequired,
+)
 from .store import OAuthStore
 from .verifier import (
     build_jwt_verifier,
@@ -75,22 +91,32 @@ from .verifier import (
 
 __all__ = [
     "ALGORITHM",
+    "IDP_CALLBACK_PATH",
+    "IDP_START_PATH",
     "AuthorizationServer",
     "AuthorizeRedirect",
     "CimdFetcher",
     "ClientInfo",
     "ClientRow",
+    "GitHubIdpProvider",
+    "HttpxIdpHttp",
+    "IdpHttp",
+    "IdpProvider",
+    "IdpStateRow",
     "IssuedTokens",
     "LoginRequired",
     "LoginThrottle",
     "OAuthError",
     "OAuthStore",
+    "OidcIdpProvider",
     "ProvisionedMachineClient",
     "PruneReport",
     "ResourceRegistry",
     "RotationOutcome",
     "SigningKey",
     "StaticCimdFetcher",
+    "StaticIdpHttp",
+    "build_idp_provider",
     "build_jwt_verifier",
     "build_oauth_router",
     "build_profile_auth",

--- a/v3/server/src/palaia_hub/oauth/idp.py
+++ b/v3/server/src/palaia_hub/oauth/idp.py
@@ -1,0 +1,322 @@
+"""GitHub and generic-OIDC sign-in (SPEC-204).
+
+Two providers, one discipline, both stated in MASTERPLAN §5.5 and enforced
+here rather than merely documented:
+
+* **Zero scopes.** GitHub's authorization request asks for none — an
+  unscoped token still resolves the signed-in username through
+  ``GET /user``, which is all this flow ever needs. A generic OIDC provider
+  cannot go quite as low (``openid`` is mandatory to get a token at all,
+  and ``profile`` is requested so the user-info response actually carries a
+  username claim), but nothing beyond that.
+* **The provider's token is read once and discarded.** It exists only inside
+  :meth:`IdpProvider.resolve_username`'s stack frame; nothing in this module
+  or its callers ever assigns it anywhere that outlives that call, and the
+  authorization server never persists it (contrast with the login *session*
+  id, which is this hub's own credential and is stored, hashed, in
+  :class:`palaia_hub.oauth.store.OAuthStore`).
+
+Both providers speak through :class:`IdpHttp`, an injectable seam so tests
+exercise the whole exchange with no outbound network call (see
+:class:`StaticIdpHttp`) while production uses :class:`HttpxIdpHttp`.
+
+**On SSRF hardening.** :mod:`palaia_hub.oauth.cimd` fetches a URL an
+unauthenticated caller supplies (a client's declared ``client_id``), so it
+goes through fastmcp's DNS-pinned ``ssrf_safe_fetch``. The targets here are
+different in kind: GitHub's endpoints are hardcoded constants, and the OIDC
+discovery URL is set by the hub's own operator in ``config.yaml``, not by
+an HTTP caller. That is also why they *can't* reuse ``ssrf_safe_fetch``
+outright — it is GET-only, and a token exchange is a POST with a body.
+:class:`HttpxIdpHttp` still keeps the cheap, always-applicable half of that
+defense (https only, no redirect following, a response-size cap, a bounded
+timeout); the DNS-pinning half is not reimplemented here. This is a
+deliberate, least-deviation choice — called out in the PR rather than
+hidden — not an oversight.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+from urllib.parse import urlencode
+
+import httpx
+
+from ..config import GitHubIdpSettings, IdpSettings, OidcIdpSettings
+from .errors import OAuthError
+
+logger = logging.getLogger("palaia_hub.oauth.idp")
+
+GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
+GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"  # noqa: S105 - a URL, not a secret
+GITHUB_USER_URL = "https://api.github.com/user"
+
+_SIGN_IN_FAILED = OAuthError(
+    "access_denied",
+    "sign-in failed. Fix: try again; if it keeps failing, check the hub's "
+    "sign-in provider settings in config.yaml.",
+)
+
+
+class IdpHttp(Protocol):
+    """The two outbound calls a sign-in exchange needs."""
+
+    async def post_form(
+        self, url: str, data: Mapping[str, str], *, headers: Mapping[str, str] | None = None
+    ) -> dict[str, Any]: ...
+
+    async def get_json(
+        self, url: str, *, headers: Mapping[str, str] | None = None
+    ) -> dict[str, Any]: ...
+
+
+class HttpxIdpHttp:
+    """Production :class:`IdpHttp`. See the module docstring for its threat model."""
+
+    def __init__(self, *, timeout: float = 10.0, max_bytes: int = 65536) -> None:
+        self._timeout = timeout
+        self._max_bytes = max_bytes
+
+    async def post_form(
+        self, url: str, data: Mapping[str, str], *, headers: Mapping[str, str] | None = None
+    ) -> dict[str, Any]:
+        return await self._request("POST", url, data=dict(data), headers=headers)
+
+    async def get_json(
+        self, url: str, *, headers: Mapping[str, str] | None = None
+    ) -> dict[str, Any]:
+        return await self._request("GET", url, data=None, headers=headers)
+
+    async def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        data: dict[str, str] | None,
+        headers: Mapping[str, str] | None,
+    ) -> dict[str, Any]:
+        if not url.lower().startswith("https://"):
+            raise OAuthError(
+                "server_error", "the sign-in provider must be reached over https."
+            )
+        merged_headers = {"Accept": "application/json", **(headers or {})}
+        try:
+            async with httpx.AsyncClient(
+                timeout=self._timeout, follow_redirects=False, verify=True
+            ) as client:
+                response = await client.request(method, url, data=data, headers=merged_headers)
+        except httpx.HTTPError as exc:
+            logger.info("sign-in provider request failed: %s", type(exc).__name__)
+            raise _SIGN_IN_FAILED from exc
+        if len(response.content) > self._max_bytes:
+            raise OAuthError("server_error", "the sign-in provider's response was too large.")
+        if response.status_code >= 400:
+            logger.info("sign-in provider returned HTTP %s", response.status_code)
+            raise _SIGN_IN_FAILED
+        try:
+            body = response.json()
+        except ValueError as exc:
+            raise OAuthError(
+                "server_error", "the sign-in provider returned an invalid response."
+            ) from exc
+        if not isinstance(body, dict):
+            raise OAuthError(
+                "server_error", "the sign-in provider returned an unexpected response."
+            )
+        return body
+
+
+@dataclass
+class StaticIdpHttp:
+    """A canned :class:`IdpHttp` for tests — no outbound network call.
+
+    ``token_responses``/``json_responses`` are keyed by the exact URL a real
+    call would hit; missing a key simulates the provider rejecting the
+    request. ``calls`` records every request made, so a test can assert on
+    what was (and was not) sent — e.g. that a token never appears in a log
+    call site, or that a discovery document is fetched only once.
+    """
+
+    token_responses: dict[str, dict[str, Any]] = field(default_factory=dict)
+    json_responses: dict[str, dict[str, Any]] = field(default_factory=dict)
+    calls: list[tuple[str, str, dict[str, Any]]] = field(default_factory=list)
+
+    async def post_form(
+        self, url: str, data: Mapping[str, str], *, headers: Mapping[str, str] | None = None
+    ) -> dict[str, Any]:
+        self.calls.append(("POST", url, dict(data)))
+        if url not in self.token_responses:
+            raise _SIGN_IN_FAILED
+        return self.token_responses[url]
+
+    async def get_json(
+        self, url: str, *, headers: Mapping[str, str] | None = None
+    ) -> dict[str, Any]:
+        self.calls.append(("GET", url, {}))
+        if url not in self.json_responses:
+            raise _SIGN_IN_FAILED
+        return self.json_responses[url]
+
+
+class IdpProvider(Protocol):
+    """What :class:`~palaia_hub.oauth.service.AuthorizationServer` needs from a provider."""
+
+    async def authorize_url(self, *, state: str, redirect_uri: str) -> str: ...
+
+    async def resolve_username(self, *, code: str, redirect_uri: str) -> str: ...
+
+
+class GitHubIdpProvider:
+    """"Sign in with GitHub" — zero scopes, username via ``GET /user``."""
+
+    def __init__(self, settings: GitHubIdpSettings, http: IdpHttp) -> None:
+        self._settings = settings
+        self._http = http
+
+    async def authorize_url(self, *, state: str, redirect_uri: str) -> str:
+        params = {
+            "client_id": self._settings.client_id,
+            "redirect_uri": redirect_uri,
+            "state": state,
+            # Zero scopes (SPEC-204 deliverable #1): an unscoped token still
+            # resolves the signed-in username, and nothing else is needed.
+            "scope": "",
+            "allow_signup": "false",
+        }
+        return f"{GITHUB_AUTHORIZE_URL}?{urlencode(params)}"
+
+    async def resolve_username(self, *, code: str, redirect_uri: str) -> str:
+        token_body = await self._http.post_form(
+            GITHUB_TOKEN_URL,
+            {
+                "client_id": self._settings.client_id,
+                "client_secret": self._settings.client_secret,
+                "code": code,
+                "redirect_uri": redirect_uri,
+            },
+        )
+        access_token = token_body.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            raise _SIGN_IN_FAILED
+        try:
+            user = await self._http.get_json(
+                GITHUB_USER_URL,
+                headers={
+                    "Authorization": f"Bearer {access_token}",
+                    "Accept": "application/vnd.github+json",
+                },
+            )
+        finally:
+            # The provider token's only use is the call above; it is not
+            # assigned anywhere else and is not returned, logged, or stored.
+            del access_token
+        login = user.get("login")
+        if not isinstance(login, str) or not login:
+            raise _SIGN_IN_FAILED
+        return login
+
+
+class OidcIdpProvider:
+    """A generic, discovery-configured OIDC provider.
+
+    The discovery document is fetched once and cached on this instance —
+    which lives for the process's lifetime (built once in
+    :class:`~palaia_hub.oauth.service.AuthorizationServer`), so a restart is
+    the only time it is re-fetched.
+    """
+
+    def __init__(self, settings: OidcIdpSettings, http: IdpHttp) -> None:
+        self._settings = settings
+        self._http = http
+        self._discovery: dict[str, Any] | None = None
+
+    async def _discover(self) -> dict[str, Any]:
+        if self._discovery is None:
+            self._discovery = await self._http.get_json(self._settings.discovery_url)
+        return self._discovery
+
+    async def _endpoint(self, doc: Mapping[str, Any], key: str) -> str:
+        value = doc.get(key)
+        if not isinstance(value, str) or not value:
+            raise OAuthError(
+                "server_error",
+                f"the sign-in provider's discovery document has no {key!r}.",
+            )
+        return value
+
+    async def authorize_url(self, *, state: str, redirect_uri: str) -> str:
+        doc = await self._discover()
+        endpoint = await self._endpoint(doc, "authorization_endpoint")
+        params = {
+            "client_id": self._settings.client_id,
+            "redirect_uri": redirect_uri,
+            "response_type": "code",
+            "state": state,
+            # The minimum that still yields a resolvable username: OIDC
+            # requires 'openid', and 'profile' is what typically carries
+            # preferred_username in the user-info response.
+            "scope": "openid profile",
+        }
+        return f"{endpoint}?{urlencode(params)}"
+
+    async def resolve_username(self, *, code: str, redirect_uri: str) -> str:
+        doc = await self._discover()
+        token_endpoint = await self._endpoint(doc, "token_endpoint")
+        userinfo_endpoint = await self._endpoint(doc, "userinfo_endpoint")
+        token_body = await self._http.post_form(
+            token_endpoint,
+            {
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "client_id": self._settings.client_id,
+                "client_secret": self._settings.client_secret,
+            },
+        )
+        access_token = token_body.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            raise _SIGN_IN_FAILED
+        try:
+            claims = await self._http.get_json(
+                userinfo_endpoint, headers={"Authorization": f"Bearer {access_token}"}
+            )
+        finally:
+            del access_token
+        value = claims.get(self._settings.username_claim)
+        if not isinstance(value, str) or not value:
+            raise _SIGN_IN_FAILED
+        return value
+
+
+def build_idp_provider(settings: IdpSettings, *, http: IdpHttp) -> IdpProvider:
+    """Build the one configured provider from ``settings``."""
+    if settings.provider == "github":
+        assert settings.github is not None  # noqa: S101 - IdpSettings validated this
+        return GitHubIdpProvider(settings.github, http)
+    assert settings.oidc is not None  # noqa: S101 - IdpSettings validated this
+    return OidcIdpProvider(settings.oidc, http)
+
+
+#: Case-folded set membership check, shared by the service layer. GitHub
+#: usernames and most OIDC username claims are themselves case-insensitive,
+#: so this matches the provider's own notion of identity.
+def is_allowed_user(username: str, allowed_users: list[str]) -> bool:
+    folded = username.casefold()
+    return any(folded == candidate.casefold() for candidate in allowed_users)
+
+
+__all__ = [
+    "GITHUB_AUTHORIZE_URL",
+    "GITHUB_TOKEN_URL",
+    "GITHUB_USER_URL",
+    "GitHubIdpProvider",
+    "HttpxIdpHttp",
+    "IdpHttp",
+    "IdpProvider",
+    "OidcIdpProvider",
+    "StaticIdpHttp",
+    "build_idp_provider",
+    "is_allowed_user",
+]

--- a/v3/server/src/palaia_hub/oauth/models.py
+++ b/v3/server/src/palaia_hub/oauth/models.py
@@ -134,6 +134,22 @@ class IssuedTokens:
 
 
 @dataclass(frozen=True, slots=True)
+class IdpStateRow:
+    """One pending IdP sign-in ticket (SPEC-204).
+
+    Everything the callback needs to resume the *outer* ``/oauth/authorize``
+    continuation lives here, server-side, keyed by the opaque ``state`` the
+    browser carries to and from the provider — the continuation itself never
+    appears in a URL. Consuming it (see
+    :meth:`palaia_hub.oauth.store.OAuthStore.consume_idp_state`) deletes the
+    row, which is what makes the ticket single-use.
+    """
+
+    provider: str
+    next_url: str
+
+
+@dataclass(frozen=True, slots=True)
 class ProvisionedMachineClient:
     """An admin-provisioned machine client, plus its secret — shown once."""
 

--- a/v3/server/src/palaia_hub/oauth/routes.py
+++ b/v3/server/src/palaia_hub/oauth/routes.py
@@ -44,6 +44,8 @@ from .login import CSRF_COOKIE, CSRF_FIELD, SESSION_COOKIE, new_csrf_token
 from .models import ClientInfo
 from .service import (
     AUTHORIZE_PATH,
+    IDP_CALLBACK_PATH,
+    IDP_START_PATH,
     JWKS_PATH,
     LOGIN_PATH,
     REGISTER_PATH,
@@ -173,7 +175,12 @@ def build_oauth_router(server: AuthorizationServer) -> APIRouter:
             # user an error rather than redirecting to an unvalidated URI.
             return _authorize_error_page(exc)
         if isinstance(outcome, LoginRequired):
-            location = f"{LOGIN_PATH}?next={_quote(outcome.next_url)}"
+            # One door only (MASTERPLAN §5.5): with an IdP configured, there
+            # is exactly one way in, so this goes straight to it rather than
+            # through an interstitial page offering a password door that
+            # does not exist.
+            start = IDP_START_PATH if server.idp_configured else LOGIN_PATH
+            location = f"{start}?next={_quote(outcome.next_url)}"
             return RedirectResponse(location, status_code=303, headers=NO_STORE)
         assert isinstance(outcome, AuthorizeRedirect)  # noqa: S101 - exhaustive union
         return RedirectResponse(outcome.location, status_code=303, headers=NO_STORE)
@@ -244,54 +251,103 @@ def build_oauth_router(server: AuthorizationServer) -> APIRouter:
         )
 
     # ----------------------------------------------------------------- login
+    #
+    # One door only (MASTERPLAN §5.5, SPEC-204 deliverable #3): neither of
+    # these routes is registered when an IdP is configured. `authorize()`
+    # above sends an unauthenticated browser straight to the IdP flow in
+    # that case, so there is no interstitial page offering a password door
+    # that does not exist — and a request to either verb here 404s exactly
+    # like any other path this server never served, rather than 403ing
+    # (which would still confirm the door exists, just locked).
 
-    @router.get(LOGIN_PATH)
-    async def login_form(request: Request) -> Response:
-        """The owner sign-in form (this SPEC's only identity; IdPs are SPEC-204)."""
-        next_url = request.query_params.get("next", "")
-        csrf = new_csrf_token()
-        response = HTMLResponse(
-            _login_page(next_url=next_url if _is_safe_next(next_url) else "", csrf=csrf, error=""),
-            headers=NO_STORE,
-        )
-        _set_cookie(response, CSRF_COOKIE, csrf, secure=secure_cookies, max_age=600)
-        return response
+    if not server.idp_configured:
 
-    @router.post(LOGIN_PATH)
-    async def login_submit(request: Request) -> Response:
-        """Verify the owner's password, open a session, continue to ``next``."""
-        form = dict(await request.form())
-        next_url = str(form.get("next", "") or "")
-        submitted_csrf = str(form.get(CSRF_FIELD, "") or "")
-        cookie_csrf = request.cookies.get(CSRF_COOKIE, "")
-        if not cookie_csrf or submitted_csrf != cookie_csrf:
-            # Double-submit mismatch: either a stale form or a cross-site POST.
-            return _login_failure(
-                next_url,
-                "This sign-in form expired. Please try again.",
-                secure=secure_cookies,
+        @router.get(LOGIN_PATH)
+        async def login_form(request: Request) -> Response:
+            """The owner sign-in form."""
+            next_url = request.query_params.get("next", "")
+            csrf = new_csrf_token()
+            response = HTMLResponse(
+                _login_page(
+                    next_url=next_url if _is_safe_next(next_url) else "", csrf=csrf, error=""
+                ),
+                headers=NO_STORE,
             )
-        username = str(form.get("username", "") or "")
-        password = str(form.get("password", "") or "")
-        try:
-            session, expires_at = await asyncio.to_thread(server.sign_in, username, password)
-        except OAuthError:
-            return _login_failure(
-                next_url,
-                "Sign-in failed. Check the username and password.",
+            _set_cookie(response, CSRF_COOKIE, csrf, secure=secure_cookies, max_age=600)
+            return response
+
+        @router.post(LOGIN_PATH)
+        async def login_submit(request: Request) -> Response:
+            """Verify the owner's password, open a session, continue to ``next``."""
+            form = dict(await request.form())
+            next_url = str(form.get("next", "") or "")
+            submitted_csrf = str(form.get(CSRF_FIELD, "") or "")
+            cookie_csrf = request.cookies.get(CSRF_COOKIE, "")
+            if not cookie_csrf or submitted_csrf != cookie_csrf:
+                # Double-submit mismatch: either a stale form or a cross-site POST.
+                return _login_failure(
+                    next_url,
+                    "This sign-in form expired. Please try again.",
+                    secure=secure_cookies,
+                )
+            username = str(form.get("username", "") or "")
+            password = str(form.get("password", "") or "")
+            try:
+                session, expires_at = await asyncio.to_thread(server.sign_in, username, password)
+            except OAuthError:
+                return _login_failure(
+                    next_url,
+                    "Sign-in failed. Check the username and password.",
+                    secure=secure_cookies,
+                )
+            target = next_url if _is_safe_next(next_url) else "/"
+            response = RedirectResponse(target, status_code=303, headers=NO_STORE)
+            _set_cookie(
+                response,
+                SESSION_COOKIE,
+                session,
                 secure=secure_cookies,
+                max_age=max(0, expires_at - server.now()),
             )
-        target = next_url if _is_safe_next(next_url) else "/"
-        response = RedirectResponse(target, status_code=303, headers=NO_STORE)
-        _set_cookie(
-            response,
-            SESSION_COOKIE,
-            session,
-            secure=secure_cookies,
-            max_age=max(0, expires_at - server.now()),
-        )
-        response.delete_cookie(CSRF_COOKIE, path="/")
-        return response
+            response.delete_cookie(CSRF_COOKIE, path="/")
+            return response
+
+    # ------------------------------------------------------------- idp (204)
+
+    if server.idp_configured:
+
+        @router.get(IDP_START_PATH)
+        async def idp_start(request: Request) -> Response:
+            """Redirect the browser to the configured provider."""
+            next_url = request.query_params.get("next", "")
+            if not _is_safe_next(next_url):
+                return _authorize_error_page(
+                    OAuthError(
+                        "invalid_request",
+                        "this sign-in link is invalid. Fix: start from the sign-in page.",
+                    )
+                )
+            location = await server.start_idp_signin(next_url)
+            return RedirectResponse(location, status_code=303, headers=NO_STORE)
+
+        @router.get(IDP_CALLBACK_PATH)
+        async def idp_callback(request: Request) -> Response:
+            """The provider sends the browser back here with ``code``/``state``."""
+            params = dict(request.query_params)
+            try:
+                session, expires_at, next_url = await server.finish_idp_signin(params)
+            except OAuthError as exc:
+                return _authorize_error_page(exc)
+            target = next_url if _is_safe_next(next_url) else "/"
+            response = RedirectResponse(target, status_code=303, headers=NO_STORE)
+            _set_cookie(
+                response,
+                SESSION_COOKIE,
+                session,
+                secure=secure_cookies,
+                max_age=max(0, expires_at - server.now()),
+            )
+            return response
 
     @router.post(LOGOUT_PATH)
     async def logout(request: Request) -> Response:

--- a/v3/server/src/palaia_hub/oauth/service.py
+++ b/v3/server/src/palaia_hub/oauth/service.py
@@ -59,6 +59,7 @@ from . import pkce
 from .cimd import CimdFetcher, match_redirect_uri
 from .clients import register_dcr_client, resolve_client
 from .errors import OAuthError
+from .idp import HttpxIdpHttp, IdpHttp, IdpProvider, build_idp_provider, is_allowed_user
 from .keys import ALGORITHM, SigningKey, now_seconds
 from .login import LoginThrottle, verify_owner_password
 from .models import ClientRow, IssuedTokens
@@ -85,6 +86,15 @@ TOKEN_PATH = "/oauth/token"
 REVOKE_PATH = "/oauth/revoke"
 REGISTER_PATH = "/oauth/register"
 JWKS_PATH = "/.well-known/jwks.json"
+#: The IdP sign-in hop (SPEC-204): started from the login page, comes back
+#: here with the provider's ``code``/``state``.
+IDP_START_PATH = "/oauth/idp/start"
+IDP_CALLBACK_PATH = "/oauth/idp/callback"
+
+#: How long a sign-in ticket (the opaque ``state``) lives before it expires
+#: unused. Generous enough for a real browser hop through a provider's
+#: consent screen, short enough that an abandoned ticket does not linger.
+IDP_STATE_TTL_SECONDS = 600
 
 
 @dataclass(frozen=True, slots=True)
@@ -119,6 +129,11 @@ class AuthorizationServer:
         throttle: failed-sign-in throttle (shared with the login routes).
         clock: seconds-resolution time source; injectable so the grace-window
             tests do not have to sleep.
+        idp_http: how the SPEC-204 sign-in flow talks to the configured
+            identity provider. The default is the real (https-only, no
+            redirects, size-capped) transport; tests substitute
+            :class:`palaia_hub.oauth.idp.StaticIdpHttp`. Unused when
+            ``settings.idp`` is ``None``.
     """
 
     def __init__(
@@ -131,6 +146,7 @@ class AuthorizationServer:
         cimd_fetcher: CimdFetcher | None = None,
         throttle: LoginThrottle | None = None,
         clock: Callable[[], int] = now_seconds,
+        idp_http: IdpHttp | None = None,
     ) -> None:
         if not settings.issuer:
             raise ValueError(
@@ -147,6 +163,14 @@ class AuthorizationServer:
         self.cimd = cimd_fetcher or CimdFetcher()
         self.throttle = throttle or LoginThrottle()
         self._clock = clock
+        # Built once, for the process's lifetime: an OIDC provider caches its
+        # discovery document on this instance, so it is fetched at most once
+        # per restart rather than once per sign-in.
+        self._idp: IdpProvider | None = (
+            build_idp_provider(settings.idp, http=idp_http or HttpxIdpHttp())
+            if settings.idp is not None
+            else None
+        )
 
     # ------------------------------------------------------------ construction
 
@@ -159,6 +183,7 @@ class AuthorizationServer:
         home: Path | None = None,
         cimd_fetcher: CimdFetcher | None = None,
         clock: Callable[[], int] = now_seconds,
+        idp_http: IdpHttp | None = None,
     ) -> AuthorizationServer:
         """Assemble a server from hub config: load/create the key, open the store."""
         resolved_home = Path(home) if home is not None else palaia_home()
@@ -172,6 +197,7 @@ class AuthorizationServer:
             key=key,
             cimd_fetcher=cimd_fetcher,
             clock=clock,
+            idp_http=idp_http,
         )
 
     @property
@@ -410,6 +436,116 @@ class AuthorizationServer:
         if not session:
             return None
         return self.store.get_login_session(session, self.now())
+
+    # --------------------------------------------------------------- idp (204)
+
+    @property
+    def idp_configured(self) -> bool:
+        """Is an identity provider configured?
+
+        The one-door rule (MASTERPLAN §5.5, SPEC-204 deliverable #3) reads
+        this everywhere it decides whether the local password route exists
+        at all.
+        """
+        return self._idp is not None
+
+    @property
+    def idp_display_name(self) -> str:
+        """The provider's plain-language name for the sign-in button.
+
+        ``"GitHub"`` for that provider (it needs no operator-supplied name);
+        the configured ``display_name`` for a generic OIDC provider (the
+        jargon rule means this hub cannot invent a label on the operator's
+        behalf — see :class:`palaia_hub.config.OidcIdpSettings`). Empty when
+        no IdP is configured.
+        """
+        idp = self.settings.idp
+        if idp is None:
+            return ""
+        if idp.provider == "github":
+            return "GitHub"
+        assert idp.oidc is not None  # noqa: S101 - IdpSettings validated this
+        return idp.oidc.display_name
+
+    async def start_idp_signin(self, next_url: str) -> str:
+        """Begin the SPEC-204 flow: mint a ticket, return the provider's URL.
+
+        Raises:
+            OAuthError: ``server_error`` if no IdP is configured (a routing
+                bug, not something a caller can trigger through normal use —
+                the route is not registered without one).
+        """
+        idp_settings = self.settings.idp
+        if self._idp is None or idp_settings is None:
+            raise OAuthError("server_error", "no sign-in provider is configured.")
+        now = self.now()
+        state = self.store.create_idp_state(
+            provider=idp_settings.provider,
+            next_url=next_url,
+            now=now,
+            ttl=IDP_STATE_TTL_SECONDS,
+        )
+        return await self._idp.authorize_url(state=state, redirect_uri=self._idp_redirect_uri())
+
+    async def finish_idp_signin(self, params: Mapping[str, str]) -> tuple[str, int, str]:
+        """Complete the SPEC-204 callback. Returns ``(session, expires_at, next_url)``.
+
+        Raises:
+            OAuthError: ``access_denied`` for an expired/replayed/mismatched
+                ticket, a provider-reported error, a failed exchange, or a
+                username outside the allow-list — one code for all of them,
+                the same "reveal nothing about which part failed" discipline
+                :func:`palaia_hub.oauth.login.verify_owner_password` follows.
+        """
+        idp_settings = self.settings.idp
+        if self._idp is None or idp_settings is None:
+            raise OAuthError("server_error", "no sign-in provider is configured.")
+        now = self.now()
+        state = params.get("state") or ""
+        ticket = self.store.consume_idp_state(state, now=now) if state else None
+        denied = OAuthError(
+            "access_denied",
+            "sign-in failed or expired. Fix: start the sign-in again from the "
+            "beginning.",
+        )
+        if ticket is None or ticket.provider != idp_settings.provider:
+            raise denied
+        if params.get("error"):
+            logger.info(
+                "sign-in via %s was cancelled or failed at the provider", idp_settings.provider
+            )
+            raise denied
+        code = params.get("code")
+        if not code:
+            raise denied
+        try:
+            username = await self._idp.resolve_username(
+                code=code, redirect_uri=self._idp_redirect_uri()
+            )
+        except OAuthError as exc:
+            logger.info("sign-in via %s failed: %s", idp_settings.provider, exc.error)
+            raise denied from exc
+        allowed_users = (
+            idp_settings.github.allowed_users
+            if idp_settings.provider == "github" and idp_settings.github is not None
+            else idp_settings.oidc.allowed_users
+            if idp_settings.oidc is not None
+            else []
+        )
+        if not is_allowed_user(username, allowed_users):
+            logger.warning(
+                "sign-in via %s rejected: the account is not on the allow-list",
+                idp_settings.provider,
+            )
+            raise denied
+        session, expires_at = self.store.create_login_session(
+            username, now=now, ttl=self.settings.session_ttl
+        )
+        logger.info("owner signed in via %s", idp_settings.provider)
+        return session, expires_at, ticket.next_url
+
+    def _idp_redirect_uri(self) -> str:
+        return f"{self.issuer}{IDP_CALLBACK_PATH}"
 
     # ------------------------------------------------------------------- token
 
@@ -711,6 +847,9 @@ __all__ = [
     "GRANT_AUTHORIZATION_CODE",
     "GRANT_CLIENT_CREDENTIALS",
     "GRANT_REFRESH_TOKEN",
+    "IDP_CALLBACK_PATH",
+    "IDP_START_PATH",
+    "IDP_STATE_TTL_SECONDS",
     "JWKS_PATH",
     "LOGIN_PATH",
     "REGISTER_PATH",

--- a/v3/server/src/palaia_hub/oauth/store.py
+++ b/v3/server/src/palaia_hub/oauth/store.py
@@ -55,6 +55,7 @@ from .models import (
     ClientSource,
     CodeRow,
     GrantRow,
+    IdpStateRow,
     PruneReport,
     RefreshRow,
     RotationOutcome,
@@ -138,6 +139,14 @@ CREATE TABLE IF NOT EXISTS login_sessions (
     username     TEXT NOT NULL,
     created_at   INTEGER NOT NULL,
     expires_at   INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS idp_states (
+    state_hash TEXT PRIMARY KEY,
+    provider   TEXT NOT NULL,
+    next_url   TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    expires_at INTEGER NOT NULL
 );
 """
 
@@ -768,6 +777,45 @@ class OAuthStore:
             conn.execute(
                 "DELETE FROM login_sessions WHERE session_hash = ?", (hash_secret(session),)
             )
+
+    # --------------------------------------------------------------- idp (204)
+
+    def create_idp_state(self, *, provider: str, next_url: str, now: int, ttl: int) -> str:
+        """Mint a fresh single-use sign-in ticket (returned plaintext, stored hashed).
+
+        ``next_url`` is the ``/oauth/authorize`` continuation the browser
+        started from — held here rather than round-tripped through the IdP,
+        per SPEC-204's "ticket never in the URL" rule.
+        """
+        state = new_secret()
+        expires_at = now + ttl
+        with self._write() as conn:
+            conn.execute("DELETE FROM idp_states WHERE expires_at < ?", (now,))
+            conn.execute(
+                "INSERT INTO idp_states(state_hash, provider, next_url, created_at, expires_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (hash_secret(state), provider, next_url, now, expires_at),
+            )
+        return state
+
+    def consume_idp_state(self, state: str, *, now: int) -> IdpStateRow | None:
+        """Fetch-and-delete the ticket matching ``state``, or ``None``.
+
+        Deleting on every lookup — whether the ticket is found live, found
+        expired, or not found at all — is what makes a ticket single-use: a
+        second presentation of the same ``state`` (a replay, or the browser's
+        back button) always misses, because the row is already gone.
+        """
+        state_hash = hash_secret(state)
+        with self._write() as conn:
+            row = conn.execute(
+                "SELECT provider, next_url, expires_at FROM idp_states WHERE state_hash = ?",
+                (state_hash,),
+            ).fetchone()
+            conn.execute("DELETE FROM idp_states WHERE state_hash = ?", (state_hash,))
+        if row is None or int(row["expires_at"]) <= now:
+            return None
+        return IdpStateRow(provider=str(row["provider"]), next_url=str(row["next_url"]))
 
 
 # ------------------------------------------------------------- row adapters

--- a/v3/server/src/palaia_hub/static.py
+++ b/v3/server/src/palaia_hub/static.py
@@ -65,8 +65,14 @@ class SPAStaticFiles(StaticFiles):
     #: unmatched — backend surfaces, not client-side routes. "api" is the
     #: REST surface (some of it opt-in per create_app()'s parameters);
     #: "mcp" is the gateway's mount namespace (palaia_hub.gateway.build,
-    #: "/mcp/<profile>"), absent entirely with no gateway given.
-    _BACKEND_PREFIXES = ("api", "mcp")
+    #: "/mcp/<profile>"), absent entirely with no gateway given. "oauth" is
+    #: the SPEC-203/204 authorization server's surface: SPEC-204's one-door
+    #: rule depends on an IdP-configured hub's password route (registered
+    #: conditionally, see :mod:`palaia_hub.oauth.routes`) 404ing when
+    #: absent — without this prefix here, an unregistered `/oauth/login`
+    #: would instead fall through to this mount and get the dashboard shell
+    #: back with a 200, silently hiding that the route does not exist.
+    _BACKEND_PREFIXES = ("api", "mcp", "oauth")
 
     async def get_response(self, path: str, scope: Scope) -> Response:
         # SPEC-110 fix: reaching this mount at all with a backend-prefixed

--- a/v3/server/tests/oauth/harness.py
+++ b/v3/server/tests/oauth/harness.py
@@ -26,6 +26,7 @@ from palaia_hub.gateway.config import GatewayConfig, ProfileConfig, VaultMountCo
 from palaia_hub.gateway.fake_vault import FakeVaultService
 from palaia_hub.oauth import (
     AuthorizationServer,
+    IdpHttp,
     OAuthStore,
     ResourceRegistry,
     SigningKey,
@@ -100,6 +101,7 @@ def build_harness(
     settings: OAuthSettings | None = None,
     with_owner: bool = True,
     with_plt_tokens: bool = True,
+    idp_http: IdpHttp | None = None,
 ) -> Harness:
     """Assemble the app, the authorization server, and the resource side."""
     clock = Clock()
@@ -120,8 +122,9 @@ def build_harness(
         key=key,
         cimd_fetcher=cimd,
         clock=clock,
+        idp_http=idp_http,
     )
-    if with_owner:
+    if with_owner and oauth_settings.idp is None:
         set_owner_password(store, OWNER_USERNAME, OWNER_PASSWORD, now=clock())
 
     token_store = TokenStore(home=home)

--- a/v3/server/tests/oauth/test_idp_config.py
+++ b/v3/server/tests/oauth/test_idp_config.py
@@ -1,0 +1,77 @@
+"""SPEC-204's config surface: :class:`palaia_hub.config.IdpSettings` and friends."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from palaia_hub.config import GitHubIdpSettings, IdpSettings, OidcIdpSettings
+
+GITHUB = GitHubIdpSettings(
+    client_id="id",
+    client_secret="secret",  # noqa: S106 - test fixture
+    allowed_users=["octocat"],
+)
+OIDC = OidcIdpSettings(
+    discovery_url="https://idp.example.com/.well-known/openid-configuration",
+    client_id="id",
+    client_secret="secret",  # noqa: S106 - test fixture
+    allowed_users=["ana@example.com"],
+    display_name="Example Workspace",
+)
+
+
+def test_github_provider_needs_its_block() -> None:
+    with pytest.raises(ValidationError, match="oauth.idp.github"):
+        IdpSettings(provider="github")
+
+
+def test_oidc_provider_needs_its_block() -> None:
+    with pytest.raises(ValidationError, match="oauth.idp.oidc"):
+        IdpSettings(provider="oidc")
+
+
+def test_only_one_provider_block_may_be_set() -> None:
+    with pytest.raises(ValidationError, match="oauth.idp.oidc"):
+        IdpSettings(provider="github", github=GITHUB, oidc=OIDC)
+
+
+def test_a_valid_github_config_round_trips() -> None:
+    settings = IdpSettings(provider="github", github=GITHUB)
+    assert settings.github is not None
+    assert settings.github.allowed_users == ["octocat"]
+
+
+def test_a_valid_oidc_config_round_trips() -> None:
+    settings = IdpSettings(provider="oidc", oidc=OIDC)
+    assert settings.oidc is not None
+    assert settings.oidc.display_name == "Example Workspace"
+
+
+def test_oidc_discovery_url_must_be_https() -> None:
+    with pytest.raises(ValidationError, match="https"):
+        OidcIdpSettings(
+            discovery_url="http://idp.example.com/.well-known/openid-configuration",
+            client_id="id",
+            client_secret="secret",  # noqa: S106 - test fixture
+            allowed_users=["ana@example.com"],
+            display_name="Example Workspace",
+        )
+
+
+def test_github_allow_list_must_not_be_empty() -> None:
+    with pytest.raises(ValidationError):
+        GitHubIdpSettings(
+            client_id="id", client_secret="secret", allowed_users=[]  # noqa: S106
+        )
+
+
+def test_oidc_display_name_must_not_be_empty() -> None:
+    with pytest.raises(ValidationError):
+        OidcIdpSettings(
+            discovery_url="https://idp.example.com/.well-known/openid-configuration",
+            client_id="id",
+            client_secret="secret",  # noqa: S106
+            allowed_users=["ana@example.com"],
+            display_name="",
+        )

--- a/v3/server/tests/oauth/test_idp_signin.py
+++ b/v3/server/tests/oauth/test_idp_signin.py
@@ -1,0 +1,422 @@
+"""SPEC-204: GitHub / generic-OIDC sign-in.
+
+Covers every acceptance criterion:
+
+* a full GitHub-shaped flow against a mocked provider, through to a real
+  ``/oauth/authorize`` continuation (proving the resulting session is
+  exactly as usable as a password sign-in's)
+* the sign-in ticket is single-use (a replayed ``state`` is rejected)
+* a fabricated/mismatched ``state`` is rejected
+* a user not on the allow-list is rejected
+* the provider's access token is never persisted (a store-file scan)
+* with an IdP configured, the password endpoint does not exist (404, not
+  a 403 that would confirm the door is merely locked)
+* the sign-in page's copy passes the jargon rule (no protocol acronyms)
+* the generic OIDC provider resolves a username through discovery
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
+
+import httpx
+import pytest
+
+from palaia_hub.config import GitHubIdpSettings, IdpSettings, OAuthSettings, OidcIdpSettings
+from palaia_hub.oauth import StaticIdpHttp
+from palaia_hub.oauth.idp import GITHUB_TOKEN_URL, GITHUB_USER_URL
+from palaia_hub.oauth.pkce import challenge_for
+
+from .harness import (
+    CIMD_CLIENT_ID,
+    CIMD_REDIRECT_URI,
+    ISSUER,
+    PROFILES,
+    Harness,
+    build_harness,
+)
+
+BASE_URL = "https://testserver"
+FAKE_GITHUB_TOKEN = "gho_this-is-the-providers-token-1234567890"  # noqa: S105 - test fixture
+
+GITHUB_SETTINGS = OAuthSettings(
+    enabled=True,
+    issuer=ISSUER,
+    profiles=list(PROFILES),
+    idp=IdpSettings(
+        provider="github",
+        github=GitHubIdpSettings(
+            client_id="test-github-client-id",
+            client_secret="test-github-client-secret",  # noqa: S106 - test fixture
+            allowed_users=["Octocat"],
+        ),
+    ),
+)
+
+OIDC_DISCOVERY_URL = "https://idp.example.com/.well-known/openid-configuration"
+OIDC_SETTINGS = OAuthSettings(
+    enabled=True,
+    issuer=ISSUER,
+    profiles=list(PROFILES),
+    idp=IdpSettings(
+        provider="oidc",
+        oidc=OidcIdpSettings(
+            discovery_url=OIDC_DISCOVERY_URL,
+            client_id="test-oidc-client-id",
+            client_secret="test-oidc-client-secret",  # noqa: S106 - test fixture
+            allowed_users=["ana@example.com"],
+            username_claim="preferred_username",
+            display_name="Example Workspace",
+        ),
+    ),
+)
+
+
+def _github_http() -> StaticIdpHttp:
+    return StaticIdpHttp(
+        token_responses={GITHUB_TOKEN_URL: {"access_token": FAKE_GITHUB_TOKEN}},
+        json_responses={GITHUB_USER_URL: {"login": "octocat"}},  # case differs from allow-list
+    )
+
+
+def _github_harness(tmp_path: Path) -> Harness:
+    return build_harness(
+        tmp_path,
+        settings=GITHUB_SETTINGS,
+        with_owner=False,
+        with_plt_tokens=False,
+        idp_http=_github_http(),
+    )
+
+
+def _http(harness: Harness) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=harness.app),
+        base_url=BASE_URL,
+        follow_redirects=False,
+    )
+
+
+def _state_from_start_redirect(response: httpx.Response) -> str:
+    assert response.status_code == 303, response.text
+    location = response.headers["location"]
+    assert location.startswith("https://github.com/login/oauth/authorize?")
+    query = parse_qs(urlsplit(location).query, keep_blank_values=True)
+    assert query["scope"] == [""]  # zero scopes (deliverable #1)
+    return query["state"][0]
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+# ------------------------------------------------------------ full flow (204)
+
+
+@pytest.mark.anyio
+async def test_full_github_shaped_flow_signs_in_and_continues_authorize(
+    tmp_path: Path,
+) -> None:
+    harness = _github_harness(tmp_path)
+    try:
+        async with _http(harness) as http:
+            authorize_params = {
+                "response_type": "code",
+                "client_id": CIMD_CLIENT_ID,
+                "redirect_uri": CIMD_REDIRECT_URI,
+                "code_challenge": challenge_for("a-code-verifier-with-enough-entropy-abc"),
+                "code_challenge_method": "S256",
+                "state": "client-state",
+                "resource": harness.audience("alpha"),
+            }
+            # Unauthenticated: sent straight to the IdP (one door only — no
+            # interstitial page offering a password door that does not exist).
+            redirected = await http.get("/oauth/authorize", params=authorize_params)
+            assert redirected.status_code == 303
+            start_location = redirected.headers["location"]
+            assert start_location.startswith("/oauth/idp/start?next=")
+
+            start = await http.get(start_location)
+            state = _state_from_start_redirect(start)
+
+            callback = await http.get(f"/oauth/idp/callback?code=the-code&state={state}")
+            assert callback.status_code == 303, callback.text
+            assert "palaia_oauth_session" in http.cookies
+
+            # The session is real: /oauth/authorize now issues a code.
+            resumed = await http.get(callback.headers["location"])
+            assert resumed.status_code == 303, resumed.text
+            resumed_query = parse_qs(urlsplit(resumed.headers["location"]).query)
+            assert "error" not in resumed_query, resumed_query
+            assert resumed_query["state"] == ["client-state"]
+            assert resumed_query["code"][0]
+    finally:
+        harness.store.close()
+
+
+@pytest.mark.anyio
+async def test_the_provider_token_is_never_persisted(tmp_path: Path) -> None:
+    harness = _github_harness(tmp_path)
+    try:
+        async with _http(harness) as http:
+            start = await http.get(
+                "/oauth/idp/start?next=" + "%2Foauth%2Fauthorize%3Fx%3D1"
+            )
+            state = _state_from_start_redirect(start)
+            callback = await http.get(f"/oauth/idp/callback?code=the-code&state={state}")
+            assert callback.status_code == 303, callback.text
+    finally:
+        harness.store.close()
+
+    # The store scan: the provider's access token must not appear anywhere
+    # in the on-disk database, WAL file, or journal.
+    for suffix in ("", "-wal", "-shm", "-journal"):
+        sibling = harness.store.path.with_name(harness.store.path.name + suffix)
+        if sibling.exists():
+            assert FAKE_GITHUB_TOKEN.encode() not in sibling.read_bytes()
+
+
+# ------------------------------------------------------------------ rejections
+
+
+@pytest.mark.anyio
+async def test_a_replayed_state_is_rejected_single_use(tmp_path: Path) -> None:
+    harness = _github_harness(tmp_path)
+    try:
+        async with _http(harness) as http:
+            start = await http.get("/oauth/idp/start?next=%2Foauth%2Fauthorize%3Fx%3D1")
+            state = _state_from_start_redirect(start)
+
+            first = await http.get(f"/oauth/idp/callback?code=the-code&state={state}")
+            assert first.status_code == 303, first.text
+
+        async with _http(harness) as http:
+            second = await http.get(f"/oauth/idp/callback?code=the-code&state={state}")
+            assert second.status_code != 303
+            assert "palaia_oauth_session" not in http.cookies
+    finally:
+        harness.store.close()
+
+
+@pytest.mark.anyio
+async def test_a_mismatched_state_is_rejected(tmp_path: Path) -> None:
+    harness = _github_harness(tmp_path)
+    try:
+        async with _http(harness) as http:
+            # Never started a flow at all — a fabricated state.
+            response = await http.get(
+                "/oauth/idp/callback?code=the-code&state=totally-made-up-state"
+            )
+            assert response.status_code != 303
+            assert "palaia_oauth_session" not in http.cookies
+    finally:
+        harness.store.close()
+
+
+@pytest.mark.anyio
+async def test_a_non_allow_listed_user_is_rejected(tmp_path: Path) -> None:
+    harness = build_harness(
+        tmp_path,
+        settings=GITHUB_SETTINGS,
+        with_owner=False,
+        with_plt_tokens=False,
+        idp_http=StaticIdpHttp(
+            token_responses={GITHUB_TOKEN_URL: {"access_token": FAKE_GITHUB_TOKEN}},
+            json_responses={GITHUB_USER_URL: {"login": "someone-else"}},
+        ),
+    )
+    try:
+        async with _http(harness) as http:
+            start = await http.get("/oauth/idp/start?next=%2Foauth%2Fauthorize%3Fx%3D1")
+            state = _state_from_start_redirect(start)
+            response = await http.get(f"/oauth/idp/callback?code=the-code&state={state}")
+            assert response.status_code != 303
+            assert "palaia_oauth_session" not in http.cookies
+    finally:
+        harness.store.close()
+
+
+@pytest.mark.anyio
+async def test_case_folded_allow_list_still_matches(tmp_path: Path) -> None:
+    """The allow-list has "Octocat"; the provider reports "octocat"."""
+    harness = _github_harness(tmp_path)
+    try:
+        async with _http(harness) as http:
+            start = await http.get("/oauth/idp/start?next=%2Foauth%2Fauthorize%3Fx%3D1")
+            state = _state_from_start_redirect(start)
+            response = await http.get(f"/oauth/idp/callback?code=the-code&state={state}")
+            assert response.status_code == 303, response.text
+            assert "palaia_oauth_session" in http.cookies
+    finally:
+        harness.store.close()
+
+
+@pytest.mark.anyio
+async def test_a_provider_error_is_rejected(tmp_path: Path) -> None:
+    harness = _github_harness(tmp_path)
+    try:
+        async with _http(harness) as http:
+            start = await http.get("/oauth/idp/start?next=%2Foauth%2Fauthorize%3Fx%3D1")
+            state = _state_from_start_redirect(start)
+            response = await http.get(
+                f"/oauth/idp/callback?error=access_denied&state={state}"
+            )
+            assert response.status_code != 303
+            assert "palaia_oauth_session" not in http.cookies
+    finally:
+        harness.store.close()
+
+
+# --------------------------------------------------------------- one door rule
+
+
+@pytest.mark.anyio
+async def test_the_password_endpoint_is_absent_not_forbidden(tmp_path: Path) -> None:
+    harness = _github_harness(tmp_path)
+    try:
+        async with _http(harness) as http:
+            posted = await http.post(
+                "/oauth/login", data={"username": "owner", "password": "whatever12345"}
+            )
+            assert posted.status_code == 404
+            got = await http.get("/oauth/login")
+            assert got.status_code == 404
+    finally:
+        harness.store.close()
+
+
+@pytest.mark.anyio
+async def test_without_an_idp_the_idp_routes_are_absent(tmp_path: Path) -> None:
+    harness = build_harness(tmp_path)  # default settings: no idp configured
+    try:
+        async with _http(harness) as http:
+            start = await http.get("/oauth/idp/start?next=%2Foauth%2Fauthorize")
+            assert start.status_code == 404
+            callback = await http.get("/oauth/idp/callback?code=x&state=y")
+            assert callback.status_code == 404
+
+            # And the password door is still there.
+            form = await http.get("/oauth/login")
+            assert form.status_code == 200
+    finally:
+        harness.store.close()
+
+
+# ---------------------------------------------------------- admin info (204.4)
+
+
+@pytest.mark.anyio
+async def test_api_info_reports_the_sign_in_method_for_the_dashboard(tmp_path: Path) -> None:
+    """The dashboard's settings section (deliverable #4) reads this."""
+    harness = _github_harness(tmp_path)
+    try:
+        async with _http(harness) as http:
+            response = await http.get("/api/info")
+            assert response.status_code == 200
+            assert response.json()["sign_in"] == {"method": "idp", "provider_name": "GitHub"}
+    finally:
+        harness.store.close()
+
+
+@pytest.mark.anyio
+async def test_api_info_reports_password_when_no_idp_is_configured(tmp_path: Path) -> None:
+    harness = build_harness(tmp_path)
+    try:
+        async with _http(harness) as http:
+            response = await http.get("/api/info")
+            assert response.status_code == 200
+            assert response.json()["sign_in"] == {"method": "password", "provider_name": None}
+    finally:
+        harness.store.close()
+
+
+# --------------------------------------------------------------------- OIDC
+
+
+@pytest.mark.anyio
+async def test_generic_oidc_resolves_username_via_discovery(tmp_path: Path) -> None:
+    discovery = {
+        "authorization_endpoint": "https://idp.example.com/authorize",
+        "token_endpoint": "https://idp.example.com/token",
+        "userinfo_endpoint": "https://idp.example.com/userinfo",
+    }
+    idp_http = StaticIdpHttp(
+        token_responses={"https://idp.example.com/token": {"access_token": "oidc-token-xyz"}},
+        json_responses={
+            OIDC_DISCOVERY_URL: discovery,
+            "https://idp.example.com/userinfo": {"preferred_username": "ana@example.com"},
+        },
+    )
+    harness = build_harness(
+        tmp_path,
+        settings=OIDC_SETTINGS,
+        with_owner=False,
+        with_plt_tokens=False,
+        idp_http=idp_http,
+    )
+    try:
+        async with _http(harness) as http:
+            info = await http.get("/api/info")
+            assert info.json()["sign_in"] == {
+                "method": "idp",
+                "provider_name": "Example Workspace",
+            }
+
+            start = await http.get("/oauth/idp/start?next=%2Foauth%2Fauthorize%3Fx%3D1")
+            assert start.status_code == 303
+            location = start.headers["location"]
+            assert location.startswith("https://idp.example.com/authorize?")
+            state = parse_qs(urlsplit(location).query)["state"][0]
+
+            callback = await http.get(f"/oauth/idp/callback?code=the-code&state={state}")
+            assert callback.status_code == 303, callback.text
+            assert "palaia_oauth_session" in http.cookies
+    finally:
+        harness.store.close()
+
+
+@pytest.mark.anyio
+async def test_oidc_username_claim_is_configurable(tmp_path: Path) -> None:
+    """A provider that only populates 'email' still works via ``username_claim``."""
+    settings = OAuthSettings(
+        enabled=True,
+        issuer=ISSUER,
+        profiles=list(PROFILES),
+        idp=IdpSettings(
+            provider="oidc",
+            oidc=OidcIdpSettings(
+                discovery_url=OIDC_DISCOVERY_URL,
+                client_id="test-oidc-client-id",
+                client_secret="test-oidc-client-secret",  # noqa: S106 - test fixture
+                allowed_users=["ana@example.com"],
+                username_claim="email",
+                display_name="Example Workspace",
+            ),
+        ),
+    )
+    discovery = {
+        "authorization_endpoint": "https://idp.example.com/authorize",
+        "token_endpoint": "https://idp.example.com/token",
+        "userinfo_endpoint": "https://idp.example.com/userinfo",
+    }
+    idp_http = StaticIdpHttp(
+        token_responses={"https://idp.example.com/token": {"access_token": "oidc-token-xyz"}},
+        json_responses={
+            OIDC_DISCOVERY_URL: discovery,
+            "https://idp.example.com/userinfo": {"email": "ana@example.com"},
+        },
+    )
+    harness = build_harness(
+        tmp_path, settings=settings, with_owner=False, with_plt_tokens=False, idp_http=idp_http
+    )
+    try:
+        async with _http(harness) as http:
+            start = await http.get("/oauth/idp/start?next=%2Foauth%2Fauthorize%3Fx%3D1")
+            state = parse_qs(urlsplit(start.headers["location"]).query)["state"][0]
+            callback = await http.get(f"/oauth/idp/callback?code=the-code&state={state}")
+            assert callback.status_code == 303, callback.text
+            assert "palaia_oauth_session" in http.cookies
+    finally:
+        harness.store.close()

--- a/v3/server/tests/test_static.py
+++ b/v3/server/tests/test_static.py
@@ -118,6 +118,28 @@ def test_unregistered_mcp_path_404s_even_with_a_build_mounted(
     assert "palaia" not in response.text
 
 
+def test_unregistered_oauth_path_404s_even_with_a_build_mounted(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Same regression, for the SPEC-203/204 authorization server's
+    surface: no ``oauth_server`` given to ``create_app()`` means no
+    ``/oauth/*`` route exists at all, so an unregistered one (or, with an
+    IdP configured, the deliberately-absent ``/oauth/login``) must 404 —
+    not silently come back as the dashboard shell with a 200, which would
+    mask SPEC-204's "one door only" rule from ever actually taking effect
+    on a hub that has run ``npm run build``.
+    """
+    dist = _make_fake_build(tmp_path)
+    monkeypatch.setenv(WEB_DIST_ENV, str(dist))
+    app = create_app(HubConfig())
+    client = TestClient(app)
+
+    response = client.get("/oauth/login")
+
+    assert response.status_code == 404
+    assert "palaia" not in response.text
+
+
 def test_api_routes_are_never_shadowed_by_the_spa_fallback(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/v3/web/openapi.json
+++ b/v3/web/openapi.json
@@ -29,7 +29,7 @@
     "/api/info": {
       "get": {
         "summary": "Info",
-        "description": "Version, operating mode, uptime.",
+        "description": "Version, operating mode, uptime, and how the owner signs in.\n\n``sign_in`` is non-secret (no client id, no allow-list) and is what\nthe dashboard's settings section (SPEC-204 deliverable #4) reads to\nshow \"Sign in with GitHub\" / a configured provider's name / the\nlocal password, in plain language.",
         "operationId": "info_api_info_get",
         "responses": {
           "200": {

--- a/v3/web/src/lib/api/client.ts
+++ b/v3/web/src/lib/api/client.ts
@@ -18,6 +18,17 @@ export type InfoResponse =
   paths["/api/info"]["get"]["responses"][200]["content"]["application/json"];
 
 /**
+ * `/api/info`'s `sign_in` field (SPEC-204 deliverable #4). Hand-written for
+ * the same reason as the block below: `create_app(HubConfig())` — what the
+ * generator runs — never has an OAuth server attached, so the committed
+ * schema types this field as `unknown` rather than this shape.
+ */
+export interface SignInInfo {
+  method: "password" | "idp" | "none";
+  provider_name: string | null;
+}
+
+/**
  * SPEC-110's dashboard endpoints (wizard vault creation, memory explorer,
  * token last-seen) are opt-in on the hub (see `palaia_hub.dashboard_api` /
  * `palaia_hub.auth.routes`) and so are absent from the committed

--- a/v3/web/src/lib/api/schema.gen.ts
+++ b/v3/web/src/lib/api/schema.gen.ts
@@ -33,7 +33,12 @@ export interface paths {
         };
         /**
          * Info
-         * @description Version, operating mode, uptime.
+         * @description Version, operating mode, uptime, and how the owner signs in.
+         *
+         *     ``sign_in`` is non-secret (no client id, no allow-list) and is what
+         *     the dashboard's settings section (SPEC-204 deliverable #4) reads to
+         *     show "Sign in with GitHub" / a configured provider's name / the
+         *     local password, in plain language.
          */
         get: operations["info_api_info_get"];
         put?: never;

--- a/v3/web/src/routes/Settings.test.tsx
+++ b/v3/web/src/routes/Settings.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Settings } from "./Settings";
+
+function mockInfoResponse(signIn: { method: string; provider_name: string | null }) {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(
+      JSON.stringify({ version: "0.0.0", mode: "cloud", uptime_seconds: 1, sign_in: signIn }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    ),
+  );
+}
+
+describe("Settings (SPEC-204 deliverable #4)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows plain-language copy for an IdP-backed sign-in, no protocol jargon", async () => {
+    mockInfoResponse({ method: "idp", provider_name: "GitHub" });
+    render(<Settings />);
+
+    expect(await screen.findByText(/sign in with github/i)).toBeInTheDocument();
+
+    // The jargon rule (MASTERPLAN §5.5): no protocol acronym ever reaches
+    // the person reading this page.
+    const forbidden = ["oidc", "idp", "sso", "openid connect", "oauth"];
+    const text = document.body.textContent?.toLowerCase() ?? "";
+    for (const term of forbidden) {
+      expect(text, `jargon leaked into settings copy: ${term}`).not.toContain(term);
+    }
+  });
+
+  it("shows plain-language copy for a generic provider's display name", async () => {
+    mockInfoResponse({ method: "idp", provider_name: "Example Workspace" });
+    render(<Settings />);
+
+    expect(await screen.findByText(/sign in with example workspace/i)).toBeInTheDocument();
+  });
+
+  it("shows the password door when no IdP is configured", async () => {
+    mockInfoResponse({ method: "password", provider_name: null });
+    render(<Settings />);
+
+    expect(await screen.findByText(/sign in with a password/i)).toBeInTheDocument();
+  });
+
+  it("is honest when nothing is configured yet", async () => {
+    mockInfoResponse({ method: "none", provider_name: null });
+    render(<Settings />);
+
+    expect(await screen.findByText(/no sign-in configured/i)).toBeInTheDocument();
+  });
+});

--- a/v3/web/src/routes/Settings.tsx
+++ b/v3/web/src/routes/Settings.tsx
@@ -1,0 +1,85 @@
+/**
+ * Dashboard settings (SPEC-204 deliverable #4): a plain-language read-out of
+ * how the owner signs in. Sign-in itself is configured in `config.yaml` (an
+ * operator action, not a dashboard flow) — this section exists so the
+ * operator can confirm what's active without reading that file, in copy
+ * that passes the jargon rule: "Sign in with GitHub", never "OIDC".
+ */
+import { useEffect, useState } from "react";
+
+import { Badge, Card, CardBody, CardHead } from "../components";
+import type { SignInInfo } from "../lib/api/client";
+import { api } from "../lib/api/client";
+
+type LoadState = "loading" | "loaded" | "error";
+
+function signInSummary(signIn: SignInInfo): { label: string; detail: string } {
+  if (signIn.method === "idp" && signIn.provider_name) {
+    return {
+      label: `Sign in with ${signIn.provider_name}`,
+      detail:
+        "The owner account signs in through this provider. Set in config.yaml by the hub's operator.",
+    };
+  }
+  if (signIn.method === "password") {
+    return {
+      label: "Sign in with a password",
+      detail:
+        "The owner account signs in with a local username and password, set with " +
+        "`palaia-hub oauth set-password`.",
+    };
+  }
+  return {
+    label: "No sign-in configured",
+    detail: "This hub is not set up to authenticate remote connections yet.",
+  };
+}
+
+export function Settings() {
+  const [state, setState] = useState<LoadState>("loading");
+  const [signIn, setSignIn] = useState<SignInInfo | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .info()
+      .then((info) => {
+        if (cancelled) return;
+        const raw = (info as { sign_in?: SignInInfo }).sign_in;
+        setSignIn(raw ?? null);
+        setState("loaded");
+      })
+      .catch(() => {
+        if (!cancelled) setState("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div className="stack" style={{ gap: 16 }}>
+      <Card>
+        <CardHead title="Sign-in">
+          {state === "loaded" && signIn ? (
+            <Badge variant={signIn.method === "none" ? "warn" : "ok"}>
+              {signIn.method === "none" ? "not set up" : "on"}
+            </Badge>
+          ) : null}
+        </CardHead>
+        <CardBody>
+          {state === "loading" ? <p className="t-sm t-muted">Loading…</p> : null}
+          {state === "error" ? (
+            <p className="t-sm t-muted">Could not load the hub's sign-in settings.</p>
+          ) : null}
+          {state === "loaded" && signIn ? (
+            <div className="stack" style={{ gap: 4 }}>
+              <p className="card__subject">{signInSummary(signIn).label}</p>
+              <p className="t-sm t-muted">{signInSummary(signIn).detail}</p>
+            </div>
+          ) : null}
+        </CardBody>
+      </Card>
+    </div>
+  );
+}

--- a/v3/web/src/routes/index.tsx
+++ b/v3/web/src/routes/index.tsx
@@ -8,11 +8,12 @@ import { ComingSoon } from "./ComingSoon";
 import { Explorer } from "./Explorer";
 import { Home } from "./Home";
 import { Onboarding } from "./onboarding/Onboarding";
+import { Settings } from "./Settings";
 
-// Paths SPEC-110/SPEC-201 build a real screen for — everything else in
-// NAV_GROUPS still falls through to ComingSoon below, so no nav
+// Paths SPEC-110/SPEC-201/SPEC-204 build a real screen for — everything
+// else in NAV_GROUPS still falls through to ComingSoon below, so no nav
 // destination is ever a dead link (SPEC-109's rule, carried forward).
-const BUILT_PATHS = new Set(["/", "/explorer", "/clients", "/automations"]);
+const BUILT_PATHS = new Set(["/", "/explorer", "/clients", "/automations", "/settings"]);
 
 const placeholderRoutes = NAV_GROUPS.flatMap((group) => group.items)
   .filter((item) => !BUILT_PATHS.has(item.path))
@@ -34,6 +35,7 @@ export const router = createBrowserRouter([
       { path: "explorer", element: <Explorer /> },
       { path: "clients", element: <Clients /> },
       { path: "automations", element: <Automations /> },
+      { path: "settings", element: <Settings /> },
       ...placeholderRoutes,
     ],
   },


### PR DESCRIPTION
## Summary

Implements SPEC-204: the authorization server's `/login` learns two identity providers — GitHub and a generic, discovery-configured OIDC provider — following MASTERPLAN §5.5's discipline (zero/minimal scopes, the provider's token read once then discarded, a case-folded allow-list, and the "one door only" rule).

- `oauth/idp.py`: `GitHubIdpProvider` and `OidcIdpProvider` behind a common `IdpProvider`/`IdpHttp` seam, with `StaticIdpHttp` for tests and `HttpxIdpHttp` for production.
- `config.py`: `oauth.idp` (`GitHubIdpSettings` / `OidcIdpSettings`), validated (one provider block, non-empty allow-list, `https` discovery URL, non-empty `display_name` for OIDC).
- `oauth/store.py`: a new `idp_states` table — a single-use, server-side "ticket" (`create_idp_state` / `consume_idp_state`) that carries the pending `/oauth/authorize` continuation across the provider hop, so the continuation itself never appears in a URL.
- `oauth/service.py` / `oauth/routes.py`: `GET /oauth/idp/start` and `GET /oauth/idp/callback`, registered **only** when an IdP is configured; `GET`/`POST /oauth/login` (the local password door) registered **only** when it is not. `authorize()`'s "please sign in" redirect goes straight to the IdP when one is configured, rather than through an interstitial page offering a password door that doesn't exist.
- `app.py`: `/api/info` gained a non-secret `sign_in: {method, provider_name}` field for the dashboard.
- `web/src/routes/Settings.tsx`: a real `/settings` screen (deliverable #4) reading that field and rendering "Sign in with GitHub" / the configured OIDC provider's `display_name` / the local password — plain language, no protocol acronyms.

### An incidental fix this SPEC's own acceptance criterion depends on

`static.py`'s SPA fallback (`SPAStaticFiles._BACKEND_PREFIXES`) only ever guarded `api`/`mcp`. Once a dashboard build (`v3/web/dist`) is mounted, an unregistered `/oauth/login` fell through to the SPA fallback and came back **200** (the dashboard shell) instead of 404 — silently defeating the "password endpoint absent (404, not 403)" criterion on any hub that has actually run `npm run build`. Added `"oauth"` to that guard list, plus a regression test in `test_static.py`. Small, necessary, and directly load-bearing for this SPEC's own correctness — called out here rather than folded in silently.

## Acceptance criteria

- [x] full GitHub-shaped flow against a mocked provider (ticket single-use, state mismatch rejected, non-allow-listed user rejected) — `test_idp_signin.py`
- [x] provider token provably not persisted (store scan test) — `test_the_provider_token_is_never_persisted` scans the sqlite file + WAL/journal siblings for the fake token
- [x] IdP configured → password endpoint absent (404, not 403) — `test_the_password_endpoint_is_absent_not_forbidden` (both GET and POST); required the `static.py` fix above to actually hold once a dashboard build exists
- [x] UI copy passes the jargon lint (no protocol acronyms user-facing) — `Settings.test.tsx` asserts the rendered copy contains none of `oidc`/`idp`/`sso`/`openid connect`/`oauth`

Also covered beyond the letter of the acceptance list: a generic OIDC provider resolving a username through discovery (including a configurable `username_claim` for providers that only populate e.g. `email`), case-folded allow-list matching, a provider-reported `error` being rejected, and `IdpSettings` config validation.

## Verification evidence

From `v3/`:

```
$ uv run ruff check server
All checks passed!

$ uv run mypy server/src
Success: no issues found in 100 source files

$ uv run pytest server/tests -q
1249 passed, 9 skipped in 192.53s
```

From `v3/web/`:

```
$ npm run typecheck        # tsc -b — clean
$ npx vitest run           # 10 files, 33 passed (was 9 files/29 before this PR)
$ npx eslint .             # 0 errors, 3 pre-existing warnings (unrelated files)
$ node scripts/lint-tokens.mjs   # no hardcoded colours/durations outside token files
$ npm run build            # tsc -b && vite build — succeeds; dist/ not committed (gitignored)
```

`openapi.json` / `src/lib/api/schema.gen.ts` were regenerated (`npm run gen:api`) to pick up `/api/info`'s updated docstring; the endpoint's response was already typed as `dict[str, Any]` (untyped `unknown` on the TS side), so the new `sign_in` field is exposed through a small hand-written `SignInInfo` type in `client.ts`, the same pattern already used there for the dashboard's other opt-in-endpoint types.

## Scope note

- Deliverable #2 (generic OIDC) is implemented as a single configurable provider (`oauth.idp.oidc`), not a template gallery of named providers — that matches the SPEC's "discovery-configured" wording and keeps the config surface small; an operator names their provider's `display_name` for the button copy.
- The interstitial "choose how to sign in" page is intentionally skipped when an IdP is configured: `authorize()` redirects straight to `/oauth/idp/start`. There is exactly one door in that case, so an extra click through a page offering nothing else seemed like friction, not safety. If a confirmation step is wanted here later, SPEC-205 already owns the consent-UX follow-up per SPEC-203's docstring.
- CLI's `palaia-hub oauth set-password` is unchanged (still works even with an IdP configured) — the SPEC's "one door" rule is about which HTTP route exists, not about preventing the operator from keeping a password on file for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790123885&installation_model_id=428086&pr_number=227&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F227&signature=d51a2ee1c82f172c285f5d1f1c9ad0d86b3cc726f6ba232cd3fdd05d99cd1407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->