### PR TITLE
docs(v3): Phase-3 SPECs 301–308 + wave plan

### DIFF
--- a/v3/IMPLEMENTATION.md
+++ b/v3/IMPLEMENTATION.md
@@ -147,6 +147,24 @@ remembers what desktop Codex learned* — a real remote client through OAuth).
 | [209](specs/SPEC-209-client-matrix.md) | Client matrix validation | 203, 205 | Sonnet 5 | low | gate evidence |
 | [210](specs/SPEC-210-phase1-followups.md) | Phase-1 follow-ups | 104, 110, 111 | Sonnet 5 | medium | — |
 
+## 4c. Phase 3 SPEC index (written at the Phase-2 gate, 2026-08-24)
+
+Waves: **3a** = 301, 303, 306, 307 (no mutual deps; 301 is the shared
+foundation and integrates first) → **3b** = 302, 305 (both need 301) →
+**3c** = 304 (needs 302 + 303), then 308 + Phase-3 gate (exit criterion:
+*install a tool once, every AI has it*).
+
+| SPEC | Title | Depends on | Model | Effort | Review gate |
+|---|---|---|---|---|---|
+| [301](specs/SPEC-301-gateway-config.md) | Gateway config in config.yaml | 210, 203, 205, 206 | Sonnet 5 | high | Fable 5 review (audience wiring) |
+| [302](specs/SPEC-302-external-servers.md) | External servers + secret store | 301 | **Opus 5** | medium | **Fable 5 security review (max)** |
+| [303](specs/SPEC-303-registry-index.md) | Registry client + curated index | 101 | Sonnet 5 | medium | Fable 5 review (index signing) |
+| [304](specs/SPEC-304-marketplace.md) | Marketplace v1 + MCP App | 302, 303 | Sonnet 5 | high | owner UX pass |
+| [305](specs/SPEC-305-profile-editor.md) | Profile editor | 301 | Sonnet 5 | medium | — |
+| [306](specs/SPEC-306-mcpb-bundles.md) | MCPB + one-click bundles | 203, 205 | Sonnet 5 | high | Fable 5 review (signing story) |
+| [307](specs/SPEC-307-automations.md) | Automations editor | 201 | Sonnet 5 | medium | — |
+| [308](specs/SPEC-308-phase3-gate.md) | Phase-3 gate evidence | 301–306 | Sonnet 5 | medium | gate evidence |
+
 ## 5. Phase 2 work packages (superseded by §4b — kept for provenance)
 
 | Package | Content | Model | Effort |

--- a/v3/specs/SPEC-301-gateway-config.md
+++ b/v3/specs/SPEC-301-gateway-config.md
@@ -1,0 +1,64 @@
+---
+id: SPEC-301
+title: Gateway config in config.yaml — profiles as first-class objects
+phase: 3
+depends_on: [SPEC-210, SPEC-203, SPEC-205, SPEC-206]
+model: sonnet-5
+effort: high
+status: ready
+---
+
+# SPEC-301: Gateway config in config.yaml
+
+## Goal
+The gateway's shape (profiles, vault mounts, tool renames) becomes durable,
+operator-editable configuration instead of code-side assembly — the
+foundation every other Phase-3 SPEC (external servers, marketplace installs,
+profile editor) builds on. This also retires three documented bridges/debts:
+the `oauth.profiles` config bridge (SPEC-203), the "enable OAuth still needs
+a manual config.yaml edit" seam (SPEC-205 deviation), and the "a
+wizard-created vault is not curated until restart" gap (SPEC-206 deviation).
+
+## Deliverables
+1. A `gateway:` section in `config.yaml`: profiles (path, mounted vaults,
+   enabled built-ins like stash, tool renames per SPEC-105's `tool_renames`),
+   with the same template-comment quality the `oauth:`/`curator:` sections
+   set. `palaia_hub.serve.build_production_app` builds the DynamicGateway
+   from it; with no section present, today's behavior (every vault on one
+   `default` profile) is the generated default, so existing setups change
+   nothing.
+2. Runtime profile CRUD: REST under `/api/gateway/profiles` (create, rename,
+   edit mounts/renames, delete), applied to the running DynamicGateway via
+   its rebuild-and-swap and **persisted back to config.yaml** (the SPEC-205
+   modes PATCH endpoint shows the write-back pattern). A profile path is
+   immutable once clients connect to it — rename the display name, never the
+   URL (document why: the path is the audience, SPEC-203).
+3. `oauth.profiles` retired: the AS reads which resources exist from the
+   gateway config (one source of truth). Config migration: a config carrying
+   the old key gets it honored + a deprecation warning naming the fix; the
+   template drops it.
+4. The SPEC-206 gap closed: a vault created at runtime joins the profiles
+   that mount "all vaults" (the default profile semantics) AND the curator's
+   tool-action map without restart.
+5. The SPEC-205 seam closed: the exposure wizard's "turn on remote access"
+   step can enable OAuth (set issuer, enable flag) through the existing
+   modes PATCH surface, now that profile/resource wiring no longer needs a
+   hand edit.
+6. Events: `gateway.profile.created/updated/deleted` (additive names,
+   docs/events.md updated).
+
+## Acceptance criteria
+- [ ] zero-config hub behaves byte-identically to today (golden tools
+      snapshot untouched; default profile serves every vault)
+- [ ] a profile created via REST is MCP-reachable without restart and
+      survives a restart (persisted to config.yaml)
+- [ ] OAuth resources follow gateway profiles: token minted for a new
+      profile's audience verifies on it e2e; `oauth.profiles` in an old
+      config still works but warns
+- [ ] wizard-created vault: curator curates a capture into it without
+      restart (regression test on SPEC-206's documented gap)
+- [ ] tool renames from config are applied and sanitized (SPEC-105 rules)
+
+## Non-goals
+External (non-palaia) servers in profiles — SPEC-302 adds that on this
+foundation. A profile-editor UI — SPEC-305.

--- a/v3/specs/SPEC-302-external-servers.md
+++ b/v3/specs/SPEC-302-external-servers.md
@@ -1,0 +1,71 @@
+---
+id: SPEC-302
+title: External MCP server aggregation + encrypted credential store
+phase: 3
+depends_on: [SPEC-301]
+model: opus-5
+effort: medium
+status: ready
+---
+
+# SPEC-302: External MCP servers behind the gateway
+
+## Goal
+MASTERPLAN §5.2 "one endpoint, many tools": the user connects an external
+MCP server (remote HTTP, or a local command/container) once, in palaia, and
+it appears — namespaced, renamable, health-checked — on whichever profiles
+mount it. Credentials live in palaia's encrypted store, never in a client
+config file again.
+
+## Deliverables
+1. `palaia_hub.upstream` package: an upstream-server registry
+   (config-backed via SPEC-301's `gateway:` section — `upstreams:` list with
+   kind `http` | `stdio`, endpoint/command, namespace, display name, enabled
+   flag) and a per-upstream FastMCP client/mount. Consult
+   `v3/spikes/gateway/FINDINGS.md` for the proven mounting mechanics on
+   fastmcp 3.4.7 (`as_proxy` is deprecated — use the current
+   client-backed-server mount; namespacing/`tool_names` apply pre-namespace).
+2. **Encrypted secret store** (fixed design, security-critical): secrets
+   (upstream API keys, OAuth client secrets, bearer tokens) live in
+   `<home>/secrets.sqlite3`, values encrypted with Fernet
+   (`cryptography`, already a dependency) under a key in
+   `<home>/secrets.key` created `0600` in the `0700` home via
+   `O_CREAT|O_EXCL` (SPEC-203's `keys.py` shows the exact pattern —
+   reuse its `enforce_private_mode`). API: `put/get/delete/list-names`;
+   **values are never returned by any REST endpoint or logged** — write-only
+   from the dashboard, names-only listing. Upstream configs reference
+   secrets by name.
+3. Upstream auth wiring: static bearer/header from the secret store for
+   `http` upstreams; env-var injection for `stdio` upstreams. (Full OAuth
+   *client* flows against third-party ASes are a non-goal — manual token
+   paste into the secret store is the v1 path, stated honestly in the UI.)
+4. Health: per-upstream reachability probe (initialize + tools/list) with
+   status surfaced via REST (`/api/gateway/upstreams`) and a
+   `gateway.upstream.up/down` event; a down upstream degrades to absent
+   tools + a clear one-line status, never a hung profile (bounded connect
+   timeouts; the mount must not block hub startup).
+5. Namespacing & renames: upstream tools appear as `<namespace>_<tool>`,
+   renamable per SPEC-105's mechanism; conflicts refused loudly at config
+   time, not silently last-write-wins.
+6. Security fences: an upstream is NEVER mounted on the curator profile
+   (SPEC-206's middleware map is fail-closed — assert a test); upstream
+   tool descriptions pass through but the profile's IDENTITY line marks
+   provenance ("via <display name>, connected by you").
+
+## Acceptance criteria
+- [ ] e2e: a real second FastMCP server (test fixture) connected as an
+      upstream is callable through a profile by a real `fastmcp.Client`,
+      namespaced, and its rename works
+- [ ] secret store: key/db files 0600; a stored value never appears in any
+      REST response, log line (redaction test), or error message; hub
+      restarts read it back
+- [ ] a down upstream: profile still initializes, its other tools work,
+      status endpoint says which upstream is down and why
+- [ ] stdio upstream: command spawned, env-var secret injected, tools
+      callable e2e, process reaped on hub shutdown
+- [ ] curator profile provably cannot see or call upstream tools
+
+## Non-goals
+OAuth client flows to third-party authorization servers; container lifecycle
+management (SPEC-304 owns the add-on/container story); registry browsing
+(SPEC-303).

--- a/v3/specs/SPEC-303-registry-index.md
+++ b/v3/specs/SPEC-303-registry-index.md
@@ -1,0 +1,55 @@
+---
+id: SPEC-303
+title: Registry client + curated add-on index
+phase: 3
+depends_on: [SPEC-101]
+model: sonnet-5
+effort: medium
+status: ready
+---
+
+# SPEC-303: Registry browse + curated index
+
+## Goal
+The marketplace's two data sources (MASTERPLAN §5.3): the official MCP
+registry (minimally moderated, delegates trust) and palaia's curated index
+(the trust layer). This SPEC delivers the data layer + REST; SPEC-304 puts
+the UI and install flows on top.
+
+## Deliverables
+1. `palaia_hub.registry`: a client for the official registry
+   (`registry.modelcontextprotocol.io`, **API v0.1 — frozen**; endpoints and
+   quirks in `v3/research/mcp-landscape-2026.md`). Search + detail, cached
+   on disk with TTL (the hub must browse fine on a flaky connection and say
+   "cached N hours ago"), size- and time-capped fetches, and a clear offline
+   state — never a hung dashboard request.
+2. Curated palaia index: a **signed JSON document** (format fixed here:
+   `{schema_version, generated_at, entries[]}`, each entry
+   `{id, name, one_liner, kind: remote|container|mcpb|skill|plugin,
+   source (registry ref | image | url), config_schema?, permissions[],
+   maintainer, verified: bool}`), fetched from a configurable URL with a
+   pinned Ed25519 public key baked into the package (verify with
+   `cryptography`; refuse an unsigned/invalid index loudly, fall back to the
+   last verified copy on disk). Ship a small starter index as a repo file
+   plus the signing script under `v3/tools/` (key NOT in the repo).
+3. Manual entries: the third source — a REST-created entry with the same
+   shape (`verified: false`, provenance `manual`).
+4. One merged read model: `/api/market/search?q=&source=` and
+   `/api/market/entry/{id}` return the same entry shape regardless of
+   source, with `source` and `verified` always present — the UI never
+   special-cases a source.
+5. Events: `market.index.updated` (additive; docs/events.md).
+
+## Acceptance criteria
+- [ ] registry search/detail against a recorded/mocked v0.1 API; live smoke
+      test env-gated on network, skipped honestly otherwise
+- [ ] a tampered curated index (bad signature, wrong key, downgraded
+      `generated_at`) is refused and the last good copy served, with a
+      WARNING naming the reason
+- [ ] offline: search returns cached results marked stale; no request hangs
+      past its timeout
+- [ ] merged search returns all three sources in one shape (contract test)
+
+## Non-goals
+Install/lifecycle (SPEC-304); any UI; submission flow for third parties
+(Phase 4/5 per masterplan).

--- a/v3/specs/SPEC-304-marketplace.md
+++ b/v3/specs/SPEC-304-marketplace.md
@@ -1,0 +1,67 @@
+---
+id: SPEC-304
+title: Marketplace v1 — install flows, add-on lifecycle, marketplace MCP App
+phase: 3
+depends_on: [SPEC-302, SPEC-303]
+model: sonnet-5
+effort: high
+status: ready
+---
+
+# SPEC-304: Marketplace v1
+
+## Goal
+The P3 pillar's first shippable slice: browse (SPEC-303's merged model),
+install with one click, configure through a generated form, see health and
+updates — in the dashboard AND as a marketplace MCP App. "Like Home
+Assistant's add-on store."
+
+## Deliverables
+1. Install flows per entry kind, each landing in existing machinery:
+   - `remote` → creates a SPEC-302 `http` upstream (secret prompts from
+     `config_schema`, values into the secret store, never echoed back);
+   - `container` → pulls and runs the declared image with the declared
+     mounts/env (docker via subprocess against the local socket — no new
+     daemon dependency), then connects it as a SPEC-302 upstream;
+     restart-on-crash policy, stop/remove on uninstall;
+   - `stdio` command entries → SPEC-302 `stdio` upstream;
+   - `skill`/`mcpb` → hand off to the connect page (SPEC-207's skill panel /
+     SPEC-306's bundle download) — the marketplace lists them, it does not
+     reinvent their delivery.
+2. Config UIs generated from the entry's `config_schema` (JSON Schema
+   subset: string/number/boolean/enum/secret — fixed here; a `secret` field
+   writes to the secret store by name). Jargon-free labels come from the
+   schema's `title`s; the form renderer is one shared component.
+3. **Consent screen before every install** (dashboard-only, per §5.7's
+   "security-sensitive administration stays dashboard-only"): shows kind,
+   source, `verified` flag, declared permissions, and — for containers —
+   image + mounts; the confirm button names the action ("Install and
+   connect"). An unverified/manual entry gets a visibly stronger warning.
+4. Update surface: `addon.update_available` event (curated index version vs
+   installed), one-click update for containers, dashboard badge. No
+   auto-update in v1.
+5. Marketplace MCP App (§5.7 table): browse/search as a card grid inside
+   the client, detail view; **Install itself always deep-links to the
+   dashboard consent screen** — the app never performs the install (same
+   security rule as #3). Shares the SPEC-208 app shell; plain-text
+   fallback lists top results.
+6. Lume adherence for all dashboard screens (normative source
+   `v3/docs/design/lume/`, serif only for memory content — none here).
+
+## Acceptance criteria
+- [ ] e2e: from a curated-index entry, one-click install of a `remote`
+      fixture upstream → its tool callable through a profile without restart
+- [ ] container lifecycle against a fixture image: install → running →
+      health visible → update → uninstall leaves no container behind
+      (env-gated on docker availability; skipped honestly otherwise)
+- [ ] a `secret` config field round-trips into the secret store and is
+      never present in any subsequent GET (contract test)
+- [ ] consent screen renders permissions + verified state; install without
+      consent POST is impossible (REST requires the consent token)
+- [ ] marketplace app renders in a host harness (SPEC-208 pattern), and its
+      install action deep-links instead of installing
+- [ ] jargon lint on all new UI copy (SPEC-205's DOM-scan pattern)
+
+## Non-goals
+Auto-updates; third-party submission flow; ratings/reviews; MCPB authoring
+(SPEC-306); semantic tool routing (SPEC-305 option).

--- a/v3/specs/SPEC-305-profile-editor.md
+++ b/v3/specs/SPEC-305-profile-editor.md
@@ -1,0 +1,54 @@
+---
+id: SPEC-305
+title: Per-client tool profiles — dashboard editor
+phase: 3
+depends_on: [SPEC-301]
+model: sonnet-5
+effort: medium
+status: ready
+---
+
+# SPEC-305: Profile editor
+
+## Goal
+MASTERPLAN §5.2's per-client profiles become editable by a person: "Codex
+gets memory only; Claude Desktop gets everything" — as a screen, not a YAML
+exercise. The URL already selects the tool surface (`/mcp/<profile>`,
+SPEC-301); this SPEC is the UI and the last-mile conveniences.
+
+## Deliverables
+1. Dashboard "Tool profiles" screen: list profiles with their endpoint URL
+   and a live tool count; create/edit assigns vaults, built-ins (stash),
+   and SPEC-302 upstreams via checkboxes; per-tool rename inline (sanitized
+   live, with the "connected clients may re-prompt for approval" warning
+   from §5.2). Data layer is SPEC-301's REST — this SPEC adds no second
+   write path.
+2. Connect-page integration: the client picker gains a profile picker;
+   every snippet/one-liner/bundle renders with the chosen profile's URL.
+3. Per-tool visibility toggles within a mounted family (e.g. a profile
+   mounts the work vault but hides `work_memory_delete`) — implemented with
+   fastmcp's tool-filtering mechanism on the profile instance (Visibility
+   is session-scoped on 3.4.7 — per-profile instances already exist, see
+   SPEC-105 findings; do NOT mutate shared tool objects).
+4. Optional **semantic tool routing** per profile (§5.2): the profile
+   exposes `find_tool`/`invoke_tool` instead of the full surface, backed by
+   the profile's real tool list. Off by default; marked experimental in the
+   UI; plain-language explanation ("for very large tool collections").
+5. Guardrails in the UI: the curator profile is visible but read-only
+   (edited only via its SPEC — link out); deleting a profile warns with the
+   connected-client consequence; the default profile cannot be deleted.
+
+## Acceptance criteria
+- [ ] create a profile in the UI → its endpoint serves exactly the chosen
+      tools (e2e via `fastmcp.Client`), no restart
+- [ ] hidden tool: absent from tools/list AND refused on call (not merely
+      unlisted)
+- [ ] rename via UI round-trips to config.yaml and the live gateway;
+      invalid names are sanitized with the warning shown
+- [ ] semantic routing profile: `find_tool` finds and `invoke_tool` invokes
+      a real tool e2e; the full surface is absent
+- [ ] jargon lint on the screen's copy; Lume tokens only
+
+## Non-goals
+Per-token (as opposed to per-profile) tool grants — scopes already govern
+that; measuring tool-call success (masterplan metric, later phase).

--- a/v3/specs/SPEC-306-mcpb-bundles.md
+++ b/v3/specs/SPEC-306-mcpb-bundles.md
@@ -1,0 +1,58 @@
+---
+id: SPEC-306
+title: MCPB bundle + one-click client bundles
+phase: 3
+depends_on: [SPEC-203, SPEC-205]
+model: sonnet-5
+effort: high
+status: ready
+---
+
+# SPEC-306: One-click client bundles
+
+## Goal
+The §6 matrix's Claude Desktop row: a signed MCPB bundle containing a thin
+stdio→hub proxy, downloaded from the connect page — double-click installs,
+Claude renders the config UI from the manifest. Plus the same "hand the
+user one artifact" treatment for the other config-file clients.
+
+## Deliverables
+1. `palaia-proxy`: a minimal stdio MCP server that forwards to the hub's
+   streamable-HTTP endpoint (URL + token/OAuth from its config), written as
+   a **self-contained Node script** (Claude Desktop ships a Node runtime for
+   MCPB; facts and constraints in `v3/research/mcp-landscape-2026.md` §MCPB
+   — read it first). Reconnect/backoff, clear stderr diagnostics, version
+   pinned to the hub release.
+2. MCPB packaging: `manifest.json` per the MCPB spec (user_config fields
+   for hub URL + credential, rendered by Claude Desktop as a form), icon,
+   the proxy, packed via the official `mcpb` tooling in CI
+   (`v3/tools/build-mcpb/`); **signed** (the spec's signing story; document
+   what signature Claude Desktop enforces today vs. what we attach, from
+   the dossier — no hand-waving).
+3. Connect page: the Claude Desktop entry becomes "Download bundle"
+   (generated for the chosen profile, hub URL pre-filled; token minted on
+   click via SPEC-108, or OAuth if enabled). Codex/Gemini/LM Studio entries
+   gain "download config file" one-clicks (their real file formats — the
+   SPEC-209-corrected snippets are the source of truth).
+4. Hub serves its own bundle: `/api/connect/mcpb` streams the packaged
+   bundle with the profile baked in; dashboard build embeds nothing —
+   the artifact is assembled server-side from the packaged template.
+5. e2e: the proxy speaks real stdio MCP — a `fastmcp.Client` (stdio
+   transport) through the proxy against a live hub round-trips
+   initialize/tools/call (this is the same proof shape SPEC-002 used).
+
+## Acceptance criteria
+- [ ] stdio e2e through the real proxy against a real hub: tools listed and
+      a memory tool called successfully
+- [ ] packed bundle validates against the MCPB manifest schema; CI job
+      builds it reproducibly
+- [ ] download endpoint bakes the chosen profile URL in; token variant
+      mints a scoped token, OAuth variant contains no secret at all
+- [ ] proxy survives hub restart (reconnect test) and reports a clear error
+      on wrong credentials (no stack trace vomit)
+- [ ] connect-page copy stays jargon-free (lint)
+
+## Non-goals
+Marketplace distribution of third-party MCPBs (listed via SPEC-303/304,
+delivery is the vendor's); Windows/macOS installer signing beyond what MCPB
+itself defines.

--- a/v3/specs/SPEC-307-automations.md
+++ b/v3/specs/SPEC-307-automations.md
@@ -1,0 +1,60 @@
+---
+id: SPEC-307
+title: Automations — actions beyond webhooks + the editor
+phase: 3
+depends_on: [SPEC-201]
+model: sonnet-5
+effort: medium
+status: ready
+---
+
+# SPEC-307: Automations editor
+
+## Goal
+MASTERPLAN §5.6's third step: hooks-as-config shipped in SPEC-201
+(webhooks); this SPEC adds the remaining action kinds and the
+trigger → condition → action editor in the dashboard.
+
+## Deliverables
+1. Action kinds beyond `webhook`, on the same outbox/delivery discipline
+   (durable, retried, never blocking the bus): `memory_write` (a capture
+   into a chosen vault's inbox, templated), `stash_set` (namespace/key/
+   value template), `notification` (dashboard notification center — a new,
+   small `/api/notifications` + bell in the shell; no email/push in v1).
+2. Conditions: a small, safe expression form — field equals/contains/
+   prefix on the envelope (`event`, `origin`, `vault`, `data.<key>`),
+   AND-combined. **No general expression language** (fixed decision: a
+   sandboxed template/matcher, not eval; document the grammar in
+   docs/events.md §automations).
+3. Templating: `{{event}}`, `{{vault}}`, `{{data.<key>}}` substitution into
+   action payloads, escaped per sink; a template referencing a missing key
+   renders empty and logs once, never fails delivery.
+4. Dashboard "Automations" screen (extends SPEC-201's hooks screen):
+   list/create/edit as trigger → condition → action cards, jargon-free
+   (say "When a memory is created … then …"), test-fire button (sends a
+   synthetic event through the real pipeline, marked `test: true`), per-
+   automation delivery log with outcomes.
+5. Recipes: 3-4 canned automations offered on the empty screen (e.g. "notify
+   me when the curator needs a review", "webhook on doctor findings") —
+   one click prefills the editor, nothing installs silently.
+6. Events about automations themselves: `automation.fired`,
+   `automation.failed` (additive; guard against loops: an automation never
+   triggers on `automation.*` events — fixed rule, tested).
+
+## Acceptance criteria
+- [ ] each new action kind delivers e2e from a real bus event (memory_write
+      lands a format-§7-valid capture; stash entry appears; notification
+      visible via REST)
+- [ ] loop guard: an automation on `automation.fired` is refused at create
+      time
+- [ ] conditions filter correctly incl. `data.<key>` paths; malformed
+      condition rejected with a plain-language error
+- [ ] test-fire runs the real pipeline and marks the delivery `test: true`
+- [ ] delivery failures retry per SPEC-201's policy and surface in the log
+- [ ] jargon lint on all screen copy
+
+## Non-goals
+Email/push notification channels; a visual multi-step workflow builder
+(one trigger → one action in v1, multiple automations compose); tool
+invocation as an action (needs per-automation auth design — Phase 4 with
+the messenger).

--- a/v3/specs/SPEC-308-phase3-gate.md
+++ b/v3/specs/SPEC-308-phase3-gate.md
@@ -1,0 +1,44 @@
+---
+id: SPEC-308
+title: Phase-3 gate — "install a tool once, every AI has it"
+phase: 3
+depends_on: [SPEC-301, SPEC-302, SPEC-303, SPEC-304, SPEC-305, SPEC-306]
+model: sonnet-5
+effort: medium
+status: ready
+---
+
+# SPEC-308: Phase-3 gate evidence
+
+## Goal
+Prove the roadmap's Phase-3 exit criterion end-to-end, honestly, with the
+SPEC-209 evidence discipline: **install a tool once (marketplace), and it
+is available to every connected AI** — different clients, different
+profiles, no per-client setup.
+
+## Deliverables
+1. e2e scenario (extends the SPEC-113 harness): curated-index entry →
+   dashboard-API install (consent flow included) → the tool answers on TWO
+   different profiles through two differently-authenticated real clients:
+   the real `claude` CLI (OAuth default path, SPEC-209's machinery) and a
+   scripted `fastmcp.Client` with a `plt_` token — one install, two AIs,
+   zero client-side tool config.
+2. The same scenario through the MCPB proxy (SPEC-306): the stdio path
+   sees the newly installed tool without any bundle change.
+3. `v3/docs/client-matrix-results.md` updated: a "tools follow the
+   profile" column/section with per-client evidence or an honest
+   "not verified", SPEC-209 rules unchanged.
+4. Gate paragraph appended to IMPLEMENTATION.md §6 draft (the architect
+   holds the gate; this SPEC assembles the evidence).
+5. Issues filed for every quirk found, SPEC-209 style.
+
+## Acceptance criteria
+- [ ] the two-clients-one-install e2e passes in one pytest run (env-gated
+      parts skip honestly)
+- [ ] the MCPB-proxy variant passes
+- [ ] client-matrix doc updated with dated evidence
+- [ ] full suite green at the end (this SPEC adds tests, changes no
+      behavior; any behavior fix it needs goes through its own issue/PR)
+
+## Non-goals
+New features. This SPEC only proves, documents, and files.


### PR DESCRIPTION
## Summary

The Phase-2-gate deliverable: eight Phase-3 SPECs and the §4c wave plan, toward the exit criterion **"install a tool once, every AI has it"**.

- **301 Gateway config in config.yaml** — profiles become durable, REST-editable config; retires the `oauth.profiles` bridge and closes the documented SPEC-205/206 seams (OAuth enable from the wizard, runtime vaults curated without restart).
- **302 External servers + encrypted secret store** — upstream MCP servers (http/stdio) behind the gateway; Fernet-encrypted secret store with fixed, security-reviewed design; curator fenced off upstreams.
- **303 Registry client + curated index** — official registry v0.1 client with offline discipline; signed curated index with pinned key.
- **304 Marketplace v1** — install flows per artifact kind, generated config UIs, consent screen (dashboard-only), container lifecycle, marketplace MCP App (deep-links installs, never performs them).
- **305 Profile editor** — the per-client tool-profile screen, per-tool visibility, optional semantic routing.
- **306 MCPB + one-click bundles** — signed stdio→hub proxy bundle for Claude Desktop, config-file one-clicks for the other clients.
- **307 Automations editor** — memory_write/stash/notification actions on the SPEC-201 outbox discipline, safe conditions (no eval), loop guard, editor UI.
- **308 Phase-3 gate evidence** — one install, two differently-authenticated real clients, plus the MCPB path; SPEC-209 honesty rules.

Waves: **3a** = 301, 303, 306, 307 → **3b** = 302, 305 → **3c** = 304, then 308 + gate. Model/effort per SPEC frontmatter; security reviews marked (302 max).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790158233&installation_model_id=428086&pr_number=237&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F237&signature=df01ce9d20f788ba9343305e54f7540916ae6cb63a1b3662017f59af9336cfe2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->