### PR TITLE
docs(v3): record the P2→P3 gate

### DIFF
--- a/v3/IMPLEMENTATION.md
+++ b/v3/IMPLEMENTATION.md
@@ -171,3 +171,18 @@ remembers what desktop Codex learned* — a real remote client through OAuth).
   providers share one memory; install without shell beyond one docker command),
   e2e harness green, importers round-trip golden vaults, owner UX pass on the
   dashboard. Reviewer: **Fable 5** (writes the Phase-2 SPECs at this gate).
+- **Gate P2→P3 (held 2026-08-24):** every Phase-2 ship merged and integrated
+  (SPECs 201–210: events+hooks, stash, OAuth 2.1 server, IdP sign-in,
+  modes+exposure wizard, curator, skills, MCP Apps, client matrix, dynamic
+  mounting), full suite green at 1436 tests. Exit criterion *"phone Claude
+  remembers what desktop Codex learned"* demonstrated up to the vendor-cloud
+  boundary: shared memory across providers (Phase-1 S1, still green), plus a
+  **real, completed OAuth login and tool round-trip by an actual native
+  client on the default zero-flag path** against a Cloud-mode hub
+  (SPEC-209 e2e; unblocked by the RFC 8252 §7.3 fix, issue #233). The
+  literal phone half needs a real claude.ai account against a publicly
+  reachable hub — a documented ~5-minute owner action
+  (`docs/client-matrix-results.md` says exactly what to run), not something
+  this environment can fake honestly. Reviewer: **Fable 5** (writes the
+  Phase-3 SPECs at this gate) + owner (phone test + UX pass on the new
+  exposure/settings/review screens).


### PR DESCRIPTION
One entry in IMPLEMENTATION.md §6: the Phase-2 gate held 2026-08-24 — what was integrated (SPECs 201–210, 1436 tests green), how the exit criterion was evidenced (real native-client OAuth login on the default path after the #233 fix, on top of Phase-1's shared-memory proof), and the one honestly-open item (the literal phone test needs the owner's claude.ai account against a publicly reachable hub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790132529&installation_model_id=428086&pr_number=236&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F236&signature=2599f39d8da3e0285b4e06ab418bb5203b1c5b7fdf14a026311ec0575debc544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->