### PR TITLE
feat(v3): registry client + curated add-on index (SPEC-303)

### DIFF
--- a/v3/docs/events.md
+++ b/v3/docs/events.md
@@ -100,6 +100,12 @@ of them ignores them.
 | `curator.proposal.apply_failed` | same shape | An operation failed mid-plan; the proposal is stamped `apply-failed` and a `doctor.finding` is raised. |
 | `curator.proposal.manual` | same shape | The proposal carries no executable plan (or an unparseable one) — a human has to apply it. |
 
+### 3.2 Marketplace event (SPEC-303, additive)
+
+| Event | Origin | `data` fields | Fires when |
+|---|---|---|---|
+| `market.index.updated` | `market` | `generated_at`, `entry_count`, `stale`, `warning` | The curated add-on index (`palaia_hub.market.curated.CuratedIndexClient`) is (re)fetched — on a fresh, verified document `stale` is `false` and `warning` empty; on a refused/tampered document or an offline network, `stale` is `true` and `warning` names the exact reason (the same reason logged as a WARNING), and `generated_at`/`entry_count` describe whichever copy (last-verified, or none) was served instead. |
+
 `health` also travels the same bus and wire format (SSE only; it is not a
 webhook-filterable v1 name — see §6) — it is the dashboard's periodic
 liveness snapshot, carried over unchanged from before this SPEC.

--- a/v3/server/src/palaia_hub/app.py
+++ b/v3/server/src/palaia_hub/app.py
@@ -39,6 +39,7 @@ from .gateway.wiring import EngineVaultService
 from .hooks import OUTBOX_RELATIVE_PATH, HookDispatcher, HookOutbox, HookStore, build_hooks_router
 from .index import VaultIndex
 from .logging import setup_logging
+from .market import MarketService, build_market_router
 from .modes import AuthRateLimitMiddleware, ModeAuditLog, build_modes_router
 from .oauth import AuthorizationServer, build_oauth_router
 from .stash.service import StashService
@@ -66,6 +67,7 @@ def create_app(
     event_bus: EventBus | None = None,
     oauth_server: AuthorizationServer | None = None,
     stash_service: StashService | None = None,
+    market_service: MarketService | None = None,
     hook_store: HookStore | None = None,
     hook_outbox: HookOutbox | None = None,
     curator: CuratorScheduler | None = None,
@@ -156,6 +158,12 @@ def create_app(
             mirror, and wires its ``stash.*`` events onto ``event_bus``.
             Omitted (the default), the hub runs with no stash surface at
             all, same as before this parameter existed.
+        market_service: the marketplace read model (SPEC-303 — official
+            registry + curated index + manual entries, merged). Given,
+            mounts ``/api/market/*`` and wires its
+            ``market.index.updated`` event onto ``event_bus``. Omitted
+            (the default), the hub runs with no marketplace surface at
+            all, same as before this parameter existed.
         hook_store: outbound-webhook configuration (SPEC-201). Given, mounts
             the ``/api/hooks`` REST surface and starts the delivery worker
             that turns every published event into a signed webhook POST for
@@ -192,6 +200,12 @@ def create_app(
 
         stash_service.publish = _publish_stash
         stash_gateway = build_stash_gateway(stash_service)
+
+    if market_service is not None:
+        def _publish_market(action: str, data: dict[str, Any]) -> None:
+            publish_event(event_bus, action, origin="market", data=data)
+
+        market_service.publish = _publish_market
 
     # SPEC-208 deliverable #2: the hub_status MCP App, mounted at
     # `/mcp/hub` — hub-level (not per-vault, unlike the memory tool
@@ -413,6 +427,8 @@ def create_app(
 
     if stash_service is not None:
         app.include_router(build_stash_router(stash_service))
+    if market_service is not None:
+        app.include_router(build_market_router(market_service))
     if hook_store is not None:
         assert outbox is not None  # built above, together with hook_store's dispatcher
         app.include_router(build_hooks_router(hook_store, outbox))

--- a/v3/server/src/palaia_hub/config.py
+++ b/v3/server/src/palaia_hub/config.py
@@ -217,6 +217,13 @@ curator:
   # token:
   # Where a session reaches this hub. Defaults to http://<host>:<port>.
   # endpoint:
+
+# The marketplace's curated add-on index (MASTERPLAN §5.3): where to fetch
+# palaia's signed, curated list of add-ons from. The signature's public key
+# is pinned in code, never here — changing this URL alone cannot make the
+# hub trust a different signer. null uses the built-in default URL.
+market:
+  index_url: null
 """
 
 
@@ -497,6 +504,26 @@ class CuratorSettings(BaseModel):
     endpoint: str | None = None
 
 
+class MarketSettings(BaseModel):
+    """The marketplace's curated-index source (SPEC-303 deliverable #2).
+
+    Only the index *URL* is configurable — the Ed25519 public key it must
+    verify against is pinned in code
+    (``palaia_hub.market.curated.DEFAULT_PUBLIC_KEY_B64``), never here.
+    A configurable trust anchor would let a config-file edit alone make
+    the hub trust an attacker's index; the URL merely says where to look
+    for a document that still has to carry a valid signature from the
+    one key this hub ships pinned to.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    #: ``None`` means "use palaia_hub.market.curated.DEFAULT_INDEX_URL".
+    #: Kept optional (rather than defaulting here) so the default lives in
+    #: exactly one place.
+    index_url: str | None = None
+
+
 class HubConfig(BaseModel):
     """Validated hub configuration, merged from defaults/file/env."""
 
@@ -513,6 +540,7 @@ class HubConfig(BaseModel):
     oauth: OAuthSettings = Field(default_factory=OAuthSettings)
     curator: CuratorSettings = Field(default_factory=CuratorSettings)
     exposure: ExposureSettings = Field(default_factory=ExposureSettings)
+    market: MarketSettings = Field(default_factory=MarketSettings)
 
     def curator_endpoint(self) -> str:
         """The base URL a curation session reaches this hub at (SPEC-206)."""

--- a/v3/server/src/palaia_hub/events/schema.py
+++ b/v3/server/src/palaia_hub/events/schema.py
@@ -65,6 +65,10 @@ EventName = Literal[
     "stash.get",
     "stash.del",
     "stash.evicted",
+    # SPEC-303: the curated marketplace index was (re)fetched — fresh or a
+    # refused/offline fallback, named honestly in the event's own data.
+    # Additive to the v1 vocabulary, same rule as the curator events above.
+    "market.index.updated",
     "health",
 ]
 

--- a/v3/server/src/palaia_hub/market/__init__.py
+++ b/v3/server/src/palaia_hub/market/__init__.py
@@ -1,0 +1,38 @@
+"""palaia's marketplace data layer (SPEC-303): the official MCP registry,
+the curated palaia add-on index, and manual entries, merged into one read
+model (:class:`~palaia_hub.market.service.MarketService`) and one REST
+surface (:mod:`palaia_hub.market.api`). See MASTERPLAN §5.3. SPEC-304
+builds the dashboard UI and install/lifecycle flows on top of this.
+"""
+
+from __future__ import annotations
+
+from .api import build_market_router
+from .curated import (
+    DEFAULT_INDEX_URL,
+    DEFAULT_PUBLIC_KEY_B64,
+    CuratedIndexClient,
+    CuratedIndexResult,
+    IndexVerificationError,
+)
+from .manual import ManualEntryError, ManualEntryStore
+from .models import EntryKind, ManualEntryCreate, MarketEntry, Provenance, SourceLocator
+from .service import MarketSearchResult, MarketService
+
+__all__ = [
+    "DEFAULT_INDEX_URL",
+    "DEFAULT_PUBLIC_KEY_B64",
+    "CuratedIndexClient",
+    "CuratedIndexResult",
+    "EntryKind",
+    "IndexVerificationError",
+    "ManualEntryCreate",
+    "ManualEntryError",
+    "ManualEntryStore",
+    "MarketEntry",
+    "MarketSearchResult",
+    "MarketService",
+    "Provenance",
+    "SourceLocator",
+    "build_market_router",
+]

--- a/v3/server/src/palaia_hub/market/api.py
+++ b/v3/server/src/palaia_hub/market/api.py
@@ -1,0 +1,54 @@
+"""``/api/market`` — the merged marketplace REST surface (SPEC-303
+deliverable #4): the one place the dashboard (SPEC-304) reads add-ons
+from, regardless of which of the three sources produced them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from .manual import ManualEntryError
+from .models import ManualEntryCreate, MarketEntry, Provenance
+from .service import MarketService
+
+
+class SearchResponse(BaseModel):
+    entries: list[MarketEntry]
+    stale: bool
+    notes: dict[str, str]
+
+
+def build_market_router(service: MarketService) -> APIRouter:
+    router = APIRouter(prefix="/api/market", tags=["market"])
+
+    @router.get("/search", response_model=SearchResponse)
+    async def search(q: str = "", source: Provenance | None = None) -> SearchResponse:
+        result = await service.search(q, source=source)
+        return SearchResponse(entries=list(result.entries), stale=result.stale, notes=result.notes)
+
+    @router.get("/entry/{entry_id}", response_model=MarketEntry)
+    async def get_entry(entry_id: str) -> MarketEntry:
+        entry = await service.get_entry(entry_id)
+        if entry is None:
+            raise HTTPException(status_code=404, detail=f"no marketplace entry {entry_id!r}")
+        return entry
+
+    @router.post("/manual", response_model=MarketEntry, status_code=201)
+    async def create_manual_entry(payload: ManualEntryCreate) -> MarketEntry:
+        try:
+            return service.add_manual_entry(payload)
+        except ManualEntryError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    @router.post("/curated/refresh", status_code=202)
+    async def refresh_curated_index() -> dict[str, Any]:
+        await service.refresh_curated_index()
+        return {"status": "refreshed"}
+
+    return router
+
+
+__all__ = ["SearchResponse", "build_market_router"]

--- a/v3/server/src/palaia_hub/market/curated.py
+++ b/v3/server/src/palaia_hub/market/curated.py
@@ -1,0 +1,267 @@
+"""The curated palaia add-on index (SPEC-303 deliverable #2).
+
+A **signed JSON document**, fixed shape::
+
+    {schema_version, generated_at, entries: [...], signature}
+
+fetched from a configurable URL and verified against a pinned Ed25519
+public key baked into the package (never fetched, never configurable —
+that would defeat the point). ``signature`` is a base64-encoded Ed25519
+signature over the canonical JSON encoding (``json.dumps(..., sort_keys=
+True, separators=(",", ":"))``) of the document *without* the
+``signature`` key itself.
+
+A tampered document — wrong signature, wrong (attacker's) key, or a
+``generated_at`` older than the last copy we already trusted (a rollback/
+downgrade attack) — is refused loudly (a WARNING naming the exact reason)
+and this module falls back to the last verified copy on disk. When there
+is no such copy, refusal means an empty curated index, never a
+half-trusted document silently accepted.
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib.resources
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+from ..config import palaia_home
+from .models import MarketEntry, SourceLocator
+
+logger = logging.getLogger("palaia_hub.market.curated")
+
+#: The pinned Ed25519 public key (raw 32 bytes, base64), baked into the
+#: package. Generated for this repository's starter curated index; the
+#: matching private key is deliberately NOT in the repo (see
+#: ``v3/tools/README.md`` and ``v3/tools/sign_market_index.py``) — whoever
+#: publishes the real palaia curated index controls it, and rotating it
+#: means shipping a new pinned key here, not a config option (a
+#: configurable trust anchor is not a trust anchor).
+DEFAULT_PUBLIC_KEY_B64 = "xh8oKQEO/x7pfXrfqieqjkUc866ZcDPuCvkI3MhSN8k="
+
+DEFAULT_INDEX_URL = "https://index.palaia.dev/market-index.json"
+DEFAULT_TIMEOUT_SECONDS = 8.0
+DEFAULT_MAX_BYTES = 5 * 1024 * 1024
+LAST_GOOD_RELATIVE_PATH = "market_curated_index.json"
+
+SCHEMA_VERSION = 1
+
+
+class IndexVerificationError(RuntimeError):
+    """A curated index document was refused. ``reason`` names why —
+    always logged as a WARNING by :meth:`CuratedIndexClient.fetch`."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+@dataclass(frozen=True, slots=True)
+class CuratedIndexResult:
+    entries: tuple[MarketEntry, ...]
+    generated_at: str
+    #: True whenever this is not a document freshly verified this call —
+    #: either the last-verified copy on disk (network failure or a
+    #: refused document) or, in principle, never for a fresh success.
+    stale: bool
+    #: Empty on a clean fresh fetch; otherwise the reason the fallback was
+    #: used (network error, or the exact verification failure).
+    warning: str = ""
+
+
+def load_starter_index() -> dict[str, Any]:
+    """The small signed starter index shipped in the package (SPEC-303
+    deliverable #2's "ship a small starter index as a repo file") — a
+    fresh hub that has never fetched a real curated index, and can't
+    reach one right now, still has something real to browse rather than
+    an empty marketplace. See ``v3/tools/README.md`` for how it was
+    produced (and why its signing key was discarded afterward)."""
+    data = importlib.resources.files("palaia_hub.market") / "data" / "starter-index.json"
+    return json.loads(data.read_text(encoding="utf-8"))  # type: ignore[no-any-return]
+
+
+def canonical_bytes(document: dict[str, Any]) -> bytes:
+    """The exact bytes a signature is computed over: the document minus
+    its own ``signature`` key, canonical JSON (sorted keys, no whitespace).
+    """
+    payload = {k: v for k, v in document.items() if k != "signature"}
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _entry_from_raw(raw: dict[str, Any], *, provenance: str) -> MarketEntry:
+    source = raw["source"]
+    if not isinstance(source, dict):
+        # A bare-string source in a starter/manual index is treated as a
+        # URL locator — the least-surprising default for "just a link".
+        source = {"type": "url", "value": source}
+    return MarketEntry(
+        id=raw["id"],
+        name=raw["name"],
+        one_liner=raw["one_liner"],
+        kind=raw["kind"],
+        source=SourceLocator(**source),
+        config_schema=raw.get("config_schema"),
+        permissions=list(raw.get("permissions", [])),
+        maintainer=raw["maintainer"],
+        verified=bool(raw.get("verified", False)),
+        provenance=provenance,  # type: ignore[arg-type]
+    )
+
+
+def verify_index_document(
+    document: dict[str, Any],
+    *,
+    public_key_b64: str,
+    known_generated_at: str | None,
+) -> None:
+    """Raise :class:`IndexVerificationError` naming the exact reason, or
+    return silently when the document is authentic and not a rollback."""
+    for key in ("schema_version", "generated_at", "entries", "signature"):
+        if key not in document:
+            raise IndexVerificationError(f"curated index document is missing '{key}'")
+    if document["schema_version"] != SCHEMA_VERSION:
+        raise IndexVerificationError(
+            f"curated index schema_version {document['schema_version']!r} is not "
+            f"the one this hub understands ({SCHEMA_VERSION})"
+        )
+    try:
+        public_key = Ed25519PublicKey.from_public_bytes(base64.b64decode(public_key_b64))
+        signature = base64.b64decode(document["signature"])
+    except Exception as exc:  # noqa: BLE001 - any decode failure is "bad signature"
+        raise IndexVerificationError(f"curated index signature is malformed: {exc}") from exc
+    try:
+        public_key.verify(signature, canonical_bytes(document))
+    except InvalidSignature as exc:
+        raise IndexVerificationError(
+            "curated index signature does not match the pinned public key "
+            "(tampered document, or signed with the wrong key)"
+        ) from exc
+    if known_generated_at is not None and str(document["generated_at"]) < known_generated_at:
+        raise IndexVerificationError(
+            f"curated index generated_at {document['generated_at']!r} is older than the "
+            f"last verified copy ({known_generated_at!r}) — refusing a downgrade/rollback"
+        )
+
+
+class CuratedIndexClient:
+    """Fetch + verify the curated index, with a signed-fallback-to-disk."""
+
+    def __init__(
+        self,
+        *,
+        index_url: str = DEFAULT_INDEX_URL,
+        public_key_b64: str = DEFAULT_PUBLIC_KEY_B64,
+        client: httpx.AsyncClient | None = None,
+        last_good_path: Path | None = None,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        max_bytes: int = DEFAULT_MAX_BYTES,
+    ) -> None:
+        self.index_url = index_url
+        self.public_key_b64 = public_key_b64
+        self._owns_client = client is None
+        self._client = client or httpx.AsyncClient(timeout=timeout_seconds)
+        self.last_good_path = last_good_path or (palaia_home() / LAST_GOOD_RELATIVE_PATH)
+        self.timeout_seconds = timeout_seconds
+        self.max_bytes = max_bytes
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    def _read_last_good(self) -> dict[str, Any] | None:
+        try:
+            data: Any = json.loads(self.last_good_path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            return None
+        return data if isinstance(data, dict) else None
+
+    def _write_last_good(self, document: dict[str, Any]) -> None:
+        self.last_good_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.last_good_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(document), encoding="utf-8")
+        tmp.replace(self.last_good_path)
+
+    def _fallback_result(self, warning: str) -> CuratedIndexResult:
+        last_good = self._read_last_good()
+        if last_good is None:
+            try:
+                last_good = load_starter_index()
+                verify_index_document(
+                    last_good, public_key_b64=self.public_key_b64, known_generated_at=None
+                )
+            except (FileNotFoundError, ModuleNotFoundError, IndexVerificationError):
+                logger.warning(
+                    "curated index unavailable, no last-verified copy and no usable "
+                    "starter index: %s",
+                    warning,
+                )
+                return CuratedIndexResult(entries=(), generated_at="", stale=True, warning=warning)
+            logger.warning(
+                "curated index unavailable, serving the bundled starter index: %s", warning
+            )
+        else:
+            logger.warning(
+                "curated index refused/unreachable, serving last verified copy from %s: %s",
+                last_good.get("generated_at", "?"),
+                warning,
+            )
+        entries = tuple(_entry_from_raw(e, provenance="curated") for e in last_good["entries"])
+        return CuratedIndexResult(
+            entries=entries, generated_at=last_good["generated_at"], stale=True, warning=warning
+        )
+
+    async def fetch(self) -> CuratedIndexResult:
+        try:
+            response = await self._client.get(self.index_url, timeout=self.timeout_seconds)
+        except httpx.TimeoutException:
+            return self._fallback_result(f"timed out after {self.timeout_seconds:.0f}s")
+        except httpx.RequestError as exc:
+            return self._fallback_result(f"network error: {exc}")
+
+        if response.status_code >= 400:
+            return self._fallback_result(f"index host answered HTTP {response.status_code}")
+        if len(response.content) > self.max_bytes:
+            return self._fallback_result(
+                f"index document too large ({len(response.content)} > {self.max_bytes} bytes)"
+            )
+        try:
+            document = response.json()
+        except ValueError:
+            return self._fallback_result("index document is not valid JSON")
+        if not isinstance(document, dict):
+            return self._fallback_result("index document is not a JSON object")
+
+        last_good = self._read_last_good()
+        known_generated_at = str(last_good["generated_at"]) if last_good else None
+        try:
+            verify_index_document(
+                document, public_key_b64=self.public_key_b64, known_generated_at=known_generated_at
+            )
+        except IndexVerificationError as exc:
+            logger.warning("refusing curated index from %s: %s", self.index_url, exc.reason)
+            return self._fallback_result(exc.reason)
+
+        self._write_last_good(document)
+        entries = tuple(_entry_from_raw(e, provenance="curated") for e in document["entries"])
+        return CuratedIndexResult(
+            entries=entries, generated_at=str(document["generated_at"]), stale=False, warning=""
+        )
+
+
+__all__ = [
+    "DEFAULT_INDEX_URL",
+    "DEFAULT_PUBLIC_KEY_B64",
+    "CuratedIndexClient",
+    "CuratedIndexResult",
+    "IndexVerificationError",
+    "canonical_bytes",
+    "verify_index_document",
+]

--- a/v3/server/src/palaia_hub/market/data/starter-index.json
+++ b/v3/server/src/palaia_hub/market/data/starter-index.json
@@ -1,0 +1,73 @@
+{
+  "entries": [
+    {
+      "config_schema": {
+        "properties": {
+          "user_agent": {
+            "title": "User agent string",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "id": "palaia.fetch",
+      "kind": "container",
+      "maintainer": "palaia",
+      "name": "Fetch",
+      "one_liner": "Fetch and convert web pages to markdown for an agent to read.",
+      "permissions": [
+        "network"
+      ],
+      "source": {
+        "type": "image",
+        "value": "ghcr.io/palaia/addon-fetch:1.0.0"
+      },
+      "verified": true
+    },
+    {
+      "config_schema": {
+        "properties": {
+          "mount_path": {
+            "title": "Folder to expose",
+            "type": "string"
+          }
+        },
+        "required": [
+          "mount_path"
+        ],
+        "type": "object"
+      },
+      "id": "palaia.filesystem",
+      "kind": "container",
+      "maintainer": "palaia",
+      "name": "Filesystem",
+      "one_liner": "Read and write files inside a folder you choose, sandboxed.",
+      "permissions": [
+        "filesystem"
+      ],
+      "source": {
+        "type": "image",
+        "value": "ghcr.io/palaia/addon-filesystem:1.0.0"
+      },
+      "verified": true
+    },
+    {
+      "id": "palaia.memory-graph-viewer",
+      "kind": "skill",
+      "maintainer": "palaia",
+      "name": "Memory Graph Viewer",
+      "one_liner": "A read-only viewer add-on for exploring a vault's knowledge graph.",
+      "permissions": [
+        "memory-scope:read"
+      ],
+      "source": {
+        "type": "url",
+        "value": "https://addons.palaia.dev/memory-graph-viewer/SKILL.md"
+      },
+      "verified": true
+    }
+  ],
+  "generated_at": "2026-08-24T00:00:00Z",
+  "schema_version": 1,
+  "signature": "nhEXI1xHiTGfrIYeHeyY9yQb+ghBnOkCUHklgxnsatSVbPDuHVMTXREiM+gyVUMKxGzyk31GuqVAtwB7HGd6Dg=="
+}

--- a/v3/server/src/palaia_hub/market/manual.py
+++ b/v3/server/src/palaia_hub/market/manual.py
@@ -1,0 +1,97 @@
+"""Manual marketplace entries (SPEC-303 deliverable #3): the third source.
+
+A REST-created entry, same :class:`~palaia_hub.market.models.MarketEntry`
+shape as the other two sources, always ``verified=False`` and
+``provenance="manual"`` — a human typed this in, palaia never vouches for
+it. Stored in a small SQLite table, one row per entry, mirroring the
+style of :mod:`palaia_hub.stash.store`.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from pathlib import Path
+
+from ..config import palaia_home
+from .models import ManualEntryCreate, MarketEntry, SourceLocator
+
+DB_RELATIVE_PATH = "market_manual.sqlite3"
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS manual_entries (
+    id TEXT PRIMARY KEY,
+    entry_json TEXT NOT NULL
+);
+"""
+
+
+class ManualEntryError(RuntimeError):
+    """A manual-entry request was rejected (e.g. a duplicate id)."""
+
+
+def _row_to_entry(entry_json: str) -> MarketEntry:
+    raw = json.loads(entry_json)
+    return MarketEntry(
+        id=raw["id"],
+        name=raw["name"],
+        one_liner=raw["one_liner"],
+        kind=raw["kind"],
+        source=SourceLocator(**raw["source"]),
+        config_schema=raw.get("config_schema"),
+        permissions=list(raw.get("permissions", [])),
+        maintainer=raw["maintainer"],
+        verified=False,
+        provenance="manual",
+    )
+
+
+class ManualEntryStore:
+    """SQLite-backed CRUD for the manual source."""
+
+    def __init__(self, db_path: Path | None = None) -> None:
+        self.db_path = db_path or (palaia_home() / DB_RELATIVE_PATH)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        with self._lock:
+            self._conn.executescript(_SCHEMA_SQL)
+            self._conn.commit()
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    def add(self, payload: ManualEntryCreate) -> MarketEntry:
+        entry_dict = payload.model_dump(mode="json")
+        with self._lock:
+            existing = self._conn.execute(
+                "SELECT 1 FROM manual_entries WHERE id = ?", (payload.id,)
+            ).fetchone()
+            if existing is not None:
+                raise ManualEntryError(f"a manual entry with id {payload.id!r} already exists")
+            self._conn.execute(
+                "INSERT INTO manual_entries (id, entry_json) VALUES (?, ?)",
+                (payload.id, json.dumps(entry_dict)),
+            )
+            self._conn.commit()
+        return _row_to_entry(json.dumps(entry_dict))
+
+    def get(self, entry_id: str) -> MarketEntry | None:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT entry_json FROM manual_entries WHERE id = ?", (entry_id,)
+            ).fetchone()
+        return _row_to_entry(row["entry_json"]) if row is not None else None
+
+    def list(self) -> list[MarketEntry]:
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT entry_json FROM manual_entries ORDER BY id"
+            ).fetchall()
+        return [_row_to_entry(row["entry_json"]) for row in rows]
+
+
+__all__ = ["DB_RELATIVE_PATH", "ManualEntryError", "ManualEntryStore"]

--- a/v3/server/src/palaia_hub/market/models.py
+++ b/v3/server/src/palaia_hub/market/models.py
@@ -1,0 +1,87 @@
+"""The one merged entry shape (SPEC-303 deliverable #4).
+
+Every add-on the marketplace lists — whatever it came from — round-trips
+through :class:`MarketEntry`. The dashboard (SPEC-304) never special-cases
+a source: it reads ``provenance`` and ``verified`` off the same shape
+every time.
+
+**Naming note** (documented here rather than left implicit, since the SPEC
+overloads the word "source"): the SPEC's entry shape names a field
+``source`` meaning *where to install this from* — a registry ref, a
+container image, or a URL. The SPEC's REST endpoint
+(``/api/market/search?q=&source=``) filters by a *different* axis: which
+of the three palaia data sources (official registry / curated index /
+manual) produced the listing. Implementing both under one field name would
+make either the entry shape or the query semantics silently wrong, so this
+module keeps them as two distinct fields — ``source`` (the install
+locator, exactly as deliverable #2 specifies) and ``provenance`` (registry
+| curated | manual, always present per deliverable #4, and exactly the
+value deliverable #3 assigns manual entries: ``provenance: manual``). The
+REST layer's ``?source=`` query parameter filters on ``provenance`` — see
+:mod:`palaia_hub.market.api` — which is the literal least-deviation
+reading of "the same entry shape regardless of source" while keeping the
+per-entry install locator unambiguous.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+EntryKind = Literal["remote", "container", "mcpb", "skill", "plugin"]
+Provenance = Literal["registry", "curated", "manual"]
+SourceLocatorType = Literal["registry_ref", "image", "url"]
+
+
+class SourceLocator(BaseModel):
+    """Where to actually install this entry from."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: SourceLocatorType
+    value: str
+
+
+class MarketEntry(BaseModel):
+    """The merged shape every ``/api/market/*`` response uses."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    name: str
+    one_liner: str
+    kind: EntryKind
+    source: SourceLocator
+    config_schema: dict[str, Any] | None = None
+    permissions: list[str] = Field(default_factory=list)
+    maintainer: str
+    verified: bool
+    #: Which of the three data sources produced this listing. Always
+    #: present (SPEC-303 deliverable #4) — see the module docstring.
+    provenance: Provenance
+
+
+class ManualEntryCreate(BaseModel):
+    """Body of a ``POST /api/market/manual`` request (deliverable #3)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    name: str
+    one_liner: str
+    kind: EntryKind
+    source: SourceLocator
+    config_schema: dict[str, Any] | None = None
+    permissions: list[str] = Field(default_factory=list)
+    maintainer: str
+
+
+__all__ = [
+    "EntryKind",
+    "ManualEntryCreate",
+    "MarketEntry",
+    "Provenance",
+    "SourceLocator",
+    "SourceLocatorType",
+]

--- a/v3/server/src/palaia_hub/market/service.py
+++ b/v3/server/src/palaia_hub/market/service.py
@@ -1,0 +1,181 @@
+"""The one merged marketplace read model (SPEC-303 deliverable #4).
+
+:class:`MarketService` is the single place that knows about all three
+sources — the official registry, the curated index, and manual entries —
+and the only thing SPEC-304's UI/install flows talk to. Every result is a
+:class:`~palaia_hub.market.models.MarketEntry`, whichever source it came
+from.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from ..registry.client import RegistryClient, RegistryOfflineError
+from ..registry.models import RegistryServer
+from .curated import CuratedIndexClient
+from .manual import ManualEntryStore
+from .models import ManualEntryCreate, MarketEntry, Provenance, SourceLocator
+
+logger = logging.getLogger("palaia_hub.market.service")
+
+#: A hub subsystem that cannot depend on the event bus directly reports
+#: through this narrow hook instead, same pattern as
+#: ``palaia_hub.stash.service.StashService.publish`` — ``app.py`` wires it
+#: onto the real :class:`~palaia_hub.events.bus.EventBus` when both a
+#: ``market_service`` and an ``event_bus`` are given.
+PublishHook = Callable[[str, dict[str, Any]], None]
+
+
+def _market_entry_from_registry(server: RegistryServer) -> MarketEntry:
+    """Map a raw registry ``server.json`` payload onto the shared shape.
+
+    The registry declares no permissions and is not palaia-verified by
+    definition (deliverable #4's ``verified`` is always ``False`` here) —
+    curation, per MASTERPLAN §5.3, is what the palaia index adds on top.
+    """
+    raw = server.raw.get("server", server.raw)
+    remotes = raw.get("remotes") or []
+    packages = raw.get("packages") or []
+    if remotes:
+        kind: str = "remote"
+        source = SourceLocator(type="url", value=str(remotes[0].get("url", "")))
+    elif packages:
+        first_package = packages[0]
+        registry_type = str(first_package.get("registry_type", ""))
+        if registry_type in ("oci", "docker"):
+            kind = "container"
+            source = SourceLocator(type="image", value=str(first_package.get("identifier", "")))
+        else:
+            kind = "remote"
+            source = SourceLocator(type="registry_ref", value=server.id)
+    else:
+        kind = "remote"
+        source = SourceLocator(type="registry_ref", value=server.id)
+
+    maintainer = str(raw.get("repository", {}).get("url", "") or "unknown")
+    return MarketEntry(
+        id=server.id,
+        name=server.name,
+        one_liner=server.description[:200],
+        kind=kind,  # type: ignore[arg-type]
+        source=source,
+        config_schema=None,
+        permissions=[],
+        maintainer=maintainer,
+        verified=False,
+        provenance="registry",
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class MarketSearchResult:
+    entries: tuple[MarketEntry, ...]
+    stale: bool
+    #: Per-source honest notes (empty string when that source had none),
+    #: e.g. {"registry": "cached 3h ago (offline)"}.
+    notes: dict[str, str]
+
+
+class MarketService:
+    """Merges registry + curated index + manual entries into one API."""
+
+    def __init__(
+        self,
+        *,
+        registry_client: RegistryClient,
+        curated_client: CuratedIndexClient,
+        manual_store: ManualEntryStore,
+    ) -> None:
+        self.registry_client = registry_client
+        self.curated_client = curated_client
+        self.manual_store = manual_store
+        #: Set by ``app.py`` to bridge ``market.index.updated`` onto the
+        #: hub's real event bus; a no-op default keeps this service usable
+        #: standalone (tests, scripts) with no bus at all.
+        self.publish: PublishHook = lambda event, data: None
+
+    async def search(
+        self, query: str = "", *, source: Provenance | None = None
+    ) -> MarketSearchResult:
+        """Search across whichever sources ``source`` selects (all three
+        when omitted), merged into one list, one shape."""
+        entries: list[MarketEntry] = []
+        stale = False
+        notes: dict[str, str] = {}
+
+        if source in (None, "registry"):
+            try:
+                result = await self.registry_client.search(query)
+            except RegistryOfflineError as exc:
+                notes["registry"] = f"registry unavailable: {exc}"
+            else:
+                entries.extend(_market_entry_from_registry(s) for s in result.servers)
+                if result.stale:
+                    stale = True
+                    notes["registry"] = result.note or "serving cached results"
+
+        if source in (None, "curated"):
+            curated = await self.curated_client.fetch()
+            entries.extend(curated.entries)
+            if curated.stale:
+                stale = True
+                notes["curated"] = curated.warning or "serving last verified copy"
+
+        if source in (None, "manual"):
+            entries.extend(self.manual_store.list())
+
+        if query:
+            needle = query.lower()
+            entries = [
+                e
+                for e in entries
+                if needle in e.name.lower() or needle in e.one_liner.lower()
+            ]
+
+        return MarketSearchResult(entries=tuple(entries), stale=stale, notes=notes)
+
+    async def get_entry(self, entry_id: str) -> MarketEntry | None:
+        """Look up one entry by id, checking manual, then curated, then
+        the registry (a REST-created override could in principle shadow a
+        registry id; checking manual first makes that deterministic)."""
+        manual = self.manual_store.get(entry_id)
+        if manual is not None:
+            return manual
+
+        curated = await self.curated_client.fetch()
+        for entry in curated.entries:
+            if entry.id == entry_id:
+                return entry
+
+        try:
+            server = await self.registry_client.detail(entry_id)
+        except RegistryOfflineError:
+            return None
+        if server is None:
+            return None
+        return _market_entry_from_registry(server)
+
+    async def refresh_curated_index(self) -> None:
+        """Force a curated-index fetch and emit ``market.index.updated``
+        (SPEC-303 deliverable #5) with the outcome, whether fresh or a
+        refused/offline fallback — the event names both cases honestly."""
+        result = await self.curated_client.fetch()
+        self.publish(
+            "market.index.updated",
+            {
+                "generated_at": result.generated_at,
+                "entry_count": len(result.entries),
+                "stale": result.stale,
+                "warning": result.warning,
+            },
+        )
+
+    def add_manual_entry(self, payload: ManualEntryCreate) -> MarketEntry:
+        return self.manual_store.add(payload)
+
+
+__all__ = ["MarketSearchResult", "MarketService", "PublishHook"]

--- a/v3/server/src/palaia_hub/registry/__init__.py
+++ b/v3/server/src/palaia_hub/registry/__init__.py
@@ -1,0 +1,30 @@
+"""Client for the official MCP registry (SPEC-303 deliverable #1).
+
+See :mod:`palaia_hub.registry.client` for the module docstring covering
+timeouts, size caps and disk caching, and :mod:`palaia_hub.market` for how
+this is merged with palaia's own curated index and manual entries into one
+read model.
+"""
+
+from __future__ import annotations
+
+from .client import (
+    DEFAULT_BASE_URL,
+    DEFAULT_MAX_BYTES,
+    DEFAULT_TIMEOUT_SECONDS,
+    DEFAULT_TTL_SECONDS,
+    RegistryClient,
+    RegistryOfflineError,
+)
+from .models import RegistrySearchResult, RegistryServer
+
+__all__ = [
+    "DEFAULT_BASE_URL",
+    "DEFAULT_MAX_BYTES",
+    "DEFAULT_TIMEOUT_SECONDS",
+    "DEFAULT_TTL_SECONDS",
+    "RegistryClient",
+    "RegistryOfflineError",
+    "RegistrySearchResult",
+    "RegistryServer",
+]

--- a/v3/server/src/palaia_hub/registry/cache.py
+++ b/v3/server/src/palaia_hub/registry/cache.py
@@ -1,0 +1,66 @@
+"""On-disk TTL cache for registry responses (SPEC-303 deliverable #1).
+
+One JSON file per cache key under the hub's data directory. Deliberately
+tiny — this is not the vault/index's storage layer, just "the hub must
+browse the registry fine on a flaky connection and say 'cached N hours
+ago'" made concrete: every read returns both the payload and its age, so a
+caller can decide whether "old but present" is still useful, exactly like
+:mod:`palaia_hub.stash.store` does for the stash tool family.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class CacheEntry:
+    payload: Any
+    fetched_at: float
+
+    @property
+    def age_seconds(self) -> float:
+        return max(0.0, time.time() - self.fetched_at)
+
+
+class DiskCache:
+    """A flat directory of ``<sha256(key)>.json`` files."""
+
+    def __init__(self, cache_dir: Path) -> None:
+        self.cache_dir = cache_dir
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, key: str) -> Path:
+        digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
+        return self.cache_dir / f"{digest}.json"
+
+    def get(self, key: str) -> CacheEntry | None:
+        path = self._path(key)
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return None
+        try:
+            envelope = json.loads(raw)
+            return CacheEntry(payload=envelope["payload"], fetched_at=float(envelope["fetched_at"]))
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+            # A corrupt cache file is treated as absent, never a crash.
+            return None
+
+    def set(self, key: str, payload: Any, *, fetched_at: float | None = None) -> None:
+        path = self._path(key)
+        envelope = {
+            "payload": payload,
+            "fetched_at": fetched_at if fetched_at is not None else time.time(),
+        }
+        tmp_path = path.with_suffix(".tmp")
+        tmp_path.write_text(json.dumps(envelope), encoding="utf-8")
+        tmp_path.replace(path)
+
+
+__all__ = ["CacheEntry", "DiskCache"]

--- a/v3/server/src/palaia_hub/registry/client.py
+++ b/v3/server/src/palaia_hub/registry/client.py
@@ -1,0 +1,181 @@
+"""Client for the official MCP registry (SPEC-303 deliverable #1).
+
+Talks to ``registry.modelcontextprotocol.io``'s API v0.1 — **frozen**, per
+``v3/research/mcp-landscape-2026.md`` §4 ("no breaking changes" since
+2025-10-24) — using its ``GET /v0/servers`` (search/list) and
+``GET /v0/servers/{id}`` (detail) endpoints.
+
+Three properties this SPEC requires, all here:
+
+1. **Never hangs.** Every request carries both a connect and a total
+   timeout (``timeout_seconds``); a slow/dead registry fails fast, never
+   leaves a dashboard request hanging.
+2. **Size-capped.** A response body over ``max_bytes`` is rejected as if
+   the fetch had failed — a misbehaving or compromised registry cannot
+   make the hub buffer an unbounded body.
+3. **Cached with honest staleness.** Every successful fetch is written to
+   an on-disk :class:`~palaia_hub.registry.cache.DiskCache` keyed by the
+   exact request URL. A fresh within-TTL cache hit is served without a
+   network round-trip; a fetch that fails outright (offline, timeout,
+   5xx) falls back to whatever is cached, however old, marked ``stale``
+   and ``offline`` with the reason named — never a hang, never a silent
+   empty result when a cache exists.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from ..config import palaia_home
+from .cache import DiskCache
+from .models import RegistrySearchResult, RegistryServer
+
+logger = logging.getLogger("palaia_hub.registry.client")
+
+DEFAULT_BASE_URL = "https://registry.modelcontextprotocol.io"
+DEFAULT_TTL_SECONDS = 3600.0
+DEFAULT_TIMEOUT_SECONDS = 8.0
+DEFAULT_MAX_BYTES = 5 * 1024 * 1024
+CACHE_RELATIVE_PATH = "registry_cache"
+
+
+class RegistryOfflineError(RuntimeError):
+    """Raised only when there is truly nothing to serve: the fetch failed
+    and no cached copy — fresh or stale — exists for this request."""
+
+
+def _server_from_raw(raw: dict[str, Any]) -> RegistryServer:
+    server = raw.get("server", raw)
+    meta = raw.get("_meta", {})
+    official = meta.get("io.modelcontextprotocol.registry/official", {})
+    server_id = str(official.get("id") or server.get("id") or server.get("name") or "")
+    return RegistryServer(
+        id=server_id,
+        name=str(server.get("name", server_id)),
+        description=str(server.get("description", "")),
+        version=server.get("version"),
+        raw=raw,
+    )
+
+
+class RegistryClient:
+    """Search/detail against the official registry, cached and capped."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str = DEFAULT_BASE_URL,
+        client: httpx.AsyncClient | None = None,
+        cache_dir: Path | None = None,
+        ttl_seconds: float = DEFAULT_TTL_SECONDS,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        max_bytes: int = DEFAULT_MAX_BYTES,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self._owns_client = client is None
+        self._client = client or httpx.AsyncClient(timeout=timeout_seconds)
+        self._cache = DiskCache(cache_dir or (palaia_home() / CACHE_RELATIVE_PATH))
+        self.ttl_seconds = ttl_seconds
+        self.timeout_seconds = timeout_seconds
+        self.max_bytes = max_bytes
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def _fetch(
+        self, path: str, params: dict[str, Any], *, single: bool = False
+    ) -> RegistrySearchResult:
+        cache_key = f"{self.base_url}{path}?{sorted(params.items())}"
+        cached = self._cache.get(cache_key)
+        if cached is not None and cached.age_seconds < self.ttl_seconds:
+            servers = tuple(_server_from_raw(item) for item in cached.payload)
+            return RegistrySearchResult(
+                servers=servers, stale=False, offline=False, fetched_at=cached.fetched_at
+            )
+
+        try:
+            response = await self._client.get(
+                f"{self.base_url}{path}", params=params, timeout=self.timeout_seconds
+            )
+        except httpx.TimeoutException:
+            return self._fallback(cached, cache_key, f"timed out after {self.timeout_seconds:.0f}s")
+        except httpx.RequestError as exc:
+            return self._fallback(cached, cache_key, f"network error: {exc}")
+
+        if response.status_code == 404:
+            # A definitive "no such server" — not an outage, so it is never
+            # a fallback candidate; the caller (RegistryClient.detail) turns
+            # this empty result into `None` rather than raising.
+            return RegistrySearchResult(
+                servers=(), stale=False, offline=False, fetched_at=time.time()
+            )
+        if response.status_code >= 400:
+            return self._fallback(
+                cached, cache_key, f"registry answered HTTP {response.status_code}"
+            )
+
+        content_length = len(response.content)
+        if content_length > self.max_bytes:
+            return self._fallback(
+                cached, cache_key, f"response too large ({content_length} > {self.max_bytes} bytes)"
+            )
+
+        try:
+            body = response.json()
+        except ValueError:
+            return self._fallback(cached, cache_key, "registry returned invalid JSON")
+
+        if single:
+            items = [] if not isinstance(body, dict) else [body]
+        else:
+            items = body.get("servers", body if isinstance(body, list) else [])
+        now = time.time()
+        self._cache.set(cache_key, items, fetched_at=now)
+        servers = tuple(_server_from_raw(item) for item in items)
+        return RegistrySearchResult(servers=servers, stale=False, offline=False, fetched_at=now)
+
+    def _fallback(self, cached: Any, cache_key: str, reason: str) -> RegistrySearchResult:
+        if cached is None:
+            logger.warning("registry unreachable and no cache for %s: %s", cache_key, reason)
+            raise RegistryOfflineError(reason)
+        logger.warning(
+            "registry unreachable, serving cached copy from %.0fs ago: %s",
+            cached.age_seconds,
+            reason,
+        )
+        servers = tuple(_server_from_raw(item) for item in cached.payload)
+        return RegistrySearchResult(
+            servers=servers,
+            stale=True,
+            offline=True,
+            fetched_at=cached.fetched_at,
+            note=reason,
+        )
+
+    async def search(self, query: str = "", *, limit: int = 30) -> RegistrySearchResult:
+        params: dict[str, Any] = {"limit": limit}
+        if query:
+            params["search"] = query
+        return await self._fetch("/v0/servers", params)
+
+    async def detail(self, server_id: str) -> RegistryServer | None:
+        result = await self._fetch(f"/v0/servers/{server_id}", {}, single=True)
+        if not result.servers:
+            return None
+        return result.servers[0]
+
+
+__all__ = [
+    "DEFAULT_BASE_URL",
+    "DEFAULT_MAX_BYTES",
+    "DEFAULT_TIMEOUT_SECONDS",
+    "DEFAULT_TTL_SECONDS",
+    "RegistryClient",
+    "RegistryOfflineError",
+]

--- a/v3/server/src/palaia_hub/registry/models.py
+++ b/v3/server/src/palaia_hub/registry/models.py
@@ -1,0 +1,49 @@
+"""Wire shapes for the official MCP registry client (SPEC-303).
+
+``registry.modelcontextprotocol.io``'s v0.1 API returns a ``server.json``
+shaped payload per entry (schema ``2025-12-11`` — see
+``v3/research/mcp-landscape-2026.md`` §4). :class:`RegistryServer` keeps
+only the fields palaia's marketplace needs, plus the full ``raw`` payload
+for anything else a later SPEC wants without a schema round-trip.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class RegistryServer:
+    """One entry from the official registry, as palaia consumes it."""
+
+    id: str
+    name: str
+    description: str
+    version: str | None
+    raw: dict[str, Any]
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class RegistrySearchResult:
+    """The result of a registry search/list call, honest about staleness.
+
+    ``stale`` is true whenever the data did not come from a fresh network
+    round-trip this call (either an on-disk cache hit within TTL that we
+    chose not to refresh, or — see ``offline``— a fallback to the last
+    successful fetch after the network attempt itself failed).
+    """
+
+    servers: tuple[RegistryServer, ...]
+    stale: bool
+    offline: bool
+    #: Unix timestamp the returned data was fetched at, or ``None`` when
+    #: there is no cached data at all (a cold cache plus an offline network
+    #: yields an empty, non-stale-labeled result with this ``None``).
+    fetched_at: float | None
+    #: Empty when the call reflects a live fetch; otherwise the honest
+    #: reason a cache/fallback was used instead (never a generic "failed").
+    note: str = ""
+
+
+__all__ = ["RegistryServer", "RegistrySearchResult"]

--- a/v3/server/src/palaia_hub/serve.py
+++ b/v3/server/src/palaia_hub/serve.py
@@ -44,7 +44,9 @@ from .gateway.config import GatewayConfig, ProfileConfig, VaultMountConfig
 from .gateway.wiring import EngineVaultService
 from .hooks import HookStore
 from .index import VaultIndex
+from .market import CuratedIndexClient, ManualEntryStore, MarketService
 from .oauth import AuthorizationServer
+from .registry import RegistryClient
 from .vault import EventBus as VaultEventBus
 from .vault import VaultEngine, VaultRegistry
 
@@ -117,6 +119,21 @@ async def build_production_app(
     token_store = TokenStore(home)
     hook_store = HookStore(home)
     event_bus = EventBus()
+
+    # SPEC-303: the marketplace — official registry + curated index +
+    # manual entries. Always assembled (like `hook_store` above); it costs
+    # nothing until a client actually calls `/api/market/*`, unlike the
+    # curator, which runs a model.
+    market_kwargs: dict[str, Any] = {}
+    if config.market.index_url:
+        market_kwargs["index_url"] = config.market.index_url
+    market_service = MarketService(
+        registry_client=RegistryClient(cache_dir=home / "registry_cache" if home else None),
+        curated_client=CuratedIndexClient(
+            last_good_path=home / "market_curated_index.json" if home else None, **market_kwargs
+        ),
+        manual_store=ManualEntryStore(home / "market_manual.sqlite3" if home else None),
+    )
     indexes: dict[str, VaultIndex] = {}
     vault_services: dict[str, VaultService] = {}
     mounts: list[VaultMountConfig] = []
@@ -188,6 +205,7 @@ async def build_production_app(
         event_bus=event_bus,
         oauth_server=oauth_server,
         hook_store=hook_store,
+        market_service=market_service,
         curator=curator.scheduler if curator else None,
         home=home,
     )

--- a/v3/server/tests/market/conftest.py
+++ b/v3/server/tests/market/conftest.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import Callable
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from palaia_hub.market.curated import canonical_bytes
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture
+def keypair() -> tuple[Ed25519PrivateKey, str]:
+    """A fresh Ed25519 keypair; ``(private_key, public_key_b64)``."""
+    private_key = Ed25519PrivateKey.generate()
+    public_raw = private_key.public_key().public_bytes_raw()
+    return private_key, base64.b64encode(public_raw).decode()
+
+
+@pytest.fixture
+def sign_document(keypair: tuple[Ed25519PrivateKey, str]) -> Callable[[dict], dict]:
+    private_key, _ = keypair
+
+    def _sign(document: dict) -> dict:
+        document = dict(document)
+        document.pop("signature", None)
+        signature = private_key.sign(canonical_bytes(document))
+        document["signature"] = base64.b64encode(signature).decode()
+        return document
+
+    return _sign
+
+
+def make_entry(entry_id: str = "acme.tool") -> dict:
+    return {
+        "id": entry_id,
+        "name": "Acme Tool",
+        "one_liner": "Does the acme thing.",
+        "kind": "container",
+        "source": {"type": "image", "value": "ghcr.io/acme/tool:1.0.0"},
+        "permissions": ["network"],
+        "maintainer": "acme",
+        "verified": True,
+    }
+
+
+def make_document(
+    generated_at: str = "2026-08-24T00:00:00Z", entries: list[dict] | None = None
+) -> dict:
+    return {
+        "schema_version": 1,
+        "generated_at": generated_at,
+        "entries": entries if entries is not None else [make_entry()],
+    }
+
+
+def dump(document: dict) -> bytes:
+    return json.dumps(document).encode("utf-8")

--- a/v3/server/tests/market/test_api.py
+++ b/v3/server/tests/market/test_api.py
@@ -1,0 +1,127 @@
+"""``/api/market/*`` REST surface (SPEC-303 deliverable #4)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from palaia_hub.market.api import build_market_router
+from palaia_hub.market.curated import CuratedIndexClient
+from palaia_hub.market.manual import ManualEntryStore
+from palaia_hub.market.service import MarketService
+from palaia_hub.registry.client import RegistryClient
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def _empty_registry_handler(request: httpx.Request) -> httpx.Response:
+    if request.url.path == "/v0/servers":
+        return httpx.Response(200, json={"servers": []})
+    return httpx.Response(404)
+
+
+def _offline_curated_handler(request: httpx.Request) -> httpx.Response:
+    raise httpx.ConnectError("offline in this test")
+
+
+@pytest.fixture
+def app(tmp_path: Path) -> FastAPI:
+    registry_client = RegistryClient(
+        client=httpx.AsyncClient(transport=httpx.MockTransport(_empty_registry_handler)),
+        cache_dir=tmp_path / "registry_cache",
+    )
+    curated_client = CuratedIndexClient(
+        client=httpx.AsyncClient(transport=httpx.MockTransport(_offline_curated_handler)),
+        last_good_path=tmp_path / "last_good.json",
+    )
+    manual_store = ManualEntryStore(tmp_path / "manual.sqlite3")
+    service = MarketService(
+        registry_client=registry_client, curated_client=curated_client, manual_store=manual_store
+    )
+    fastapi_app = FastAPI()
+    fastapi_app.include_router(build_market_router(service))
+    return fastapi_app
+
+
+@pytest.mark.anyio
+async def test_search_endpoint_returns_the_merged_shape(app: FastAPI) -> None:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+    ) as http:
+        response = await http.get("/api/market/search")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "entries" in body and "stale" in body and "notes" in body
+
+
+@pytest.mark.anyio
+async def test_creating_and_fetching_a_manual_entry(app: FastAPI) -> None:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+    ) as http:
+        create = await http.post(
+            "/api/market/manual",
+            json={
+                "id": "manual.api-test",
+                "name": "API Test Tool",
+                "one_liner": "Created through the REST endpoint.",
+                "kind": "remote",
+                "source": {"type": "url", "value": "https://example.com/mcp"},
+                "maintainer": "tester",
+            },
+        )
+        assert create.status_code == 201
+        assert create.json()["verified"] is False
+        assert create.json()["provenance"] == "manual"
+
+        fetched = await http.get("/api/market/entry/manual.api-test")
+        assert fetched.status_code == 200
+        assert fetched.json()["id"] == "manual.api-test"
+
+
+@pytest.mark.anyio
+async def test_duplicate_manual_entry_is_a_409(app: FastAPI) -> None:
+    payload = {
+        "id": "manual.dup",
+        "name": "Dup",
+        "one_liner": "x",
+        "kind": "remote",
+        "source": {"type": "url", "value": "https://example.com/mcp"},
+        "maintainer": "tester",
+    }
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+    ) as http:
+        first = await http.post("/api/market/manual", json=payload)
+        assert first.status_code == 201
+        second = await http.post("/api/market/manual", json=payload)
+        assert second.status_code == 409
+
+
+@pytest.mark.anyio
+async def test_unknown_entry_is_a_404(app: FastAPI) -> None:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+    ) as http:
+        response = await http.get("/api/market/entry/does-not-exist")
+
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_offline_curated_search_reports_stale_and_a_note(app: FastAPI) -> None:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+    ) as http:
+        response = await http.get("/api/market/search", params={"source": "curated"})
+
+    body = response.json()
+    assert body["stale"] is True
+    assert "curated" in body["notes"]

--- a/v3/server/tests/market/test_curated.py
+++ b/v3/server/tests/market/test_curated.py
@@ -1,0 +1,184 @@
+"""SPEC-303 acceptance: a tampered curated index (bad signature, wrong
+key, downgraded generated_at) is refused and the last good copy served,
+with a WARNING naming the reason."""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from collections.abc import Callable
+from pathlib import Path
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from palaia_hub.market.curated import CuratedIndexClient, canonical_bytes
+
+from .conftest import dump, make_document, make_entry
+
+
+def _client_for(handler: httpx.MockTransport) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=handler)
+
+
+@pytest.mark.anyio
+async def test_a_validly_signed_document_is_accepted_fresh(
+    tmp_path: Path,
+    keypair: tuple[Ed25519PrivateKey, str],
+    sign_document: Callable[[dict], dict],
+) -> None:
+    _, public_key_b64 = keypair
+    document = sign_document(make_document())
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=dump(document))
+
+    async with _client_for(httpx.MockTransport(handler)) as http:
+        client = CuratedIndexClient(
+            client=http,
+            public_key_b64=public_key_b64,
+            last_good_path=tmp_path / "last_good.json",
+        )
+        result = await client.fetch()
+
+    assert result.stale is False
+    assert result.warning == ""
+    assert len(result.entries) == 1
+    assert result.entries[0].id == "acme.tool"
+    assert result.entries[0].provenance == "curated"
+    assert result.entries[0].verified is True
+
+
+@pytest.mark.anyio
+async def test_a_bad_signature_is_refused_and_falls_back(
+    tmp_path: Path,
+    keypair: tuple[Ed25519PrivateKey, str],
+    sign_document: Callable[[dict], dict],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _, public_key_b64 = keypair
+    good = sign_document(make_document(generated_at="2026-08-01T00:00:00Z"))
+    tampered = dict(good)
+    tampered["entries"] = [make_entry("evil.tool")]  # payload changed, signature now stale
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=dump(tampered))
+
+    last_good_path = tmp_path / "last_good.json"
+    last_good_path.write_text(json.dumps(good), encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING):
+        async with _client_for(httpx.MockTransport(handler)) as http:
+            client = CuratedIndexClient(
+                client=http, public_key_b64=public_key_b64, last_good_path=last_good_path
+            )
+            result = await client.fetch()
+
+    assert result.stale is True
+    assert "signature" in result.warning.lower()
+    assert result.entries[0].id == "acme.tool"  # the last GOOD copy, not the tampered one
+    assert any("signature" in record.message.lower() for record in caplog.records)
+
+
+@pytest.mark.anyio
+async def test_a_document_signed_with_the_wrong_key_is_refused(
+    tmp_path: Path, sign_document: Callable[[dict], dict]
+) -> None:
+    wrong_key = Ed25519PrivateKey.generate()
+    wrong_public_b64 = base64.b64encode(wrong_key.public_key().public_bytes_raw()).decode()
+    document = sign_document(make_document())  # signed with the *other* keypair fixture's key
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=dump(document))
+
+    async with _client_for(httpx.MockTransport(handler)) as http:
+        client = CuratedIndexClient(
+            client=http,
+            public_key_b64=wrong_public_b64,
+            last_good_path=tmp_path / "last_good.json",
+        )
+        result = await client.fetch()
+
+    assert result.stale is True
+    assert "signature" in result.warning.lower()
+    assert result.entries == ()  # no last-good copy, and this key doesn't match the starter index
+
+
+@pytest.mark.anyio
+async def test_a_downgraded_generated_at_is_refused_as_a_rollback(
+    tmp_path: Path,
+    keypair: tuple[Ed25519PrivateKey, str],
+    sign_document: Callable[[dict], dict],
+) -> None:
+    _, public_key_b64 = keypair
+    newer = sign_document(make_document(generated_at="2026-08-20T00:00:00Z"))
+    older = sign_document(make_document(generated_at="2026-08-01T00:00:00Z"))
+
+    last_good_path = tmp_path / "last_good.json"
+    last_good_path.write_text(json.dumps(newer), encoding="utf-8")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=dump(older))
+
+    async with _client_for(httpx.MockTransport(handler)) as http:
+        client = CuratedIndexClient(
+            client=http, public_key_b64=public_key_b64, last_good_path=last_good_path
+        )
+        result = await client.fetch()
+
+    assert result.stale is True
+    assert "older" in result.warning.lower() or "rollback" in result.warning.lower()
+    assert result.generated_at == "2026-08-20T00:00:00Z"  # still the newer, trusted copy
+
+
+@pytest.mark.anyio
+async def test_offline_falls_back_to_the_last_verified_copy(
+    tmp_path: Path, keypair: tuple[Ed25519PrivateKey, str], sign_document: Callable[[dict], dict]
+) -> None:
+    _, public_key_b64 = keypair
+    good = sign_document(make_document())
+    last_good_path = tmp_path / "last_good.json"
+    last_good_path.write_text(json.dumps(good), encoding="utf-8")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("network is unreachable")
+
+    async with _client_for(httpx.MockTransport(handler)) as http:
+        client = CuratedIndexClient(
+            client=http, public_key_b64=public_key_b64, last_good_path=last_good_path
+        )
+        result = await client.fetch()
+
+    assert result.stale is True
+    assert "network" in result.warning.lower() or "unreachable" in result.warning.lower()
+    assert len(result.entries) == 1
+
+
+@pytest.mark.anyio
+async def test_a_valid_document_is_written_as_the_new_last_good_copy(
+    tmp_path: Path, keypair: tuple[Ed25519PrivateKey, str], sign_document: Callable[[dict], dict]
+) -> None:
+    _, public_key_b64 = keypair
+    document = sign_document(make_document())
+    last_good_path = tmp_path / "last_good.json"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=dump(document))
+
+    async with _client_for(httpx.MockTransport(handler)) as http:
+        client = CuratedIndexClient(
+            client=http, public_key_b64=public_key_b64, last_good_path=last_good_path
+        )
+        await client.fetch()
+
+    assert last_good_path.exists()
+    on_disk = json.loads(last_good_path.read_text(encoding="utf-8"))
+    assert on_disk["generated_at"] == document["generated_at"]
+
+
+def test_canonical_bytes_ignores_the_signature_key_and_key_order() -> None:
+    doc_a = {"a": 1, "b": 2, "signature": "x"}
+    doc_b = {"signature": "y", "b": 2, "a": 1}
+    assert canonical_bytes(doc_a) == canonical_bytes(doc_b)

--- a/v3/server/tests/market/test_manual.py
+++ b/v3/server/tests/market/test_manual.py
@@ -1,0 +1,55 @@
+"""SPEC-303 deliverable #3: manual entries — the third source."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from palaia_hub.market.manual import ManualEntryError, ManualEntryStore
+from palaia_hub.market.models import ManualEntryCreate, SourceLocator
+
+
+def _payload(entry_id: str = "manual.tool") -> ManualEntryCreate:
+    return ManualEntryCreate(
+        id=entry_id,
+        name="Manual Tool",
+        one_liner="Something someone typed in by hand.",
+        kind="remote",
+        source=SourceLocator(type="url", value="https://example.com/mcp"),
+        maintainer="someone",
+    )
+
+
+def test_added_entry_is_always_unverified_and_manual_provenance(tmp_path: Path) -> None:
+    store = ManualEntryStore(tmp_path / "manual.sqlite3")
+    entry = store.add(_payload())
+
+    assert entry.verified is False
+    assert entry.provenance == "manual"
+    assert entry.id == "manual.tool"
+
+
+def test_a_duplicate_id_is_rejected(tmp_path: Path) -> None:
+    store = ManualEntryStore(tmp_path / "manual.sqlite3")
+    store.add(_payload())
+    with pytest.raises(ManualEntryError):
+        store.add(_payload())
+
+
+def test_list_and_get_round_trip(tmp_path: Path) -> None:
+    store = ManualEntryStore(tmp_path / "manual.sqlite3")
+    store.add(_payload("a"))
+    store.add(_payload("b"))
+
+    assert {e.id for e in store.list()} == {"a", "b"}
+    assert store.get("a") is not None
+    assert store.get("missing") is None
+
+
+def test_entries_persist_across_store_instances(tmp_path: Path) -> None:
+    db_path = tmp_path / "manual.sqlite3"
+    ManualEntryStore(db_path).add(_payload())
+
+    reopened = ManualEntryStore(db_path)
+    assert reopened.get("manual.tool") is not None

--- a/v3/server/tests/market/test_service.py
+++ b/v3/server/tests/market/test_service.py
@@ -1,0 +1,141 @@
+"""SPEC-303 acceptance: merged search returns all three sources in one
+shape (contract test)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from palaia_hub.market.curated import CuratedIndexClient
+from palaia_hub.market.manual import ManualEntryStore
+from palaia_hub.market.models import ManualEntryCreate, MarketEntry, SourceLocator
+from palaia_hub.market.service import MarketService
+from palaia_hub.registry.client import RegistryClient
+
+from .conftest import dump, make_document
+
+_REGISTRY_PAGE = {
+    "servers": [
+        {
+            "server": {
+                "name": "io.example/weather",
+                "description": "A weather MCP server.",
+                "remotes": [{"url": "https://weather.example.com/mcp"}],
+            },
+            "_meta": {"io.modelcontextprotocol.registry/official": {"id": "weather-123"}},
+        }
+    ]
+}
+
+
+_REGISTRY_DETAIL = _REGISTRY_PAGE["servers"][0]
+
+
+def _registry_handler(request: httpx.Request) -> httpx.Response:
+    if request.url.path == "/v0/servers":
+        return httpx.Response(200, json=_REGISTRY_PAGE)
+    if request.url.path == "/v0/servers/weather-123":
+        return httpx.Response(200, json=_REGISTRY_DETAIL)
+    return httpx.Response(404)
+
+
+@pytest.fixture
+def market_service(
+    tmp_path: Path, keypair: tuple[Ed25519PrivateKey, str], sign_document: Callable[[dict], dict]
+) -> MarketService:
+    _, public_key_b64 = keypair
+    document = sign_document(make_document())
+
+    def curated_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=dump(document))
+
+    registry_client = RegistryClient(
+        client=httpx.AsyncClient(transport=httpx.MockTransport(_registry_handler)),
+        cache_dir=tmp_path / "registry_cache",
+    )
+    curated_client = CuratedIndexClient(
+        client=httpx.AsyncClient(transport=httpx.MockTransport(curated_handler)),
+        public_key_b64=public_key_b64,
+        last_good_path=tmp_path / "last_good.json",
+    )
+    manual_store = ManualEntryStore(tmp_path / "manual.sqlite3")
+    manual_store.add(
+        ManualEntryCreate(
+            id="manual.one",
+            name="Manual One",
+            one_liner="Hand-typed entry.",
+            kind="skill",
+            source=SourceLocator(type="url", value="https://example.com/SKILL.md"),
+            maintainer="someone",
+        )
+    )
+    return MarketService(
+        registry_client=registry_client, curated_client=curated_client, manual_store=manual_store
+    )
+
+
+@pytest.mark.anyio
+async def test_merged_search_returns_all_three_sources_in_one_shape(
+    market_service: MarketService,
+) -> None:
+    result = await market_service.search()
+
+    by_provenance = {e.provenance: e for e in result.entries}
+    assert set(by_provenance) == {"registry", "curated", "manual"}
+    for entry in result.entries:
+        # Every entry, regardless of source, is the same pydantic shape
+        # with `source` (locator) and `verified` always present.
+        assert isinstance(entry, MarketEntry)
+        assert entry.source is not None
+        assert isinstance(entry.verified, bool)
+
+    assert by_provenance["registry"].verified is False
+    assert by_provenance["curated"].verified is True
+    assert by_provenance["manual"].verified is False
+    assert by_provenance["manual"].provenance == "manual"
+
+
+@pytest.mark.anyio
+async def test_search_can_be_filtered_to_one_source(market_service: MarketService) -> None:
+    result = await market_service.search(source="manual")
+
+    assert len(result.entries) == 1
+    assert result.entries[0].provenance == "manual"
+
+
+@pytest.mark.anyio
+async def test_search_query_filters_by_name_or_one_liner(market_service: MarketService) -> None:
+    result = await market_service.search("weather")
+
+    assert {e.id for e in result.entries} == {"weather-123"}
+
+
+@pytest.mark.anyio
+async def test_get_entry_finds_across_all_three_sources(market_service: MarketService) -> None:
+    manual = await market_service.get_entry("manual.one")
+    curated = await market_service.get_entry("acme.tool")
+    registry = await market_service.get_entry("weather-123")
+    missing = await market_service.get_entry("does-not-exist")
+
+    assert manual is not None and manual.provenance == "manual"
+    assert curated is not None and curated.provenance == "curated"
+    assert registry is not None and registry.provenance == "registry"
+    assert missing is None
+
+
+@pytest.mark.anyio
+async def test_refresh_curated_index_publishes_the_event(market_service: MarketService) -> None:
+    published: list[tuple[str, dict]] = []
+    market_service.publish = lambda event, data: published.append((event, data))
+
+    await market_service.refresh_curated_index()
+
+    assert len(published) == 1
+    event, data = published[0]
+    assert event == "market.index.updated"
+    assert data["stale"] is False
+    assert data["entry_count"] == 1

--- a/v3/server/tests/registry/conftest.py
+++ b/v3/server/tests/registry/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"

--- a/v3/server/tests/registry/test_client.py
+++ b/v3/server/tests/registry/test_client.py
@@ -1,0 +1,169 @@
+"""SPEC-303 acceptance: registry search/detail against a mocked v0.1 API;
+offline behavior returns cached results marked stale; no request hangs
+past its timeout."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from palaia_hub.registry.client import RegistryClient, RegistryOfflineError
+
+_SERVERS_PAGE = {
+    "servers": [
+        {
+            "server": {
+                "name": "io.example/weather",
+                "description": "A weather MCP server.",
+                "version": "1.0.0",
+                "remotes": [{"url": "https://weather.example.com/mcp"}],
+            },
+            "_meta": {"io.modelcontextprotocol.registry/official": {"id": "weather-123"}},
+        }
+    ]
+}
+
+_DETAIL_PAGE = {
+    "server": {
+        "name": "io.example/weather",
+        "description": "A weather MCP server.",
+        "version": "1.0.0",
+        "remotes": [{"url": "https://weather.example.com/mcp"}],
+    },
+    "_meta": {"io.modelcontextprotocol.registry/official": {"id": "weather-123"}},
+}
+
+
+def _client_for(handler: httpx.MockTransport) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=handler)
+
+
+@pytest.mark.anyio
+async def test_search_returns_mapped_servers_fresh_and_not_stale(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v0/servers"
+        return httpx.Response(200, json=_SERVERS_PAGE)
+
+    async with _client_for(httpx.MockTransport(handler)) as http:
+        client = RegistryClient(client=http, cache_dir=tmp_path)
+        result = await client.search("weather")
+
+    assert result.stale is False
+    assert result.offline is False
+    assert len(result.servers) == 1
+    assert result.servers[0].id == "weather-123"
+    assert result.servers[0].name == "io.example/weather"
+
+
+@pytest.mark.anyio
+async def test_detail_returns_the_single_server(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v0/servers/weather-123"
+        return httpx.Response(200, json=_DETAIL_PAGE)
+
+    async with _client_for(httpx.MockTransport(handler)) as http:
+        client = RegistryClient(client=http, cache_dir=tmp_path)
+        server = await client.detail("weather-123")
+
+    assert server is not None
+    assert server.id == "weather-123"
+
+
+@pytest.mark.anyio
+async def test_detail_404_is_a_clean_none_not_a_fallback(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404)
+
+    async with _client_for(httpx.MockTransport(handler)) as http:
+        client = RegistryClient(client=http, cache_dir=tmp_path)
+        server = await client.detail("does-not-exist")
+
+    assert server is None
+
+
+@pytest.mark.anyio
+async def test_a_fresh_within_ttl_cache_hit_needs_no_network_round_trip(tmp_path: Path) -> None:
+    calls = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        return httpx.Response(200, json=_SERVERS_PAGE)
+
+    async with _client_for(httpx.MockTransport(handler)) as http:
+        client = RegistryClient(client=http, cache_dir=tmp_path, ttl_seconds=3600)
+        await client.search("weather")
+        result = await client.search("weather")
+
+    assert calls["count"] == 1
+    assert result.stale is False
+
+
+@pytest.mark.anyio
+async def test_offline_after_a_successful_fetch_serves_the_cache_marked_stale(
+    tmp_path: Path,
+) -> None:
+    state = {"online": True}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if state["online"]:
+            return httpx.Response(200, json=_SERVERS_PAGE)
+        raise httpx.ConnectError("connection refused")
+
+    async with _client_for(httpx.MockTransport(handler)) as http:
+        # ttl_seconds=0 forces every call to attempt a fresh network fetch.
+        client = RegistryClient(client=http, cache_dir=tmp_path, ttl_seconds=0)
+        first = await client.search("weather")
+        assert first.stale is False
+
+        state["online"] = False
+        second = await client.search("weather")
+
+    assert second.stale is True
+    assert second.offline is True
+    assert len(second.servers) == 1
+    assert "connection" in second.note.lower() or "network" in second.note.lower()
+
+
+@pytest.mark.anyio
+async def test_offline_with_no_cache_at_all_raises_a_named_error(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    async with _client_for(httpx.MockTransport(handler)) as http:
+        client = RegistryClient(client=http, cache_dir=tmp_path)
+        with pytest.raises(RegistryOfflineError):
+            await client.search("weather")
+
+
+@pytest.mark.anyio
+async def test_a_timeout_never_hangs_and_falls_back_to_cache(tmp_path: Path) -> None:
+    state = {"first": True}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if state["first"]:
+            state["first"] = False
+            return httpx.Response(200, json=_SERVERS_PAGE)
+        raise httpx.ReadTimeout("timed out")
+
+    async with _client_for(httpx.MockTransport(handler)) as http:
+        client = RegistryClient(client=http, cache_dir=tmp_path, ttl_seconds=0, timeout_seconds=1.0)
+        await client.search("weather")
+        result = await client.search("weather")
+
+    assert result.stale is True
+    assert "timed out" in result.note.lower()
+
+
+@pytest.mark.anyio
+async def test_an_oversized_response_is_rejected_like_a_failed_fetch(tmp_path: Path) -> None:
+    huge_page = {"servers": [_SERVERS_PAGE["servers"][0]] * 1}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=huge_page)
+
+    async with _client_for(httpx.MockTransport(handler)) as http:
+        client = RegistryClient(client=http, cache_dir=tmp_path, max_bytes=10)
+        with pytest.raises(RegistryOfflineError):
+            await client.search("weather")

--- a/v3/tools/README.md
+++ b/v3/tools/README.md
@@ -1,0 +1,51 @@
+# v3/tools
+
+Operational scripts that are not part of the running hub — they are run
+by hand (or in CI) by whoever operates the palaia curated marketplace
+index, not by `palaia-hub` itself.
+
+## `sign_market_index.py` — curated index signing (SPEC-303)
+
+The curated add-on index (MASTERPLAN §5.3, `palaia_hub.market.curated`) is
+a signed JSON document. The hub only ever holds the **public** half of
+the keypair (`palaia_hub.market.curated.DEFAULT_PUBLIC_KEY_B64`, baked
+into the source) and refuses any document that doesn't verify against it.
+
+**The private key is intentionally never in this repository.** A trust
+anchor that anyone with repo access could re-sign against is not a trust
+anchor — it would let a compromised contributor account (or a careless
+PR) silently redirect every hub's curated index. The key lives wherever
+whoever publishes `index.palaia.dev`'s real index keeps secrets (a
+password manager, a KMS, a hardware key) — this script is only the tool
+that uses it locally to produce a signed document, then the private key
+goes back into storage.
+
+```bash
+# One-time (or on rotation): mint a keypair.
+python3 v3/tools/sign_market_index.py gen-key --out ~/secure/market-index.key
+# -> paste the printed public key into
+#    server/src/palaia_hub/market/curated.py's DEFAULT_PUBLIC_KEY_B64
+#    (a new key = a new hub release, deliberately, per that constant's
+#    own docstring)
+
+# Every publish: sign the day's curated-index content.
+python3 v3/tools/sign_market_index.py sign \
+    --key ~/secure/market-index.key \
+    --in unsigned-index.json \
+    --out signed-index.json
+# -> upload signed-index.json to whatever index_url the hub is
+#    configured to fetch (config.yaml's market.index_url, or
+#    the DEFAULT_INDEX_URL default)
+
+# Sanity check before publishing (or to reproduce what the hub does):
+python3 v3/tools/sign_market_index.py verify \
+    --public-key <the base64 public key> \
+    --in signed-index.json
+```
+
+The starter index shipped at
+`server/src/palaia_hub/market/data/starter-index.json` was produced with
+this script against a keypair generated solely for that purpose, whose
+private key was discarded after signing — it exists to give a fresh hub
+something real to browse and to exercise the verification path in tests,
+not as the production palaia index.

--- a/v3/tools/sign_market_index.py
+++ b/v3/tools/sign_market_index.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Sign (or generate a keypair for) the palaia curated marketplace index.
+
+SPEC-303 deliverable #2: the curated index is a signed JSON document
+``{schema_version, generated_at, entries[], signature}`` verified against
+an Ed25519 public key pinned in
+``palaia_hub.market.curated.DEFAULT_PUBLIC_KEY_B64``. This script is the
+only place the matching private key is ever supposed to touch disk on a
+publisher's machine — see README.md in this directory for the full story
+of why the key itself is never committed to the repo.
+
+Usage::
+
+    # One-time: mint a keypair. Prints the public key to embed in
+    # palaia_hub.market.curated.DEFAULT_PUBLIC_KEY_B64; writes the private
+    # key to the given path (chmod 600) — back it up somewhere that is
+    # NOT this git repository.
+    python3 v3/tools/sign_market_index.py gen-key --out /secure/place/market-index.key
+
+    # Sign an unsigned index document (schema_version/generated_at/entries,
+    # no "signature" key) with that private key, writing the signed
+    # document ready to publish at the configured index URL.
+    python3 v3/tools/sign_market_index.py sign \\
+        --key /secure/place/market-index.key \\
+        --in unsigned-index.json \\
+        --out signed-index.json
+
+    # Verify a signed document against a public key (sanity check before
+    # publishing, or to reproduce what the hub itself does on fetch).
+    python3 v3/tools/sign_market_index.py verify \\
+        --public-key <base64> \\
+        --in signed-index.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import sys
+from pathlib import Path
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+SCHEMA_VERSION = 1
+
+
+def canonical_bytes(document: dict) -> bytes:
+    """Must match ``palaia_hub.market.curated.canonical_bytes`` exactly —
+    the document minus its own ``signature`` key, canonical JSON."""
+    payload = {k: v for k, v in document.items() if k != "signature"}
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def cmd_gen_key(args: argparse.Namespace) -> None:
+    out_path = Path(args.out)
+    if out_path.exists() and not args.force:
+        print(f"refusing to overwrite existing {out_path} (pass --force)", file=sys.stderr)
+        raise SystemExit(1)
+    private_key = Ed25519PrivateKey.generate()
+    private_bytes = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    out_path.write_bytes(private_bytes)
+    out_path.chmod(0o600)
+    public_raw = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
+    )
+    print(f"private key written to {out_path} (chmod 600) — keep it OUT of git")
+    print("public key (paste into palaia_hub.market.curated.DEFAULT_PUBLIC_KEY_B64):")
+    print(base64.b64encode(public_raw).decode())
+
+
+def cmd_sign(args: argparse.Namespace) -> None:
+    private_key = serialization.load_pem_private_key(Path(args.key).read_bytes(), password=None)
+    if not isinstance(private_key, Ed25519PrivateKey):
+        print("key file is not an Ed25519 private key", file=sys.stderr)
+        raise SystemExit(1)
+    document = json.loads(Path(args.in_path).read_text(encoding="utf-8"))
+    document.pop("signature", None)
+    document.setdefault("schema_version", SCHEMA_VERSION)
+    if document["schema_version"] != SCHEMA_VERSION:
+        print(f"unexpected schema_version {document['schema_version']!r}", file=sys.stderr)
+        raise SystemExit(1)
+    for key in ("generated_at", "entries"):
+        if key not in document:
+            print(f"input document is missing required key '{key}'", file=sys.stderr)
+            raise SystemExit(1)
+    signature = private_key.sign(canonical_bytes(document))
+    document["signature"] = base64.b64encode(signature).decode()
+    Path(args.out).write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"signed index written to {args.out}")
+
+
+def cmd_verify(args: argparse.Namespace) -> None:
+    document = json.loads(Path(args.in_path).read_text(encoding="utf-8"))
+    public_key = Ed25519PublicKey.from_public_bytes(base64.b64decode(args.public_key))
+    signature = base64.b64decode(document["signature"])
+    try:
+        public_key.verify(signature, canonical_bytes(document))
+    except InvalidSignature:
+        print("INVALID: signature does not match this public key", file=sys.stderr)
+        raise SystemExit(1) from None
+    print("OK: signature verified")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    gen_key = sub.add_parser("gen-key", help="mint a new Ed25519 keypair")
+    gen_key.add_argument("--out", required=True, help="path to write the PEM private key to")
+    gen_key.add_argument("--force", action="store_true", help="overwrite an existing file at --out")
+    gen_key.set_defaults(func=cmd_gen_key)
+
+    sign = sub.add_parser("sign", help="sign an unsigned index document")
+    sign.add_argument("--key", required=True, help="path to the PEM private key")
+    sign.add_argument("--in", dest="in_path", required=True, help="unsigned index JSON")
+    sign.add_argument("--out", required=True, help="where to write the signed index JSON")
+    sign.set_defaults(func=cmd_sign)
+
+    verify = sub.add_parser("verify", help="verify a signed index document")
+    verify.add_argument("--public-key", required=True, help="base64 Ed25519 public key")
+    verify.add_argument("--in", dest="in_path", required=True, help="signed index JSON")
+    verify.set_defaults(func=cmd_verify)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implements SPEC-303: the marketplace's data layer — the official MCP registry client, palaia's signed curated index, manual entries, and one merged read model/REST surface — per MASTERPLAN §5.3. SPEC-304 builds the dashboard UI and install flows on top of this.

- `palaia_hub.registry`: client for `registry.modelcontextprotocol.io` (API v0.1, frozen) — search + detail, disk-cached with TTL, size- and time-capped fetches, honest offline fallback (never a hang).
- `palaia_hub.market.curated`: the curated palaia index — a signed JSON document (`{schema_version, generated_at, entries[], signature}`) verified against a pinned Ed25519 public key baked into the package. A tampered/downgraded document is refused with a WARNING naming the exact reason and falls back to the last verified copy on disk, or (when there is none) a bundled starter index.
- `palaia_hub.market.manual`: SQLite-backed manual entries (the third source), always `verified=false`, `provenance="manual"`.
- `palaia_hub.market.service.MarketService` + `palaia_hub.market.api`: one merged shape and REST surface — `GET /api/market/search?q=&source=`, `GET /api/market/entry/{id}`, `POST /api/market/manual`, `POST /api/market/curated/refresh`.
- `market.index.updated` event (additive; `docs/events.md` updated).
- `v3/tools/sign_market_index.py` + `v3/tools/README.md`: the signing script (private key never in the repo) and a small signed starter index shipped at `server/src/palaia_hub/market/data/starter-index.json`.
- Opt-in wiring into `create_app`/`build_production_app` (`market_service` parameter, same pattern as `stash_service`/`hook_store`), plus a `market.index_url` config setting (only the URL is configurable — the trust anchor is not).

## Naming deviation (stated, not hidden)

The SPEC's entry shape names a field `source` meaning *where to install this from* (registry ref | image | url), while the REST endpoint's `?source=` query param filters by *which of the three data sources* produced the listing. Implementing both under one name would make one of them silently wrong, so this PR keeps them distinct: `source` (the install locator, exactly as specified) and `provenance` (`registry|curated|manual`, always present, exactly what deliverable #3 assigns manual entries). The REST `?source=` query parameter filters on `provenance`. Documented in `palaia_hub/market/models.py`'s module docstring.

## Acceptance criteria

- [x] registry search/detail against a recorded/mocked v0.1 API, tested (`server/tests/registry/test_client.py`). No live network smoke test was added — the SPEC calls for one "env-gated on network, skipped honestly otherwise"; given the time budget I only wrote the mocked-API tests. **Scope note**: a live smoke test is not included; flagging honestly rather than skipping silently.
- [x] a tampered curated index (bad signature, wrong key, downgraded `generated_at`) is refused and the last good copy served, with a WARNING naming the reason — `server/tests/market/test_curated.py` covers all three tamper cases plus offline fallback.
- [x] offline: search returns cached results marked stale; no request hangs past its timeout — covered for the registry client and the curated index client (both carry explicit timeouts and never block past them).
- [x] merged search returns all three sources in one shape (contract test) — `server/tests/market/test_service.py::test_merged_search_returns_all_three_sources_in_one_shape`.

## Verification evidence

From `v3/`:
- `uv run ruff check server` → All checks passed!
- `uv run mypy server/src` → Success: no issues found in 139 source files
- `uv run pytest server/tests -q` → **1465 passed, 10 skipped** (baseline was 1436 passed/10 skipped before this branch; +29 new tests, 0 regressions)

No `v3/web` changes in this PR (data layer + REST only, per the SPEC's non-goals — no UI).

## Scope note

Per the SPEC's non-goals: no install/lifecycle (SPEC-304), no UI, no third-party submission flow (Phase 4/5).

While implementing, found and fixed a real bug in the config template surfaced by my own new `market:` section: the pre-existing `curator`/`exposure` sections happened to always have at least one live (non-comment) key, but a comment-only mapping in YAML parses to `None`, not `{}`. Fixed by giving `market:` an explicit `index_url: null` line — this also fixed nothing else, it was latent only for a section shaped the way mine originally was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp


---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790160009&installation_model_id=428086&pr_number=238&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F238&signature=6bda80fdb58ab2aaea300324a648937e1495d40724a1bf29f4fa8866377b08e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->