### PR TITLE
fix(v3): RFC 8252 loopback-port exemption in redirect_uri matching

### DIFF
--- a/v3/docs/client-matrix-results.md
+++ b/v3/docs/client-matrix-results.md
@@ -130,9 +130,9 @@ UX/trust issue (a user who checks status before signing in sees a
 scary-sounding, wrong verdict on a hub that works fine), not a functional
 one.
 
-### 2.3 The real login blocker — filed as #233 — and its confirmed workaround
+### 2.3 The default-path login blocker — filed as #233, now fixed
 
-`test_claude_code_cli_native_oauth_login_needs_a_preregistered_redirect_uri`
+`test_claude_code_cli_native_oauth_login_completes_on_the_default_path`
 (skipped, not failed, when this sandbox cannot reach `claude.ai` — the
 CIMD document fetch needs real internet):
 
@@ -140,21 +140,25 @@ CIMD document fetch needs real internet):
 ... ` then `claude mcp login <name> --no-browser`, exactly the connect-page's
 advertised one-liner): the CLI fetches Claude Code's own real, published
 CIMD document (`https://claude.ai/oauth/claude-code-client-metadata`),
-prints a real authorize URL, and — signed in for real as the owner — hits:
+prints a real authorize URL, and — signed in for real as the owner — the
+authorize request now completes with a `303` to the CLI's loopback
+callback, and the login finishes (`Authenticated with …`, exit 0).
 
-```
-400 invalid_redirect_uri
-"the redirect_uri does not exactly match one this client registered."
-```
+The blocker this section originally documented: Anthropic's CIMD document
+registers a **portless** loopback redirect URI
+(`http://localhost/callback`) while the CLI's real request always carries
+a live ephemeral port, and `palaia_hub.oauth.cimd.match_redirect_uri` was
+byte-exact with no RFC 8252 §7.3 loopback-port exemption — so every
+default, zero-flag login failed with `400 invalid_redirect_uri`. Filed as
+[byte5ai/palaia#233](https://github.com/byte5ai/palaia/issues/233) and
+fixed by adding exactly that exemption: an `http` loopback redirect URI
+matches a registered one when scheme, hostname, path and query all agree,
+ignoring only the port; nothing else about exact matching changed
+(`tests/oauth/test_cimd_and_pkce.py` pins both halves).
 
-Root cause: Anthropic's CIMD document registers a **portless** loopback
-redirect URI (`http://localhost/callback`); the CLI's real request always
-carries a live ephemeral port; `palaia_hub.oauth.cimd.match_redirect_uri`
-does byte-exact matching with no RFC 8252 §7.3 loopback-port exemption. The
-port differs on every attempt, so this can never match — every default,
-zero-flag Claude Code OAuth login fails, today, for everyone.
-
-**Part 2, the documented CLI workaround, completed for real**: Claude
+**Part 2, the CLI's fixed-port escape hatch, completed for real** (kept
+green as the DCR-path regression test — this was the pre-fix workaround):
+Claude
 Code's own `mcp add --help` names exactly this scenario ("`--callback-port`:
 Fixed port for OAuth callback, for servers requiring pre-registered
 redirect URIs"). The test pre-registers a real DCR client with a literal,
@@ -175,16 +179,9 @@ $ claude -p "call work_memory_write …" --allowedTools mcp__palaia__work_memory
 {"permalink":"native-login-e2e","title":"Native Login E2E", …}
 ```
 
-Exit code `0`. This proves the resource server, PKCE, DCR, and the CLI's
-own OAuth plumbing are all fine — **only** the loopback-port exemption is
-missing, and it specifically breaks the connect-page's no-extra-flags
-promise. Filed as
-[byte5ai/palaia#233](https://github.com/byte5ai/palaia/issues/233), with a
-suggested direction (accept a presented loopback redirect URI that matches
-a registered one on scheme/host/path but not port) flagged for an
-owner/architect decision rather than patched here — it touches SPEC-203's
-security-critical redirect-matching code and its existing exact-match
-tests.
+Exit code `0`. Together the two parts prove the resource server, PKCE,
+CIMD, DCR, and the CLI's own OAuth plumbing end to end — on the default
+path and on the fixed-port path.
 
 ## 3. Connect-page corrections shipped in this PR
 
@@ -235,12 +232,13 @@ green) exercises directly:
   resource-indicator-shape and scope-enforcement behaviors any of these
   clients could hit.
 
-Byte5ai/palaia#233's redirect_uri finding (§2.3) plausibly affects any of
-these clients too **if** their own published CIMD/DCR redirect URI is a
-portless loopback address the way Claude Code's is — genuinely not known
-without their real client, so left "not verified" rather than guessed at.
-ChatGPT and Grok are browser/mobile-first (not loopback-native-app clients
-in the RFC 8252 sense), so they are less likely to hit it than a CLI is;
+Byte5ai/palaia#233's redirect_uri finding (§2.3) — now fixed by the
+RFC 8252 §7.3 loopback-port exemption — would have affected any of these
+clients whose published CIMD/DCR redirect URI is a portless loopback
+address the way Claude Code's is; with the exemption in place they get the
+same behavior. ChatGPT and Grok are browser/mobile-first (not
+loopback-native-app clients in the RFC 8252 sense), so the exemption is
+unlikely to matter for them;
 Codex, being another native CLI, is the one worth checking first once a
 real Codex install is available.
 

--- a/v3/server/README.md
+++ b/v3/server/README.md
@@ -252,6 +252,19 @@ SSRF-hardened fetcher, so reconnects reuse one row instead of creating one.
 DCR remains as a fenced fallback — public clients only, PKCE mandatory, no way
 to request `client_credentials`, hard ceiling, GC'd.
 
+Two deployment notes from real-client validation (issue #233):
+
+- **Behind a mandatory egress proxy** (corporate networks, some container
+  platforms), set `FASTMCP_SSRF_TRUST_PROXY=1` for the hub process: fastmcp's
+  SSRF-safe fetcher resolves DNS and dials the target IP directly by design,
+  bypassing `HTTPS_PROXY` — without the variable, every CIMD-based login
+  (Claude Code, claude.ai, ChatGPT, Codex) fails at the metadata-fetch step.
+- Redirect-URI matching is byte-exact per OAuth 2.1 §4.1.3, with the one
+  carve-out that spec mandates (RFC 8252 §7.3): an `http` loopback redirect
+  URI matches its registered form ignoring only the port, because a native
+  client picks an ephemeral port at request time. Claude Code's default,
+  zero-flag `claude mcp login` depends on this.
+
 Access tokens are signed **ES256** rather than the Ed25519 the SPEC names:
 fastmcp 3.4.7's `JWTVerifier` — which deliverable #4 requires the resource
 side to use — accepts no `EdDSA`, and reimplementing JWT validation here is

--- a/v3/server/src/palaia_hub/oauth/cimd.py
+++ b/v3/server/src/palaia_hub/oauth/cimd.py
@@ -250,22 +250,58 @@ class StaticCimdFetcher(CimdFetcher):
         return validate_metadata(self.documents[client_id], expected_client_id=client_id)
 
 
+#: Hosts the loopback-port exemption below applies to. The RFC names the
+#: loopback IP literals; ``localhost`` is included because real native
+#: clients (Claude Code's published CIMD document among them) register it,
+#: and :func:`validate_redirect_uri` already accepts it as loopback.
+_LOOPBACK_HOSTS = ("127.0.0.1", "::1", "localhost")
+
+
 def match_redirect_uri(registered: Sequence[str], presented: str) -> str:
-    """Return ``presented`` if it exactly matches a registered redirect URI.
+    """Return ``presented`` if it matches a registered redirect URI.
 
     Exact string comparison, deliberately: prefix or "same origin" matching
     is how open redirectors get built, and OAuth 2.1 §4.1.3 requires exact
     matching for this reason.
+
+    One spec-mandated carve-out (RFC 8252 §7.3, folded into OAuth 2.1
+    §10.3.3, issue #233): a native client redirecting to an ``http``
+    loopback URI picks an **ephemeral port at request time**, so for those
+    URIs — and only those — the port is ignored. Everything else must still
+    agree exactly: scheme (``http``), hostname (the same loopback name, no
+    cross-host equivalence), path, query, and no fragment. Without this,
+    a client whose registered loopback URI carries no port (Claude Code's
+    default CIMD registration) can never complete a login.
 
     Raises:
         OAuthError: ``invalid_redirect_uri`` on any mismatch.
     """
     if presented in registered:
         return presented
+    if _matches_loopback_port_variant(registered, presented):
+        return presented
     raise OAuthError(
         "invalid_redirect_uri",
         "the redirect_uri does not exactly match one this client registered.",
     )
+
+
+def _matches_loopback_port_variant(registered: Sequence[str], presented: str) -> bool:
+    """RFC 8252 §7.3: match an http-loopback URI ignoring only its port."""
+    parts = urlsplit(presented)
+    if parts.scheme != "http" or parts.hostname not in _LOOPBACK_HOSTS or parts.fragment:
+        return False
+    for candidate in registered:
+        known = urlsplit(candidate)
+        if (
+            known.scheme == "http"
+            and known.hostname == parts.hostname
+            and known.path == parts.path
+            and known.query == parts.query
+            and not known.fragment
+        ):
+            return True
+    return False
 
 
 __all__ = [

--- a/v3/server/tests/e2e/test_spec209_client_matrix.py
+++ b/v3/server/tests/e2e/test_spec209_client_matrix.py
@@ -26,19 +26,20 @@ Three things, building on each other:
    palaia's canonical audience shape never satisfies, reporting a scary
    "Failed to connect" on a hub that is otherwise working fine. Also local.
 
-3. :func:`test_claude_code_cli_native_oauth_login_needs_a_preregistered_redirect_uri`
-   documents byte5ai/palaia#233, the actual blocker on the CLI's default,
-   zero-flag login path: Claude Code's real, published Client ID Metadata
-   Document registers a *portless* loopback ``redirect_uri``
-   (``http://localhost/callback``); the CLI's real authorize request always
-   carries an ephemeral port; palaia's redirect_uri matching is byte-exact
-   with no RFC 8252 §7.3 loopback-port exemption, so the match can never
-   succeed. It then proves the fix's absence is the *only* thing missing by
-   completing a real login anyway, using the CLI's own documented escape
-   hatch for authorization servers like this one (``--client-id`` pointing
-   at a DCR client this test pre-registers with a literal, fixed-port
-   redirect_uri, plus ``--callback-port`` naming that same port) — and
-   round-tripping a real tool call on the resulting stored credential.
+3. :func:`test_claude_code_cli_native_oauth_login_completes_on_the_default_path`
+   covers byte5ai/palaia#233 and its fix: Claude Code's real, published
+   Client ID Metadata Document registers a *portless* loopback
+   ``redirect_uri`` (``http://localhost/callback``) while the CLI's real
+   authorize request always carries an ephemeral port — which the
+   RFC 8252 §7.3 loopback-port exemption in
+   :func:`palaia_hub.oauth.cimd.match_redirect_uri` now accepts, so the
+   default, zero-flag ``claude mcp add`` + ``claude mcp login`` path
+   completes for real. The second half exercises the same login through
+   the CLI's ``--client-id``/``--callback-port`` escape hatch (a DCR
+   client this test pre-registers with a literal, fixed-port
+   redirect_uri) — the pre-fix workaround, kept green as the DCR-path
+   regression test — and round-trips a real tool call on the resulting
+   stored credential.
    Needs real outbound HTTPS to ``claude.ai`` (to fetch the real CIMD
    document) and ``FASTMCP_SSRF_TRUST_PROXY=1`` in an egress-proxied
    environment (see the hub fixture); skipped, not failed, when that
@@ -401,11 +402,11 @@ def test_claude_mcp_get_reports_failed_to_connect_before_any_token_exists(
         _run_claude(["mcp", "remove", server_name, "-s", "local"], cwd=work_dir)
 
 
-def test_claude_code_cli_native_oauth_login_needs_a_preregistered_redirect_uri(
+def test_claude_code_cli_native_oauth_login_completes_on_the_default_path(
     oauth_hub: int, tmp_path: Path
 ) -> None:
-    """byte5ai/palaia#233, in full: the default path fails, the documented
-    CLI escape hatch for this class of authorization server completes it.
+    """byte5ai/palaia#233, fixed: the default zero-flag CIMD login completes
+    (part 1), and the fixed-port DCR escape hatch keeps working (part 2).
     """
     if not _claude_ai_cimd_reachable():
         pytest.skip("no outbound network path to claude.ai's real CIMD document")
@@ -416,8 +417,10 @@ def test_claude_code_cli_native_oauth_login_needs_a_preregistered_redirect_uri(
     work_dir.mkdir()
     mcp_url = f"{base_url}/mcp/default/"
 
-    # --- part 1: the plain, zero-flag path Claude Code's default CIMD
-    # client hits the missing loopback-port exemption on every attempt.
+    # --- part 1: the plain, zero-flag path. Claude Code's default CIMD
+    # client registers portless loopback redirect URIs and presents an
+    # ephemeral port at request time — accepted by match_redirect_uri's
+    # RFC 8252 §7.3 loopback-port exemption, so the login completes.
     server_name = "palaia-spec209-cimd"
     add_result = _run_claude(
         ["mcp", "add", "--transport", "http", server_name, mcp_url, "--scope", "local"],
@@ -436,8 +439,14 @@ def test_claude_code_cli_native_oauth_login_needs_a_preregistered_redirect_uri(
         client = httpx.Client(follow_redirects=False, timeout=15.0)
         _csrf_and_sign_in(client, base_url)
         authorize_response = client.get(authorize_url)
-        assert authorize_response.status_code == 400, authorize_response.text
-        assert "invalid_redirect_uri" in authorize_response.text
+        assert authorize_response.status_code == 303, authorize_response.text
+        redirect_url = authorize_response.headers["location"]
+        assert "/callback" in redirect_url and "code=" in redirect_url, redirect_url
+
+        session.write_line(redirect_url)
+        final_output = session.read_until(re.compile(r"Authenticated with|error"), _LOGIN_TIMEOUT)
+        assert "Authenticated with" in final_output, final_output
+        assert session.process.wait(timeout=10) == 0
     finally:
         session.close()
         _run_claude(["mcp", "remove", server_name, "-s", "local"], cwd=work_dir)

--- a/v3/server/tests/oauth/test_cimd_and_pkce.py
+++ b/v3/server/tests/oauth/test_cimd_and_pkce.py
@@ -142,6 +142,38 @@ def test_redirect_matching_is_exact_never_prefix() -> None:
             match_redirect_uri(registered, attempt)
 
 
+def test_loopback_redirects_match_ignoring_only_the_port() -> None:
+    """RFC 8252 §7.3 (issue #233): an http loopback redirect URI picks its
+    port at request time, so the port — and nothing else — is ignored."""
+    registered = ("http://localhost/callback", "http://127.0.0.1/callback")
+
+    for presented in (
+        "http://localhost:49152/callback",
+        "http://localhost:/callback",  # the empty-port form Claude Code sends
+        "http://127.0.0.1:8123/callback",
+        "http://localhost/callback",
+    ):
+        assert match_redirect_uri(registered, presented) == presented
+
+    for attempt in (
+        "http://localhost:49152/other",  # different path
+        "http://localhost:49152/callback?x=1",  # different query
+        "http://[::1]:49152/callback",  # a loopback host the client never registered
+        "http://192.168.1.10:49152/callback",  # not loopback at all
+        "https://localhost:49152/callback",  # exemption is http-only
+        "http://localhost:49152/callback#frag",  # fragments are never valid
+    ):
+        with pytest.raises(OAuthError):
+            match_redirect_uri(registered, attempt)
+
+
+def test_loopback_port_exemption_never_applies_to_https_registrations() -> None:
+    """A registered https URI (even on a loopback name) keeps exact matching."""
+    registered = ("https://localhost/callback",)
+    with pytest.raises(OAuthError):
+        match_redirect_uri(registered, "http://localhost:49152/callback")
+
+
 # --------------------------------------------------------------- SSRF fence
 
 


### PR DESCRIPTION
## Summary

Closes #233 — the one real blocker SPEC-209's validation found: Claude Code's default, zero-flag `claude mcp login` could never complete against palaia, because its published CIMD document registers **portless** loopback redirect URIs (`http://localhost/callback`) while every real login presents an ephemeral port, and `match_redirect_uri` was byte-exact with no carve-out.

The fix is the carve-out the specs themselves mandate (RFC 8252 §7.3, folded into OAuth 2.1 §10.3.3), no more:

- An **`http` loopback** redirect URI (127.0.0.1 / ::1 / localhost) matches its registered form **ignoring only the port**. Scheme, hostname (no cross-host equivalence — presented `localhost` only matches registered `localhost`), path and query must still agree exactly; fragments never match.
- Everything else keeps byte-exact matching, including `https` registrations on loopback names.

## What changed

- `oauth/cimd.py`: `match_redirect_uri` + `_matches_loopback_port_variant`, docstring states the rule and its bounds.
- `tests/oauth/test_cimd_and_pkce.py`: positive cases (ephemeral port, Claude Code's empty-port form) and negatives (different path/query/host, non-loopback, https, fragment; https-registration stays exact).
- `tests/e2e/test_spec209_client_matrix.py`: the pinned-failure assertion (designed to turn red on this fix) is now the real thing — **the default zero-flag `claude mcp add` + `claude mcp login --no-browser` completes end-to-end against the real CLI and the real claude.ai CIMD document** (`Authenticated with …`, exit 0). The fixed-port DCR escape hatch stays covered as a regression test.
- `server/README.md`: two deployment notes from #233 (the `FASTMCP_SSRF_TRUST_PROXY=1` requirement behind mandatory egress proxies, and the exemption itself); `docs/client-matrix-results.md` §2.3 updated from "blocker" to "fixed", with the evidence.

## Verification

```
uv run ruff check server    All checks passed!
uv run mypy server/src      Success: no issues found in 128 source files
uv run pytest server/tests  1436 passed, 10 skipped (includes the real-CLI default-path login e2e)
```

## Scope

`v3/server/**` + `v3/docs/client-matrix-results.md`. No v2 files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790132368&installation_model_id=428086&pr_number=235&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F235&signature=a13635c6fe3967c47bba9809418f3928925c4f9a7bbab271e34ccd682aabeafa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->