### PR TITLE
feat(v3): the curator — inbox to knowledge (SPEC-206)

### DIFF
--- a/v3/docs/events.md
+++ b/v3/docs/events.md
@@ -82,6 +82,23 @@ deliveries carry the same JSON as the POST body (§4).
 | `index.embed_backlog_drained` | `index` | `embedded` | The embed backlog reaches zero after a batch of work (not fired on every batch — only once the backlog is actually caught up). |
 | `doctor.finding` | `index` | `code`, `severity`, `detail` | One `verify()` finding — fired once per finding, not once per `verify()` call. |
 
+### 3.1 Curator events (SPEC-206, additive)
+
+`origin` is `curator` for all of them. Added after v1 shipped, which is
+exactly what the evolution rule in §5 is for: a consumer that has never heard
+of them ignores them.
+
+| Event | `data` | Fires when |
+|---|---|---|
+| `curator.capture.ingested` | the capture record: `capture_id`, `permalink`, `outcome`, `targets`, `attempts`, `reason`, `self_reported`, `duration_seconds` | A real vault note is verified to carry a capture's provenance line — the capture is filed and its `inbox/` entry removed. |
+| `curator.capture.needs_review` | same shape | Only a `review/` proposal carries it: a human decision is pending, and the capture is done. |
+| `curator.capture.unverified` | same shape | Nothing in the vault carries it. The capture stays, with a `- [curation-failed]` line appended. Also raises a `doctor.finding`. |
+| `curator.capture.retired` | same shape (`retired: true`) | The retry cap is reached; the capture is stamped `status: curation-failed` and will not be retried. |
+| `curator.run.finished` | `vault`, `pending`, `sessions`, `records`, `summary` | One curation pass over one vault ends (including a pass that found an empty inbox). |
+| `curator.proposal.applied` | `permalink`, `status`, `operations`, `applied`, `reason` | An approved proposal's plan ran to completion. |
+| `curator.proposal.apply_failed` | same shape | An operation failed mid-plan; the proposal is stamped `apply-failed` and a `doctor.finding` is raised. |
+| `curator.proposal.manual` | same shape | The proposal carries no executable plan (or an unparseable one) — a human has to apply it. |
+
 `health` also travels the same bus and wire format (SSE only; it is not a
 webhook-filterable v1 name — see §6) — it is the dashboard's periodic
 liveness snapshot, carried over unchanged from before this SPEC.

--- a/v3/server/README.md
+++ b/v3/server/README.md
@@ -257,6 +257,58 @@ fastmcp 3.4.7's `JWTVerifier` — which deliverable #4 requires the resource
 side to use — accepts no `EdDSA`, and reimplementing JWT validation here is
 exactly what that deliverable forbids. See `oauth/keys.py`'s module docstring.
 
+## The curator (SPEC-206)
+
+`palaia_hub.curator` is the background job that turns `inbox/` captures into
+well-placed vault knowledge. Two tiers, and the split is enforced in code, not
+in prompt text:
+
+- **INGEST is autonomous** — a new note in the right place, or additive
+  observations on an existing one.
+- **MAINTENANCE never is** — rewriting, merging, renaming or retiring an
+  existing note becomes a `review/` proposal, and a human approves it by
+  flipping its `status` to `approved`. Applying an approved proposal is plain
+  code executing the proposal's typed plan: **no model in the apply path**.
+
+The enforcement lives at the gateway. The curator connects to its own profile
+(`/mcp/curator`) with its own token, and that profile exposes only `search`,
+`read`, `list`, `recent_activity`, `build_context`, `write` and `edit`. On top
+of that, `CuratorScopeMiddleware` refuses: any `edit` that replaces a body, any
+`write` with overwrite semantics, any write into `inbox/`, any edit of an
+existing `review/` note, and any write missing the capture's provenance line
+`- [source] inbox capture <capture_id>`.
+
+Outcomes are **verified, not trusted**: after each session the runner searches
+the vault for that provenance line and classifies `ingested` /`needs_review` /
+`unverified`. Only a verified outcome deletes the inbox entry; an unverified
+one appends `- [curation-failed] <ts>: <reason>` to the capture and retires it
+after three attempts. Every outcome lands in the stash (`ops:curator.*`) and
+on the event bus (`curator.*`), and anything that did not land also raises a
+`doctor.finding`.
+
+```yaml
+# config.yaml — off by default: the curator runs a model
+curator:
+  enabled: true
+  runner_command: [claude, -p, --mcp-config, '{mcp_config}', --strict-mcp-config,
+                   --allowed-tools, '{allowed_tools}', --output-format, text]
+  debounce_seconds: 30      # a burst of captures is one pass
+  interval_seconds: 900     # fallback for captures written into inbox/ by hand
+  max_attempts: 3
+```
+
+```bash
+uv run palaia-hub curator token          # mint the curator's own token
+export PALAIA_CURATOR_TOKEN=plt_…
+uv run palaia-hub curator run            # curate everything pending, now
+uv run palaia-hub curator apply          # apply approved proposals, now
+```
+
+The runner command is provider-neutral config, not code: the prompt arrives on
+the command's stdin and `{mcp_config}`, `{allowed_tools}`, `{endpoint}`,
+`{vault}` and `{capture_id}` are substituted per session, so any CLI that
+reads a prompt from stdin works.
+
 ## Running it
 
 ```bash

--- a/v3/server/src/palaia_hub/app.py
+++ b/v3/server/src/palaia_hub/app.py
@@ -22,6 +22,7 @@ from fastapi import FastAPI, HTTPException
 from . import __version__
 from .auth import TokenRecord, TokenStore, build_auth_router, check_gateway_auth_policy
 from .config import HubConfig, load_config, palaia_home
+from .curator import CuratorScheduler
 from .dashboard_api import build_dashboard_router
 from .events import (
     EventBus,
@@ -65,6 +66,7 @@ def create_app(
     stash_service: StashService | None = None,
     hook_store: HookStore | None = None,
     hook_outbox: HookOutbox | None = None,
+    curator: CuratorScheduler | None = None,
 ) -> FastAPI:
     """Build the hub's ASGI app.
 
@@ -152,6 +154,11 @@ def create_app(
             every matching, enabled hook. Omitted (the default), the hub
             publishes events on its bus same as always, just with no
             webhook consumer attached.
+        curator: the SPEC-206 curator scheduler. Given, it is started with
+            this app and stopped with it — the curator is a hook-driven
+            automation living inside the hub, not a second daemon (MASTERPLAN
+            §5.1). Omitted (the default), no curation ever runs from this
+            process; ``palaia-hub curator run`` still works on demand.
         hook_outbox: the durable delivery queue backing ``hook_store``.
             Defaults to :class:`~palaia_hub.hooks.HookOutbox` at its
             standard path under the hub's data directory when ``hook_store``
@@ -235,6 +242,8 @@ def create_app(
             await dynamic_gateway.start()
         if dispatcher is not None:
             tasks.append(asyncio.create_task(dispatcher.run_forever()))
+        if curator is not None:
+            await curator.start()
         publish_event(
             event_bus,
             "hub.started",
@@ -250,6 +259,8 @@ def create_app(
                 yield
         finally:
             await stop_background_tasks(tasks)
+            if curator is not None:
+                await curator.aclose()
             if dynamic_gateway is not None:
                 await dynamic_gateway.aclose()
             if indexes is not None:

--- a/v3/server/src/palaia_hub/cli.py
+++ b/v3/server/src/palaia_hub/cli.py
@@ -19,7 +19,11 @@ from pathlib import Path
 import uvicorn
 
 from .auth import TokenError, TokenStore
+from .auth.scopes import vault_scope
 from .config import ConfigError, HubConfig, load_config, palaia_home
+from .curator import CURATOR_PROFILE_PATH, ApplyReport, CuratorRunReport, ProposalApplier
+from .curator.wiring import TOKEN_ENV, CuratorWiring, build_curator
+from .gateway.config import VaultMountConfig
 from .importers import ImportReport, ImportRunner, v2_source
 from .importers import basic_memory_source as bm_source
 from .index import VaultIndex, embed_progress
@@ -65,6 +69,7 @@ def _build_parser() -> argparse.ArgumentParser:
     revoke_parser.add_argument("token_id", help="Token id, from 'token list'")
 
     _add_oauth_parser(subparsers)
+    _add_curator_parser(subparsers)
 
     import_parser = subparsers.add_parser("import", help="Import notes from another store")
     import_subparsers = import_parser.add_subparsers(dest="import_source", required=True)
@@ -114,6 +119,46 @@ def _add_oauth_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPa
 
     oauth_subparsers.add_parser("clients", help="List registered clients (no secrets shown)")
     oauth_subparsers.add_parser("gc", help="Prune orphaned registered clients now")
+
+
+def _add_curator_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """The ``palaia-hub curator ...`` surface (SPEC-206).
+
+    ``run`` and ``apply`` are the same two passes the hub runs on a schedule
+    when ``curator.enabled`` is on — exposed as commands so an operator can
+    curate on demand, and so the curator is usable at all on a hub that
+    would rather not run a background job.
+    """
+    curator_parser = subparsers.add_parser("curator", help="Curate the inbox into the vault")
+    curator_subparsers = curator_parser.add_subparsers(dest="curator_command", required=True)
+
+    run_parser = curator_subparsers.add_parser(
+        "run", help="Curate every pending inbox capture once"
+    )
+    _add_curator_common_args(run_parser)
+
+    apply_parser = curator_subparsers.add_parser(
+        "apply", help="Apply approved review/ proposals (no model involved)"
+    )
+    _add_curator_common_args(apply_parser)
+
+    token_parser = curator_subparsers.add_parser(
+        "token", help="Mint the curator's own token, bound to the curator profile"
+    )
+    token_parser.add_argument(
+        "--name", default="curator", help="Human-readable name for the token"
+    )
+
+
+def _add_curator_common_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--vault",
+        dest="vaults",
+        action="append",
+        default=[],
+        help="Vault to work on; repeatable. Default: every registered vault.",
+    )
+    parser.add_argument("--json", action="store_true", help="Print the report as JSON")
 
 
 def _add_import_args(parser: argparse.ArgumentParser) -> None:
@@ -327,6 +372,94 @@ def _token_revoke(token_id: str) -> None:
     print(f"Revoked token {info.id!r} ({info.name!r}).")
 
 
+async def _curator_context(
+    vault_keys: Sequence[str],
+) -> tuple[CuratorWiring, dict[str, VaultEngine]]:
+    """Open the requested vaults (all of them by default) and wire the curator."""
+    config = load_config()
+    registry = VaultRegistry()
+    names = list(vault_keys) or sorted(registry.names())
+    engines: dict[str, VaultEngine] = {}
+    mounts: list[VaultMountConfig] = []
+    for name in names:
+        engine = await registry.get(name)
+        engines[name] = engine
+        mounts.append(
+            VaultMountConfig(
+                key=name,
+                name=name,
+                purpose=engine.info().purpose or "A palaia memory vault.",
+            )
+        )
+    return build_curator(config, engines, mounts, home=palaia_home()), engines
+
+
+async def _run_curator(vault_keys: Sequence[str]) -> list[CuratorRunReport]:
+    wiring, _engines = await _curator_context(vault_keys)
+    try:
+        return [await runner.run_once() for runner in wiring.runners.values()]
+    finally:
+        await wiring.aclose()
+
+
+async def _run_curator_apply(vault_keys: Sequence[str]) -> list[ApplyReport]:
+    wiring, engines = await _curator_context(vault_keys)
+    try:
+        # `curator.auto_apply: false` means "do not apply on the schedule",
+        # never "do not apply when asked" — an explicit `curator apply` is
+        # exactly the asking.
+        appliers = wiring.appliers or {
+            key: ProposalApplier(engine) for key, engine in engines.items()
+        }
+        return [await applier.run_once() for applier in appliers.values()]
+    finally:
+        await wiring.aclose()
+
+
+def _curator_run(args: argparse.Namespace) -> None:
+    reports = asyncio.run(_run_curator(args.vaults))
+    if args.json:
+        print(json.dumps([report.model_dump() for report in reports], indent=2))
+        return
+    if not reports:
+        print("No vaults to curate. Create one first (`palaia-hub serve`, then the wizard).")
+        return
+    for report in reports:
+        print(report.summary())
+
+
+def _curator_apply(args: argparse.Namespace) -> None:
+    reports = asyncio.run(_run_curator_apply(args.vaults))
+    if args.json:
+        print(json.dumps([report.model_dump() for report in reports], indent=2))
+        return
+    for report in reports:
+        print(report.summary())
+
+
+def _curator_token(name: str) -> None:
+    """Mint a token bound to the curator profile, with every vault's scopes.
+
+    The curator needs read *and* write on every vault it curates — the
+    narrowing that makes it safe is its profile's tool surface (SPEC-206 rule
+    2), not a thinner scope set.
+    """
+    store = TokenStore()
+    scopes = [
+        scope
+        for key in sorted(VaultRegistry().names())
+        for scope in (vault_scope(key, "read"), vault_scope(key, "write"))
+    ]
+    try:
+        created = store.create(name, CURATOR_PROFILE_PATH, scopes)
+    except TokenError as exc:
+        print(f"palaia-hub: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    print(f"Created curator token {created.info.id!r} (profile={CURATOR_PROFILE_PATH!r}).")
+    print("Copy it now — it will not be shown again, and put it in the environment:")
+    print(f"  export {TOKEN_ENV}={created.token}")
+
+
 async def _open_engine_and_index(
     vault_root: str, vault_name: str, *, dry_run: bool
 ) -> tuple[VaultEngine, VaultIndex | None]:
@@ -431,6 +564,13 @@ def main(argv: Sequence[str] | None = None) -> None:
             _oauth_clients()
         elif args.oauth_command == "gc":
             _oauth_gc()
+    elif args.command == "curator":
+        if args.curator_command == "run":
+            _curator_run(args)
+        elif args.curator_command == "apply":
+            _curator_apply(args)
+        elif args.curator_command == "token":
+            _curator_token(args.name)
     elif args.command == "import":
         if args.import_source == "v2":
             _import_v2(args)

--- a/v3/server/src/palaia_hub/config.py
+++ b/v3/server/src/palaia_hub/config.py
@@ -19,6 +19,24 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_valida
 
 APP_NAME = "palaia-hub"
 
+# The default curator runner command, duplicated here as a plain tuple rather
+# than imported from palaia_hub.curator.session: this module must stay
+# importable without pulling in the curator package (which imports the
+# gateway, which imports fastmcp) — config load happens first, always.
+# palaia_hub.curator.session.DEFAULT_RUNNER_COMMAND is the same list, and a
+# test asserts the two never drift apart.
+_DEFAULT_CURATOR_COMMAND: tuple[str, ...] = (
+    "claude",
+    "-p",
+    "--mcp-config",
+    "{mcp_config}",
+    "--strict-mcp-config",
+    "--allowed-tools",
+    "{allowed_tools}",
+    "--output-format",
+    "text",
+)
+
 _ENV_PREFIX = "PALAIA_"
 
 # The config keys that may be overridden by PALAIA_<KEY> env vars. Kept as an
@@ -126,6 +144,45 @@ oauth:
   # MCP profile paths this server issues audience-scoped tokens for. Must
   # match the gateway's profile paths.
   profiles: []
+
+# The curator (SPEC-206): the background job that turns inbox captures into
+# well-placed vault notes. Off by default — it runs a model, which costs
+# money. Adding knowledge is autonomous; rewriting, merging or retiring an
+# existing note is never autonomous, it becomes a proposal in review/ that
+# you approve by flipping its `status` to `approved`.
+curator:
+  enabled: false
+  # The command that runs one curation session. The prompt arrives on the
+  # command's stdin; {mcp_config}, {allowed_tools}, {endpoint}, {vault} and
+  # {capture_id} are filled in per session. Any CLI that reads a prompt from
+  # stdin works here — this is not tied to one provider.
+  runner_command:
+    - claude
+    - -p
+    - --mcp-config
+    - '{mcp_config}'
+    - --strict-mcp-config
+    - --allowed-tools
+    - '{allowed_tools}'
+    - --output-format
+    - text
+  # Seconds one session may take before it is killed.
+  session_timeout: 300
+  # Wait this long after a capture arrives, so a burst becomes one pass.
+  debounce_seconds: 30
+  # Fallback pass interval, for captures written into inbox/ by hand.
+  interval_seconds: 900
+  # Attempts before a capture is left alone with `status: curation-failed`.
+  max_attempts: 3
+  # Apply approved proposals in the same pass (no model is ever involved in
+  # applying one). Turn off to apply them yourself with
+  # `palaia-hub curator apply`.
+  auto_apply: true
+  # The curator's own token, from `palaia-hub curator token`. Prefer the
+  # PALAIA_CURATOR_TOKEN environment variable over writing it here.
+  # token:
+  # Where a session reaches this hub. Defaults to http://<host>:<port>.
+  # endpoint:
 """
 
 
@@ -244,6 +301,53 @@ class OAuthSettings(BaseModel):
     profiles: list[str] = Field(default_factory=list)
 
 
+class CuratorSettings(BaseModel):
+    """The curator's settings (SPEC-206).
+
+    ``enabled`` is off by default: the curator spends money. Turning it on
+    mounts the curator MCP profile (``/mcp/curator``, narrowed and guarded —
+    see :mod:`palaia_hub.curator.profile`) and starts the scheduled runner.
+
+    ``runner_command`` is the provider-neutral seam the SPEC requires: the
+    default is a headless ``claude -p`` reading its prompt from stdin, but
+    any CLI that does the same works. Placeholders ``{mcp_config}``,
+    ``{allowed_tools}``, ``{endpoint}``, ``{vault}`` and ``{capture_id}`` are
+    substituted per session (:class:`palaia_hub.curator.session.
+    SubprocessSessionRunner`).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    #: The command that runs one curation session. See the class docstring.
+    runner_command: list[str] = Field(
+        default_factory=lambda: list(_DEFAULT_CURATOR_COMMAND)
+    )
+    #: Seconds a single session may take before it is killed.
+    session_timeout: float = Field(default=300.0, gt=0.0, le=3600.0)
+    #: Seconds to wait after an ``inbox.captured`` event, so a burst of
+    #: captures coalesces into one curation pass.
+    debounce_seconds: float = Field(default=30.0, ge=0.0, le=3600.0)
+    #: Seconds between fallback passes when no event arrives (captures
+    #: written into ``inbox/`` by hand produce no event).
+    interval_seconds: float = Field(default=900.0, ge=60.0)
+    #: Attempts before a capture is retired with ``status: curation-failed``.
+    max_attempts: int = Field(default=3, ge=1, le=10)
+    #: Apply approved proposals automatically in the same pass. The apply
+    #: path has no model in it (SPEC-206 rule 4), so this only decides *when*
+    #: an approved proposal is executed, never *whether* a human approved it.
+    auto_apply: bool = True
+    #: The curator token (profile ``curator``). Prefer the
+    #: ``PALAIA_CURATOR_TOKEN`` environment variable — a token in a config
+    #: file is a secret in a config file. Mint one with
+    #: ``palaia-hub curator token``.
+    token: str | None = None
+    #: The base URL a curation session reaches this hub at. Defaults to
+    #: ``http://<host>:<port>`` from the settings above, which is right for
+    #: the normal case (the session runs on the same machine as the hub).
+    endpoint: str | None = None
+
+
 class HubConfig(BaseModel):
     """Validated hub configuration, merged from defaults/file/env."""
 
@@ -258,6 +362,15 @@ class HubConfig(BaseModel):
     auth_enabled: bool = True
     recall: RecallSettings = Field(default_factory=RecallSettings)
     oauth: OAuthSettings = Field(default_factory=OAuthSettings)
+    curator: CuratorSettings = Field(default_factory=CuratorSettings)
+
+    def curator_endpoint(self) -> str:
+        """The base URL a curation session reaches this hub at (SPEC-206)."""
+        configured = (self.curator.endpoint or "").strip().rstrip("/")
+        if configured:
+            return configured
+        host = "127.0.0.1" if self.host in ("0.0.0.0", "::") else self.host
+        return f"http://{host}:{self.port}"
 
     @model_validator(mode="after")
     def _check_operating_mode_policy(self) -> HubConfig:

--- a/v3/server/src/palaia_hub/curator/__init__.py
+++ b/v3/server/src/palaia_hub/curator/__init__.py
@@ -1,0 +1,102 @@
+"""The curator (SPEC-206): inbox captures become vault knowledge.
+
+The asynchronous half of palaia's two write paths (MASTERPLAN §5.1). An
+agent drops a capture mid-work; later, unattended, the curator turns that
+capture into a well-placed note — or, when placing it would mean rewriting
+what already exists, into a ``review/`` proposal a human approves.
+
+The package's shape follows the policy, which is fixed in the SPEC:
+
+- :mod:`~palaia_hub.curator.policy` — the binding rules as pure functions
+  (the tool surface, the write guards, the provenance requirement).
+- :mod:`~palaia_hub.curator.middleware` / :mod:`~palaia_hub.curator.profile`
+  — where those rules are enforced: the curator's own gateway profile.
+- :mod:`~palaia_hub.curator.prompt` — the SPEC's role block, plus the
+  vault's own ``meta/curation.md`` rules and the capture itself.
+- :mod:`~palaia_hub.curator.session` — how one bounded session is launched
+  (a config-driven, provider-neutral command).
+- :mod:`~palaia_hub.curator.verify` / :mod:`~palaia_hub.curator.runner` —
+  verification instead of trust, retries, and retirement.
+- :mod:`~palaia_hub.curator.apply` — approved proposals, applied by plain
+  code with no model in the path.
+- :mod:`~palaia_hub.curator.service` — when it all runs (events, debounced,
+  plus an interval fallback).
+"""
+
+from __future__ import annotations
+
+from .apply import PlanError, ProposalApplier, parse_plan
+from .audit import CuratorAudit
+from .middleware import CuratorScopeMiddleware
+from .models import (
+    ApplyReport,
+    CaptureRecord,
+    CuratorRunReport,
+    PendingCapture,
+    Plan,
+    ProposalResult,
+    SelfReport,
+    SessionResult,
+    parse_self_report,
+)
+from .policy import (
+    CURATOR_TOOL_ACTIONS,
+    PROVENANCE_PREFIX,
+    ActiveCaptures,
+    provenance_line,
+    rejection_for,
+)
+from .profile import (
+    CURATOR_PROFILE_PATH,
+    allowed_tool_specs,
+    curator_profile,
+    curator_profile_middleware,
+    curator_tool_actions,
+)
+from .prompt import ROLE_BLOCK, build_prompt
+from .runner import CuratorRunner
+from .service import CuratorScheduler
+from .session import (
+    DEFAULT_RUNNER_COMMAND,
+    SessionRequest,
+    SessionRunner,
+    SubprocessSessionRunner,
+)
+from .verify import Verification, verify_capture
+
+__all__ = [
+    "CURATOR_PROFILE_PATH",
+    "CURATOR_TOOL_ACTIONS",
+    "DEFAULT_RUNNER_COMMAND",
+    "PROVENANCE_PREFIX",
+    "ROLE_BLOCK",
+    "ActiveCaptures",
+    "ApplyReport",
+    "CaptureRecord",
+    "CuratorAudit",
+    "CuratorRunReport",
+    "CuratorRunner",
+    "CuratorScheduler",
+    "CuratorScopeMiddleware",
+    "PendingCapture",
+    "Plan",
+    "PlanError",
+    "ProposalApplier",
+    "ProposalResult",
+    "SelfReport",
+    "SessionRequest",
+    "SessionResult",
+    "SessionRunner",
+    "SubprocessSessionRunner",
+    "Verification",
+    "allowed_tool_specs",
+    "build_prompt",
+    "curator_profile",
+    "curator_profile_middleware",
+    "curator_tool_actions",
+    "parse_plan",
+    "parse_self_report",
+    "provenance_line",
+    "rejection_for",
+    "verify_capture",
+]

--- a/v3/server/src/palaia_hub/curator/apply.py
+++ b/v3/server/src/palaia_hub/curator/apply.py
@@ -1,0 +1,313 @@
+"""Deterministic apply: approved proposals, executed by plain code (rule 4).
+
+**No model is in this path.** A human flips a ``review/`` proposal's
+``status`` to ``approved`` (in Obsidian, in the dashboard, or in the future
+review-queue app — all three edit the same frontmatter field, format spec
+§8), and this module executes the typed plan the proposal carries:
+
+- the plan is a fenced ```json block (info string ``json plan``; a lone
+  ```json block in the proposal is accepted too) parsed into
+  :class:`~palaia_hub.curator.models.Plan`;
+- every note the plan touches gets its **pre-image appended to the
+  proposal** before anything is written, so the state before the change is
+  recorded in the vault itself, not only in git;
+- operations run in order through the vault engine — every one of them an
+  attributed git commit, like any other engine write;
+- **every exit path stamps a terminal status**: ``applied`` when the whole
+  plan ran, ``apply-failed`` when an operation failed (with the reason
+  appended to the proposal), ``manual`` when there is no machine-executable
+  plan to run at all.
+
+A proposal is never left in ``approved`` by a run that touched it: that is
+what would make an apply pass silently repeat itself forever.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from pydantic import ValidationError
+
+from ..vault import Note, VaultEngine, VaultError
+from .audit import CuratorAudit
+from .models import (
+    AppendOp,
+    ApplyReport,
+    MergeOp,
+    MoveOp,
+    Plan,
+    PlanOperation,
+    ProposalResult,
+    ProposalStatus,
+    ReplaceBodyOp,
+    RetireOp,
+    RetitleOp,
+)
+
+logger = logging.getLogger("palaia_hub.curator.apply")
+
+#: The status a human sets to queue a proposal for this pass (format spec §8).
+APPROVED_STATUS = "approved"
+
+#: Appended to a proposal when its apply run fails — additive, like every
+#: other failure record in the vault.
+APPLY_FAILED_PREFIX = "- [apply-failed] "
+
+_PLAN_FENCE_RE = re.compile(
+    r"^```[ \t]*json[ \t]*(?P<label>[A-Za-z0-9_-]*)[ \t]*\n(?P<body>.*?)^```",
+    re.DOTALL | re.MULTILINE,
+)
+
+
+class PlanError(ValueError):
+    """The proposal carries a plan block, but not one that can be executed."""
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def parse_plan(body: str) -> Plan | None:
+    """The proposal's typed plan, or ``None`` when it carries none.
+
+    Raises:
+        PlanError: a plan block is present but is not valid JSON, or names an
+            operation this apply pass does not implement. That is a
+            ``manual`` outcome, never a silent skip — the human who wrote
+            the plan needs to hear about it.
+    """
+    blocks = [
+        (match.group("label"), match.group("body")) for match in _PLAN_FENCE_RE.finditer(body or "")
+    ]
+    labelled = [text for label, text in blocks if label == "plan"]
+    candidates = labelled or [text for label, text in blocks if not label]
+    if not candidates:
+        return None
+    if len(candidates) > 1:
+        raise PlanError(
+            f"the proposal carries {len(candidates)} plan blocks; exactly one is "
+            "executable. Fix: keep one ```json plan block."
+        )
+    try:
+        payload = json.loads(candidates[0])
+    except json.JSONDecodeError as exc:
+        raise PlanError(f"the plan block is not valid JSON ({exc})") from exc
+    if not isinstance(payload, dict):
+        raise PlanError("the plan block must be a JSON object with an 'operations' list")
+    try:
+        return Plan.model_validate(payload)
+    except ValidationError as exc:
+        raise PlanError(
+            f"the plan's operations are not valid ({exc.error_count()} problem(s))"
+        ) from exc
+
+
+def render_pre_images(notes: Mapping[str, Note]) -> str:
+    """The pre-image section appended to a proposal before it is applied."""
+    lines = [f"## Pre-images ({_now_iso()})", ""]
+    for reference, note in notes.items():
+        lines.append(f"### `{reference}` — {note.path}")
+        lines.append("")
+        lines.append("````markdown")
+        lines.append(note.text.rstrip("\n"))
+        lines.append("````")
+        lines.append("")
+    return "\n".join(lines)
+
+
+class ProposalApplier:
+    """Applies a vault's approved proposals, one deterministic pass."""
+
+    def __init__(self, engine: VaultEngine, *, audit: CuratorAudit | None = None) -> None:
+        self._engine = engine
+        self._audit = audit or CuratorAudit()
+
+    async def approved_proposals(self) -> list[Note]:
+        """``review/`` notes with ``type: proposal`` and ``status: approved``."""
+        await self._engine.refresh()
+        found: list[Note] = []
+        for entry in sorted(self._engine.catalog.values(), key=lambda e: e.path):
+            if not entry.path.startswith("review/"):
+                continue
+            try:
+                note = await self._engine.read_note(entry.path)
+            except VaultError:  # pragma: no cover - unreadable note, skip it
+                logger.warning("curator apply: could not read %s", entry.path)
+                continue
+            frontmatter = note.frontmatter
+            if str(frontmatter.get("type", "note")) != "proposal":
+                continue
+            if str(frontmatter.get("status") or "") != APPROVED_STATUS:
+                continue
+            found.append(note)
+        return found
+
+    async def run_once(self) -> ApplyReport:
+        proposals = await self.approved_proposals()
+        report = ApplyReport(vault=self._engine.name, approved=len(proposals))
+        for proposal in proposals:
+            result = await self.apply(proposal)
+            report.results.append(result)
+            await self._audit.proposal(result)
+        await self._audit.apply_pass(report)
+        return report
+
+    async def apply(self, proposal: Note) -> ProposalResult:
+        """Apply one proposal; always leaves it in a terminal status."""
+        permalink = proposal.permalink or proposal.path
+        try:
+            plan = parse_plan(proposal.body)
+        except PlanError as exc:
+            return await self._finish(proposal, "manual", reason=str(exc))
+        if plan is None or not plan.operations:
+            return await self._finish(
+                proposal,
+                "manual",
+                reason=(
+                    "no executable plan block — this proposal has to be applied by "
+                    "hand, then marked applied"
+                ),
+            )
+
+        try:
+            await self._append_pre_images(proposal, plan)
+        except VaultError as exc:
+            return await self._finish(
+                proposal,
+                "apply-failed",
+                reason=f"could not record pre-images, so nothing was applied ({exc})",
+                operations=len(plan.operations),
+            )
+
+        applied = 0
+        for operation in plan.operations:
+            try:
+                await self._execute(operation)
+            except (VaultError, ValueError) as exc:
+                logger.warning(
+                    "curator apply: %s failed on %s: %s", permalink, operation.op, exc
+                )
+                return await self._finish(
+                    proposal,
+                    "apply-failed",
+                    reason=(
+                        f"operation {applied + 1} of {len(plan.operations)} "
+                        f"({operation.op}) failed: {exc}"
+                    ),
+                    operations=len(plan.operations),
+                    applied=applied,
+                )
+            applied += 1
+        return await self._finish(
+            proposal, "applied", operations=len(plan.operations), applied=applied
+        )
+
+    # ------------------------------------------------------------- internals
+
+    async def _append_pre_images(self, proposal: Note, plan: Plan) -> None:
+        pre_images: dict[str, Note] = {}
+        for reference in plan.targets():
+            try:
+                pre_images[reference] = await self._engine.read_note(reference)
+            except VaultError:
+                # A plan may legitimately name a note that does not exist yet
+                # (an op that creates one); there is no pre-image to record.
+                continue
+        if not pre_images:
+            return
+        current = await self._engine.read_note(proposal.path)
+        body = f"{current.body.rstrip(chr(10))}\n\n{render_pre_images(pre_images)}"
+        await self._engine.edit_note(
+            proposal.path, body=body, expected_checksum=current.checksum
+        )
+
+    async def _execute(self, operation: PlanOperation) -> None:
+        if isinstance(operation, AppendOp):
+            await self._append(operation.target, operation.text)
+        elif isinstance(operation, ReplaceBodyOp):
+            note = await self._engine.read_note(operation.target)
+            await self._engine.edit_note(
+                operation.target, body=operation.body, expected_checksum=note.checksum
+            )
+        elif isinstance(operation, RetitleOp):
+            note = await self._engine.read_note(operation.target)
+            await self._engine.edit_note(
+                operation.target, title=operation.title, expected_checksum=note.checksum
+            )
+        elif isinstance(operation, MoveOp):
+            note = await self._engine.read_note(operation.target)
+            filename = note.path.rsplit("/", 1)[-1]
+            folder = operation.folder.strip("/")
+            await self._engine.move_note(
+                operation.target, f"{folder}/{filename}" if folder else filename
+            )
+        elif isinstance(operation, RetireOp):
+            await self._engine.delete_note(operation.target)
+        elif isinstance(operation, MergeOp):
+            source = await self._engine.read_note(operation.source)
+            await self._append(
+                operation.target,
+                f"\n## Merged from {source.title}\n\n{source.body.strip()}",
+            )
+            await self._engine.delete_note(operation.source)
+
+    async def _append(self, reference: str, text: str) -> None:
+        note = await self._engine.read_note(reference)
+        body = f"{note.body.rstrip(chr(10))}\n{text}\n"
+        await self._engine.edit_note(reference, body=body, expected_checksum=note.checksum)
+
+    async def _finish(
+        self,
+        proposal: Note,
+        status: ProposalStatus,
+        *,
+        reason: str = "",
+        operations: int = 0,
+        applied: int = 0,
+    ) -> ProposalResult:
+        """Stamp the terminal status on ``proposal`` and build the result.
+
+        Runs even when the vault refuses the stamp: the caller still learns
+        what happened, and a failed stamp is logged rather than swallowed —
+        but it never turns a successful apply into a reported failure.
+        """
+        permalink = proposal.permalink or proposal.path
+        frontmatter: dict[str, Any] = {"status": status}
+        try:
+            current = await self._engine.read_note(proposal.path)
+            body = current.body
+            if status == "apply-failed" and reason:
+                body = f"{body.rstrip(chr(10))}\n{APPLY_FAILED_PREFIX}{_now_iso()}: {reason}\n"
+            await self._engine.edit_note(
+                proposal.path,
+                body=body,
+                frontmatter=frontmatter,
+                expected_checksum=current.checksum,
+            )
+        except VaultError:
+            logger.exception(
+                "curator apply: could not stamp status %r on %s", status, permalink
+            )
+        return ProposalResult(
+            vault=self._engine.name,
+            permalink=permalink,
+            status=status,
+            operations=operations,
+            applied=applied,
+            reason=reason,
+        )
+
+
+__all__ = [
+    "APPLY_FAILED_PREFIX",
+    "APPROVED_STATUS",
+    "PlanError",
+    "ProposalApplier",
+    "parse_plan",
+    "render_pre_images",
+]

--- a/v3/server/src/palaia_hub/curator/audit.py
+++ b/v3/server/src/palaia_hub/curator/audit.py
@@ -1,0 +1,151 @@
+"""The curator's audit trail (SPEC-206 deliverable #4).
+
+Every outcome lands in two places, both optional and both write-only from
+here:
+
+- **the stash** (``ops:curator.*``, SPEC-202) — the durable record: what
+  happened to a capture, and when. Keyed per capture / per proposal / per
+  run, so the last outcome for anything is one ``stash_get`` away.
+- **the event bus** (SPEC-201) — ``curator.*`` envelopes for whoever is
+  listening (the dashboard, a webhook, the future review-queue app).
+
+Plus one rule that is not bookkeeping but the point: a capture the runner
+could **not** verify also raises a ``doctor.finding`` — the hub's existing
+"something needs a human" channel — so an inbox quietly filling up with
+captures no session can land becomes visible without anyone reading logs.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any, Protocol
+
+from .models import ApplyReport, CaptureRecord, CuratorRunReport, ProposalResult
+
+logger = logging.getLogger("palaia_hub.curator.audit")
+
+#: ``publish(event_name, data)`` — the same narrow hook shape the rest of the
+#: hub reports events through (:data:`palaia_hub.events.schema.HubEventHook`).
+Publisher = Callable[[str, dict[str, Any]], None]
+
+#: The stash namespace and key prefix the SPEC fixes: ``ops:curator.*``.
+STASH_NAMESPACE = "ops"
+STASH_PREFIX = "curator"
+
+
+class StashLike(Protocol):
+    """Just the one stash call the audit needs (:class:`palaia_hub.stash.StashService`)."""
+
+    async def set(  # noqa: A003 - mirrors StashService.set exactly
+        self,
+        namespace: str,
+        key: str,
+        value: Any,
+        *,
+        ttl_seconds: float | None = ...,
+        stale_after_seconds: float | None = ...,
+    ) -> Any: ...
+
+
+class CuratorAudit:
+    """Records curator outcomes to the stash and the event bus.
+
+    Both sinks are optional: a runner built with neither still runs, still
+    curates and still reports to its caller — it just leaves no trail. That
+    is what keeps the runner testable without a SQLite file or a bus.
+    """
+
+    def __init__(
+        self, *, publish: Publisher | None = None, stash: StashLike | None = None
+    ) -> None:
+        self._publish = publish
+        self._stash = stash
+
+    # ------------------------------------------------------------------ sinks
+
+    def _emit(self, event: str, data: dict[str, Any]) -> None:
+        if self._publish is None:
+            return
+        try:
+            self._publish(event, data)
+        except Exception:  # noqa: BLE001 - audit must never break a run
+            logger.exception("curator event publish failed", extra={"event": event})
+
+    async def _store(self, key: str, value: dict[str, Any]) -> None:
+        if self._stash is None:
+            return
+        try:
+            await self._stash.set(STASH_NAMESPACE, f"{STASH_PREFIX}.{key}", value)
+        except Exception:  # noqa: BLE001 - audit must never break a run
+            logger.exception("curator stash write failed", extra={"key": key})
+
+    # ---------------------------------------------------------------- records
+
+    async def capture(self, record: CaptureRecord) -> None:
+        """Record one capture's outcome; unverified also raises a finding."""
+        data = record.model_dump()
+        self._emit(f"curator.capture.{record.outcome}", data)
+        await self._store(f"capture.{record.capture_id}", data)
+        if record.retired:
+            self._emit("curator.capture.retired", data)
+        if record.outcome == "unverified":
+            self._emit(
+                "doctor.finding",
+                {
+                    "vault": record.vault,
+                    "permalink": record.permalink,
+                    "code": "curation-unverified",
+                    "severity": "error" if record.retired else "warning",
+                    "detail": (
+                        f"capture {record.capture_id} was not verified in the vault "
+                        f"after attempt {record.attempts}: {record.reason}"
+                    ),
+                    "fix": (
+                        "curate it by hand, or fix what stopped the curator and let "
+                        "the next run retry it"
+                        if not record.retired
+                        else "this capture is retired (status: curation-failed) and "
+                        "will not be retried — curate it by hand"
+                    ),
+                },
+            )
+
+    async def run(self, report: CuratorRunReport) -> None:
+        data = report.model_dump()
+        data["summary"] = report.summary()
+        self._emit("curator.run.finished", {"vault": report.vault, **data})
+        await self._store(f"run.{report.vault}", data)
+
+    async def proposal(self, result: ProposalResult) -> None:
+        data = result.model_dump()
+        event = {
+            "applied": "curator.proposal.applied",
+            "apply-failed": "curator.proposal.apply_failed",
+            "manual": "curator.proposal.manual",
+        }[result.status]
+        self._emit(event, data)
+        await self._store(f"proposal.{result.permalink}", data)
+        if result.status == "apply-failed":
+            self._emit(
+                "doctor.finding",
+                {
+                    "vault": result.vault,
+                    "permalink": result.permalink,
+                    "code": "proposal-apply-failed",
+                    "severity": "error",
+                    "detail": f"applying the approved proposal failed: {result.reason}",
+                    "fix": (
+                        "read the proposal's pre-images, finish or revert the change "
+                        "by hand, then set its status to applied or rejected"
+                    ),
+                },
+            )
+
+    async def apply_pass(self, report: ApplyReport) -> None:
+        data = report.model_dump()
+        data["summary"] = report.summary()
+        await self._store(f"apply.{report.vault}", data)
+
+
+__all__ = ["STASH_NAMESPACE", "STASH_PREFIX", "CuratorAudit", "Publisher", "StashLike"]

--- a/v3/server/src/palaia_hub/curator/middleware.py
+++ b/v3/server/src/palaia_hub/curator/middleware.py
@@ -1,0 +1,118 @@
+"""The curator-scope middleware: policy enforcement at the gateway (SPEC-206).
+
+One fastmcp :class:`~fastmcp.server.middleware.Middleware`, attached to the
+curator profile's own :class:`~fastmcp.FastMCP` server (see
+:mod:`palaia_hub.curator.profile`), doing two things and nothing else:
+
+1. **Narrows the tool surface.** ``tools/list`` on a curator profile returns
+   only the actions in :data:`~palaia_hub.curator.policy.CURATOR_TOOL_ACTIONS`,
+   and a ``tools/call`` for anything else is refused — even though the vault
+   tool server mounted underneath is the very same object the ordinary
+   profile mounts. Sharing that object is what keeps one definition of each
+   tool; the profile's own middleware is what makes the *profile* narrower.
+2. **Applies the per-call guards** of :func:`~palaia_hub.curator.policy.
+   rejection_for` — replacing operations, overwrite semantics, ``inbox/``
+   writes, ``review/`` edits, and writes with no capture provenance.
+
+A refusal comes back as ``ToolResult(is_error=True)``, the same shape the
+memory tools already use for a missing scope (SPEC-108) — an MCP-level tool
+error the model reads and reacts to, not a transport failure. The SPEC's own
+prompt tells the session as much: "a rejected call is information, not an
+obstacle".
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+
+import mcp.types as mt
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools.base import Tool, ToolResult
+
+from .policy import CURATOR_TOOL_ACTIONS, ActiveCaptures, rejection_for
+
+logger = logging.getLogger("palaia_hub.curator.middleware")
+
+
+class CuratorScopeMiddleware(Middleware):
+    """Enforces the curator's tool surface and write guards on one profile.
+
+    Args:
+        tool_actions: ``{tool name as the client sees it: base action}`` for
+            every tool this profile exposes — built by
+            :func:`palaia_hub.curator.profile.curator_tool_actions` from the
+            profile's vault namespaces, so a renamed tool
+            (``tool_renames``) is still mapped to the action it really is.
+            A tool name absent from this mapping is refused: an unmapped
+            name is one this middleware cannot classify, and the policy is
+            fail-closed.
+        active_captures: the in-process capture binding
+            (:class:`~palaia_hub.curator.policy.ActiveCaptures`) the runner
+            registers each session against. Omitted, provenance checking is
+            shape-only — see that class's docstring.
+    """
+
+    def __init__(
+        self,
+        tool_actions: Mapping[str, str],
+        *,
+        active_captures: ActiveCaptures | None = None,
+    ) -> None:
+        self._tool_actions = dict(tool_actions)
+        self._active_captures = active_captures or ActiveCaptures()
+
+    @property
+    def active_captures(self) -> ActiveCaptures:
+        return self._active_captures
+
+    def action_for(self, tool_name: str) -> str | None:
+        """The base action ``tool_name`` maps to, or ``None`` if unknown here."""
+        return self._tool_actions.get(tool_name)
+
+    def allowed_tool_names(self) -> frozenset[str]:
+        return frozenset(
+            name
+            for name, action in self._tool_actions.items()
+            if action in CURATOR_TOOL_ACTIONS
+        )
+
+    async def on_list_tools(
+        self,
+        context: MiddlewareContext[mt.ListToolsRequest],
+        call_next: CallNext[mt.ListToolsRequest, Sequence[Tool]],
+    ) -> Sequence[Tool]:
+        tools = await call_next(context)
+        allowed = self.allowed_tool_names()
+        return [tool for tool in tools if tool.name in allowed]
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        name = context.message.name
+        arguments = context.message.arguments or {}
+        action = self.action_for(name)
+        if action is None:
+            return _refusal(
+                f"rejected: {name!r} is not a tool this curator profile serves. "
+                f"The curator's surface is {', '.join(CURATOR_TOOL_ACTIONS)}, "
+                "on this vault's own tools only."
+            )
+        message = rejection_for(
+            action, arguments, expected_captures=self._active_captures.current()
+        )
+        if message is not None:
+            logger.info(
+                "curator guard refused %s (%s)", name, message.split(".", 1)[0]
+            )
+            return _refusal(message)
+        return await call_next(context)
+
+
+def _refusal(message: str) -> ToolResult:
+    return ToolResult(content=message, is_error=True)
+
+
+__all__ = ["CuratorScopeMiddleware"]

--- a/v3/server/src/palaia_hub/curator/models.py
+++ b/v3/server/src/palaia_hub/curator/models.py
@@ -1,0 +1,280 @@
+"""Data shapes the curator runner and the apply pass exchange (SPEC-206).
+
+Everything here is a plain pydantic model or dataclass: the runner's report
+is what the CLI prints, what the stash audit stores (``ops:curator.*``) and
+what the bus event carries, so it has exactly one definition.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+#: How a capture's session ended, decided by verification and nothing else
+#: (SPEC-206 rule 3):
+#:
+#: - ``ingested`` — a real vault note carries the capture id.
+#: - ``needs_review`` — only a ``review/`` proposal carries it.
+#: - ``unverified`` — nothing does; the capture stays, with an additive
+#:   failure line appended.
+CaptureOutcome = Literal["ingested", "needs_review", "unverified"]
+
+#: Terminal statuses an apply run stamps on a proposal (format spec §8).
+ProposalStatus = Literal["applied", "apply-failed", "manual"]
+
+
+@dataclass(frozen=True, slots=True)
+class PendingCapture:
+    """One uncurated ``inbox/`` capture, as the runner found it."""
+
+    vault: str
+    path: str
+    permalink: str
+    capture_id: str
+    title: str
+    text: str
+    attempts: int = 0
+    checksum: str = ""
+
+
+class SelfReport(BaseModel):
+    """The model's own last-line JSON — recorded, never trusted."""
+
+    model_config = ConfigDict(extra="allow")
+
+    action: str = ""
+    targets: list[str] = Field(default_factory=list)
+    summary: str = ""
+    reason: str = ""
+
+
+def parse_self_report(stdout: str) -> SelfReport | None:
+    """The last parseable JSON object in ``stdout``, or ``None``.
+
+    Scanned from the end backwards because the prompt asks for the JSON as
+    the *last* line, and a chatty session may have printed other braces
+    earlier. A malformed or missing report is not an error: the outcome comes
+    from verification either way (and a session that reports nothing at all
+    but did the work still counts as ``ingested``).
+    """
+    for line in reversed((stdout or "").strip().splitlines()):
+        candidate = line.strip().strip("`").strip()
+        if not candidate.startswith("{") or not candidate.endswith("}"):
+            continue
+        try:
+            payload = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        try:
+            return SelfReport.model_validate(payload)
+        except ValidationError:
+            continue
+    return None
+
+
+@dataclass(frozen=True, slots=True)
+class SessionResult:
+    """What one bounded LLM session did, mechanically speaking."""
+
+    exit_code: int
+    stdout: str = ""
+    stderr: str = ""
+    timed_out: bool = False
+    duration_seconds: float = 0.0
+    launched: bool = True
+
+    @property
+    def failed(self) -> bool:
+        return self.timed_out or self.exit_code != 0
+
+
+class CaptureRecord(BaseModel):
+    """One capture's outcome — the audit unit (stash + event payload)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    vault: str
+    capture_id: str
+    permalink: str
+    outcome: CaptureOutcome
+    targets: list[str] = Field(default_factory=list)
+    attempts: int = 0
+    retired: bool = False
+    reason: str = ""
+    self_reported: str = ""
+    duration_seconds: float = 0.0
+
+    @property
+    def verified(self) -> bool:
+        """Did this outcome earn the inbox entry's removal (rule 3)?"""
+        return self.outcome in ("ingested", "needs_review")
+
+
+class CuratorRunReport(BaseModel):
+    """One ``curator run`` pass over one vault."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    vault: str
+    pending: int = 0
+    sessions: int = 0
+    records: list[CaptureRecord] = Field(default_factory=list)
+
+    @property
+    def ingested(self) -> int:
+        return sum(1 for r in self.records if r.outcome == "ingested")
+
+    @property
+    def needs_review(self) -> int:
+        return sum(1 for r in self.records if r.outcome == "needs_review")
+
+    @property
+    def unverified(self) -> int:
+        return sum(1 for r in self.records if r.outcome == "unverified")
+
+    def summary(self) -> str:
+        if not self.pending:
+            return f"{self.vault}: inbox empty, no session started."
+        return (
+            f"{self.vault}: {self.pending} pending, {self.sessions} session(s) — "
+            f"{self.ingested} ingested, {self.needs_review} needs-review, "
+            f"{self.unverified} unverified "
+            f"({sum(1 for r in self.records if r.retired)} retired)."
+        )
+
+
+# --- the proposal plan (format spec §8) ------------------------------------
+
+
+class _Op(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class AppendOp(_Op):
+    """Append text to an existing note (the only additive maintenance op)."""
+
+    op: Literal["append"]
+    target: str
+    text: str
+
+
+class ReplaceBodyOp(_Op):
+    """Replace a note's whole body with ``body``."""
+
+    op: Literal["replace_body"]
+    target: str
+    body: str
+
+
+class RetitleOp(_Op):
+    """Change a note's title (its permalink stays, format spec §4.2)."""
+
+    op: Literal["retitle"]
+    target: str
+    title: str
+
+
+class MoveOp(_Op):
+    """Move a note's file into ``folder``; the permalink does not change."""
+
+    op: Literal["move"]
+    target: str
+    folder: str
+
+
+class RetireOp(_Op):
+    """Delete a note. Reversible through git, like every other engine write."""
+
+    op: Literal["retire"]
+    target: str
+
+
+class MergeOp(_Op):
+    """Append ``source``'s body onto ``target``, then retire ``source``."""
+
+    op: Literal["merge"]
+    source: str
+    target: str
+
+
+PlanOperation = Annotated[
+    AppendOp | ReplaceBodyOp | RetitleOp | MoveOp | RetireOp | MergeOp,
+    Field(discriminator="op"),
+]
+
+
+class Plan(BaseModel):
+    """A proposal's typed plan: what the apply pass will execute, in order."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    operations: list[PlanOperation] = Field(default_factory=list)
+
+    def targets(self) -> list[str]:
+        """Every note this plan touches, in first-mention order, deduplicated."""
+        seen: list[str] = []
+        for op in self.operations:
+            refs = [op.source, op.target] if isinstance(op, MergeOp) else [op.target]
+            for ref in refs:
+                if ref not in seen:
+                    seen.append(ref)
+        return seen
+
+
+class ProposalResult(BaseModel):
+    """What one approved proposal's apply attempt did."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    vault: str
+    permalink: str
+    status: ProposalStatus
+    operations: int = 0
+    applied: int = 0
+    reason: str = ""
+
+
+class ApplyReport(BaseModel):
+    """One ``curator apply`` pass over one vault."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    vault: str
+    approved: int = 0
+    results: list[ProposalResult] = Field(default_factory=list)
+
+    def summary(self) -> str:
+        if not self.approved:
+            return f"{self.vault}: no approved proposals."
+        counts: dict[str, int] = {}
+        for result in self.results:
+            counts[result.status] = counts.get(result.status, 0) + 1
+        rendered = ", ".join(f"{count} {status}" for status, count in sorted(counts.items()))
+        return f"{self.vault}: {self.approved} approved proposal(s) — {rendered}."
+
+
+__all__ = [
+    "AppendOp",
+    "ApplyReport",
+    "CaptureOutcome",
+    "CaptureRecord",
+    "CuratorRunReport",
+    "MergeOp",
+    "MoveOp",
+    "PendingCapture",
+    "Plan",
+    "PlanOperation",
+    "ProposalResult",
+    "ProposalStatus",
+    "ReplaceBodyOp",
+    "RetireOp",
+    "RetitleOp",
+    "SelfReport",
+    "SessionResult",
+    "parse_self_report",
+]

--- a/v3/server/src/palaia_hub/curator/policy.py
+++ b/v3/server/src/palaia_hub/curator/policy.py
@@ -1,0 +1,308 @@
+"""The curator's binding policy, as pure functions (SPEC-206 rule 2).
+
+**The tool surface IS the policy.** This module owns the two halves of that
+sentence that can be decided without touching a vault:
+
+- :data:`CURATOR_TOOL_ACTIONS` — the only actions a curator session may see
+  at all. Everything else the memory tool family offers (``move``,
+  ``delete``, ``capture``, ``inbox_status``, ``recall``) is neither listed
+  nor callable on a curator profile.
+- :func:`rejection_for` — the per-call guard: given an action and the raw
+  tool arguments, either ``None`` (this call may proceed) or the
+  explanatory error the caller gets back instead of the call happening.
+
+Nothing here reaches for a vault, a token or a server object, so the guard
+matrix can be tested as a table of arguments (SPEC-206 acceptance criterion
+#1) and enforced from a fastmcp middleware
+(:mod:`palaia_hub.curator.middleware`) in the same breath.
+
+Why server-side at all, when the prompt already says it? Because a prompt is
+advice. MASTERPLAN §5.1: "the curator's limits are enforced in code (its tool
+surface *is* the policy), not in prompt text" — the model literally cannot
+hold a capability the policy forbids, so a jailbreak, a confused session or a
+future prompt regression cannot turn INGEST into MAINTENANCE.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Collection, Mapping
+from typing import Any
+
+#: The seven actions a curator session may use, verbatim from SPEC-206 rule
+#: 2. Read-only reconnaissance plus the two INGEST verbs — and nothing that
+#: could rewrite, move or retire what already exists.
+CURATOR_TOOL_ACTIONS: tuple[str, ...] = (
+    "search",
+    "read",
+    "list",
+    "recent_activity",
+    "build_context",
+    "write",
+    "edit",
+)
+
+#: Every note the curator writes carries this line (SPEC-206 rule 2 / the
+#: prompt's "Every note you write carries ..."), so verification can find it
+#: again by content alone (:mod:`palaia_hub.curator.verify`).
+PROVENANCE_PREFIX = "- [source] inbox capture "
+
+#: The provenance line's shape, anchored to a line of its own. ``capture_id``
+#: is format spec §7's ``"cap-" + sha256(permalink)[:10]``, but the pattern
+#: stays deliberately looser than that (any non-space token) so a vault whose
+#: captures were imported with a differently-shaped id is not locked out.
+_PROVENANCE_RE = re.compile(
+    rf"^{re.escape(PROVENANCE_PREFIX)}(?P<capture_id>\S+)\s*$", re.MULTILINE
+)
+
+#: Reserved directories the curator may never write into or edit, and why.
+#: ``inbox/`` is the capture's own home (format spec §7: "the curator may not
+#: edit ``inbox/`` content"); ``review/`` may receive *new* proposals but
+#: never edits of existing ones — that is what self-approval would look like.
+INBOX_PREFIX = "inbox/"
+REVIEW_PREFIX = "review/"
+
+#: Argument names that mean "folder" on a write (the memory tool family
+#: absorbs ``dir``/``path`` as aliases for it — see
+#: :mod:`palaia_hub.gateway.memory_tools`), checked together so the guard
+#: cannot be walked around by picking the alias.
+_FOLDER_ARGUMENT_NAMES: tuple[str, ...] = ("folder", "dir", "path")
+
+#: Argument names that would give ``write`` overwrite semantics. The v3
+#: ``write`` tool has none of them (it is create-only: the engine adapter
+#: passes ``must_create=True``, so writing over an existing note fails with
+#: the engine's own explanatory error). They are rejected here anyway, by
+#: name: if a future SPEC ever grows the tool surface such a parameter, the
+#: curator profile must refuse it on the day it appears rather than on the
+#: day someone notices.
+_OVERWRITE_ARGUMENT_NAMES: tuple[str, ...] = (
+    "overwrite",
+    "replace",
+    "force",
+    "must_create",
+    "mode",
+)
+_OVERWRITE_MODE_VALUES: frozenset[str] = frozenset({"overwrite", "replace", "force"})
+
+
+def provenance_line(capture_id: str) -> str:
+    """The exact provenance line a curator write must carry for ``capture_id``."""
+    return f"{PROVENANCE_PREFIX}{capture_id}"
+
+
+def provenance_ids(text: str) -> set[str]:
+    """Every capture id ``text`` claims provenance from (possibly empty)."""
+    return {match.group("capture_id") for match in _PROVENANCE_RE.finditer(text or "")}
+
+
+def _folder_argument(arguments: Mapping[str, Any]) -> str:
+    for name in _FOLDER_ARGUMENT_NAMES:
+        value = arguments.get(name)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _in_reserved_folder(value: str, prefix: str) -> bool:
+    """Is ``value`` inside the reserved directory ``prefix``?
+
+    Accepts the folder forms a tool call can carry — ``"inbox"``,
+    ``"inbox/"``, ``"/inbox"``, ``"inbox/2026"`` — and permalink forms
+    (``"inbox/rate-limit-decision"``), because ``edit`` addresses a note by
+    permalink and a permalink's first segment is its folder.
+    """
+    normalized = value.strip().strip("/").lower()
+    if not normalized:
+        return False
+    reserved = prefix.rstrip("/")
+    return normalized == reserved or normalized.startswith(f"{reserved}/")
+
+
+def _overwrite_rejection(arguments: Mapping[str, Any]) -> str | None:
+    for name in _OVERWRITE_ARGUMENT_NAMES:
+        if name not in arguments:
+            continue
+        value = arguments[name]
+        if name == "must_create":
+            if value is False:
+                return name
+            continue
+        if name == "mode":
+            if isinstance(value, str) and value.strip().lower() in _OVERWRITE_MODE_VALUES:
+                return name
+            continue
+        if value:
+            return name
+    return None
+
+
+def _write_rejection(
+    arguments: Mapping[str, Any], expected_captures: Collection[str]
+) -> str | None:
+    folder = _folder_argument(arguments)
+    if _in_reserved_folder(folder, INBOX_PREFIX):
+        return (
+            "rejected: the curator never writes into inbox/. That folder is the "
+            "capture's own home (vault-format §7) — file the knowledge where it "
+            "belongs in the vault, or raise a proposal in review/, and leave the "
+            "capture alone; the runner removes it once your write is verified."
+        )
+    if (offender := _overwrite_rejection(arguments)) is not None:
+        return (
+            f"rejected: write is create-only for the curator, so {offender!r} is "
+            "refused. Overwriting an existing note is MAINTENANCE, never INGEST: "
+            "append observations with edit(append=...), or write a proposal into "
+            "review/ describing the rewrite you want a human to approve."
+        )
+    body = arguments.get("body")
+    body_text = body if isinstance(body, str) else ""
+    return _provenance_rejection(body_text, expected_captures, what="every note you write")
+
+
+def _edit_rejection(
+    arguments: Mapping[str, Any], expected_captures: Collection[str]
+) -> str | None:
+    target = arguments.get("permalink")
+    target_text = target if isinstance(target, str) else ""
+    if _in_reserved_folder(target_text, INBOX_PREFIX):
+        return (
+            "rejected: the curator never edits inbox/ content (vault-format §7). "
+            "The capture is the input, not the workspace — write the knowledge "
+            "into the vault instead; the runner retires the capture itself."
+        )
+    if _in_reserved_folder(target_text, REVIEW_PREFIX):
+        return (
+            "rejected: the curator may create new proposals in review/ but never "
+            "edit existing ones — approving your own proposal is exactly what "
+            "this guard exists to prevent. Write a new proposal if the old one "
+            "is wrong, and let a human decide."
+        )
+    if arguments.get("body") is not None:
+        return (
+            "rejected: edit(body=...) replaces a note's content, which is "
+            "MAINTENANCE and never autonomous. Use edit(append=...) to add "
+            "observations, or write a proposal into review/ for the rewrite."
+        )
+    append = arguments.get("append")
+    if append is None:
+        return (
+            "rejected: an edit needs append=... — additive observations are the "
+            "only edit the curator may make. Nothing else on an existing note is "
+            "INGEST."
+        )
+    append_text = append if isinstance(append, str) else ""
+    return _provenance_rejection(
+        append_text, expected_captures, what="everything you append to an existing note"
+    )
+
+
+def _provenance_rejection(
+    text: str, expected_captures: Collection[str], *, what: str
+) -> str | None:
+    found = provenance_ids(text)
+    expected = {capture_id for capture_id in expected_captures if capture_id}
+    if not found:
+        wanted = (
+            provenance_line(sorted(expected)[0])
+            if len(expected) == 1
+            else f"{PROVENANCE_PREFIX}<capture_id>"
+        )
+        return (
+            f"rejected: {what} must carry its provenance line, and this one has "
+            f"none. Add a line exactly like `{wanted}` — verification finds your "
+            "work by that id, and a write it cannot find never counts as done."
+        )
+    if expected and not (found & expected):
+        return (
+            f"rejected: this write claims provenance from {sorted(found)!r}, but "
+            f"this session is curating {sorted(expected)!r}. Cite the capture you "
+            "were given — a write attributed to another capture is unverifiable."
+        )
+    return None
+
+
+def rejection_for(
+    action: str,
+    arguments: Mapping[str, Any] | None = None,
+    *,
+    expected_captures: Collection[str] = (),
+) -> str | None:
+    """``None`` if a curator session may make this call; else why it may not.
+
+    Args:
+        action: the base memory-tool action (``"write"``, ``"edit"``, ...) —
+            already stripped of the vault's tool-name namespace by the
+            caller (:mod:`palaia_hub.curator.middleware`).
+        arguments: the raw tool arguments, exactly as they arrived over MCP
+            (alias names included — the guard checks the alias group, not
+            just the canonical name).
+        expected_captures: the capture id(s) the session currently running is
+            allowed to claim provenance from. Empty means "any well-formed
+            provenance line is accepted" — the honest fallback for a curator
+            session this process did not launch itself (see
+            :class:`ActiveCaptures`).
+
+    The returned string is the message the model sees. It always says what
+    was refused *and* what to do instead: per the SPEC's prompt, "a rejected
+    call is information, not an obstacle".
+    """
+    arguments = arguments or {}
+    if action not in CURATOR_TOOL_ACTIONS:
+        return (
+            f"rejected: {action!r} is not part of the curator's tool surface. "
+            f"The curator may only use {', '.join(CURATOR_TOOL_ACTIONS)} — "
+            "rewriting, moving, renaming, retiring or capturing are MAINTENANCE "
+            "and belong in a review/ proposal a human approves."
+        )
+    if action == "write":
+        return _write_rejection(arguments, expected_captures)
+    if action == "edit":
+        return _edit_rejection(arguments, expected_captures)
+    return None
+
+
+class ActiveCaptures:
+    """Which capture id(s) curator sessions may cite right now.
+
+    The provenance guard is strongest when it knows *which* capture the
+    running session was handed: a write citing some other capture is then
+    refused rather than merely well-formed. The runner
+    (:class:`palaia_hub.curator.runner.CuratorRunner`) holds one of these and
+    registers a capture for exactly the duration of that capture's session,
+    so the binding is in-process state, not something a prompt can claim.
+
+    When no session is registered — a curator session launched out of process,
+    or a hub where the runner is not the one driving — :meth:`current` is
+    empty and the guard falls back to shape-only provenance checking. That is
+    a deliberate, documented weakening rather than a refusal: the guard still
+    rejects a write with *no* provenance at all, which is what makes
+    verification possible.
+    """
+
+    def __init__(self) -> None:
+        self._active: dict[str, int] = {}
+
+    def current(self) -> frozenset[str]:
+        return frozenset(self._active)
+
+    def acquire(self, capture_id: str) -> None:
+        self._active[capture_id] = self._active.get(capture_id, 0) + 1
+
+    def release(self, capture_id: str) -> None:
+        remaining = self._active.get(capture_id, 0) - 1
+        if remaining > 0:
+            self._active[capture_id] = remaining
+        else:
+            self._active.pop(capture_id, None)
+
+
+__all__ = [
+    "CURATOR_TOOL_ACTIONS",
+    "INBOX_PREFIX",
+    "PROVENANCE_PREFIX",
+    "REVIEW_PREFIX",
+    "ActiveCaptures",
+    "provenance_ids",
+    "provenance_line",
+    "rejection_for",
+]

--- a/v3/server/src/palaia_hub/curator/profile.py
+++ b/v3/server/src/palaia_hub/curator/profile.py
@@ -1,0 +1,123 @@
+"""The curator gateway profile: a second door onto the same vaults.
+
+SPEC-206 rule 2: "the curator session authenticates with a dedicated curator
+token whose profile exposes ONLY search, read, list, recent_activity,
+build_context, write and edit". A profile is already the gateway's unit of
+exposure (one :class:`~fastmcp.FastMCP` instance per profile path, SPEC-002
+finding Q2), and a token is already bound to exactly one profile
+(:class:`palaia_hub.auth.verifier.PalaiaTokenVerifier`) — so the curator
+profile is an ordinary profile over the same vault tool servers, with
+:class:`~palaia_hub.curator.middleware.CuratorScopeMiddleware` attached.
+
+**Known limitation, deliberately fail-closed:** the tool-name → action map
+(:func:`curator_tool_actions`) is built from the vaults known when the hub
+wires the curator up. A vault created at runtime through the wizard is added
+to the *default* profile only (see :mod:`palaia_hub.dashboard_api`), so its
+tools are absent from the curator's map — and an unmapped tool name is
+refused, not waved through. The curator starts curating that vault's inbox
+after the next hub restart.
+
+That middleware is passed into the gateway *builder*, not bolted onto the
+built server: a profile can be rebuilt at runtime (a vault created through
+the wizard, :class:`palaia_hub.gateway.dynamic.DynamicGateway`), and a policy
+that had to be re-attached after every rebuild would eventually be forgotten
+exactly once — which is all it takes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+
+from fastmcp.server.middleware import Middleware
+
+from ..gateway.config import ProfileConfig, VaultMountConfig
+from ..gateway.naming import compose_tool_name, resolve_tool_names
+from ..gateway.vault_protocol import (
+    INBOX_TOOL_ACTIONS,
+    MEMORY_TOOL_ACTIONS,
+    RECALL_TOOL_ACTIONS,
+)
+from .middleware import CuratorScopeMiddleware
+from .policy import CURATOR_TOOL_ACTIONS, ActiveCaptures
+from .session import MCP_SERVER_NAME
+
+#: The profile path the curator connects to: ``/mcp/curator``.
+CURATOR_PROFILE_PATH = "curator"
+
+#: Every action the memory tool family exposes, curator-relevant or not. The
+#: middleware needs all of them: mapping a *forbidden* tool name to its
+#: action is what lets it refuse the call with a message naming what was
+#: refused, instead of the generic "unknown tool".
+_ALL_ACTIONS: tuple[str, ...] = (
+    *MEMORY_TOOL_ACTIONS,
+    *INBOX_TOOL_ACTIONS,
+    *RECALL_TOOL_ACTIONS,
+)
+
+
+def curator_profile(vault_keys: Sequence[str]) -> ProfileConfig:
+    """The curator profile over ``vault_keys`` (all of a hub's vaults, normally)."""
+    return ProfileConfig(path=CURATOR_PROFILE_PATH, vaults=list(vault_keys))
+
+
+def curator_tool_actions(vaults: Iterable[VaultMountConfig]) -> dict[str, str]:
+    """``{tool name as a client sees it: base action}`` for these vaults.
+
+    Renames are honored the same way the mount does it — the configured
+    pre-namespace value, composed with the vault's namespace
+    (:func:`palaia_hub.gateway.naming.compose_tool_name`) — so a vault whose
+    ``write`` is exposed as ``work_memory_remember`` is still recognized as
+    a write by the guard.
+    """
+    mapping: dict[str, str] = {}
+    for vault in vaults:
+        renames = resolve_tool_names(vault.namespace, vault.tool_renames)
+        for action in _ALL_ACTIONS:
+            final = compose_tool_name(vault.namespace, renames.get(action, action))
+            mapping[final] = action
+    return mapping
+
+
+def allowed_tool_specs(
+    vaults: Iterable[VaultMountConfig], *, server_name: str = MCP_SERVER_NAME
+) -> tuple[str, ...]:
+    """The ``--allowed-tools`` values for a curator session, sorted.
+
+    A client namespaces an MCP server's tools as
+    ``mcp__<server>__<tool>``; the session is launched with the generated
+    config's server name (:data:`palaia_hub.curator.session.MCP_SERVER_NAME`),
+    so the two must agree. Belt to the middleware's braces: the client is
+    *told* which tools it may call, and the gateway refuses the rest anyway.
+    """
+    mapping = curator_tool_actions(vaults)
+    return tuple(
+        sorted(
+            f"mcp__{server_name}__{name}"
+            for name, action in mapping.items()
+            if action in CURATOR_TOOL_ACTIONS
+        )
+    )
+
+
+def curator_profile_middleware(
+    vaults: Iterable[VaultMountConfig],
+    *,
+    active_captures: ActiveCaptures | None = None,
+) -> dict[str, list[Middleware]]:
+    """The ``profile_middleware`` mapping to hand to the gateway builder."""
+    return {
+        CURATOR_PROFILE_PATH: [
+            CuratorScopeMiddleware(
+                curator_tool_actions(vaults), active_captures=active_captures
+            )
+        ]
+    }
+
+
+__all__ = [
+    "CURATOR_PROFILE_PATH",
+    "allowed_tool_specs",
+    "curator_profile",
+    "curator_profile_middleware",
+    "curator_tool_actions",
+]

--- a/v3/server/src/palaia_hub/curator/prompt.py
+++ b/v3/server/src/palaia_hub/curator/prompt.py
@@ -1,0 +1,75 @@
+"""The curator's system prompt, assembled at runtime (SPEC-206 "The prompt").
+
+Three parts, in this order:
+
+(a) :data:`ROLE_BLOCK` — fixed, quoted verbatim from the SPEC. It is not
+    edited here, ever: the SPEC calls it a "binding starting point — tune via
+    PR", which means a prompt change is a spec change, not a code change.
+(b) the vault's own ``meta/curation.md`` note, read live if it exists —
+    per-vault rules the owner maintains in the vault itself. Absent is fine;
+    the format spec's defaults apply.
+(c) the capture being curated: its id, permalink and full text.
+
+The JSON self-report the last line asks for is parsed
+(:func:`palaia_hub.curator.models.parse_self_report`) and recorded, but never
+believed — classification is the runner's own vault search (SPEC-206 rule 3).
+It is asked for anyway because it makes a session's *intent* legible in the
+audit trail when verification disagrees with it.
+"""
+
+from __future__ import annotations
+
+#: The vault note holding per-vault curation rules (part (b) above).
+CURATION_NOTE_PERMALINK = "meta/curation"
+
+#: SPEC-206 "The prompt (binding starting point — tune via PR)", verbatim.
+#: ``{vault_name}`` and ``{purpose}`` fill the SPEC's own ``<name>`` /
+#: ``<purpose>`` placeholders.
+ROLE_BLOCK = """\
+You are the palaia curator for the vault "{vault_name}" — {purpose}. Session
+agents drop raw captures into inbox/ while working on something else; this
+run turns ONE capture into well-formed, findable vault knowledge. You are
+unattended: you cannot ask questions — writing a proposal into review/ is
+how you raise one, and it is a first-class outcome, not a failure.
+INGEST is yours: a new note in the right place, or additive observations on
+an existing note. MAINTENANCE is never yours: rewriting, merging, renaming
+or retiring what exists — propose it in review/ and stop. The restriction
+is enforced, not advisory; a rejected call is information, not an obstacle.
+Search the vault at least twice (entity name, then the claim itself) before
+writing; the title is the key — extend rather than duplicate. Titles and
+link targets stay volatility-free. Every note you write carries
+`- [source] inbox capture <capture_id>`. Never invent facts the capture
+does not contain. Be conservative: a proposal costs the owner thirty
+seconds; a wrong note costs the vault its trustworthiness.
+End with one line of JSON: {{"action":"ingested"|"needs_review",
+"targets":[…],"summary":"…","reason":"…"}}"""
+
+
+def build_prompt(
+    *,
+    vault_name: str,
+    purpose: str,
+    capture_id: str,
+    capture_permalink: str,
+    capture_text: str,
+    curation_note: str | None = None,
+) -> str:
+    """Assemble the full prompt for one capture's session."""
+    parts = [ROLE_BLOCK.format(vault_name=vault_name, purpose=purpose.rstrip("."))]
+    if curation_note and curation_note.strip():
+        parts.append(
+            "## This vault's own curation rules (meta/curation.md)\n\n"
+            f"{curation_note.strip()}"
+        )
+    parts.append(
+        "## The capture to curate\n\n"
+        f"capture_id: {capture_id}\n"
+        f"permalink: {capture_permalink}\n"
+        f"provenance line every note you write must carry: "
+        f"- [source] inbox capture {capture_id}\n\n"
+        f"{capture_text.strip()}"
+    )
+    return "\n\n".join(parts) + "\n"
+
+
+__all__ = ["CURATION_NOTE_PERMALINK", "ROLE_BLOCK", "build_prompt"]

--- a/v3/server/src/palaia_hub/curator/runner.py
+++ b/v3/server/src/palaia_hub/curator/runner.py
@@ -1,0 +1,334 @@
+"""The curator runner: one capture, one session, one verified outcome.
+
+The loop, per SPEC-206 rules 3 and 5:
+
+1. **List the pending captures.** ``inbox/`` notes with ``type: capture`` and
+   ``status: uncurated``, oldest first. An empty inbox ends the run here —
+   one catalog query, no session, no cost (deliverable #5).
+2. **Run one bounded session per capture** through the configured
+   :class:`~palaia_hub.curator.session.SessionRunner`, with the capture id
+   registered in :class:`~palaia_hub.curator.policy.ActiveCaptures` for
+   exactly that session's duration, so the gateway guard knows which
+   provenance the session is allowed to claim.
+3. **Verify against the vault** (:mod:`palaia_hub.curator.verify`) — never
+   against the session's self-report, which is recorded and ignored.
+4. **Act on the verdict.** ``ingested``/``needs_review`` delete the inbox
+   entry; ``unverified`` appends ``- [curation-failed] <ts>: <reason>`` to
+   the capture — additive, never destructive (format spec §7) — and, on the
+   third failure, stamps ``status: curation-failed`` so it stops being
+   retried.
+5. **Audit it** (:mod:`palaia_hub.curator.audit`): stash + bus, and a
+   ``doctor.finding`` for anything that did not land.
+
+Nothing in here is allowed to raise on a single bad capture: one unparseable
+note or one failing session must not stop the rest of the run.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from datetime import UTC, datetime
+
+from ..vault import ChecksumConflictError, VaultEngine, VaultError
+from .audit import CuratorAudit
+from .models import (
+    CaptureRecord,
+    CuratorRunReport,
+    PendingCapture,
+    SessionResult,
+    parse_self_report,
+)
+from .policy import ActiveCaptures
+from .prompt import CURATION_NOTE_PERMALINK, build_prompt
+from .session import SessionRequest, SessionRunner
+from .verify import verify_capture
+
+logger = logging.getLogger("palaia_hub.curator.runner")
+
+#: Format spec §7's failure line: additive, never destructive.
+FAILURE_PREFIX = "- [curation-failed] "
+
+#: Format spec §7's terminal capture status after the retry cap.
+FAILED_STATUS = "curation-failed"
+
+#: SPEC-206 rule 3: "retries capped (3)".
+DEFAULT_MAX_ATTEMPTS = 3
+
+#: Format spec §8: a new proposal opens the review lifecycle.
+PROPOSED_STATUS = "proposed"
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def count_failures(body: str) -> int:
+    """How many curation attempts this capture already survived, per its body."""
+    return sum(1 for line in body.splitlines() if line.startswith(FAILURE_PREFIX))
+
+
+class CuratorRunner:
+    """Turns one vault's pending captures into verified vault knowledge.
+
+    Args:
+        engine: the vault's own (already opened) engine. The runner reads
+            captures, deletes verified ones and appends failure lines
+            through it — plain code, no model in this path.
+        session_runner: how a session is launched (subprocess in production,
+            a scripted stand-in in tests).
+        endpoint: the curator profile's MCP URL, handed to each session.
+        token: the curator token, handed to each session.
+        allowed_tools: the tool names a session may call, handed to each
+            session (:func:`palaia_hub.curator.profile.allowed_tool_specs`).
+        audit: where outcomes are recorded. Omitted, the run is silent
+            beyond its return value.
+        active_captures: the binding the gateway guard reads. Pass the *same*
+            instance the curator profile's middleware was built with, or the
+            guard falls back to shape-only provenance checks.
+        max_attempts: retries before a capture is retired (SPEC-206: 3).
+        purpose: the vault's one-line purpose, for the prompt.
+    """
+
+    def __init__(
+        self,
+        engine: VaultEngine,
+        *,
+        session_runner: SessionRunner,
+        endpoint: str = "",
+        token: str | None = None,
+        allowed_tools: Sequence[str] = (),
+        audit: CuratorAudit | None = None,
+        active_captures: ActiveCaptures | None = None,
+        max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+        purpose: str = "",
+    ) -> None:
+        self._engine = engine
+        self._session_runner = session_runner
+        self._endpoint = endpoint
+        self._token = token
+        self._allowed_tools = tuple(allowed_tools)
+        self._audit = audit or CuratorAudit()
+        self._active_captures = active_captures or ActiveCaptures()
+        self._max_attempts = max(1, max_attempts)
+        self._purpose = purpose
+
+    # ------------------------------------------------------------- discovery
+
+    async def pending_captures(self) -> list[PendingCapture]:
+        """The uncurated captures waiting in ``inbox/``, oldest first."""
+        await self._engine.refresh()
+        pending: list[tuple[str, PendingCapture]] = []
+        for entry in list(self._engine.catalog.values()):
+            if not entry.path.startswith("inbox/"):
+                continue
+            try:
+                note = await self._engine.read_note(entry.path)
+            except VaultError:  # pragma: no cover - unreadable note, skip it
+                logger.warning("curator: could not read %s", entry.path)
+                continue
+            frontmatter = note.frontmatter
+            if str(frontmatter.get("type", "note")) != "capture":
+                continue
+            if str(frontmatter.get("status") or "") != "uncurated":
+                continue
+            capture_id = str(frontmatter.get("capture_id") or "")
+            if not capture_id:
+                logger.warning(
+                    "curator: capture %s has no capture_id; skipping (nothing to "
+                    "verify against)",
+                    entry.path,
+                )
+                continue
+            created = str(frontmatter.get("created") or "")
+            pending.append(
+                (
+                    created,
+                    PendingCapture(
+                        vault=self._engine.name,
+                        path=entry.path,
+                        permalink=note.permalink or entry.path,
+                        capture_id=capture_id,
+                        title=note.title,
+                        text=note.text,
+                        attempts=count_failures(note.body),
+                        checksum=note.checksum,
+                    ),
+                )
+            )
+        pending.sort(key=lambda item: (item[0], item[1].path))
+        return [capture for _, capture in pending]
+
+    async def _curation_note(self) -> str | None:
+        """The vault's own ``meta/curation.md`` rules, read live (or ``None``)."""
+        try:
+            note = await self._engine.read_note(CURATION_NOTE_PERMALINK)
+        except VaultError:
+            return None
+        return note.body
+
+    # ------------------------------------------------------------------- run
+
+    async def run_once(self) -> CuratorRunReport:
+        """Curate everything currently pending; return what happened."""
+        captures = await self.pending_captures()
+        report = CuratorRunReport(vault=self._engine.name, pending=len(captures))
+        if not captures:
+            # Deliverable #5: an empty inbox costs one catalog query.
+            await self._audit.run(report)
+            return report
+        curation_note = await self._curation_note()
+        for capture in captures:
+            record = await self._curate(capture, curation_note)
+            report.records.append(record)
+            report.sessions += 1
+        await self._audit.run(report)
+        return report
+
+    async def _curate(self, capture: PendingCapture, curation_note: str | None) -> CaptureRecord:
+        prompt = build_prompt(
+            vault_name=self._engine.name,
+            purpose=self._purpose or (self._engine.info().purpose or "a palaia memory vault"),
+            capture_id=capture.capture_id,
+            capture_permalink=capture.permalink,
+            capture_text=capture.text,
+            curation_note=curation_note,
+        )
+        request = SessionRequest(
+            vault=self._engine.name,
+            capture_id=capture.capture_id,
+            prompt=prompt,
+            endpoint=self._endpoint,
+            allowed_tools=self._allowed_tools,
+            token=self._token,
+        )
+        self._active_captures.acquire(capture.capture_id)
+        try:
+            session = await self._session_runner.run(request)
+        except Exception as exc:  # noqa: BLE001 - a broken session is an outcome
+            logger.exception("curator: session for %s raised", capture.capture_id)
+            session = SessionResult(exit_code=-1, stderr=f"session raised: {exc}")
+        finally:
+            self._active_captures.release(capture.capture_id)
+
+        verification = await verify_capture(self._engine, capture)
+        self_report = parse_self_report(session.stdout)
+        record = CaptureRecord(
+            vault=self._engine.name,
+            capture_id=capture.capture_id,
+            permalink=capture.permalink,
+            outcome=verification.outcome,
+            targets=verification.targets,
+            attempts=capture.attempts + 1,
+            self_reported=(self_report.action if self_report else ""),
+            duration_seconds=round(session.duration_seconds, 3),
+        )
+        if record.verified:
+            await self._stamp_new_proposals(verification.proposals)
+            await self._retire_capture(capture)
+        else:
+            record = record.model_copy(
+                update={
+                    "reason": self._failure_reason(session),
+                    "retired": capture.attempts + 1 >= self._max_attempts,
+                }
+            )
+            await self._record_failure(capture, record.reason, retire=record.retired)
+        await self._audit.capture(record)
+        return record
+
+    @staticmethod
+    def _failure_reason(session: SessionResult) -> str:
+        if not session.launched:
+            return "the runner command could not be started"
+        if session.timed_out:
+            return "the session timed out"
+        if session.exit_code != 0:
+            detail = (session.stderr or "").strip().splitlines()
+            tail = detail[-1] if detail else "no stderr"
+            return f"the session exited {session.exit_code} ({tail[:200]})"
+        return (
+            "the session finished without leaving a note or proposal carrying "
+            "this capture's provenance line"
+        )
+
+    # ---------------------------------------------------------------- effects
+
+    async def _stamp_new_proposals(self, permalinks: Sequence[str]) -> None:
+        """Give a freshly written proposal its ``status: proposed`` (format §8).
+
+        The ``write`` tool takes a ``type`` but no ``status``, so a proposal a
+        session creates arrives without one — and format spec §8 fixes the
+        review lifecycle as ``proposed → approved → applied``. The runner
+        stamps the opening status itself, in plain code after verification:
+        the curator cannot approve anything (the guard refuses every edit of a
+        ``review/`` note), and a proposal with no status at all would be
+        invisible to a review queue that filters on it.
+        """
+        for permalink in permalinks:
+            try:
+                note = await self._engine.read_note(permalink)
+            except VaultError:  # pragma: no cover - it was just verified
+                continue
+            if str(note.frontmatter.get("status") or ""):
+                continue
+            try:
+                await self._engine.edit_note(
+                    permalink,
+                    frontmatter={"status": PROPOSED_STATUS},
+                    expected_checksum=note.checksum,
+                )
+            except VaultError:  # pragma: no cover - best effort, never fatal
+                logger.warning("curator: could not stamp status on %s", permalink)
+
+    async def _retire_capture(self, capture: PendingCapture) -> None:
+        """Delete a verified capture's inbox entry (rule 3: only verified ones)."""
+        try:
+            await self._engine.delete_note(capture.path)
+        except VaultError:
+            logger.exception("curator: could not delete curated capture %s", capture.path)
+
+    async def _record_failure(self, capture: PendingCapture, reason: str, *, retire: bool) -> None:
+        """Append a failure line (and, at the cap, stamp ``curation-failed``)."""
+        line = f"{FAILURE_PREFIX}{_now_iso()}: {reason}"
+        frontmatter = {"status": FAILED_STATUS} if retire else None
+        for attempt in range(2):
+            try:
+                note = await self._engine.read_note(capture.path)
+            except VaultError:
+                logger.warning(
+                    "curator: capture %s vanished before its failure could be "
+                    "recorded",
+                    capture.path,
+                )
+                return
+            body = f"{note.body.rstrip(chr(10))}\n{line}\n"
+            try:
+                await self._engine.edit_note(
+                    capture.path,
+                    body=body,
+                    frontmatter=frontmatter,
+                    expected_checksum=note.checksum,
+                )
+                return
+            except ChecksumConflictError:
+                if attempt == 0:
+                    continue  # someone wrote the capture in between; re-read once
+                logger.warning(
+                    "curator: could not append the failure line to %s (the note "
+                    "kept changing under us)",
+                    capture.path,
+                )
+                return
+            except VaultError:
+                logger.exception("curator: could not append failure line to %s", capture.path)
+                return
+
+
+__all__ = [
+    "DEFAULT_MAX_ATTEMPTS",
+    "FAILED_STATUS",
+    "FAILURE_PREFIX",
+    "CuratorRunner",
+    "count_failures",
+]

--- a/v3/server/src/palaia_hub/curator/service.py
+++ b/v3/server/src/palaia_hub/curator/service.py
@@ -1,0 +1,153 @@
+"""Scheduling the curator: event-driven, with an interval fallback.
+
+SPEC-206 deliverable #1: "event-driven via SPEC-201 (``inbox.captured``,
+debounced) plus interval fallback". Both, because each covers the other's
+blind spot — an event makes curation feel immediate, and the interval catches
+a capture written straight into ``inbox/`` by hand (or by a client that
+bypassed the ``capture`` tool), which no bus event ever announced.
+
+Debouncing is what keeps a burst of captures from becoming a burst of
+sessions: an agent that drops four captures in ten seconds should produce one
+curation pass, not four overlapping ones. And an empty inbox costs one
+catalog query per pass (:meth:`~palaia_hub.curator.runner.CuratorRunner.
+run_once`), so the interval fallback on an idle hub is genuinely almost free.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Callable, Mapping
+
+from ..events.schema import Envelope
+from .apply import ProposalApplier
+from .models import ApplyReport, CuratorRunReport
+from .runner import CuratorRunner
+
+logger = logging.getLogger("palaia_hub.curator.service")
+
+#: Seconds to wait after an ``inbox.captured`` event before curating, so a
+#: burst of captures coalesces into one pass.
+DEFAULT_DEBOUNCE_SECONDS = 30.0
+
+#: Seconds between fallback passes when no event arrives.
+DEFAULT_INTERVAL_SECONDS = 900.0
+
+
+class CuratorScheduler:
+    """Runs the curator (and the apply pass) on events and on a timer.
+
+    Args:
+        runners: one :class:`~palaia_hub.curator.runner.CuratorRunner` per
+            vault key.
+        appliers: one :class:`~palaia_hub.curator.apply.ProposalApplier` per
+            vault key. Optional: a hub may want curation without an
+            automatic apply pass, in which case approved proposals are
+            applied by ``palaia-hub curator apply``.
+        debounce_seconds / interval_seconds: see the module docstring.
+        subscribe: the event bus's ``on()`` (``EventBus.on``), used to
+            listen for ``inbox.captured``. Omitted, the scheduler is
+            interval-only.
+    """
+
+    def __init__(
+        self,
+        runners: Mapping[str, CuratorRunner],
+        *,
+        appliers: Mapping[str, ProposalApplier] | None = None,
+        debounce_seconds: float = DEFAULT_DEBOUNCE_SECONDS,
+        interval_seconds: float = DEFAULT_INTERVAL_SECONDS,
+        subscribe: Callable[[Callable[[Envelope], None]], Callable[[], None]] | None = None,
+    ) -> None:
+        self._runners = dict(runners)
+        self._appliers = dict(appliers or {})
+        self._debounce = max(0.0, debounce_seconds)
+        self._interval = max(1.0, interval_seconds)
+        self._subscribe = subscribe
+        self._unsubscribe: Callable[[], None] | None = None
+        self._nudged = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+        #: Passes completed since start — the handle tests wait on.
+        self.passes = 0
+
+    # ------------------------------------------------------------- lifecycle
+
+    async def start(self) -> None:
+        if self._subscribe is not None:
+            self._unsubscribe = self._subscribe(self._on_event)
+        self._task = asyncio.create_task(self._loop())
+
+    async def aclose(self) -> None:
+        if self._unsubscribe is not None:
+            self._unsubscribe()
+            self._unsubscribe = None
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+
+    # ---------------------------------------------------------------- events
+
+    def _on_event(self, envelope: Envelope) -> None:
+        """Bus subscriber: an ``inbox.captured`` event nudges the next pass."""
+        if envelope.event != "inbox.captured":
+            return
+        if envelope.data.get("duplicate"):
+            # A duplicate capture wrote nothing, so there is nothing new to
+            # curate — waking the curator for it would be pure cost.
+            return
+        self.nudge()
+
+    def nudge(self) -> None:
+        """Ask for a pass soon (debounced). Safe to call from a callback."""
+        self._nudged.set()
+
+    # ------------------------------------------------------------------ loop
+
+    async def _loop(self) -> None:
+        while True:
+            try:
+                await asyncio.wait_for(self._nudged.wait(), timeout=self._interval)
+            except TimeoutError:
+                pass
+            else:
+                self._nudged.clear()
+                if self._debounce:
+                    await asyncio.sleep(self._debounce)
+                self._nudged.clear()
+            try:
+                await self.run_all()
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 - a bad pass must not kill the loop
+                logger.exception("curator: scheduled pass failed")
+            self.passes += 1
+
+    async def run_all(self) -> tuple[list[CuratorRunReport], list[ApplyReport]]:
+        """One pass: curate every vault's inbox, then apply what was approved."""
+        runs: list[CuratorRunReport] = []
+        applies: list[ApplyReport] = []
+        for vault, runner in self._runners.items():
+            try:
+                runs.append(await runner.run_once())
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 - one vault must not stop the rest
+                logger.exception("curator: run failed for vault %r", vault)
+        for vault, applier in self._appliers.items():
+            try:
+                applies.append(await applier.run_once())
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 - one vault must not stop the rest
+                logger.exception("curator: apply pass failed for vault %r", vault)
+        return runs, applies
+
+
+__all__ = [
+    "DEFAULT_DEBOUNCE_SECONDS",
+    "DEFAULT_INTERVAL_SECONDS",
+    "CuratorScheduler",
+]

--- a/v3/server/src/palaia_hub/curator/session.py
+++ b/v3/server/src/palaia_hub/curator/session.py
@@ -1,0 +1,193 @@
+"""Launching one bounded curation session (SPEC-206 deliverable #1).
+
+The session is a **config-driven runner command**, not a hardcoded vendor
+call: the default is a headless ``claude -p`` with a strict MCP config
+pointing only at the curator profile, but the command is a template in
+``config.yaml`` (:class:`palaia_hub.config.CuratorSettings`), so a different
+provider's CLI is a config edit rather than a code change. palaia is
+provider-neutral by design (MASTERPLAN §2) and the curator is no exception.
+
+Contract with whatever command is configured:
+
+- the **prompt arrives on stdin** — every CLI worth using reads a prompt
+  there, and it keeps a multi-kilobyte prompt out of argv;
+- ``{mcp_config}`` in any argument is replaced by the path to a generated,
+  single-server MCP config file (the curator profile, with the curator
+  token's ``Authorization`` header);
+- ``{allowed_tools}`` is replaced by the comma-separated list of tools the
+  session may call, ``{endpoint}``/``{vault}``/``{capture_id}`` by their
+  obvious values;
+- exit code, stdout and stderr are recorded, a timeout kills the process.
+
+Nothing in the outcome depends on any of that succeeding: a session that
+crashes, times out or lies is classified by :mod:`palaia_hub.curator.verify`
+like any other.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import tempfile
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+from .models import SessionResult
+
+logger = logging.getLogger("palaia_hub.curator.session")
+
+#: The MCP server name the generated config uses. It shows up in a client's
+#: tool names (``mcp__palaia__work_memory_write``), which is why
+#: :func:`palaia_hub.curator.profile.allowed_tool_specs` builds its
+#: ``--allowed-tools`` values from the same constant.
+MCP_SERVER_NAME = "palaia"
+
+#: The default runner command (SPEC-206 deliverable #1). ``claude -p`` reads
+#: the prompt from stdin; ``--strict-mcp-config`` makes the generated config
+#: the *only* MCP config in effect, so the session cannot reach a vault
+#: through some other server the user happens to have configured.
+DEFAULT_RUNNER_COMMAND: tuple[str, ...] = (
+    "claude",
+    "-p",
+    "--mcp-config",
+    "{mcp_config}",
+    "--strict-mcp-config",
+    "--allowed-tools",
+    "{allowed_tools}",
+    "--output-format",
+    "text",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SessionRequest:
+    """Everything one session needs to know."""
+
+    vault: str
+    capture_id: str
+    prompt: str
+    endpoint: str
+    allowed_tools: tuple[str, ...] = ()
+    token: str | None = None
+
+
+class SessionRunner(Protocol):
+    """Runs one curation session and reports how it went, mechanically.
+
+    The seam tests replace: a scripted runner performs a fixed set of MCP
+    calls with no model involved (``tests/curator/scripted.py``), while
+    production spawns :class:`SubprocessSessionRunner`.
+    """
+
+    async def run(self, request: SessionRequest) -> SessionResult: ...
+
+
+def mcp_config_document(request: SessionRequest) -> dict[str, object]:
+    """The strict, single-server MCP config a session is launched with."""
+    server: dict[str, object] = {"type": "http", "url": request.endpoint}
+    if request.token:
+        server["headers"] = {"Authorization": f"Bearer {request.token}"}
+    return {"mcpServers": {MCP_SERVER_NAME: server}}
+
+
+@dataclass
+class SubprocessSessionRunner:
+    """Spawns the configured command with the prompt on stdin.
+
+    Args:
+        command: the argv template (see :data:`DEFAULT_RUNNER_COMMAND`).
+        timeout: seconds before the session is killed and reported as timed
+            out. A curation session is a background job; a hung one must
+            never wedge the runner.
+        env: extra environment for the child process.
+        cwd: working directory for the child process.
+    """
+
+    command: Sequence[str] = DEFAULT_RUNNER_COMMAND
+    timeout: float = 300.0
+    env: Mapping[str, str] = field(default_factory=dict)
+    cwd: Path | None = None
+
+    def argv(self, request: SessionRequest, mcp_config_path: Path) -> list[str]:
+        """The concrete argv for ``request``, with every placeholder filled."""
+        replacements = {
+            "{mcp_config}": str(mcp_config_path),
+            "{allowed_tools}": ",".join(request.allowed_tools),
+            "{endpoint}": request.endpoint,
+            "{vault}": request.vault,
+            "{capture_id}": request.capture_id,
+        }
+        argv: list[str] = []
+        for argument in self.command:
+            filled = argument
+            for placeholder, value in replacements.items():
+                filled = filled.replace(placeholder, value)
+            argv.append(filled)
+        return argv
+
+    async def run(self, request: SessionRequest) -> SessionResult:
+        started = time.monotonic()
+        with tempfile.TemporaryDirectory(prefix="palaia-curator-") as tmp:
+            config_path = Path(tmp) / "mcp.json"
+            config_path.write_text(
+                json.dumps(mcp_config_document(request), indent=2), encoding="utf-8"
+            )
+            argv = self.argv(request, config_path)
+            try:
+                process = await asyncio.create_subprocess_exec(
+                    *argv,
+                    stdin=asyncio.subprocess.PIPE,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    env={**os.environ, **self.env},
+                    cwd=str(self.cwd) if self.cwd else None,
+                )
+            except OSError as exc:
+                logger.warning("curator runner command failed to start: %s", exc)
+                return SessionResult(
+                    exit_code=127,
+                    stderr=(
+                        f"could not start the curator runner command {argv[0]!r}: {exc}. "
+                        "Fix: install it, or set `curator.runner_command` in "
+                        "config.yaml to a command this hub can run."
+                    ),
+                    duration_seconds=time.monotonic() - started,
+                    launched=False,
+                )
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    process.communicate(request.prompt.encode("utf-8")),
+                    timeout=self.timeout,
+                )
+            except TimeoutError:
+                process.kill()
+                with contextlib.suppress(ProcessLookupError):
+                    await process.wait()
+                return SessionResult(
+                    exit_code=-1,
+                    stderr=f"curation session exceeded {self.timeout:.0f}s and was killed",
+                    timed_out=True,
+                    duration_seconds=time.monotonic() - started,
+                )
+        return SessionResult(
+            exit_code=process.returncode if process.returncode is not None else -1,
+            stdout=stdout.decode("utf-8", errors="replace"),
+            stderr=stderr.decode("utf-8", errors="replace"),
+            duration_seconds=time.monotonic() - started,
+        )
+
+
+__all__ = [
+    "DEFAULT_RUNNER_COMMAND",
+    "MCP_SERVER_NAME",
+    "SessionRequest",
+    "SessionRunner",
+    "SubprocessSessionRunner",
+    "mcp_config_document",
+]

--- a/v3/server/src/palaia_hub/curator/verify.py
+++ b/v3/server/src/palaia_hub/curator/verify.py
@@ -1,0 +1,74 @@
+"""Verification, not trust (SPEC-206 rule 3).
+
+A session's own report is a claim. This module is the check: after the
+session ends, look for the capture's provenance line
+(:func:`palaia_hub.curator.policy.provenance_line`) in the vault itself and
+classify from what is actually on disk —
+
+- a **real note** carries it → ``ingested``
+- only a ``review/`` **proposal** carries it → ``needs_review``
+- **nothing** carries it → ``unverified``
+
+The scan reads files through the engine rather than querying the search
+index: the index is a derived, eventually-consistent view (its embed backlog
+drains in the background), and a capture must never be deleted because a
+stale index happened to say the work landed. Files are the only truth.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ..vault import VaultEngine
+from .models import CaptureOutcome, PendingCapture
+from .policy import INBOX_PREFIX, REVIEW_PREFIX, provenance_ids
+
+
+@dataclass(frozen=True, slots=True)
+class Verification:
+    """What the vault says happened, independent of what the session said."""
+
+    outcome: CaptureOutcome
+    notes: list[str] = field(default_factory=list)
+    proposals: list[str] = field(default_factory=list)
+
+    @property
+    def targets(self) -> list[str]:
+        return [*self.notes, *self.proposals]
+
+
+async def verify_capture(engine: VaultEngine, capture: PendingCapture) -> Verification:
+    """Classify ``capture``'s outcome by searching the vault for its id.
+
+    ``inbox/`` is skipped wholesale: the capture note itself carries its own
+    ``capture_id`` in frontmatter, and no other inbox entry can be evidence
+    that this one was curated.
+    """
+    await engine.refresh()
+    notes: list[str] = []
+    proposals: list[str] = []
+    for entry in list(engine.catalog.values()):
+        if entry.path.startswith(INBOX_PREFIX):
+            continue
+        note = await engine.read_note(entry.path)
+        if capture.capture_id not in note.text:
+            continue
+        if capture.capture_id not in provenance_ids(note.body):
+            # The id appears, but not as a provenance line — prose mentioning
+            # a capture id is not evidence that the knowledge landed.
+            continue
+        permalink = note.permalink or note.path
+        if entry.path.startswith(REVIEW_PREFIX):
+            proposals.append(permalink)
+        else:
+            notes.append(permalink)
+    notes.sort()
+    proposals.sort()
+    if notes:
+        return Verification(outcome="ingested", notes=notes, proposals=proposals)
+    if proposals:
+        return Verification(outcome="needs_review", proposals=proposals)
+    return Verification(outcome="unverified")
+
+
+__all__ = ["Verification", "verify_capture"]

--- a/v3/server/src/palaia_hub/curator/wiring.py
+++ b/v3/server/src/palaia_hub/curator/wiring.py
@@ -1,0 +1,158 @@
+"""One place that assembles a working curator (SPEC-206).
+
+Both entry points — the hub's own scheduled curator
+(:func:`palaia_hub.serve.build_production_app`) and the ``palaia-hub curator``
+CLI — go through :func:`build_curator`, so "how the curator is put together"
+has one definition: same guards, same audit sinks, same runner command.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from fastmcp.server.middleware import Middleware
+
+from ..config import HubConfig
+from ..events.schema import Envelope
+from ..gateway.config import VaultMountConfig
+from ..stash import StashService, StashStore
+from ..vault import VaultEngine
+from .apply import ProposalApplier
+from .audit import CuratorAudit, Publisher
+from .policy import ActiveCaptures
+from .profile import CURATOR_PROFILE_PATH, allowed_tool_specs, curator_profile_middleware
+from .runner import CuratorRunner
+from .service import CuratorScheduler
+from .session import SessionRunner, SubprocessSessionRunner
+
+#: ``EventBus.on`` — how the scheduler subscribes to ``inbox.captured``.
+SchedulerSubscribe = Callable[[Callable[[Envelope], None]], Callable[[], None]]
+
+#: The environment variable holding the curator token. Preferred over
+#: ``curator.token`` in ``config.yaml``: a token in a config file is a secret
+#: in a config file.
+TOKEN_ENV = "PALAIA_CURATOR_TOKEN"
+
+#: The stash file the curator's audit trail lands in, under the hub's home.
+STASH_FILENAME = "stash.db"
+
+
+@dataclass
+class CuratorWiring:
+    """Everything a wired-up curator consists of."""
+
+    scheduler: CuratorScheduler
+    runners: dict[str, CuratorRunner]
+    appliers: dict[str, ProposalApplier]
+    active_captures: ActiveCaptures
+    profile_middleware: dict[str, list[Middleware]] = field(default_factory=dict)
+    stash_store: StashStore | None = None
+
+    async def aclose(self) -> None:
+        await self.scheduler.aclose()
+        if self.stash_store is not None:
+            self.stash_store.close()
+
+
+def curator_token(config: HubConfig) -> str | None:
+    """The curator token: environment first, then ``config.yaml``."""
+    return os.environ.get(TOKEN_ENV) or config.curator.token
+
+
+def build_curator(
+    config: HubConfig,
+    engines: Mapping[str, VaultEngine],
+    mounts: Sequence[VaultMountConfig],
+    *,
+    home: Path | None = None,
+    publish: Publisher | None = None,
+    session_runner: SessionRunner | None = None,
+    with_stash: bool = True,
+    subscribe: SchedulerSubscribe | None = None,
+) -> CuratorWiring:
+    """Assemble runners, appliers, the scheduler and the profile guard.
+
+    Args:
+        config: the hub config (``curator:`` section).
+        engines: the vaults to curate, ``{vault_key: opened engine}``.
+        mounts: the same vaults' gateway mount configs — the guard needs
+            them to know each vault's tool names.
+        home: where the audit stash lives (the hub's data dir).
+        publish: the event sink (``publish(event, data)``); omitted, no
+            events are emitted.
+        session_runner: overrides how a session is launched. Tests pass a
+            scripted runner; production leaves this alone and gets
+            :class:`~palaia_hub.curator.session.SubprocessSessionRunner`
+            built from ``config.curator.runner_command``.
+        with_stash: open the audit stash. ``False`` keeps the whole wiring
+            free of any file I/O beyond the vaults themselves.
+        subscribe: the event bus's ``on()``, so a capture wakes the curator
+            (debounced). Omitted, the scheduler runs on its interval only —
+            which is what the one-shot CLI wants.
+    """
+    settings = config.curator
+    stash_store: StashStore | None = None
+    stash_service: StashService | None = None
+    if with_stash:
+        stash_store = StashStore(Path(home or Path.cwd()) / STASH_FILENAME)
+        stash_service = StashService(stash_store)
+    audit = CuratorAudit(publish=publish, stash=stash_service)
+
+    runner = session_runner or SubprocessSessionRunner(
+        command=list(settings.runner_command), timeout=settings.session_timeout
+    )
+    active_captures = ActiveCaptures()
+    allowed_tools = allowed_tool_specs(mounts)
+    endpoint = f"{config.curator_endpoint()}/mcp/{CURATOR_PROFILE_PATH}"
+    token = curator_token(config)
+    purposes = {mount.key: mount.purpose for mount in mounts}
+
+    runners = {
+        key: CuratorRunner(
+            engine,
+            session_runner=runner,
+            endpoint=endpoint,
+            token=token,
+            allowed_tools=allowed_tools,
+            audit=audit,
+            active_captures=active_captures,
+            max_attempts=settings.max_attempts,
+            purpose=purposes.get(key, ""),
+        )
+        for key, engine in engines.items()
+    }
+    appliers = (
+        {key: ProposalApplier(engine, audit=audit) for key, engine in engines.items()}
+        if settings.auto_apply
+        else {}
+    )
+    scheduler = CuratorScheduler(
+        runners,
+        appliers=appliers,
+        debounce_seconds=settings.debounce_seconds,
+        interval_seconds=settings.interval_seconds,
+        subscribe=subscribe,
+    )
+    return CuratorWiring(
+        scheduler=scheduler,
+        runners=runners,
+        appliers=appliers,
+        active_captures=active_captures,
+        profile_middleware=curator_profile_middleware(
+            mounts, active_captures=active_captures
+        ),
+        stash_store=stash_store,
+    )
+
+
+__all__ = [
+    "STASH_FILENAME",
+    "TOKEN_ENV",
+    "CuratorWiring",
+    "SchedulerSubscribe",
+    "build_curator",
+    "curator_token",
+]

--- a/v3/server/src/palaia_hub/events/schema.py
+++ b/v3/server/src/palaia_hub/events/schema.py
@@ -49,6 +49,17 @@ EventName = Literal[
     "index.reindexed",
     "index.embed_backlog_drained",
     "doctor.finding",
+    # SPEC-206 (the curator): one event per capture outcome, one per applied
+    # proposal, one per run. Additive to the v1 vocabulary — a consumer that
+    # has never heard of them ignores them (docs/events.md "Evolution rule").
+    "curator.capture.ingested",
+    "curator.capture.needs_review",
+    "curator.capture.unverified",
+    "curator.capture.retired",
+    "curator.run.finished",
+    "curator.proposal.applied",
+    "curator.proposal.apply_failed",
+    "curator.proposal.manual",
     "stash.set",
     "stash.get",
     "stash.del",

--- a/v3/server/src/palaia_hub/gateway/build.py
+++ b/v3/server/src/palaia_hub/gateway/build.py
@@ -26,12 +26,13 @@ Binding findings this module follows exactly (SPEC-002,
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
 from fastmcp import FastMCP
 from fastmcp.server.auth import TokenVerifier
+from fastmcp.server.middleware import Middleware
 from fastmcp.utilities.lifespan import combine_lifespans
 from starlette.types import ASGIApp
 
@@ -99,6 +100,7 @@ def _build_profile_server(
     config: GatewayConfig,
     vault_servers: Mapping[str, FastMCP],
     auth: TokenVerifier | None,
+    middleware: Sequence[Middleware] = (),
 ) -> FastMCP:
     # `mount()` does not propagate a mounted server's `instructions` to its
     # parent, so a real client connecting to this profile would otherwise
@@ -121,6 +123,12 @@ def _build_profile_server(
     server = FastMCP(
         name=f"palaia-gateway-{profile.path}", instructions=instructions, auth=auth
     )
+    # `middleware` (SPEC-206): per-profile request middleware, applied here
+    # rather than after the fact, so a profile *rebuilt* at runtime
+    # (DynamicGateway) never comes back without the policy it was mounted
+    # with. Empty (the default) leaves the server exactly as before.
+    for item in middleware:
+        server.add_middleware(item)
     for vault_config in vault_configs:
         tool_names = resolve_tool_names(vault_config.namespace, vault_config.tool_renames)
         server.mount(
@@ -136,6 +144,7 @@ def build_gateway(
     vault_services: Mapping[str, VaultService],
     *,
     token_verifiers: Mapping[str, TokenVerifier] | None = None,
+    profile_middleware: Mapping[str, Sequence[Middleware]] | None = None,
 ) -> GatewayASGI:
     """Build the full gateway from a validated config and its backing services.
 
@@ -148,6 +157,12 @@ def build_gateway(
             here is mounted with no auth at all, exactly as before this
             parameter existed; a profile with an entry requires every
             request to present a bearer token that verifier accepts.
+        profile_middleware: optional per-profile-path fastmcp middleware
+            (SPEC-206 — see :func:`palaia_hub.curator.profile.
+            curator_profile_middleware`). Attached while the profile's
+            server is built, so a later rebuild of that profile carries the
+            same middleware. A profile with no entry is built exactly as
+            before this parameter existed.
 
     Raises :class:`GatewayConfigError` if a configured vault has no entry in
     ``vault_services``. Structural config problems (duplicate keys, unknown
@@ -161,7 +176,8 @@ def build_gateway(
     lifespans: list[Lifespan] = []
     for profile in config.profiles:
         auth = (token_verifiers or {}).get(profile.path)
-        server = _build_profile_server(profile, config, vault_servers, auth)
+        middleware = (profile_middleware or {}).get(profile.path, ())
+        server = _build_profile_server(profile, config, vault_servers, auth, middleware)
         profile_servers[profile.path] = server
         asgi_app = server.http_app(path="/")
         mounts[f"/mcp/{profile.path}"] = asgi_app

--- a/v3/server/src/palaia_hub/gateway/dynamic.py
+++ b/v3/server/src/palaia_hub/gateway/dynamic.py
@@ -84,13 +84,14 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
 
 from fastmcp import FastMCP
 from fastmcp.server.auth import TokenVerifier
 from fastmcp.server.http import StarletteWithLifespan
+from fastmcp.server.middleware import Middleware
 from starlette.routing import Mount, Router
 from starlette.types import ASGIApp
 
@@ -130,6 +131,10 @@ class DynamicGateway:
             ``config.yaml`` at startup does.
         token_verifiers: optional per-profile-path verifier, same contract
             as :func:`~.build.build_gateway`.
+        profile_middleware: optional per-profile-path fastmcp middleware,
+            same contract as :func:`~.build.build_gateway` — re-applied on
+            every rebuild of that profile (SPEC-206: the curator profile's
+            policy must survive a vault being added at runtime).
     """
 
     def __init__(
@@ -139,12 +144,16 @@ class DynamicGateway:
         *,
         mode: str = "locked",
         token_verifiers: Mapping[str, TokenVerifier] | None = None,
+        profile_middleware: Mapping[str, Sequence[Middleware]] | None = None,
     ) -> None:
         self._config = config
         self._vault_services: dict[str, VaultService] = dict(vault_services)
         self._vault_servers: dict[str, FastMCP] = _build_vault_servers(config, self._vault_services)
         self._mode = mode
         self._token_verifiers: dict[str, TokenVerifier] = dict(token_verifiers or {})
+        self._profile_middleware: dict[str, Sequence[Middleware]] = dict(
+            profile_middleware or {}
+        )
         self.router = Router(routes=[])
         self._profile_servers: dict[str, FastMCP] = {}
         self._lock = asyncio.Lock()
@@ -224,7 +233,10 @@ class DynamicGateway:
         caller's own task) and hand it to the lifecycle task to actually
         mount. Caller holds ``self._lock``."""
         auth = self._token_verifiers.get(profile.path)
-        server = _build_profile_server(profile, self._config, self._vault_servers, auth)
+        middleware = self._profile_middleware.get(profile.path, ())
+        server = _build_profile_server(
+            profile, self._config, self._vault_servers, auth, middleware
+        )
         asgi_app = server.http_app(path="/")
         done: asyncio.Future[None] = asyncio.get_running_loop().create_future()
         await self._queue.put(_MountCommand(profile.path, server, asgi_app, done))

--- a/v3/server/src/palaia_hub/serve.py
+++ b/v3/server/src/palaia_hub/serve.py
@@ -34,6 +34,8 @@ from fastapi import FastAPI
 from .app import create_app
 from .auth import TokenStore, build_profile_verifiers
 from .config import HubConfig
+from .curator import curator_profile
+from .curator.wiring import CuratorWiring, build_curator
 from .dashboard_api import DEFAULT_GATEWAY_PROFILE
 from .events import EventBus, publish_from_hook
 from .events.schema import HubEventHook
@@ -44,7 +46,7 @@ from .hooks import HookStore
 from .index import VaultIndex
 from .oauth import AuthorizationServer
 from .vault import EventBus as VaultEventBus
-from .vault import VaultRegistry
+from .vault import VaultEngine, VaultRegistry
 
 
 @dataclass
@@ -58,6 +60,10 @@ class ProductionApp:
     indexes: dict[str, VaultIndex]
     event_bus: EventBus
     token_store: TokenStore
+    #: The wired-up curator (SPEC-206), or ``None`` when
+    #: ``curator.enabled`` is off. Its scheduler is started and stopped by
+    #: the app's own lifespan; its stash handle is closed here.
+    curator: CuratorWiring | None = None
 
 
 def _index_event_hook(event_bus: EventBus, vault_key: str) -> HubEventHook:
@@ -72,6 +78,15 @@ def _index_event_hook(event_bus: EventBus, vault_key: str) -> HubEventHook:
 
     def _hook(event: str, data: dict[str, Any]) -> None:
         publish_from_hook(event_bus, event, {"vault": vault_key, **data}, origin="index")
+
+    return _hook
+
+
+def _curator_event_hook(event_bus: EventBus) -> HubEventHook:
+    """Promote the curator's ``curator.*``/``doctor.finding`` reports onto the bus."""
+
+    def _hook(event: str, data: dict[str, Any]) -> None:
+        publish_from_hook(event_bus, event, data, origin="curator")
 
     return _hook
 
@@ -105,12 +120,14 @@ async def build_production_app(
     indexes: dict[str, VaultIndex] = {}
     vault_services: dict[str, VaultService] = {}
     mounts: list[VaultMountConfig] = []
+    engines: dict[str, VaultEngine] = {}
 
     for record in registry.records():
         engine = await registry.get(record.name)
         index = VaultIndex(engine, on_event=_index_event_hook(event_bus, record.name))
         await index.open()
         indexes[record.name] = index
+        engines[record.name] = engine
         vault_services[record.name] = EngineVaultService(engine, index)
         mounts.append(
             VaultMountConfig(
@@ -125,18 +142,40 @@ async def build_production_app(
         if mounts
         else []
     )
+
+    # SPEC-206: the curator gets its own profile over the same vaults —
+    # narrowed to seven actions and guarded by its own middleware (see
+    # palaia_hub.curator.profile). Built before the gateway so the middleware
+    # is attached while each profile's server is constructed, which is what
+    # makes it survive a later profile rebuild.
+    curator: CuratorWiring | None = None
+    if config.curator.enabled and mounts:
+        curator = build_curator(
+            config,
+            engines,
+            mounts,
+            home=home,
+            publish=_curator_event_hook(event_bus),
+            subscribe=event_bus.on,
+        )
+        profiles.append(curator_profile([m.key for m in mounts]))
+
     gateway_config = GatewayConfig(vaults=mounts, profiles=profiles)
     # `auth_enabled` (config.py): mandatory in cloud/open (already enforced
     # at config-load time), on by default in locked mode too — see that
     # field's docstring. Building verifiers here, unconditionally on the
     # flag rather than on `mode`, matches that documented behavior exactly.
     token_verifiers = (
-        build_profile_verifiers([DEFAULT_GATEWAY_PROFILE], token_store)
+        build_profile_verifiers([p.path for p in profiles], token_store)
         if config.auth_enabled
         else {}
     )
     dynamic_gateway = DynamicGateway(
-        gateway_config, vault_services, mode=config.mode, token_verifiers=token_verifiers
+        gateway_config,
+        vault_services,
+        mode=config.mode,
+        token_verifiers=token_verifiers,
+        profile_middleware=curator.profile_middleware if curator else None,
     )
 
     app = create_app(
@@ -149,6 +188,7 @@ async def build_production_app(
         event_bus=event_bus,
         oauth_server=oauth_server,
         hook_store=hook_store,
+        curator=curator.scheduler if curator else None,
     )
     return ProductionApp(
         app=app,
@@ -157,6 +197,7 @@ async def build_production_app(
         indexes=indexes,
         event_bus=event_bus,
         token_store=token_store,
+        curator=curator,
     )
 
 

--- a/v3/server/tests/curator/conftest.py
+++ b/v3/server/tests/curator/conftest.py
@@ -1,0 +1,40 @@
+"""Fixtures for the curator suite (SPEC-206)."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+
+import pytest
+
+from palaia_hub.gateway.config import VaultMountConfig
+from palaia_hub.vault import VaultEngine
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture
+def vault_mount() -> VaultMountConfig:
+    return VaultMountConfig(
+        key="work", name="work", purpose="Team knowledge for ACME engineering."
+    )
+
+
+@pytest.fixture
+def vault_root(tmp_path: Path) -> Iterator[Path]:
+    root = tmp_path / "work"
+    root.mkdir()
+    yield root
+
+
+@pytest.fixture
+async def engine(vault_root: Path) -> AsyncIterator[VaultEngine]:
+    engine = VaultEngine(vault_root, name="work")
+    await engine.open(purpose="Team knowledge for ACME engineering.", create=True)
+    try:
+        yield engine
+    finally:
+        await engine.close()

--- a/v3/server/tests/curator/harness.py
+++ b/v3/server/tests/curator/harness.py
@@ -1,0 +1,131 @@
+"""One helper that wires a real curator over a real vault, for the tests.
+
+Same pieces production uses (:mod:`palaia_hub.curator.wiring` builds the same
+graph): a vault engine, the gateway's curator profile with its middleware, and
+a runner whose sessions are scripted instead of modelled.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from fastmcp import FastMCP
+from scripted import Script, ScriptedSessionRunner
+
+from palaia_hub.curator.audit import CuratorAudit
+from palaia_hub.curator.models import CaptureRecord, CuratorRunReport
+from palaia_hub.curator.policy import ActiveCaptures
+from palaia_hub.curator.profile import (
+    CURATOR_PROFILE_PATH,
+    curator_profile,
+    curator_profile_middleware,
+)
+from palaia_hub.curator.runner import CuratorRunner
+from palaia_hub.gateway.build import build_gateway
+from palaia_hub.gateway.config import GatewayConfig, VaultMountConfig
+from palaia_hub.gateway.wiring import EngineVaultService
+from palaia_hub.vault import VaultEngine
+
+
+@dataclass
+class RecordingStash:
+    """A stash stand-in that just remembers what was written."""
+
+    entries: dict[tuple[str, str], Any] = field(default_factory=dict)
+
+    async def set(
+        self,
+        namespace: str,
+        key: str,
+        value: Any,
+        *,
+        ttl_seconds: float | None = None,
+        stale_after_seconds: float | None = None,
+    ) -> None:
+        self.entries[(namespace, key)] = value
+
+
+@dataclass
+class CuratorHarness:
+    engine: VaultEngine
+    mount: VaultMountConfig
+    service: EngineVaultService
+    profile: FastMCP
+    active_captures: ActiveCaptures
+    session_runner: ScriptedSessionRunner
+    runner: CuratorRunner
+    events: list[tuple[str, dict[str, Any]]]
+    stash: RecordingStash
+
+    @property
+    def namespace(self) -> str:
+        return self.mount.namespace
+
+    async def capture(
+        self, *, what_it_concerns: str, why_keep: str, content: str
+    ) -> str:
+        """Drop a real capture into ``inbox/`` and return its capture_id."""
+        result = await self.service.capture(
+            what_it_concerns=what_it_concerns, why_keep=why_keep, content=content
+        )
+        return result.capture_id
+
+    async def run_once(self) -> CuratorRunReport:
+        return await self.runner.run_once()
+
+    def event_names(self) -> list[str]:
+        return [name for name, _ in self.events]
+
+    def records(self, report: CuratorRunReport) -> list[CaptureRecord]:
+        return list(report.records)
+
+
+def build_harness(
+    engine: VaultEngine,
+    mount: VaultMountConfig,
+    script: Script,
+    *,
+    stdout: str = "",
+    exit_code: int = 0,
+    max_attempts: int = 3,
+) -> CuratorHarness:
+    service = EngineVaultService(engine)
+    active_captures = ActiveCaptures()
+    middleware = curator_profile_middleware([mount], active_captures=active_captures)
+    gateway = build_gateway(
+        GatewayConfig(vaults=[mount], profiles=[curator_profile([mount.key])]),
+        {mount.key: service},
+        profile_middleware=middleware,
+    )
+    profile = gateway.profile_servers[CURATOR_PROFILE_PATH]
+    session_runner = ScriptedSessionRunner(
+        server=profile, script=script, stdout=stdout, exit_code=exit_code
+    )
+    events: list[tuple[str, dict[str, Any]]] = []
+    stash = RecordingStash()
+    audit = CuratorAudit(
+        publish=lambda event, data: events.append((event, data)), stash=stash
+    )
+    runner = CuratorRunner(
+        engine,
+        session_runner=session_runner,
+        endpoint="http://testserver/mcp/curator",
+        token="plt_test",
+        allowed_tools=(),
+        audit=audit,
+        active_captures=active_captures,
+        max_attempts=max_attempts,
+        purpose=mount.purpose,
+    )
+    return CuratorHarness(
+        engine=engine,
+        mount=mount,
+        service=service,
+        profile=profile,
+        active_captures=active_captures,
+        session_runner=session_runner,
+        runner=runner,
+        events=events,
+        stash=stash,
+    )

--- a/v3/server/tests/curator/scripted.py
+++ b/v3/server/tests/curator/scripted.py
@@ -1,0 +1,142 @@
+"""A scripted curation session: the fake LLM runner used by the curator tests.
+
+SPEC-206 acceptance criterion #5 wants an end-to-end run "with a scripted
+fake LLM runner (no real model in CI)". This is that runner — and it is a
+*real* client of the curator profile: every call it makes goes through the
+gateway's middleware, the memory tool family and the vault engine, exactly
+like a model's would. Only the deciding is scripted.
+
+Nothing here shortcuts the guards. A script that tries a forbidden call gets
+the same refusal a model would (see ``lying_session`` and the guard matrix).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+
+from fastmcp import Client, FastMCP
+
+from palaia_hub.curator.models import SessionResult
+from palaia_hub.curator.session import SessionRequest
+
+#: A script: given a connected client and the session's request, do things.
+Script = Callable[[Client, SessionRequest], Awaitable[None]]
+
+
+@dataclass
+class ScriptedSessionRunner:
+    """Runs ``script`` against ``server`` instead of spawning a model."""
+
+    server: FastMCP
+    script: Script
+    stdout: str = ""
+    exit_code: int = 0
+    #: Every request this runner was asked to run, in order — so a test can
+    #: assert that an empty inbox launched no session at all.
+    requests: list[SessionRequest] = field(default_factory=list)
+    #: Every ``(tool, arguments, is_error, text)`` the script performed.
+    calls: list[tuple[str, dict[str, object], bool, str]] = field(default_factory=list)
+
+    async def run(self, request: SessionRequest) -> SessionResult:
+        self.requests.append(request)
+        async with Client(self.server) as client:
+            recorder = _RecordingClient(client, self.calls)
+            await self.script(recorder, request)  # type: ignore[arg-type]
+        return SessionResult(exit_code=self.exit_code, stdout=self.stdout)
+
+
+class _RecordingClient:
+    """Thin proxy that records every ``call_tool`` a script makes."""
+
+    def __init__(
+        self, client: Client, sink: list[tuple[str, dict[str, object], bool, str]]
+    ) -> None:
+        self._client = client
+        self._sink = sink
+
+    async def call_tool(
+        self, name: str, arguments: dict[str, object] | None = None
+    ) -> object:
+        result = await self._client.call_tool(name, arguments or {}, raise_on_error=False)
+        text = result.content[0].text if result.content else ""  # type: ignore[union-attr]
+        self._sink.append((name, arguments or {}, bool(result.is_error), text))
+        return result
+
+    def __getattr__(self, item: str) -> object:  # pragma: no cover - passthrough
+        return getattr(self._client, item)
+
+
+def ingest_session(namespace: str, *, folder: str = "projects") -> Script:
+    """A well-behaved session: search twice, then write one note with provenance."""
+
+    async def script(client: Client, request: SessionRequest) -> None:
+        await client.call_tool(f"{namespace}_search", {"query": "rate limit"})
+        await client.call_tool(f"{namespace}_search", {"query": "ingest cap"})
+        await client.call_tool(
+            f"{namespace}_write",
+            {
+                "title": "API Gateway ingest limit",
+                "body": (
+                    "The ingest limit is 100 req/min.\n\n"
+                    "- [limit] 100 req/min because the embed queue saturates above that\n"
+                    f"- [source] inbox capture {request.capture_id}\n"
+                ),
+                "folder": folder,
+            },
+        )
+
+    return script
+
+
+def proposal_session(namespace: str) -> Script:
+    """A conservative session: raise a proposal instead of rewriting a note."""
+
+    async def script(client: Client, request: SessionRequest) -> None:
+        await client.call_tool(f"{namespace}_search", {"query": "rate limit"})
+        await client.call_tool(
+            f"{namespace}_write",
+            {
+                "title": "Merge the two rate-limit notes",
+                "body": (
+                    "Two notes claim different ingest limits; merging them is a "
+                    "rewrite, so here is the plan.\n\n"
+                    f"- [source] inbox capture {request.capture_id}\n\n"
+                    "```json plan\n"
+                    '{"operations": [{"op": "append", "target": '
+                    '"projects/api-gateway", "text": "- [limit] 100 req/min"}]}\n'
+                    "```\n"
+                ),
+                "folder": "review",
+                "type": "proposal",
+            },
+        )
+
+    return script
+
+
+def lying_session(namespace: str) -> Script:
+    """A session that claims success and writes nothing that can be verified.
+
+    It also *tries* the two calls the policy forbids — deleting the capture
+    and editing it — so the test proves both that the guards refuse them and
+    that the refusal does not become a false 'ingested'.
+    """
+
+    async def script(client: Client, request: SessionRequest) -> None:
+        await client.call_tool(f"{namespace}_delete", {"permalink": "inbox/anything"})
+        await client.call_tool(
+            f"{namespace}_edit",
+            {"permalink": "inbox/anything", "append": "- [note] curated, trust me"},
+        )
+
+    return script
+
+
+def silent_session() -> Script:
+    """A session that does nothing at all."""
+
+    async def script(client: Client, request: SessionRequest) -> None:
+        return None
+
+    return script

--- a/v3/server/tests/curator/support/curator_hub.py
+++ b/v3/server/tests/curator/support/curator_hub.py
@@ -1,0 +1,48 @@
+"""A standalone hub serving only the curator profile, for the smoke test.
+
+Invoked as ``sys.executable curator_hub.py <vault_root> <port>`` by
+``tests/curator/test_real_runner_smoke.py`` (env-gated, never in CI). No
+token verifier is attached: the point of the smoke test is the *policy*
+surface — that a real session can reach exactly the seven allowed tools and
+nothing else — and adding auth would only add a second thing to debug when
+the CLI cannot connect.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import uvicorn
+
+from palaia_hub.app import create_app
+from palaia_hub.config import HubConfig
+from palaia_hub.curator.profile import curator_profile, curator_profile_middleware
+from palaia_hub.gateway.build import build_gateway
+from palaia_hub.gateway.config import GatewayConfig, VaultMountConfig
+from palaia_hub.gateway.wiring import EngineVaultService
+from palaia_hub.vault import VaultEngine
+
+
+async def _run(vault_root: Path, port: int) -> None:
+    engine = VaultEngine(vault_root, name="work")
+    await engine.open(purpose="Smoke-test vault for the curator.", create=True)
+    mount = VaultMountConfig(key="work", name="work", purpose="Smoke-test vault.")
+    gateway = build_gateway(
+        GatewayConfig(vaults=[mount], profiles=[curator_profile([mount.key])]),
+        {mount.key: EngineVaultService(engine)},
+        profile_middleware=curator_profile_middleware([mount]),
+    )
+    app = create_app(HubConfig(auth_enabled=False), gateway=gateway)
+    server = uvicorn.Server(
+        uvicorn.Config(app, host="127.0.0.1", port=port, log_config=None)
+    )
+    try:
+        await server.serve()
+    finally:
+        await engine.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(_run(Path(sys.argv[1]), int(sys.argv[2])))

--- a/v3/server/tests/curator/test_apply.py
+++ b/v3/server/tests/curator/test_apply.py
@@ -1,0 +1,230 @@
+"""Deterministic apply (SPEC-206 rule 4, acceptance criterion #3).
+
+State machine under test: an ``approved`` proposal leaves this pass in
+exactly one terminal status — ``applied``, ``apply-failed`` or ``manual`` —
+never in ``approved``, and never without its pre-images recorded first.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from palaia_hub.curator.apply import (
+    APPLY_FAILED_PREFIX,
+    PlanError,
+    ProposalApplier,
+    parse_plan,
+)
+from palaia_hub.curator.audit import CuratorAudit
+from palaia_hub.vault import NoteNotFoundError, VaultEngine
+
+PLAN_APPEND: dict[str, Any] = {
+    "operations": [
+        {"op": "append", "target": "projects/api-gateway", "text": "- [limit] 100 req/min"}
+    ]
+}
+
+
+async def _seed_note(engine: VaultEngine, path: str, title: str, body: str) -> None:
+    await engine.write_note(path, title=title, body=body)
+
+
+async def _proposal(
+    engine: VaultEngine,
+    *,
+    path: str = "review/merge-rate-limits.md",
+    status: str = "approved",
+    plan: dict[str, Any] | None = None,
+    plan_text: str | None = None,
+    label: str = "plan",
+) -> str:
+    body = "Two notes disagree about the ingest limit; merge them.\n"
+    if plan_text is not None:
+        body += f"\n```json {label}\n{plan_text}\n```\n"
+    elif plan is not None:
+        body += f"\n```json {label}\n{json.dumps(plan)}\n```\n"
+    result = await engine.write_note(
+        path,
+        title="Merge rate limits",
+        body=body,
+        frontmatter={"type": "proposal", "status": status},
+    )
+    assert result.note is not None
+    return result.note.path
+
+
+@pytest.mark.anyio
+async def test_an_approved_proposal_applies_and_preserves_pre_images(
+    engine: VaultEngine,
+) -> None:
+    await _seed_note(engine, "projects/api-gateway.md", "API Gateway", "The gateway.\n")
+    path = await _proposal(engine, plan=PLAN_APPEND)
+    events: list[tuple[str, dict[str, Any]]] = []
+    applier = ProposalApplier(
+        engine, audit=CuratorAudit(publish=lambda e, d: events.append((e, d)))
+    )
+
+    report = await applier.run_once()
+
+    assert report.approved == 1
+    [result] = report.results
+    assert result.status == "applied"
+    assert (result.operations, result.applied) == (1, 1)
+    target = await engine.read_note("projects/api-gateway")
+    assert "- [limit] 100 req/min" in target.body
+    proposal = await engine.read_note(path)
+    assert str(proposal.frontmatter["status"]) == "applied"
+    # The pre-image of the touched note is in the proposal, before the change.
+    assert "## Pre-images" in proposal.body
+    assert "The gateway." in proposal.body
+    assert "- [limit] 100 req/min" not in proposal.body.split("## Pre-images")[1].split(
+        "````"
+    )[1]
+    assert "curator.proposal.applied" in [name for name, _ in events]
+    # A second pass finds nothing: the terminal status ends the loop.
+    assert (await applier.run_once()).approved == 0
+
+
+@pytest.mark.anyio
+async def test_a_failing_operation_stamps_apply_failed(engine: VaultEngine) -> None:
+    path = await _proposal(
+        engine,
+        plan={
+            "operations": [
+                {"op": "append", "target": "projects/does-not-exist", "text": "- [x] y"}
+            ]
+        },
+    )
+    events: list[tuple[str, dict[str, Any]]] = []
+    applier = ProposalApplier(
+        engine, audit=CuratorAudit(publish=lambda e, d: events.append((e, d)))
+    )
+
+    [result] = (await applier.run_once()).results
+
+    assert result.status == "apply-failed"
+    assert result.applied == 0
+    proposal = await engine.read_note(path)
+    assert str(proposal.frontmatter["status"]) == "apply-failed"
+    assert APPLY_FAILED_PREFIX in proposal.body
+    assert "curator.proposal.apply_failed" in [name for name, _ in events]
+    assert "doctor.finding" in [name for name, _ in events]
+
+
+@pytest.mark.anyio
+async def test_a_proposal_without_a_plan_is_manual(engine: VaultEngine) -> None:
+    path = await _proposal(engine, plan=None)
+
+    [result] = (await ProposalApplier(engine).run_once()).results
+
+    assert result.status == "manual"
+    assert "by hand" in result.reason
+    assert str((await engine.read_note(path)).frontmatter["status"]) == "manual"
+
+
+@pytest.mark.anyio
+async def test_a_malformed_plan_is_manual_not_a_crash(engine: VaultEngine) -> None:
+    path = await _proposal(engine, plan_text="{not json at all")
+
+    [result] = (await ProposalApplier(engine).run_once()).results
+
+    assert result.status == "manual"
+    assert "not valid JSON" in result.reason
+    assert str((await engine.read_note(path)).frontmatter["status"]) == "manual"
+
+
+@pytest.mark.anyio
+async def test_an_unknown_operation_is_manual(engine: VaultEngine) -> None:
+    await _proposal(
+        engine, plan={"operations": [{"op": "rm -rf", "target": "projects/x"}]}
+    )
+
+    [result] = (await ProposalApplier(engine).run_once()).results
+
+    assert result.status == "manual"
+    assert "not valid" in result.reason
+
+
+@pytest.mark.anyio
+async def test_only_approved_proposals_are_touched(engine: VaultEngine) -> None:
+    await _seed_note(engine, "projects/api-gateway.md", "API Gateway", "The gateway.\n")
+    proposed = await _proposal(
+        engine, path="review/waiting.md", status="proposed", plan=PLAN_APPEND
+    )
+    rejected = await _proposal(
+        engine, path="review/rejected.md", status="rejected", plan=PLAN_APPEND
+    )
+
+    report = await ProposalApplier(engine).run_once()
+
+    assert report.approved == 0
+    assert str((await engine.read_note(proposed)).frontmatter["status"]) == "proposed"
+    assert str((await engine.read_note(rejected)).frontmatter["status"]) == "rejected"
+    assert "- [limit]" not in (await engine.read_note("projects/api-gateway")).body
+
+
+@pytest.mark.anyio
+async def test_every_operation_kind_runs_deterministically(engine: VaultEngine) -> None:
+    await _seed_note(engine, "projects/one.md", "One", "First note.\n")
+    await _seed_note(engine, "projects/two.md", "Two", "Second note.\n")
+    await _seed_note(engine, "projects/three.md", "Three", "Third note.\n")
+    await _seed_note(engine, "projects/four.md", "Four", "Fourth note.\n")
+    await _proposal(
+        engine,
+        plan={
+            "operations": [
+                {"op": "append", "target": "projects/one", "text": "- [a] appended"},
+                {"op": "replace_body", "target": "projects/two", "body": "Rewritten.\n"},
+                {"op": "retitle", "target": "projects/three", "title": "Three Renamed"},
+                {"op": "move", "target": "projects/four", "folder": "archive"},
+                {"op": "merge", "source": "projects/three", "target": "projects/one"},
+            ]
+        },
+    )
+
+    [result] = (await ProposalApplier(engine).run_once()).results
+
+    assert (result.status, result.applied) == ("applied", 5)
+    one = await engine.read_note("projects/one")
+    assert "- [a] appended" in one.body
+    assert "Merged from Three Renamed" in one.body
+    assert (await engine.read_note("projects/two")).body.strip() == "Rewritten."
+    with pytest.raises(NoteNotFoundError):
+        await engine.read_note("projects/three")
+    assert (await engine.read_note("projects/four")).path == "archive/four.md"
+
+
+@pytest.mark.anyio
+async def test_retire_deletes_the_named_note(engine: VaultEngine) -> None:
+    await _seed_note(engine, "projects/stale.md", "Stale", "Old.\n")
+    await _proposal(engine, plan={"operations": [{"op": "retire", "target": "projects/stale"}]})
+
+    [result] = (await ProposalApplier(engine).run_once()).results
+
+    assert result.status == "applied"
+    with pytest.raises(NoteNotFoundError):
+        await engine.read_note("projects/stale")
+
+
+def test_parse_plan_accepts_a_lone_json_block_and_rejects_two() -> None:
+    single = "text\n\n```json\n{\"operations\": []}\n```\n"
+    plan = parse_plan(single)
+    assert plan is not None
+    assert plan.operations == []
+    two = single + "\n```json\n{\"operations\": []}\n```\n"
+    with pytest.raises(PlanError):
+        parse_plan(two)
+    assert parse_plan("no code block here") is None
+
+
+def test_parse_plan_prefers_the_labelled_block() -> None:
+    body = (
+        "```json\n{\"operations\": [{\"op\": \"retire\", \"target\": \"a\"}]}\n```\n"
+        "```json plan\n{\"operations\": [{\"op\": \"retire\", \"target\": \"b\"}]}\n```\n"
+    )
+    plan = parse_plan(body)
+    assert plan is not None
+    assert plan.targets() == ["b"]

--- a/v3/server/tests/curator/test_cli_curator.py
+++ b/v3/server/tests/curator/test_cli_curator.py
@@ -1,0 +1,64 @@
+"""``palaia-hub curator run/apply/token`` in-process (SPEC-206 deliverable #1)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from palaia_hub.auth.store import TokenStore
+from palaia_hub.cli import main
+from palaia_hub.curator.profile import CURATOR_PROFILE_PATH
+from palaia_hub.curator.wiring import TOKEN_ENV
+
+
+def test_curator_token_is_bound_to_the_curator_profile(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("PALAIA_HOME", str(tmp_path))
+
+    main(["curator", "token"])
+
+    out = capsys.readouterr().out
+    assert TOKEN_ENV in out
+    assert "plt_" in out
+    [info] = TokenStore(tmp_path).list_tokens()
+    assert info.profile == CURATOR_PROFILE_PATH
+    assert info.name == "curator"
+
+
+def test_curator_run_on_a_hub_with_no_vaults_says_so(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("PALAIA_HOME", str(tmp_path))
+
+    main(["curator", "run"])
+
+    assert "No vaults to curate" in capsys.readouterr().out
+
+
+def test_curator_run_reports_an_empty_inbox_per_vault(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("PALAIA_HOME", str(tmp_path))
+    from palaia_hub.vault import VaultRegistry
+
+    registry = VaultRegistry(tmp_path)
+    import asyncio
+
+    asyncio.run(_create_vault(registry, tmp_path))
+
+    main(["curator", "run"])
+
+    out = capsys.readouterr().out
+    assert "work: inbox empty, no session started." in out
+
+    main(["curator", "apply", "--json"])
+    assert '"approved": 0' in capsys.readouterr().out
+
+
+async def _create_vault(registry: object, tmp_path: Path) -> None:
+    engine = await registry.create(  # type: ignore[attr-defined]
+        "work", tmp_path / "vaults" / "work", purpose="CLI test vault."
+    )
+    await engine.close()

--- a/v3/server/tests/curator/test_e2e_scripted.py
+++ b/v3/server/tests/curator/test_e2e_scripted.py
@@ -1,0 +1,86 @@
+"""End-to-end, with a scripted fake runner (acceptance criterion #5).
+
+Two journeys, both through the real pieces — the curator profile with its
+middleware, the memory tool family, the vault engine, the runner's
+verification, and the deterministic apply pass. Only the model is scripted.
+
+1. capture → curated note → inbox entry gone
+2. capture → proposal → a human approves it → applied
+"""
+
+from __future__ import annotations
+
+import pytest
+from harness import build_harness
+from scripted import ingest_session, proposal_session
+
+from palaia_hub.curator.apply import ProposalApplier
+from palaia_hub.gateway.config import VaultMountConfig
+from palaia_hub.vault import NoteNotFoundError, VaultEngine
+
+
+@pytest.mark.anyio
+async def test_capture_becomes_a_curated_note_and_the_inbox_empties(
+    engine: VaultEngine, vault_mount: VaultMountConfig
+) -> None:
+    harness = build_harness(engine, vault_mount, ingest_session(vault_mount.namespace))
+    capture_id = await harness.capture(
+        what_it_concerns="API Gateway",
+        why_keep="The limit was chosen deliberately.",
+        content="We capped ingest at 100 req/min.",
+    )
+    [pending] = await harness.runner.pending_captures()
+
+    report = await harness.run_once()
+
+    assert report.ingested == 1
+    note = await engine.read_note("projects/api-gateway-ingest-limit")
+    assert f"- [source] inbox capture {capture_id}" in note.body
+    assert "100 req/min" in note.body
+    with pytest.raises(NoteNotFoundError):
+        await engine.read_note(pending.path)
+    # Every curator action is a git commit (MASTERPLAN §5.1).
+    history = await engine.history("projects/api-gateway-ingest-limit")
+    assert history
+
+
+@pytest.mark.anyio
+async def test_capture_becomes_a_proposal_a_human_approves_and_applies(
+    engine: VaultEngine, vault_mount: VaultMountConfig
+) -> None:
+    # An existing note the curator must not rewrite on its own.
+    await engine.write_note(
+        "projects/api-gateway.md", title="API Gateway", body="The gateway.\n"
+    )
+    harness = build_harness(engine, vault_mount, proposal_session(vault_mount.namespace))
+    await harness.capture(
+        what_it_concerns="API Gateway",
+        why_keep="Two notes disagree about the limit.",
+        content="The ingest limit is 100 req/min, not 50.",
+    )
+
+    report = await harness.run_once()
+
+    assert report.needs_review == 1
+    proposal_path = "review/merge-the-two-rate-limit-notes.md"
+    proposal = await engine.read_note(proposal_path)
+    assert str(proposal.frontmatter["type"]) == "proposal"
+    assert str(proposal.frontmatter["status"]) == "proposed"
+    # Nothing was applied while it waited for a human.
+    assert "- [limit] 100 req/min" not in (await engine.read_note("projects/api-gateway")).body
+
+    # The human approves it — the same frontmatter field Obsidian, the
+    # dashboard and the review-queue app all edit (format spec §8).
+    await engine.edit_note(
+        proposal_path,
+        frontmatter={"status": "approved"},
+        expected_checksum=proposal.checksum,
+    )
+
+    [result] = (await ProposalApplier(engine).run_once()).results
+
+    assert result.status == "applied"
+    assert "- [limit] 100 req/min" in (await engine.read_note("projects/api-gateway")).body
+    applied = await engine.read_note(proposal_path)
+    assert str(applied.frontmatter["status"]) == "applied"
+    assert "## Pre-images" in applied.body

--- a/v3/server/tests/curator/test_guard_matrix.py
+++ b/v3/server/tests/curator/test_guard_matrix.py
@@ -1,0 +1,284 @@
+"""The guard matrix: every forbidden call is refused at the gateway.
+
+SPEC-206 acceptance criterion #1, table-driven. Two layers are asserted:
+
+- the pure policy (:func:`palaia_hub.curator.policy.rejection_for`) — the
+  table itself;
+- the same table driven through a **real curator profile** over a real
+  ``FastMCP`` client, so what is tested is what a session actually reaches:
+  the middleware, mounted on the profile the gateway builder produced.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastmcp import Client
+
+from palaia_hub.curator.policy import CURATOR_TOOL_ACTIONS, provenance_line, rejection_for
+from palaia_hub.curator.profile import (
+    CURATOR_PROFILE_PATH,
+    allowed_tool_specs,
+    curator_profile,
+    curator_profile_middleware,
+    curator_tool_actions,
+)
+from palaia_hub.gateway.build import build_gateway
+from palaia_hub.gateway.config import GatewayConfig, VaultMountConfig
+from palaia_hub.gateway.fake_vault import FakeVaultService
+
+CAPTURE_ID = "cap-3f9a1c02d4"
+PROVENANCE = provenance_line(CAPTURE_ID)
+NOT_ON_SURFACE = "not part of the curator's tool surface"
+
+#: ``(label, action, arguments, expected substring)`` — every row is a call
+#: SPEC-206 rule 2 forbids, plus the reason it must be refused with.
+FORBIDDEN: list[tuple[str, str, dict[str, Any], str]] = [
+    (
+        "move is not on the surface",
+        "move",
+        {"permalink": "projects/x", "folder": "archive"},
+        NOT_ON_SURFACE,
+    ),
+    ("delete is not on the surface", "delete", {"permalink": "projects/x"}, NOT_ON_SURFACE),
+    ("capture is not on the surface", "capture", {"what_it_concerns": "x"}, NOT_ON_SURFACE),
+    ("recall is not on the surface", "recall", {"query": "x"}, NOT_ON_SURFACE),
+    (
+        "edit replacing the body",
+        "edit",
+        {"permalink": "projects/api-gateway", "body": f"rewritten\n{PROVENANCE}"},
+        "MAINTENANCE",
+    ),
+    (
+        "edit with neither append nor body",
+        "edit",
+        {"permalink": "projects/api-gateway", "tags": ["infra"]},
+        "append",
+    ),
+    (
+        "edit of an existing review/ proposal",
+        "edit",
+        {"permalink": "review/merge-rate-limits", "append": f"- [note] ok\n{PROVENANCE}"},
+        "never edit existing ones",
+    ),
+    (
+        "edit of an inbox capture",
+        "edit",
+        {"permalink": "inbox/rate-limit", "append": f"- [note] ok\n{PROVENANCE}"},
+        "never edits inbox/",
+    ),
+    (
+        "write into inbox/",
+        "write",
+        {"title": "Rate limit", "body": PROVENANCE, "folder": "inbox"},
+        "never writes into inbox/",
+    ),
+    (
+        "write into inbox/ via the folder alias",
+        "write",
+        {"title": "Rate limit", "body": PROVENANCE, "path": "inbox/2026"},
+        "never writes into inbox/",
+    ),
+    (
+        "write with overwrite semantics",
+        "write",
+        {"title": "Rate limit", "body": PROVENANCE, "overwrite": True},
+        "create-only",
+    ),
+    (
+        "write with must_create disabled",
+        "write",
+        {"title": "Rate limit", "body": PROVENANCE, "must_create": False},
+        "create-only",
+    ),
+    (
+        "write with mode=replace",
+        "write",
+        {"title": "Rate limit", "body": PROVENANCE, "mode": "replace"},
+        "create-only",
+    ),
+    (
+        "write with no provenance line",
+        "write",
+        {"title": "Rate limit", "body": "The limit is 100 req/min."},
+        "provenance line",
+    ),
+    (
+        "write citing another capture",
+        "write",
+        {"title": "Rate limit", "body": provenance_line("cap-0000000000")},
+        "this session is curating",
+    ),
+    (
+        "append with no provenance line",
+        "edit",
+        {"permalink": "projects/api-gateway", "append": "- [note] the limit is 100"},
+        "provenance line",
+    ),
+]
+
+#: Calls the policy must allow — the other half of a guard matrix.
+ALLOWED: list[tuple[str, str, dict[str, Any]]] = [
+    ("search", "search", {"query": "rate limit"}),
+    ("read", "read", {"permalink": "projects/api-gateway"}),
+    ("list", "list", {"folder": "projects"}),
+    ("recent_activity", "recent_activity", {}),
+    ("build_context", "build_context", {"ref": "projects/api-gateway"}),
+    (
+        "write a new note with provenance",
+        "write",
+        {"title": "Rate limit", "body": f"100 req/min.\n{PROVENANCE}", "folder": "projects"},
+    ),
+    (
+        "write a new proposal into review/",
+        "write",
+        {"title": "Merge rate limits", "body": f"...\n{PROVENANCE}", "folder": "review"},
+    ),
+    (
+        "append observations with provenance",
+        "edit",
+        {"permalink": "projects/api-gateway", "append": f"- [limit] 100\n{PROVENANCE}"},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("label", "action", "arguments", "expected"),
+    FORBIDDEN,
+    ids=[row[0] for row in FORBIDDEN],
+)
+def test_policy_refuses_every_forbidden_call(
+    label: str, action: str, arguments: dict[str, Any], expected: str
+) -> None:
+    message = rejection_for(action, arguments, expected_captures={CAPTURE_ID})
+    assert message is not None, f"{label} must be refused"
+    assert expected in message
+    # Every refusal says what to do instead (SPEC-206's prompt: "a rejected
+    # call is information, not an obstacle").
+    assert message.startswith("rejected: ")
+    assert len(message) > 80
+
+
+@pytest.mark.parametrize(
+    ("label", "action", "arguments"), ALLOWED, ids=[row[0] for row in ALLOWED]
+)
+def test_policy_allows_the_curator_surface(
+    label: str, action: str, arguments: dict[str, Any]
+) -> None:
+    assert rejection_for(action, arguments, expected_captures={CAPTURE_ID}) is None
+
+
+def test_provenance_is_shape_checked_when_no_session_is_registered() -> None:
+    """No active capture (an out-of-process session) still requires provenance."""
+    assert rejection_for("write", {"title": "x", "body": "no provenance"}) is not None
+    assert rejection_for("write", {"title": "x", "body": provenance_line("cap-abc")}) is None
+
+
+# --- the same matrix, through a real profile -------------------------------
+
+
+def _curator_gateway(mount: VaultMountConfig) -> Any:
+    config = GatewayConfig(vaults=[mount], profiles=[curator_profile([mount.key])])
+    middleware = curator_profile_middleware([mount])
+    gateway = build_gateway(
+        config, {mount.key: FakeVaultService()}, profile_middleware=middleware
+    )
+    return gateway, middleware[CURATOR_PROFILE_PATH][0]
+
+
+@pytest.mark.anyio
+async def test_curator_profile_lists_only_the_allowed_tools(
+    vault_mount: VaultMountConfig,
+) -> None:
+    gateway, _middleware = _curator_gateway(vault_mount)
+    async with Client(gateway.profile_servers[CURATOR_PROFILE_PATH]) as client:
+        names = {tool.name for tool in await client.list_tools()}
+    expected = {
+        name
+        for name, action in curator_tool_actions([vault_mount]).items()
+        if action in CURATOR_TOOL_ACTIONS
+    }
+    assert names == expected
+    # The forbidden half is genuinely absent, not merely unadvertised.
+    assert f"{vault_mount.namespace}_delete" not in names
+    assert f"{vault_mount.namespace}_capture" not in names
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("label", "action", "arguments", "expected"),
+    FORBIDDEN,
+    ids=[row[0] for row in FORBIDDEN],
+)
+async def test_gateway_refuses_every_forbidden_call(
+    vault_mount: VaultMountConfig,
+    label: str,
+    action: str,
+    arguments: dict[str, Any],
+    expected: str,
+) -> None:
+    gateway, middleware = _curator_gateway(vault_mount)
+    middleware.active_captures.acquire(CAPTURE_ID)
+    tool = f"{vault_mount.namespace}_{action}"
+    async with Client(gateway.profile_servers[CURATOR_PROFILE_PATH]) as client:
+        result = await client.call_tool(tool, arguments, raise_on_error=False)
+    assert result.is_error, f"{label} reached the vault"
+    assert expected in result.content[0].text  # type: ignore[union-attr]
+
+
+@pytest.mark.anyio
+async def test_allowed_write_reaches_the_vault(vault_mount: VaultMountConfig) -> None:
+    gateway, middleware = _curator_gateway(vault_mount)
+    middleware.active_captures.acquire(CAPTURE_ID)
+    async with Client(gateway.profile_servers[CURATOR_PROFILE_PATH]) as client:
+        result = await client.call_tool(
+            f"{vault_mount.namespace}_write",
+            {
+                "title": "Ingest rate limit",
+                "body": f"100 req/min.\n{PROVENANCE}",
+                "folder": "projects",
+            },
+            raise_on_error=False,
+        )
+    assert not result.is_error
+    assert "created" in result.content[0].text  # type: ignore[union-attr]
+
+
+@pytest.mark.anyio
+async def test_a_released_session_loses_its_capture_binding(
+    vault_mount: VaultMountConfig,
+) -> None:
+    """The binding lives exactly as long as the session it was acquired for."""
+    gateway, middleware = _curator_gateway(vault_mount)
+    middleware.active_captures.acquire(CAPTURE_ID)
+    assert middleware.active_captures.current() == {CAPTURE_ID}
+    middleware.active_captures.release(CAPTURE_ID)
+    assert middleware.active_captures.current() == frozenset()
+    async with Client(gateway.profile_servers[CURATOR_PROFILE_PATH]) as client:
+        result = await client.call_tool(
+            f"{vault_mount.namespace}_write",
+            {"title": "Whatever", "body": provenance_line("cap-somethingelse")},
+            raise_on_error=False,
+        )
+    # Shape-only checking: any well-formed provenance passes once no session
+    # is registered (documented fallback, see ActiveCaptures).
+    assert not result.is_error
+
+
+def test_allowed_tool_specs_match_the_narrowed_surface(
+    vault_mount: VaultMountConfig,
+) -> None:
+    specs = allowed_tool_specs([vault_mount])
+    assert len(specs) == len(CURATOR_TOOL_ACTIONS)
+    assert f"mcp__palaia__{vault_mount.namespace}_write" in specs
+    assert all(spec.startswith("mcp__palaia__") for spec in specs)
+    assert not any(spec.endswith("_delete") for spec in specs)
+
+
+def test_renamed_tools_are_still_classified_by_their_action() -> None:
+    """A vault that renames ``write`` does not thereby escape the guard."""
+    mount = VaultMountConfig(key="work", name="work", tool_renames={"write": "remember"})
+    mapping = curator_tool_actions([mount])
+    assert mapping[f"{mount.namespace}_remember"] == "write"
+    assert f"{mount.namespace}_write" not in mapping

--- a/v3/server/tests/curator/test_real_runner_smoke.py
+++ b/v3/server/tests/curator/test_real_runner_smoke.py
@@ -1,0 +1,126 @@
+"""Real-runner smoke test (SPEC-206 acceptance criterion #6).
+
+Excluded from CI by construction: it needs ``PALAIA_CURATOR_SMOKE=1`` **and**
+the ``claude`` CLI on PATH, and it spends real model calls. What it proves is
+the one thing no scripted runner can: that the configured command, the
+generated strict MCP config and the curator profile actually fit together —
+a real model, over real HTTP, curating one real capture.
+
+Run it with::
+
+    PALAIA_CURATOR_SMOKE=1 uv run pytest \\
+        server/tests/curator/test_real_runner_smoke.py -q -s
+
+The assertion is deliberately weak: the *outcome* of a model session is not
+deterministic, so what is asserted is that the session ran, that the guards
+were in force, and that the runner's verdict is one of the three legal ones.
+A run that ends ``unverified`` prints why and still passes — an inconclusive
+smoke test is not a failing policy.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from palaia_hub.config import HubConfig
+from palaia_hub.curator.profile import allowed_tool_specs
+from palaia_hub.curator.runner import CuratorRunner
+from palaia_hub.curator.session import SubprocessSessionRunner
+from palaia_hub.gateway.config import VaultMountConfig
+from palaia_hub.gateway.wiring import EngineVaultService
+from palaia_hub.vault import VaultEngine
+
+ENV_FLAG = "PALAIA_CURATOR_SMOKE"
+
+pytestmark = [
+    pytest.mark.skipif(
+        os.environ.get(ENV_FLAG) != "1",
+        reason=f"real-runner smoke test: set {ENV_FLAG}=1 to run it (spends model calls)",
+    ),
+    pytest.mark.skipif(
+        shutil.which("claude") is None, reason="the `claude` CLI is not on PATH"
+    ),
+]
+
+_HUB_SCRIPT = Path(__file__).parent / "support" / "curator_hub.py"
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@pytest.fixture
+def running_hub(tmp_path: Path) -> Iterator[tuple[str, Path]]:
+    """A real hub process serving the curator profile over HTTP."""
+    port = _free_port()
+    root = tmp_path / "work"
+    process = subprocess.Popen(  # noqa: S603 - fixed argv, test-only
+        [sys.executable, str(_HUB_SCRIPT), str(root), str(port)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    base = f"http://127.0.0.1:{port}"
+    deadline = time.monotonic() + 20.0
+    try:
+        while time.monotonic() < deadline:
+            try:
+                with urllib.request.urlopen(f"{base}/api/health", timeout=1.0) as response:
+                    if response.status == 200:
+                        break
+            except (urllib.error.URLError, TimeoutError):
+                time.sleep(0.2)
+        else:  # pragma: no cover - startup failure
+            raise RuntimeError("the smoke-test hub did not start")
+        yield base, root
+    finally:
+        process.terminate()
+        process.wait(timeout=10)
+
+
+@pytest.mark.anyio
+async def test_a_real_session_curates_one_capture(
+    running_hub: tuple[str, Path],
+) -> None:
+    base, root = running_hub
+    engine = VaultEngine(root, name="work")
+    await engine.open(purpose="Smoke-test vault for the curator.", create=False)
+    service = EngineVaultService(engine)
+    capture = await service.capture(
+        what_it_concerns="API Gateway",
+        why_keep="The ingest limit was chosen deliberately.",
+        content="We capped ingest at 100 req/min because the embed queue saturates.",
+    )
+    mount = VaultMountConfig(key="work", name="work", purpose="Smoke-test vault.")
+    settings = HubConfig().curator
+    runner = CuratorRunner(
+        engine,
+        session_runner=SubprocessSessionRunner(
+            command=list(settings.runner_command), timeout=settings.session_timeout
+        ),
+        endpoint=f"{base}/mcp/curator",
+        allowed_tools=allowed_tool_specs([mount]),
+        purpose=mount.purpose,
+    )
+
+    report = await runner.run_once()
+    await engine.close()
+
+    assert report.sessions == 1
+    [record] = report.records
+    print(f"\nreal-runner outcome: {record.outcome} — {record.reason or 'no reason'}")
+    print(f"targets: {record.targets}")
+    assert record.capture_id == capture.capture_id
+    assert record.outcome in ("ingested", "needs_review", "unverified")

--- a/v3/server/tests/curator/test_runner_verification.py
+++ b/v3/server/tests/curator/test_runner_verification.py
@@ -1,0 +1,217 @@
+"""Verification, retries and retirement (SPEC-206 rule 3, criteria #2 and #4).
+
+The point of every test in here: the outcome comes from the **vault**, never
+from what the session said about itself.
+"""
+
+from __future__ import annotations
+
+import pytest
+from harness import build_harness
+from scripted import ingest_session, lying_session, proposal_session, silent_session
+
+from palaia_hub.curator.runner import FAILED_STATUS, FAILURE_PREFIX, count_failures
+from palaia_hub.gateway.config import VaultMountConfig
+from palaia_hub.vault import NoteNotFoundError, VaultEngine
+
+CAPTURE = {
+    "what_it_concerns": "API Gateway",
+    "why_keep": "The limit was chosen deliberately; future work will trip over it.",
+    "content": "We capped ingest at 100 req/min because the embed queue saturates.",
+}
+
+
+async def _capture(harness) -> str:  # noqa: ANN001 - test helper over the harness
+    return await harness.capture(**CAPTURE)
+
+
+@pytest.mark.anyio
+async def test_a_real_note_carrying_the_capture_id_is_ingested(
+    engine: VaultEngine, vault_mount: VaultMountConfig
+) -> None:
+    harness = build_harness(engine, vault_mount, ingest_session(vault_mount.namespace))
+    await _capture(harness)
+    [pending] = await harness.runner.pending_captures()
+
+    report = await harness.run_once()
+
+    assert report.pending == 1
+    assert report.sessions == 1
+    [record] = report.records
+    assert record.outcome == "ingested"
+    assert record.targets == ["projects/api-gateway-ingest-limit"]
+    # Only a verified outcome deletes the inbox entry (rule 3).
+    assert pending.path.startswith("inbox/")
+    with pytest.raises(NoteNotFoundError):
+        await engine.read_note(pending.path)
+    assert await harness.runner.pending_captures() == []
+    assert "curator.capture.ingested" in harness.event_names()
+
+
+@pytest.mark.anyio
+async def test_only_a_proposal_carrying_it_means_needs_review(
+    engine: VaultEngine, vault_mount: VaultMountConfig
+) -> None:
+    harness = build_harness(engine, vault_mount, proposal_session(vault_mount.namespace))
+    await _capture(harness)
+
+    report = await harness.run_once()
+
+    [record] = report.records
+    assert record.outcome == "needs_review"
+    assert record.targets == ["review/merge-the-two-rate-limit-notes"]
+    # A proposal is a first-class outcome: the capture is done, not retried.
+    assert await harness.runner.pending_captures() == []
+    assert "curator.capture.needs_review" in harness.event_names()
+
+
+@pytest.mark.anyio
+async def test_a_lying_session_is_unverified_and_keeps_its_capture(
+    engine: VaultEngine, vault_mount: VaultMountConfig
+) -> None:
+    """Criterion #2: the runner ignores the model's self-report."""
+    harness = build_harness(
+        engine,
+        vault_mount,
+        lying_session(vault_mount.namespace),
+        stdout='{"action":"ingested","targets":["projects/whatever"],"summary":"done"}',
+    )
+    await _capture(harness)
+
+    report = await harness.run_once()
+
+    [record] = report.records
+    assert record.self_reported == "ingested"  # what it claimed
+    assert record.outcome == "unverified"  # what actually happened
+    assert record.targets == []
+    assert not record.retired
+    # Both forbidden calls the script tried were refused at the gateway.
+    assert [is_error for _, _, is_error, _ in harness.session_runner.calls] == [True, True]
+    # The capture survives, with an additive failure line.
+    pending = await harness.runner.pending_captures()
+    assert len(pending) == 1
+    assert pending[0].attempts == 1
+    note = await engine.read_note(pending[0].path)
+    assert FAILURE_PREFIX in note.body
+    assert "curator.capture.unverified" in harness.event_names()
+    assert "doctor.finding" in harness.event_names()
+
+
+@pytest.mark.anyio
+async def test_prose_mentioning_the_capture_id_is_not_evidence(
+    engine: VaultEngine, vault_mount: VaultMountConfig
+) -> None:
+    harness = build_harness(engine, vault_mount, silent_session())
+    capture_id = await _capture(harness)
+    # A note that names the capture id without the provenance line.
+    await engine.write_note(
+        "projects/hearsay.md",
+        title="Hearsay",
+        body=f"Someone mentioned {capture_id} in passing.\n",
+    )
+
+    report = await harness.run_once()
+
+    assert report.records[0].outcome == "unverified"
+
+
+@pytest.mark.anyio
+async def test_three_strikes_retires_the_capture_additively(
+    engine: VaultEngine, vault_mount: VaultMountConfig
+) -> None:
+    """Criterion #4: 3-strikes retirement, failure notes appended additively."""
+    harness = build_harness(engine, vault_mount, silent_session(), max_attempts=3)
+    capture_id = await _capture(harness)
+    [pending] = await harness.runner.pending_captures()
+    path = pending.path
+
+    outcomes = []
+    for _ in range(3):
+        report = await harness.run_once()
+        outcomes.append((report.records[0].attempts, report.records[0].retired))
+
+    assert outcomes == [(1, False), (2, False), (3, True)]
+    note = await engine.read_note(path)
+    # Every attempt left its own line, and none overwrote an earlier one.
+    assert count_failures(note.body) == 3
+    assert str(note.frontmatter["status"]) == FAILED_STATUS
+    # The capture's original content is untouched.
+    assert capture_id in note.text
+    assert CAPTURE["content"] in note.body
+    # A retired capture is no longer pending, so a fourth run starts no session.
+    assert await harness.runner.pending_captures() == []
+    fourth = await harness.run_once()
+    assert fourth.pending == 0
+    assert len(harness.session_runner.requests) == 3
+    assert "curator.capture.retired" in harness.event_names()
+
+
+@pytest.mark.anyio
+async def test_an_empty_inbox_starts_no_session(
+    engine: VaultEngine, vault_mount: VaultMountConfig
+) -> None:
+    """Deliverable #5: an empty inbox costs (almost) nothing."""
+    harness = build_harness(engine, vault_mount, ingest_session(vault_mount.namespace))
+
+    report = await harness.run_once()
+
+    assert report.pending == 0
+    assert report.sessions == 0
+    assert report.records == []
+    assert harness.session_runner.requests == []
+    assert report.summary().endswith("inbox empty, no session started.")
+
+
+@pytest.mark.anyio
+async def test_the_session_is_bound_to_its_own_capture(
+    engine: VaultEngine, vault_mount: VaultMountConfig
+) -> None:
+    """The provenance guard knows which capture the session was handed."""
+    namespace = vault_mount.namespace
+
+    async def script(client, request) -> None:  # noqa: ANN001 - test script
+        # Citing a different capture is refused...
+        await client.call_tool(
+            f"{namespace}_write",
+            {"title": "Wrong provenance", "body": "- [source] inbox capture cap-0000000000"},
+        )
+        # ...citing its own is not.
+        await client.call_tool(
+            f"{namespace}_write",
+            {
+                "title": "Right provenance",
+                "body": f"- [source] inbox capture {request.capture_id}",
+                "folder": "projects",
+            },
+        )
+
+    harness = build_harness(engine, vault_mount, script)
+    await _capture(harness)
+
+    report = await harness.run_once()
+
+    refused, allowed = harness.session_runner.calls
+    assert refused[2] is True
+    assert "this session is curating" in refused[3]
+    assert allowed[2] is False
+    assert report.records[0].outcome == "ingested"
+    # The binding is released once the session is over.
+    assert harness.active_captures.current() == frozenset()
+
+
+@pytest.mark.anyio
+async def test_stash_audit_records_every_outcome(
+    engine: VaultEngine, vault_mount: VaultMountConfig
+) -> None:
+    """Deliverable #4: outcomes reach ``ops:curator.*``."""
+    harness = build_harness(engine, vault_mount, ingest_session(vault_mount.namespace))
+    capture_id = await _capture(harness)
+
+    await harness.run_once()
+
+    keys = set(harness.stash.entries)
+    assert ("ops", f"curator.capture.{capture_id}") in keys
+    assert ("ops", "curator.run.work") in keys
+    assert harness.stash.entries[("ops", f"curator.capture.{capture_id}")]["outcome"] == (
+        "ingested"
+    )

--- a/v3/server/tests/curator/test_scheduler_and_wiring.py
+++ b/v3/server/tests/curator/test_scheduler_and_wiring.py
@@ -1,0 +1,201 @@
+"""When the curator runs, and how it is wired (SPEC-206 deliverable #1/#2).
+
+Event-driven with a debounce, an interval fallback, and — the part that
+matters most — the guard travelling with the profile: a curator profile
+*rebuilt* at runtime comes back with its middleware still attached.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from fastmcp import Client
+
+from palaia_hub.config import HubConfig
+from palaia_hub.curator.apply import ProposalApplier
+from palaia_hub.curator.policy import CURATOR_TOOL_ACTIONS
+from palaia_hub.curator.profile import CURATOR_PROFILE_PATH, curator_profile
+from palaia_hub.curator.service import CuratorScheduler
+from palaia_hub.curator.wiring import TOKEN_ENV, build_curator, curator_token
+from palaia_hub.events import EventBus, publish_event
+from palaia_hub.gateway.config import GatewayConfig, VaultMountConfig
+from palaia_hub.gateway.dynamic import DynamicGateway
+from palaia_hub.gateway.fake_vault import FakeVaultService
+from palaia_hub.vault import VaultEngine
+
+
+class _CountingRunner:
+    """Stands in for a CuratorRunner: counts passes, does nothing else."""
+
+    def __init__(self) -> None:
+        self.runs = 0
+
+    async def run_once(self) -> Any:
+        self.runs += 1
+        return None
+
+
+@pytest.mark.anyio
+async def test_an_inbox_captured_event_triggers_a_debounced_pass() -> None:
+    runner = _CountingRunner()
+    bus = EventBus()
+    scheduler = CuratorScheduler(
+        {"work": runner},  # type: ignore[dict-item]
+        debounce_seconds=0.01,
+        interval_seconds=3600,
+        subscribe=bus.on,
+    )
+    await scheduler.start()
+    try:
+        publish_event(bus, "inbox.captured", origin="test", data={"capture_id": "cap-1"})
+        publish_event(bus, "inbox.captured", origin="test", data={"capture_id": "cap-2"})
+        for _ in range(200):
+            if runner.runs:
+                break
+            await asyncio.sleep(0.01)
+    finally:
+        await scheduler.aclose()
+    # A burst coalesced into one pass, not one per capture.
+    assert runner.runs == 1
+
+
+@pytest.mark.anyio
+async def test_a_duplicate_capture_does_not_wake_the_curator() -> None:
+    runner = _CountingRunner()
+    bus = EventBus()
+    scheduler = CuratorScheduler(
+        {"work": runner},  # type: ignore[dict-item]
+        debounce_seconds=0.0,
+        interval_seconds=3600,
+        subscribe=bus.on,
+    )
+    await scheduler.start()
+    try:
+        publish_event(
+            bus,
+            "inbox.captured",
+            origin="test",
+            data={"capture_id": "cap-1", "duplicate": True},
+        )
+        await asyncio.sleep(0.1)
+    finally:
+        await scheduler.aclose()
+    assert runner.runs == 0
+
+
+@pytest.mark.anyio
+async def test_the_interval_fallback_runs_without_any_event() -> None:
+    runner = _CountingRunner()
+    scheduler = CuratorScheduler(
+        {"work": runner},  # type: ignore[dict-item]
+        debounce_seconds=0.0,
+        interval_seconds=1.0,
+    )
+    # The floor is one second, so drive the loop directly rather than waiting
+    # it out: what matters here is that a pass needs no event to happen.
+    await scheduler.run_all()
+    assert runner.runs == 1
+    await scheduler.aclose()
+
+
+@pytest.mark.anyio
+async def test_one_failing_vault_does_not_stop_the_others() -> None:
+    class _Boom:
+        async def run_once(self) -> Any:
+            raise RuntimeError("vault on fire")
+
+    good = _CountingRunner()
+    scheduler = CuratorScheduler(
+        {"broken": _Boom(), "work": good},  # type: ignore[dict-item]
+    )
+    runs, _applies = await scheduler.run_all()
+    # The healthy vault still ran; the broken one contributed no report.
+    assert good.runs == 1
+    assert len(runs) == 1
+
+
+@pytest.mark.anyio
+async def test_the_guard_survives_a_profile_rebuild(
+    engine: VaultEngine, vault_mount: VaultMountConfig
+) -> None:
+    """A vault added at runtime rebuilds profiles — the policy must return."""
+    config = GatewayConfig(
+        vaults=[vault_mount], profiles=[curator_profile([vault_mount.key])]
+    )
+    hub_config = HubConfig(curator={"enabled": True})
+    wiring = build_curator(
+        hub_config, {vault_mount.key: engine}, [vault_mount], with_stash=False
+    )
+    gateway = DynamicGateway(
+        config,
+        {vault_mount.key: FakeVaultService()},
+        profile_middleware=wiring.profile_middleware,
+    )
+    await gateway.start()
+    try:
+        second = VaultMountConfig(key="personal", name="personal")
+        await gateway.add_vault(
+            second, FakeVaultService(), profile_paths=[CURATOR_PROFILE_PATH]
+        )
+        profile = gateway.profile_servers[CURATOR_PROFILE_PATH]
+        async with Client(profile) as client:
+            names = {tool.name for tool in await client.list_tools()}
+            refused = await client.call_tool(
+                f"{vault_mount.namespace}_delete",
+                {"permalink": "projects/x"},
+                raise_on_error=False,
+            )
+    finally:
+        await gateway.aclose()
+    # The rebuilt profile still hides the forbidden tools of the vault it
+    # knows about, and still refuses them.
+    assert f"{vault_mount.namespace}_write" in names
+    assert f"{vault_mount.namespace}_delete" not in names
+    assert refused.is_error
+    # The vault added at runtime is fail-closed: its tools are unmapped, so
+    # nothing of it is exposed until the hub restarts (documented limitation).
+    assert not any(name.startswith("personal_memory_") for name in names)
+    assert len(names) == len(CURATOR_TOOL_ACTIONS)
+
+
+def test_the_token_comes_from_the_environment_first(monkeypatch) -> None:  # noqa: ANN001
+    config = HubConfig(curator={"token": "from-config"})
+    assert curator_token(config) == "from-config"
+    monkeypatch.setenv(TOKEN_ENV, "from-env")
+    assert curator_token(config) == "from-env"
+
+
+@pytest.mark.anyio
+async def test_wiring_builds_runners_appliers_and_the_guard(
+    engine: VaultEngine, vault_mount: VaultMountConfig
+) -> None:
+    config = HubConfig(curator={"enabled": True, "auto_apply": True, "max_attempts": 2})
+    wiring = build_curator(
+        config, {vault_mount.key: engine}, [vault_mount], with_stash=False
+    )
+    try:
+        assert set(wiring.runners) == {vault_mount.key}
+        assert isinstance(wiring.appliers[vault_mount.key], ProposalApplier)
+        assert CURATOR_PROFILE_PATH in wiring.profile_middleware
+        # The same ActiveCaptures instance reaches both the runner and the
+        # middleware — that is what binds a session to its own capture.
+        middleware = wiring.profile_middleware[CURATOR_PROFILE_PATH][0]
+        assert middleware.active_captures is wiring.active_captures  # type: ignore[attr-defined]
+    finally:
+        await wiring.aclose()
+
+
+@pytest.mark.anyio
+async def test_auto_apply_off_means_no_scheduled_applier(
+    engine: VaultEngine, vault_mount: VaultMountConfig
+) -> None:
+    config = HubConfig(curator={"enabled": True, "auto_apply": False})
+    wiring = build_curator(
+        config, {vault_mount.key: engine}, [vault_mount], with_stash=False
+    )
+    try:
+        assert wiring.appliers == {}
+    finally:
+        await wiring.aclose()

--- a/v3/server/tests/curator/test_session_and_prompt.py
+++ b/v3/server/tests/curator/test_session_and_prompt.py
@@ -1,0 +1,144 @@
+"""The session launcher and the prompt (SPEC-206 deliverable #1, "The prompt").
+
+The runner command is config, not code: these tests pin the contract a
+configured command can rely on (prompt on stdin, placeholders substituted,
+strict single-server MCP config) and that the prompt is assembled from the
+SPEC's own role block, verbatim.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from palaia_hub.config import HubConfig
+from palaia_hub.curator.prompt import ROLE_BLOCK, build_prompt
+from palaia_hub.curator.session import (
+    DEFAULT_RUNNER_COMMAND,
+    MCP_SERVER_NAME,
+    SessionRequest,
+    SubprocessSessionRunner,
+    mcp_config_document,
+)
+
+REQUEST = SessionRequest(
+    vault="work",
+    capture_id="cap-3f9a1c02d4",
+    prompt="curate this",
+    endpoint="http://127.0.0.1:8420/mcp/curator",
+    allowed_tools=("mcp__palaia__work_memory_write", "mcp__palaia__work_memory_read"),
+    token="plt_secret",
+)
+
+
+def test_the_config_default_matches_the_session_default() -> None:
+    """``config.yaml``'s default command and the code's must not drift."""
+    assert tuple(HubConfig().curator.runner_command) == DEFAULT_RUNNER_COMMAND
+
+
+def test_the_mcp_config_names_exactly_one_server_with_the_token() -> None:
+    document = mcp_config_document(REQUEST)
+    assert list(document["mcpServers"]) == [MCP_SERVER_NAME]  # type: ignore[index]
+    server = document["mcpServers"][MCP_SERVER_NAME]  # type: ignore[index]
+    assert server["url"] == REQUEST.endpoint
+    assert server["headers"] == {"Authorization": "Bearer plt_secret"}
+
+
+def test_argv_substitutes_every_placeholder(tmp_path) -> None:  # noqa: ANN001
+    runner = SubprocessSessionRunner(
+        command=[
+            "runner",
+            "--config={mcp_config}",
+            "--tools={allowed_tools}",
+            "--at={endpoint}",
+            "--vault={vault}",
+            "--capture={capture_id}",
+        ]
+    )
+    argv = runner.argv(REQUEST, tmp_path / "mcp.json")
+    assert argv[1].endswith("mcp.json")
+    assert argv[2] == "--tools=mcp__palaia__work_memory_write,mcp__palaia__work_memory_read"
+    assert argv[3] == f"--at={REQUEST.endpoint}"
+    assert argv[4] == "--vault=work"
+    assert argv[5] == "--capture=cap-3f9a1c02d4"
+
+
+@pytest.mark.anyio
+async def test_the_prompt_arrives_on_stdin_and_the_exit_code_is_reported() -> None:
+    runner = SubprocessSessionRunner(
+        command=[sys.executable, "-c", "import sys; print(sys.stdin.read().strip())"]
+    )
+    result = await runner.run(REQUEST)
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "curate this"
+    assert not result.failed
+
+
+@pytest.mark.anyio
+async def test_a_hung_session_is_killed_and_reported_as_timed_out() -> None:
+    runner = SubprocessSessionRunner(
+        command=[sys.executable, "-c", "import time; time.sleep(30)"], timeout=0.3
+    )
+    result = await runner.run(REQUEST)
+    assert result.timed_out
+    assert result.failed
+
+
+@pytest.mark.anyio
+async def test_a_missing_runner_command_is_an_outcome_not_a_crash() -> None:
+    runner = SubprocessSessionRunner(command=["palaia-no-such-command-exists"])
+    result = await runner.run(REQUEST)
+    assert not result.launched
+    assert result.failed
+    assert "config.yaml" in result.stderr
+
+
+def test_the_prompt_carries_the_spec_role_block_verbatim() -> None:
+    prompt = build_prompt(
+        vault_name="work",
+        purpose="Team knowledge for ACME engineering.",
+        capture_id="cap-3f9a1c02d4",
+        capture_permalink="inbox/api-gateway",
+        capture_text="- [entity] API Gateway\n- [why] deliberate limit\n",
+    )
+    assert prompt.startswith(
+        'You are the palaia curator for the vault "work" — Team knowledge for '
+        "ACME engineering."
+    )
+    for sentence in (
+        "INGEST is yours",
+        "MAINTENANCE is never yours",
+        "The restriction\nis enforced, not advisory",
+        "Search the vault at least twice",
+        "Every note you write carries",
+        "Never invent facts the capture",
+        'End with one line of JSON: {"action":"ingested"|"needs_review"',
+    ):
+        assert sentence in prompt
+    assert "- [source] inbox capture cap-3f9a1c02d4" in prompt
+    assert "- [entity] API Gateway" in prompt
+    # No stray format braces survived the templating.
+    assert "{vault_name}" not in prompt
+    assert "{{" not in ROLE_BLOCK.format(vault_name="x", purpose="y")
+
+
+def test_the_vaults_own_curation_rules_are_included_when_present() -> None:
+    prompt = build_prompt(
+        vault_name="work",
+        purpose="Team knowledge",
+        capture_id="cap-1",
+        capture_permalink="inbox/x",
+        capture_text="text",
+        curation_note="- Never file anything under projects/legacy.",
+    )
+    assert "meta/curation.md" in prompt
+    assert "Never file anything under projects/legacy." in prompt
+
+
+def test_the_endpoint_defaults_to_the_hubs_own_address() -> None:
+    assert HubConfig().curator_endpoint() == "http://127.0.0.1:8420"
+    wildcard = HubConfig(mode="open", host="0.0.0.0", port=9000)  # noqa: S104
+    assert wildcard.curator_endpoint() == "http://127.0.0.1:9000"
+    explicit = HubConfig(curator={"endpoint": "https://hub.example.com/"})
+    assert explicit.curator_endpoint() == "https://hub.example.com"


### PR DESCRIPTION
## Summary

SPEC-206: the asynchronous brain that turns inbox captures into well-formed vault knowledge. The policy is implemented as fixed in-spec; nothing about it was redesigned.

New package `palaia_hub.curator`:

- **`policy.py`** — the binding rules as pure functions: the seven-action curator surface, and the per-call guard (`rejection_for`) covering replacing edits, overwrite semantics, `inbox/` writes, edits of existing `review/` notes, and writes missing `- [source] inbox capture <capture_id>`. Every refusal names what was refused *and* what to do instead ("a rejected call is information, not an obstacle").
- **`middleware.py` / `profile.py`** — where the policy is enforced: the curator's own gateway profile (`/mcp/curator`), narrowed by `CuratorScopeMiddleware` (filters `tools/list`, refuses everything else, applies the guards). Provenance is bound per session through `ActiveCaptures`, so a write citing a *different* capture is refused, not merely well-formed.
- **`prompt.py`** — the SPEC's role block verbatim, plus the vault's live `meta/curation.md` and the capture itself.
- **`session.py`** — the config-driven, provider-neutral runner command (default: headless `claude -p` with a strict single-server MCP config); prompt on stdin, placeholders substituted, timeouts and a missing command are outcomes, not crashes.
- **`verify.py` / `runner.py`** — verification instead of trust, retries, 3-strikes retirement with additive `- [curation-failed]` lines.
- **`apply.py`** — approved proposals applied by plain code from their typed plan (format §8), pre-images appended to the proposal first, a terminal status stamped on every exit path. No model in this path.
- **`service.py` / `wiring.py`** — event-driven (`inbox.captured`, debounced) plus interval fallback; one wiring function shared by `palaia-hub serve` and the CLI.
- **`audit.py`** — outcomes to the stash (`ops:curator.*`) and the bus (`curator.*`); anything that did not land also raises a `doctor.finding`.

Also: `curator:` config section (off by default) + `PALAIA_CURATOR_TOKEN`, `palaia-hub curator run|apply|token`, a generic `profile_middleware` parameter on `build_gateway`/`DynamicGateway` (so the policy survives a runtime profile rebuild), the additive `curator.*` event names, and docs (`docs/events.md` §3.1, `server/README.md`).

## Acceptance criteria

- [x] **guard matrix test: every forbidden call from policy rule 2 is rejected at the gateway with an explanatory error (table-driven)** — `tests/curator/test_guard_matrix.py`: one 16-row table driven twice, once against the pure policy and once through a real curator profile over a `fastmcp.Client`, plus an 8-row allowed table and a check that renamed tools are still classified by their action.
- [x] **runner ignores the model's self-report: verification classifies via capture_id search (tests for all three outcomes, incl. a lying session)** — `tests/curator/test_runner_verification.py`: `ingested`, `needs_review`, and a lying session whose stdout claims `{"action":"ingested"}` while it only attempted two forbidden calls → `unverified`. Also: prose mentioning a capture id is not evidence.
- [x] **approved proposal applies deterministically; pre-images preserved; every exit path stamps a terminal status (state-machine test)** — `tests/curator/test_apply.py`: `applied`, `apply-failed`, `manual` (no plan / unparseable JSON / unknown op), all six operation kinds, pre-images asserted to hold the state *before* the change, non-approved proposals untouched, and a second pass finding nothing.
- [x] **3-strikes retirement; failure notes appended additively** — three runs give `(1,False) (2,False) (3,True)`, three distinct failure lines, `status: curation-failed`, original capture content intact, and a fourth run starting no session.
- [x] **e2e with a scripted fake LLM runner (no real model in CI): capture → curated note → inbox entry gone; capture → proposal → approve → applied** — `tests/curator/test_e2e_scripted.py`. The fake runner is a real MCP client of the curator profile, so the guards, the tool family and the engine are all in the path; only the deciding is scripted.
- [x] **real-runner smoke test behind an env flag (uses the sandbox claude CLI if present), excluded from CI** — `tests/curator/test_real_runner_smoke.py`, gated on `PALAIA_CURATOR_SMOKE=1` **and** `claude` on PATH; skips otherwise. **Not executed here** — no `claude` CLI in this sandbox, so it is verified as "collected and skipped", not as "passing against a real model".

## Verification

From `v3/`:

```
$ uv run ruff check server
All checks passed!

$ uv run mypy server/src
Success: no issues found in 112 source files

$ uv run pytest server/tests -q
1313 passed, 10 skipped, 1 warning in 182.18s (0:03:02)
```

Curator suite alone: `84 passed, 1 skipped` (the skip is the env-gated real-runner smoke test). No `v3/web` files touched, so no web checks were needed.

## Deviations and notes (please read)

1. **"any `write` with overwrite semantics"** — the v3 `write` tool has no overwrite parameter at all: the engine adapter passes `must_create=True`, so writing over an existing note already fails with the engine's own explanatory error. The guard therefore rejects overwrite-*ish* arguments by name (`overwrite`, `replace`, `force`, `must_create: false`, `mode: replace|overwrite|force`) so the curator refuses such a parameter on the day the tool surface ever grows one. What it does **not** do is pre-empt a same-title collision with its own message before the engine refuses it. Tested; stated here rather than hidden.
2. **Provenance binding falls back to shape-only checking** when no session is registered in `ActiveCaptures` (i.e. a curator session this process did not launch). It still refuses a write with *no* provenance — which is what makes verification possible — but cannot tell which capture an out-of-process session was handed. Documented in `ActiveCaptures` and tested both ways.
3. **A vault created at runtime through the wizard is not curated until the next hub restart.** The curator's tool-name → action map is built when the hub wires the curator up, and an unmapped tool name is *refused*, not waved through — so this is fail-closed, not a hole. Documented in `curator/profile.py` and asserted in `test_scheduler_and_wiring.py`.
4. **The runner stamps `status: proposed` on a proposal a session just created.** The `write` tool takes a `type` but no `status`, and format §8 fixes the review lifecycle — so the runner (plain code, after verification) sets the opening status. The curator itself still cannot touch a `review/` note: every edit of one is refused, so it cannot approve anything.
5. **Plan block format.** Format §8 says "an optional fenced ```json block named `plan`"; the parser accepts an info string of `json plan` and, for tolerance, a single unlabelled ```json block. Two candidate blocks are a `manual` outcome rather than a guess.
6. **The audit's stash is the curator's own `stash.db` under the hub home** — `serve` does not currently wire a `StashService` at all, so the curator opens its own rather than inventing hub-wide stash wiring inside this SPEC.
7. **Pre-existing flake, not caused by this PR:** `tests/auth/test_cli_token.py::test_revoke_marks_token_revoked` fails whenever `secrets.token_urlsafe(9)` happens to produce an id starting with `-` (argparse then reads it as an option). It failed once during a full run here and passed 8/8 re-runs; the final full-suite run above is green. Worth a one-line `--` fix in a follow-up, out of scope here.

## Scope

Only `v3/` is touched. No v2 root files, no pin changes (fastmcp stays 3.4.7), the golden tools snapshot is untouched (the default profile's tool surface is unchanged — the curator profile is a second, narrowed profile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790126088&installation_model_id=428086&pr_number=229&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F229&signature=99846c02d1ef7d3fa96f4b973c26bcd7c8809c9e33d917cd3f83c8a471a13998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->