### PR TITLE
feat(v3): gateway config in config.yaml (SPEC-301)

### DIFF
--- a/v3/docs/events.md
+++ b/v3/docs/events.md
@@ -56,7 +56,7 @@ write.
 | `ts` | number | Unix timestamp (seconds, float) when the envelope was built. |
 | `vault` | string \| null | The vault this event concerns, when there is one. |
 | `permalink` | string \| null | The entry this event concerns, when there is one. |
-| `origin` | string | Which subsystem published it: `vault`, `hub`, `auth`, `inbox`, `index`, `doctor`. |
+| `origin` | string | Which subsystem published it: `vault`, `hub`, `auth`, `inbox`, `index`, `doctor`, `gateway`. |
 | `data` | object | Event-specific payload (§3). May also repeat `vault`/`permalink` for a consumer reading only `data`. |
 | `id` | string | Stable idempotency key for this occurrence — unchanged across webhook retries of the same delivery. |
 | `schema_version` | integer | Currently `1`. See §5. |
@@ -99,6 +99,14 @@ of them ignores them.
 | `curator.proposal.applied` | `permalink`, `status`, `operations`, `applied`, `reason` | An approved proposal's plan ran to completion. |
 | `curator.proposal.apply_failed` | same shape | An operation failed mid-plan; the proposal is stamped `apply-failed` and a `doctor.finding` is raised. |
 | `curator.proposal.manual` | same shape | The proposal carries no executable plan (or an unparseable one) — a human has to apply it. |
+
+### 3.2 Gateway profile events (SPEC-301, additive)
+
+| Event | Origin | `data` fields | Fires when |
+|---|---|---|---|
+| `gateway.profile.created` | `gateway` | `path`, `vaults`, `stash` | `POST /api/gateway/profiles` creates a new MCP profile. |
+| `gateway.profile.updated` | `gateway` | `path`, `vaults`, `stash` | `PATCH /api/gateway/profiles/{path}` changes an existing profile's label, mounted vaults, or stash flag. |
+| `gateway.profile.deleted` | `gateway` | `path` | `DELETE /api/gateway/profiles/{path}` removes a profile. |
 
 `health` also travels the same bus and wire format (SSE only; it is not a
 webhook-filterable v1 name — see §6) — it is the dashboard's periodic

--- a/v3/server/src/palaia_hub/app.py
+++ b/v3/server/src/palaia_hub/app.py
@@ -23,6 +23,7 @@ from . import __version__
 from .auth import TokenRecord, TokenStore, build_auth_router, check_gateway_auth_policy
 from .config import HubConfig, load_config, palaia_home
 from .curator import CuratorScheduler
+from .curator.wiring import CuratorWiring
 from .dashboard_api import build_dashboard_router
 from .events import (
     EventBus,
@@ -33,6 +34,7 @@ from .events import (
     stop_background_tasks,
 )
 from .gateway import DynamicGateway, GatewayASGI, VaultService
+from .gateway.api import build_gateway_profiles_router
 from .gateway.apps.hub_status_app import HubStatusDeps, build_hub_status_server
 from .gateway.stash_tools import build_stash_gateway
 from .gateway.wiring import EngineVaultService
@@ -69,6 +71,7 @@ def create_app(
     hook_store: HookStore | None = None,
     hook_outbox: HookOutbox | None = None,
     curator: CuratorScheduler | None = None,
+    curator_wiring: CuratorWiring | None = None,
     home: Path | None = None,
 ) -> FastAPI:
     """Build the hub's ASGI app.
@@ -167,6 +170,14 @@ def create_app(
             automation living inside the hub, not a second daemon (MASTERPLAN
             §5.1). Omitted (the default), no curation ever runs from this
             process; ``palaia-hub curator run`` still works on demand.
+        curator_wiring: the same curator, as its whole
+            :class:`~palaia_hub.curator.wiring.CuratorWiring` rather than
+            just its scheduler (SPEC-301). Given, a vault created through
+            the wizard also joins this curator's vault set live (see
+            :meth:`~palaia_hub.curator.wiring.CuratorWiring.add_vault`,
+            wired into :mod:`palaia_hub.dashboard_api`'s ``create_vault``).
+            Omitted, a wizard-created vault stays off the curator until a
+            restart, exactly as before this parameter existed.
         hook_outbox: the durable delivery queue backing ``hook_store``.
             Defaults to :class:`~palaia_hub.hooks.HookOutbox` at its
             standard path under the hub's data directory when ``hook_store``
@@ -408,6 +419,24 @@ def create_app(
                 vault_registry,
                 indexes=indexes,
                 dynamic_gateway=dynamic_gateway,
+                curator=curator_wiring,
+            )
+        )
+
+    # SPEC-301 deliverable #2: the runtime profile-editor REST surface.
+    # Needs a live gateway to apply an edit to and `home` to persist it to
+    # `config.yaml` — the same opt-in-on-`dynamic_gateway` gate the
+    # dashboard router above uses, since there is nothing to edit without
+    # one.
+    if dynamic_gateway is not None:
+        app.include_router(
+            build_gateway_profiles_router(
+                dynamic_gateway,
+                home=hub_home,
+                config=config,
+                event_bus=event_bus,
+                oauth_server=oauth_server,
+                token_store=token_store,
             )
         )
 

--- a/v3/server/src/palaia_hub/cli.py
+++ b/v3/server/src/palaia_hub/cli.py
@@ -23,7 +23,8 @@ from .auth.scopes import vault_scope
 from .config import ConfigError, HubConfig, load_config, palaia_home
 from .curator import CURATOR_PROFILE_PATH, ApplyReport, CuratorRunReport, ProposalApplier
 from .curator.wiring import TOKEN_ENV, CuratorWiring, build_curator
-from .gateway.config import VaultMountConfig
+from .gateway.config import DEFAULT_GATEWAY_PROFILE, ProfileConfig, VaultMountConfig
+from .gateway.settings_bridge import GatewaySettingsError, resolve_full_gateway_profiles
 from .importers import ImportReport, ImportRunner, v2_source
 from .importers import basic_memory_source as bm_source
 from .index import VaultIndex, embed_progress
@@ -192,7 +193,11 @@ def serve(host: str | None = None, port: int | None = None) -> None:
     if overrides:
         config = config.model_copy(update=overrides)
 
-    asyncio.run(_serve_async(config))
+    try:
+        asyncio.run(_serve_async(config))
+    except GatewaySettingsError as exc:
+        print(f"palaia-hub: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
 
 
 async def _serve_async(config: HubConfig) -> None:
@@ -218,18 +223,49 @@ async def _serve_async(config: HubConfig) -> None:
     await server.serve()
 
 
-def _profile_scopes(profiles: Sequence[str], vault_keys: Sequence[str]) -> dict[str, list[str]]:
-    """``{profile: grantable scopes}`` for every profile, over ``vault_keys``.
-
-    Until the gateway's own config reaches ``config.yaml`` (see
-    ``OAuthSettings.profiles``), the scope ceiling is derived from the vault
-    registry: every registered vault contributes a read and a write scope.
-    That is the same vocabulary SPEC-108 tokens use
-    (:func:`palaia_hub.auth.scopes.vault_scope`), so a client's scopes mean
-    the same thing whichever credential carried them.
+def _profile_scopes(profiles: Sequence[ProfileConfig]) -> dict[str, list[str]]:
+    """``{profile: grantable scopes}``, one entry per profile, scoped to
+    exactly the vaults *that* profile mounts (SPEC-301) — every vault a
+    profile serves contributes a read and a write scope, the same
+    vocabulary SPEC-108 tokens use (:func:`palaia_hub.auth.scopes.
+    vault_scope`), so a client's scopes mean the same thing whichever
+    credential carried them.
     """
-    scopes = [scope for key in vault_keys for scope in (f"vault:{key}:read", f"vault:{key}:write")]
-    return {profile: list(scopes) for profile in profiles}
+    return {
+        profile.path: [
+            scope
+            for key in profile.vaults
+            for scope in (f"vault:{key}:read", f"vault:{key}:write")
+        ]
+        for profile in profiles
+    }
+
+
+def _gateway_profiles_for_oauth(config: HubConfig) -> list[ProfileConfig]:
+    """The profiles the OAuth server should issue tokens for — the *same*
+    resolution ``palaia_hub.serve.build_production_app`` uses to build the
+    real gateway (SPEC-301 deliverable #3's "one source of truth"), so the
+    CLI's OAuth-server assembly (built before the gateway exists, see
+    ``_maybe_oauth_server``'s caller) never disagrees with it.
+
+    Falls back to the deprecated ``oauth.profiles`` list only when nothing
+    resolves from the gateway's own shape at all (no ``gateway:`` section
+    *and* no vault registered yet) — "an old config still works" (SPEC-301
+    acceptance criterion), for the one case that genuinely has nothing
+    else to go on. The moment even one vault exists, the gateway's own
+    ``default`` profile resolves and takes over, same as any other config.
+    """
+    vault_keys = sorted(VaultRegistry().names())
+    try:
+        profiles = resolve_full_gateway_profiles(
+            config, vault_keys, default_profile=DEFAULT_GATEWAY_PROFILE
+        )
+    except GatewaySettingsError as exc:
+        print(f"palaia-hub: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    if not profiles and config.oauth.profiles:
+        profiles = [ProfileConfig(path=legacy) for legacy in config.oauth.profiles]
+    return profiles
 
 
 def _maybe_oauth_server(config: HubConfig) -> AuthorizationServer | None:
@@ -244,20 +280,19 @@ def _maybe_oauth_server(config: HubConfig) -> AuthorizationServer | None:
             file=sys.stderr,
         )
         raise SystemExit(1)
-    vault_keys = sorted(VaultRegistry().names())
-    profiles = config.oauth.profiles
+    profiles = _gateway_profiles_for_oauth(config)
     if not profiles:
         print(
-            "palaia-hub: oauth.enabled is true but oauth.profiles is empty, so no MCP "
-            "resource can be named in a token. Fix: list your gateway's profile paths "
-            "under `oauth.profiles` in config.yaml.",
+            "palaia-hub: oauth.enabled is true but this hub serves no MCP profiles "
+            "yet, so no resource can be named in a token. Fix: create a vault first "
+            "(the wizard, or `palaia-hub import ...`).",
             file=sys.stderr,
         )
         raise SystemExit(1)
-    server = AuthorizationServer.build(config, _profile_scopes(profiles, vault_keys))
+    server = AuthorizationServer.build(config, _profile_scopes(profiles))
     print(
         f"OAuth 2.1 authorization server enabled (issuer {server.issuer}); "
-        f"profiles: {', '.join(profiles)}"
+        f"profiles: {', '.join(p.path for p in profiles)}"
     )
     return server
 
@@ -294,7 +329,8 @@ def _oauth_machine_client(name: str, profile: str, scopes: list[str]) -> None:
             file=sys.stderr,
         )
         raise SystemExit(1)
-    registry = ResourceRegistry(config.oauth.issuer, config.oauth.profiles or [profile])
+    profile_paths = [p.path for p in _gateway_profiles_for_oauth(config)] or [profile]
+    registry = ResourceRegistry(config.oauth.issuer, profile_paths)
     try:
         audience = registry.audience(profile)
         provisioned = provision_machine_client(

--- a/v3/server/src/palaia_hub/config.py
+++ b/v3/server/src/palaia_hub/config.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import ipaddress
 import os
+import warnings
 from pathlib import Path
 from typing import Any, Literal
 
@@ -125,6 +126,11 @@ recall:
 # guessed from the bind address above. Turn it on to connect claude.ai,
 # ChatGPT or a phone as a remote connector; per-client `plt_` tokens keep
 # working alongside it either way.
+#
+# Which MCP resources this server issues audience-scoped tokens for is no
+# longer set here (SPEC-301): it always follows the gateway's own profiles
+# below (or the single `default` profile over every vault, when no `gateway:`
+# section is present) — one source of truth for "what this hub serves".
 oauth:
   enabled: false
   # issuer: https://hub.example.com
@@ -141,9 +147,6 @@ oauth:
   # Admin-provisioned machine clients are never pruned.
   client_gc_ttl: 2592000
   client_gc_interval: 3600
-  # MCP profile paths this server issues audience-scoped tokens for. Must
-  # match the gateway's profile paths.
-  profiles: []
   # Sign in with an identity provider instead of the local password
   # (SPEC-204). Uncomment ONE of the blocks below. Setting this removes the
   # password sign-in route entirely — "one door only" (MASTERPLAN §5.5):
@@ -178,6 +181,35 @@ exposure:
   # How the public URL above is served: 'tailscale', 'cloudflared', or
   # 'reverse_proxy' (bring-your-own). Purely informational.
   tunnel: null
+
+# The gateway's shape (SPEC-301): which MCP profiles this hub serves, which
+# vaults each one mounts, and any per-vault tool renames or per-profile
+# built-ins (like the stash tools). Absent (the default, as below) — every
+# registered vault is served on one profile named 'default', exactly as
+# before this section existed; nothing to change for a zero-config hub.
+#
+# Uncomment and edit to shape it yourself, or use the dashboard's profile
+# editor / `POST /api/gateway/profiles` — either way edits here are picked
+# up live, no restart needed, and a REST-made edit is written back here.
+#
+# gateway:
+#   # Per-vault identity overrides (optional — a vault not listed here uses
+#   # its own name/purpose and no tool renames, same as always).
+#   vaults:
+#     - key: work
+#       name: work
+#       purpose: "Work notes and decisions."
+#       tool_renames:
+#         search: find
+#   # Which profiles exist, and what each one mounts. A profile's `path` is
+#   # its identity (the MCP URL segment, and the OAuth resource audience if
+#   # OAuth is on) — set once, never renamed; give it a `label` instead if
+#   # you want a friendlier display name.
+#   profiles:
+#     - path: default
+#       label: Default
+#       vaults: [work]
+#       stash: false
 
 # The curator (SPEC-206): the background job that turns inbox captures into
 # well-placed vault notes. Off by default — it runs a model, which costs
@@ -407,22 +439,35 @@ class OAuthSettings(BaseModel):
     #: Minimum interval between GC passes (it is triggered opportunistically
     #: from the token/registration endpoints).
     client_gc_interval: int = Field(default=3600, ge=60)
-    #: Which MCP profile paths this authorization server issues tokens for.
-    #:
-    #: A bridge, not a permanent design: the profiles a hub serves are the
-    #: gateway's (:class:`palaia_hub.gateway.config.GatewayConfig`), which
-    #: does not reach ``config.yaml`` yet — ``palaia_hub.cli.serve`` still
-    #: mounts no gateway (see its comment). Until it does, an operator names
-    #: the profiles here so the ``serve`` entry point can host the OAuth
-    #: endpoints; a caller that builds a gateway itself passes the real
-    #: profile set to :meth:`palaia_hub.oauth.AuthorizationServer.build` and
-    #: ignores this list.
+    #: **Deprecated (SPEC-301), ignored.** Used to be how an operator named
+    #: which MCP profiles this authorization server issues tokens for — a
+    #: bridge from before the gateway's own shape reached ``config.yaml``.
+    #: Now the AS always reads that from the gateway's own profiles (the
+    #: ``gateway:`` section below, or the single ``default`` profile when
+    #: that section is absent) — one source of truth for "what this hub
+    #: serves", per SPEC-301 deliverable #3. Kept only so an old
+    #: ``config.yaml`` that still sets this parses without error; see
+    #: :func:`load_config`'s deprecation warning. Fix: delete this key.
     profiles: list[str] = Field(default_factory=list)
     #: An identity provider fronting sign-in (SPEC-204). ``None`` (default)
     #: keeps the local owner password as the only door; setting this removes
     #: the password route entirely rather than adding a second door next to
     #: it (MASTERPLAN §5.5's "one door only" rule).
     idp: IdpSettings | None = None
+
+    @model_validator(mode="after")
+    def _warn_deprecated_profiles(self) -> OAuthSettings:
+        if self.profiles:
+            warnings.warn(
+                "config.yaml: `oauth.profiles` is deprecated and no longer read — "
+                "the OAuth server now always issues tokens for the gateway's own "
+                "profiles (the `gateway:` section, or the single 'default' profile "
+                "when that section is absent). Fix: remove `oauth.profiles` from "
+                "config.yaml.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return self
 
 
 class ExposureSettings(BaseModel):
@@ -448,6 +493,87 @@ class ExposureSettings(BaseModel):
     #: changes which copy-paste config the wizard offers, never the hub's
     #: own behavior.
     tunnel: Literal["tailscale", "cloudflared", "reverse_proxy"] | None = None
+
+
+class GatewayVaultSettings(BaseModel):
+    """One vault's gateway identity override (SPEC-301 deliverable #1).
+
+    A vault registered with :class:`~palaia_hub.vault.VaultRegistry` but
+    absent from ``gateway.vaults`` uses its own name/purpose and no tool
+    renames — exactly as before this section existed. Listing it here
+    overrides the display name, one-line purpose, and/or per-tool renames
+    (SPEC-105's ``tool_renames``: base action name → desired tool name,
+    applied wherever this vault is mounted) that the gateway actually
+    builds tools from.
+
+    Deliberately duplicated here rather than importing
+    :class:`palaia_hub.gateway.config.VaultMountConfig` directly: this
+    module must stay importable without pulling in the gateway package
+    (which imports fastmcp) — see :data:`_DEFAULT_CURATOR_COMMAND`'s
+    comment above for the same rule applied to the curator. A test
+    (``tests/gateway/test_settings_bridge.py``) asserts the two shapes
+    never drift apart.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    key: str
+    #: Display name shown in tool names (e.g. ``work`` → ``work_memory_*``).
+    #: ``None`` keeps the vault's own name (the registry key, normally).
+    name: str | None = None
+    #: One-line purpose leading every one of this vault's tool descriptions.
+    #: ``None`` keeps whatever the vault's own manifest declares.
+    purpose: str | None = None
+    #: Base action name → desired tool name (pre-namespace). Invalid
+    #: characters are sanitized with a warning at build time, same as any
+    #: other rename (SPEC-105).
+    tool_renames: dict[str, str] = Field(default_factory=dict)
+
+
+class GatewayProfileSettings(BaseModel):
+    """One MCP profile's shape (SPEC-301 deliverable #1).
+
+    ``path`` is this profile's permanent identity — the MCP mount segment
+    and (when OAuth is on) its resource audience. It is set once, here or
+    via ``POST /api/gateway/profiles``, and never renamed afterwards; use
+    ``label`` for a friendly display name instead. See
+    :class:`palaia_hub.gateway.config.ProfileConfig`'s docstring for why.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+    label: str | None = None
+    vaults: list[str] = Field(default_factory=list)
+    #: Mount the stash tool family inside this profile too (SPEC-202/301).
+    stash: bool = False
+
+
+class GatewaySettings(BaseModel):
+    """The ``gateway:`` config.yaml section (SPEC-301): profiles as
+    first-class, operator-editable configuration.
+
+    Absent (``None`` on :class:`HubConfig`, the default) — the gateway is
+    built exactly as it always has been: one profile named ``default``
+    mounting every registered vault, no renames, no stash. Present with an
+    empty ``profiles`` list — same default, so adding ``gateway:\\n  vaults:
+    ...`` alone (identity overrides, no profile shape yet) changes nothing
+    about which profiles exist. Present with ``profiles`` populated — that
+    list is authoritative for which profiles exist and what each mounts;
+    see :mod:`palaia_hub.gateway.settings_bridge` for how it is resolved
+    against the vaults actually registered, and how a runtime
+    create/edit/delete through ``POST /api/gateway/profiles`` is written
+    back here.
+
+    The curator's own profile (``/mcp/curator``, SPEC-206) is never listed
+    here — it is synthesized separately from ``curator.enabled``, the same
+    way it always was; this section is only ever the *ordinary* profiles.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    vaults: list[GatewayVaultSettings] = Field(default_factory=list)
+    profiles: list[GatewayProfileSettings] = Field(default_factory=list)
 
 
 class CuratorSettings(BaseModel):
@@ -513,6 +639,11 @@ class HubConfig(BaseModel):
     oauth: OAuthSettings = Field(default_factory=OAuthSettings)
     curator: CuratorSettings = Field(default_factory=CuratorSettings)
     exposure: ExposureSettings = Field(default_factory=ExposureSettings)
+    #: The gateway's profiles/vault-identity shape (SPEC-301). ``None`` (the
+    #: default, and what an old config.yaml with no ``gateway:`` section
+    #: parses to) means "today's zero-config behavior": every vault on one
+    #: ``default`` profile. See :class:`GatewaySettings`.
+    gateway: GatewaySettings | None = None
 
     def curator_endpoint(self) -> str:
         """The base URL a curation session reaches this hub at (SPEC-206)."""

--- a/v3/server/src/palaia_hub/curator/middleware.py
+++ b/v3/server/src/palaia_hub/curator/middleware.py
@@ -66,6 +66,21 @@ class CuratorScopeMiddleware(Middleware):
     def active_captures(self) -> ActiveCaptures:
         return self._active_captures
 
+    def add_tool_actions(self, tool_actions: Mapping[str, str]) -> None:
+        """Merge more ``{tool name: base action}`` entries in, live.
+
+        SPEC-301 deliverable #4: a vault created at runtime joins the
+        curator profile without a restart, and this profile is rebuilt
+        (a new :class:`~fastmcp.FastMCP` server) each time — but this
+        *middleware instance* is the same object every rebuild reuses (see
+        :mod:`palaia_hub.curator.profile`'s docstring), so mutating its map
+        here is what makes the new vault's tools recognized without also
+        having to re-attach a fresh middleware instance anywhere. Never
+        removes an entry — closing a vault's tools back off this profile
+        is not a case this SPEC needs (vaults are not deleted at runtime).
+        """
+        self._tool_actions.update(tool_actions)
+
     def action_for(self, tool_name: str) -> str | None:
         """The base action ``tool_name`` maps to, or ``None`` if unknown here."""
         return self._tool_actions.get(tool_name)

--- a/v3/server/src/palaia_hub/curator/service.py
+++ b/v3/server/src/palaia_hub/curator/service.py
@@ -104,6 +104,22 @@ class CuratorScheduler:
         """Ask for a pass soon (debounced). Safe to call from a callback."""
         self._nudged.set()
 
+    def add_vault(
+        self,
+        key: str,
+        runner: CuratorRunner,
+        applier: ProposalApplier | None = None,
+    ) -> None:
+        """Add a vault created at runtime (SPEC-301 deliverable #4).
+
+        Safe to call between passes (:meth:`run_all` snapshots its own
+        runner/applier lists before awaiting anything, so a vault added
+        mid-pass is simply picked up starting the *next* pass, never a
+        half-iterated one)."""
+        self._runners[key] = runner
+        if applier is not None:
+            self._appliers[key] = applier
+
     # ------------------------------------------------------------------ loop
 
     async def _loop(self) -> None:
@@ -129,14 +145,20 @@ class CuratorScheduler:
         """One pass: curate every vault's inbox, then apply what was approved."""
         runs: list[CuratorRunReport] = []
         applies: list[ApplyReport] = []
-        for vault, runner in self._runners.items():
+        # Snapshot both mappings before awaiting anything: `add_vault` can
+        # be called from a different coroutine (a wizard-created vault,
+        # SPEC-301) while a pass is in flight, and mutating a dict while
+        # `.items()` iterates it raises `RuntimeError: dictionary changed
+        # size during iteration` — a vault added mid-pass is simply first
+        # curated on the *next* pass instead.
+        for vault, runner in list(self._runners.items()):
             try:
                 runs.append(await runner.run_once())
             except asyncio.CancelledError:
                 raise
             except Exception:  # noqa: BLE001 - one vault must not stop the rest
                 logger.exception("curator: run failed for vault %r", vault)
-        for vault, applier in self._appliers.items():
+        for vault, applier in list(self._appliers.items()):
             try:
                 applies.append(await applier.run_once())
             except asyncio.CancelledError:

--- a/v3/server/src/palaia_hub/curator/wiring.py
+++ b/v3/server/src/palaia_hub/curator/wiring.py
@@ -22,8 +22,14 @@ from ..stash import StashService, StashStore
 from ..vault import VaultEngine
 from .apply import ProposalApplier
 from .audit import CuratorAudit, Publisher
+from .middleware import CuratorScopeMiddleware
 from .policy import ActiveCaptures
-from .profile import CURATOR_PROFILE_PATH, allowed_tool_specs, curator_profile_middleware
+from .profile import (
+    CURATOR_PROFILE_PATH,
+    allowed_tool_specs,
+    curator_profile_middleware,
+    curator_tool_actions,
+)
 from .runner import CuratorRunner
 from .service import CuratorScheduler
 from .session import SessionRunner, SubprocessSessionRunner
@@ -42,7 +48,14 @@ STASH_FILENAME = "stash.db"
 
 @dataclass
 class CuratorWiring:
-    """Everything a wired-up curator consists of."""
+    """Everything a wired-up curator consists of.
+
+    The fields after ``stash_store`` are private wiring context, kept only
+    so :meth:`add_vault` can build a *matching* runner/applier for a vault
+    created after this curator was assembled — SPEC-301 deliverable #4,
+    closing SPEC-206's documented "known limitation, deliberately
+    fail-closed" gap (see :mod:`palaia_hub.curator.profile`'s docstring).
+    """
 
     scheduler: CuratorScheduler
     runners: dict[str, CuratorRunner]
@@ -50,11 +63,63 @@ class CuratorWiring:
     active_captures: ActiveCaptures
     profile_middleware: dict[str, list[Middleware]] = field(default_factory=dict)
     stash_store: StashStore | None = None
+    _session_runner: SessionRunner | None = field(default=None, repr=False)
+    _audit: CuratorAudit | None = field(default=None, repr=False)
+    _endpoint: str = field(default="", repr=False)
+    _token: str | None = field(default=None, repr=False)
+    _max_attempts: int = field(default=3, repr=False)
+    _auto_apply: bool = field(default=True, repr=False)
+    _mounts: list[VaultMountConfig] = field(default_factory=list, repr=False)
 
     async def aclose(self) -> None:
         await self.scheduler.aclose()
         if self.stash_store is not None:
             self.stash_store.close()
+
+    async def add_vault(self, engine: VaultEngine, mount: VaultMountConfig) -> None:
+        """Wire a vault created at runtime into this curator, live.
+
+        Called by the wizard's ``POST /api/vaults`` handler
+        (:mod:`palaia_hub.dashboard_api`) right after the vault joins the
+        gateway's curator profile. Builds a new :class:`CuratorRunner` (and,
+        when ``auto_apply`` was on, a matching :class:`ProposalApplier`),
+        registers both with the scheduler, and merges this vault's tool
+        names into the curator profile's guard — the exact three things
+        SPEC-206's profile module named as the gap ("its tools are absent
+        from the curator's map ... the curator starts curating that
+        vault's inbox after the next hub restart"). A no-op if this vault
+        key is already known (idempotent against a retry).
+        """
+        if mount.key in self.runners:
+            return
+        if self._session_runner is None:
+            raise RuntimeError(
+                "CuratorWiring.add_vault called on a wiring with no session "
+                "runner recorded — build it via curator.wiring.build_curator, "
+                "which always sets one."
+            )
+        self._mounts.append(mount)
+        allowed_tools = allowed_tool_specs(self._mounts)
+        runner = CuratorRunner(
+            engine,
+            session_runner=self._session_runner,
+            endpoint=self._endpoint,
+            token=self._token,
+            allowed_tools=allowed_tools,
+            audit=self._audit,
+            active_captures=self.active_captures,
+            max_attempts=self._max_attempts,
+            purpose=mount.purpose,
+        )
+        self.runners[mount.key] = runner
+        applier: ProposalApplier | None = None
+        if self._auto_apply:
+            applier = ProposalApplier(engine, audit=self._audit)
+            self.appliers[mount.key] = applier
+        self.scheduler.add_vault(mount.key, runner, applier)
+        for item in self.profile_middleware.get(CURATOR_PROFILE_PATH, []):
+            if isinstance(item, CuratorScopeMiddleware):
+                item.add_tool_actions(curator_tool_actions([mount]))
 
 
 def curator_token(config: HubConfig) -> str | None:
@@ -71,6 +136,7 @@ def build_curator(
     publish: Publisher | None = None,
     session_runner: SessionRunner | None = None,
     with_stash: bool = True,
+    stash_service: StashService | None = None,
     subscribe: SchedulerSubscribe | None = None,
 ) -> CuratorWiring:
     """Assemble runners, appliers, the scheduler and the profile guard.
@@ -80,7 +146,8 @@ def build_curator(
         engines: the vaults to curate, ``{vault_key: opened engine}``.
         mounts: the same vaults' gateway mount configs — the guard needs
             them to know each vault's tool names.
-        home: where the audit stash lives (the hub's data dir).
+        home: where the audit stash lives (the hub's data dir). Unused when
+            ``stash_service`` is given.
         publish: the event sink (``publish(event, data)``); omitted, no
             events are emitted.
         session_runner: overrides how a session is launched. Tests pass a
@@ -88,15 +155,25 @@ def build_curator(
             :class:`~palaia_hub.curator.session.SubprocessSessionRunner`
             built from ``config.curator.runner_command``.
         with_stash: open the audit stash. ``False`` keeps the whole wiring
-            free of any file I/O beyond the vaults themselves.
+            free of any file I/O beyond the vaults themselves. Ignored
+            when ``stash_service`` is given.
+        stash_service: use this stash instead of opening a new store — the
+            hub's *one* stash (SPEC-301: ``build_production_app`` builds a
+            single :class:`~palaia_hub.stash.service.StashService` for both
+            the ``/mcp/stash`` tool family and the curator's own audit
+            trail, so a client's ``stash_list`` and the curator's audit
+            entries are the same store, not two SQLite connections racing
+            each other on one file). The returned
+            :class:`CuratorWiring`'s ``stash_store`` stays ``None`` in this
+            case — ownership (who opens it, who closes it) stays with
+            whoever built ``stash_service``, not with this function.
         subscribe: the event bus's ``on()``, so a capture wakes the curator
             (debounced). Omitted, the scheduler runs on its interval only —
             which is what the one-shot CLI wants.
     """
     settings = config.curator
     stash_store: StashStore | None = None
-    stash_service: StashService | None = None
-    if with_stash:
+    if stash_service is None and with_stash:
         stash_store = StashStore(Path(home or Path.cwd()) / STASH_FILENAME)
         stash_service = StashService(stash_store)
     audit = CuratorAudit(publish=publish, stash=stash_service)
@@ -145,6 +222,13 @@ def build_curator(
             mounts, active_captures=active_captures
         ),
         stash_store=stash_store,
+        _session_runner=runner,
+        _audit=audit,
+        _endpoint=endpoint,
+        _token=token,
+        _max_attempts=settings.max_attempts,
+        _auto_apply=settings.auto_apply,
+        _mounts=list(mounts),
     )
 
 

--- a/v3/server/src/palaia_hub/dashboard_api.py
+++ b/v3/server/src/palaia_hub/dashboard_api.py
@@ -45,7 +45,9 @@ from typing import Literal
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, ConfigDict
 
-from .gateway.config import VaultMountConfig
+from .curator.profile import CURATOR_PROFILE_PATH
+from .curator.wiring import CuratorWiring
+from .gateway.config import DEFAULT_GATEWAY_PROFILE, VaultMountConfig
 from .gateway.dynamic import DynamicGateway
 from .gateway.vault_protocol import (
     NoteRecord,
@@ -70,13 +72,6 @@ from .vault import (
 )
 from .vault import permalink as pl
 from .vault.links import iter_links
-
-#: The gateway profile a vault created through the wizard/API is mounted
-#: under when a :class:`~.gateway.dynamic.DynamicGateway` is wired in
-#: (SPEC-210 deliverable #1). Matches the single-profile convention every
-#: other production/e2e assembly in this codebase already uses (see
-#: ``tests/e2e/support/hub_server.py``'s ``--profile`` default).
-DEFAULT_GATEWAY_PROFILE = "default"
 
 # Two starter notes offered by the wizard's "start from a template" switch
 # (deliverable #1). Deliberately small and deletable — a template is a
@@ -256,6 +251,7 @@ def build_dashboard_router(
     *,
     indexes: dict[str, VaultIndex] | None = None,
     dynamic_gateway: DynamicGateway | None = None,
+    curator: CuratorWiring | None = None,
 ) -> APIRouter:
     """Build the wizard + explorer router, bound to ``registry``.
 
@@ -277,6 +273,13 @@ def build_dashboard_router(
             (unchanged default), a wizard-created vault stays
             dashboard/REST-visible only, exactly as documented in this
             module's docstring before this parameter existed.
+        curator: the hub's wired-up curator (SPEC-206/301), when
+            ``curator.enabled``. Given, a vault created here also joins the
+            curator profile's vault set and its guard's tool-action map —
+            closing SPEC-206's documented "curator starts curating that
+            vault's inbox after the next hub restart" gap (SPEC-301
+            deliverable #4). Omitted, behavior is unchanged: the vault is
+            still mounted on :data:`DEFAULT_GATEWAY_PROFILE` alone.
     """
     router = APIRouter(tags=["dashboard"])
 
@@ -304,7 +307,16 @@ def build_dashboard_router(
                 name=body.key,
                 purpose=body.purpose or "A palaia memory vault.",
             )
-            await dynamic_gateway.add_vault(mount, service, profile_paths=[DEFAULT_GATEWAY_PROFILE])
+            # Curator wiring first: by the time the curator profile becomes
+            # reachable with this vault mounted (next), its guard already
+            # recognizes the vault's tools — fail-closed in between rather
+            # than briefly wide open.
+            if curator is not None:
+                await curator.add_vault(engine, mount)
+            profile_paths = [DEFAULT_GATEWAY_PROFILE]
+            if curator is not None:
+                profile_paths.append(CURATOR_PROFILE_PATH)
+            await dynamic_gateway.add_vault(mount, service, profile_paths=profile_paths)
 
         return _vault_out(body.key, engine.info())
 

--- a/v3/server/src/palaia_hub/events/schema.py
+++ b/v3/server/src/palaia_hub/events/schema.py
@@ -65,6 +65,12 @@ EventName = Literal[
     "stash.get",
     "stash.del",
     "stash.evicted",
+    # SPEC-301 (gateway config): one per runtime profile-editor mutation
+    # (create/edit/delete) through `POST/PATCH/DELETE /api/gateway/profiles`.
+    # Additive to the v1 vocabulary.
+    "gateway.profile.created",
+    "gateway.profile.updated",
+    "gateway.profile.deleted",
     "health",
 ]
 

--- a/v3/server/src/palaia_hub/gateway/__init__.py
+++ b/v3/server/src/palaia_hub/gateway/__init__.py
@@ -22,7 +22,7 @@ Public surface:
 from __future__ import annotations
 
 from .build import GatewayASGI, GatewayConfigError, build_gateway
-from .config import GatewayConfig, ProfileConfig, VaultMountConfig
+from .config import DEFAULT_GATEWAY_PROFILE, GatewayConfig, ProfileConfig, VaultMountConfig
 from .dynamic import DynamicGateway
 from .fake_vault import FakeVaultService
 from .stash_tools import (
@@ -45,6 +45,7 @@ from .vault_protocol import (
 from .wiring import EngineVaultService
 
 __all__ = [
+    "DEFAULT_GATEWAY_PROFILE",
     "INBOX_TOOL_ACTIONS",
     "MEMORY_TOOL_ACTIONS",
     "STASH_TOOL_ACTIONS",

--- a/v3/server/src/palaia_hub/gateway/api.py
+++ b/v3/server/src/palaia_hub/gateway/api.py
@@ -1,0 +1,272 @@
+"""Runtime profile CRUD: ``/api/gateway/profiles`` (SPEC-301 deliverable #2).
+
+Every route here does the same three things, in order: validate against the
+gateway actually running, apply the change live to the
+:class:`~.dynamic.DynamicGateway` (so an MCP client sees it with no
+restart), then write the new shape back to ``config.yaml`` (so it survives
+one) — the same "live now, persisted for next time" contract
+:mod:`palaia_hub.modes.api` already established for mode changes, except a
+profile edit here needs no ``restart_required`` escape hatch: unlike
+mode/host/auth, a profile's shape is exactly the thing
+:class:`~.dynamic.DynamicGateway` was built to rebuild without one.
+
+The curator's own profile (``/mcp/curator``) is deliberately off-limits
+here — it is not a ``gateway.profiles`` entry at all, but something
+synthesized from ``curator.enabled`` (see
+:mod:`palaia_hub.gateway.settings_bridge`), so editing it through this
+generic surface would silently fight with that synthesis on the next
+restart. An operator who wants to change what the curator sees edits
+``curator:`` settings or adds a vault through the wizard instead.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+from fastmcp.server.auth import AuthProvider
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from ..auth.policy import AuthPolicyError
+from ..auth.store import TokenStore
+from ..config import GatewayProfileSettings, GatewaySettings, HubConfig, config_file_path
+from ..events import EventBus, publish_event
+from ..oauth import AuthorizationServer
+from ..oauth.verifier import build_profile_auth
+from .build import GatewayConfigError
+from .config import ProfileConfig
+from .dynamic import DynamicGateway
+from .settings_bridge import persist_gateway_settings
+
+# Kept as a plain string (not imported from `palaia_hub.curator.profile`):
+# this module has no other reason to pull in the curator package, and the
+# path itself is what matters here — protecting it from the generic CRUD
+# below, see the module docstring.
+_CURATOR_PROFILE_PATH = "curator"
+
+
+class GatewayProfileOut(BaseModel):
+    """One profile, as the editor sees it."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+    label: str | None
+    vaults: list[str]
+    stash: bool
+    #: The curator's own profile is listed (so the editor can show it) but
+    #: every write route below refuses to touch it — see the module
+    #: docstring.
+    managed: bool
+
+
+class CreateGatewayProfileRequest(BaseModel):
+    """``POST /api/gateway/profiles`` — ``path`` is set here, once, and
+    never appears in :class:`UpdateGatewayProfileRequest` below: there is
+    no "rename the URL" operation (see ``ProfileConfig``'s docstring)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+    label: str | None = None
+    vaults: list[str] = []
+    stash: bool = False
+
+
+class UpdateGatewayProfileRequest(BaseModel):
+    """``PATCH /api/gateway/profiles/{path}`` — every field optional; an
+    omitted one keeps its current value. ``vaults``, when given, *replaces*
+    the whole mounted-vault list (there is no separate add/remove verb)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    label: str | None = None
+    vaults: list[str] | None = None
+    stash: bool | None = None
+
+
+def _out(profile: ProfileConfig) -> GatewayProfileOut:
+    return GatewayProfileOut(
+        path=profile.path,
+        label=profile.label,
+        vaults=list(profile.vaults),
+        stash=profile.stash,
+        managed=profile.path == _CURATOR_PROFILE_PATH,
+    )
+
+
+def build_gateway_profiles_router(
+    dynamic_gateway: DynamicGateway,
+    *,
+    home: Path,
+    config: HubConfig,
+    event_bus: EventBus | None = None,
+    oauth_server: AuthorizationServer | None = None,
+    token_store: TokenStore | None = None,
+) -> APIRouter:
+    """Build the profile-editor router, bound to ``dynamic_gateway``.
+
+    Args:
+        dynamic_gateway: the live gateway every route reads from and
+            applies to.
+        home: the hub's home directory — where ``config.yaml`` lives.
+        config: the live, running configuration. Only its
+            ``gateway.vaults`` (per-vault identity overrides, untouched by
+            any route here) and ``auth_enabled`` flag are read; ``mode`` is
+            not consulted directly — :meth:`DynamicGateway.upsert_profile`
+            already refuses an unauthenticated profile in cloud/open via
+            :func:`palaia_hub.auth.policy.check_gateway_auth_policy`.
+        event_bus: publishes ``gateway.profile.created/updated/deleted``
+            when given (SPEC-301 deliverable #6). Omitted, edits still
+            apply and persist, just silently.
+        oauth_server: given, a brand-new profile also gets a JWT verifier
+            pinned to its (freshly registered) audience — same as every
+            profile built at startup gets one (see
+            ``palaia_hub.serve.build_production_app``).
+        token_store: given (and ``config.auth_enabled``), a brand-new
+            profile also accepts SPEC-108 ``plt_`` tokens, alongside OAuth.
+    """
+    router = APIRouter(tags=["gateway"])
+    path = config_file_path(home)
+
+    def _new_profile_auth(profile_path: str) -> AuthProvider | None:
+        """The verifier a genuinely new profile should get, mirroring
+        exactly how ``build_production_app`` builds one at startup."""
+        providers = build_profile_auth(
+            [profile_path],
+            key=oauth_server.key if oauth_server is not None else None,
+            resources=oauth_server.resources if oauth_server is not None else None,
+            token_store=token_store if config.auth_enabled else None,
+        )
+        return providers.get(profile_path)
+
+    def _persist() -> None:
+        existing_vaults = config.gateway.vaults if config.gateway is not None else []
+        profiles = [
+            p for p in dynamic_gateway.config.profiles if p.path != _CURATOR_PROFILE_PATH
+        ]
+        settings = GatewaySettings(
+            vaults=existing_vaults,
+            profiles=[
+                GatewayProfileSettings(
+                    path=p.path, label=p.label, vaults=list(p.vaults), stash=p.stash
+                )
+                for p in profiles
+            ],
+        )
+        persist_gateway_settings(path, settings)
+
+    def _publish(event: str, data: dict[str, object]) -> None:
+        if event_bus is not None:
+            publish_event(event_bus, event, origin="gateway", data=data)
+
+    def _require_editable(profile_path: str) -> None:
+        if profile_path == _CURATOR_PROFILE_PATH:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "the curator profile is managed automatically from "
+                    "`curator:` settings, not through this API. Fix: edit "
+                    "config.yaml's `curator:` section, or add a vault through "
+                    "the wizard (it joins the curator profile on its own)."
+                ),
+            )
+
+    @router.get("/api/gateway/profiles", response_model=list[GatewayProfileOut])
+    async def list_profiles() -> list[GatewayProfileOut]:
+        return [_out(p) for p in dynamic_gateway.config.profiles]
+
+    @router.post("/api/gateway/profiles", response_model=GatewayProfileOut)
+    async def create_profile(body: CreateGatewayProfileRequest) -> GatewayProfileOut:
+        _require_editable(body.path)
+        existing = {p.path for p in dynamic_gateway.config.profiles}
+        if body.path in existing:
+            raise HTTPException(
+                status_code=400,
+                detail=f"a profile at path {body.path!r} already exists. Fix: "
+                "PATCH it instead, or choose a different path.",
+            )
+        try:
+            ProfileConfig(path=body.path, label=body.label, vaults=body.vaults, stash=body.stash)
+        except ValidationError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        try:
+            await dynamic_gateway.upsert_profile(
+                body.path,
+                body.vaults,
+                label=body.label,
+                stash=body.stash,
+                auth=_new_profile_auth(body.path),  # type: ignore[arg-type]
+            )
+        except GatewayConfigError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except AuthPolicyError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        _persist()
+        result = next(p for p in dynamic_gateway.config.profiles if p.path == body.path)
+        _publish(
+            "gateway.profile.created",
+            {"path": result.path, "vaults": list(result.vaults), "stash": result.stash},
+        )
+        return _out(result)
+
+    @router.patch("/api/gateway/profiles/{profile_path}", response_model=GatewayProfileOut)
+    async def update_profile(
+        profile_path: str, body: UpdateGatewayProfileRequest
+    ) -> GatewayProfileOut:
+        _require_editable(profile_path)
+        current = next(
+            (p for p in dynamic_gateway.config.profiles if p.path == profile_path), None
+        )
+        if current is None:
+            raise HTTPException(
+                status_code=404, detail=f"no profile at path {profile_path!r}"
+            )
+        label = body.label if body.label is not None else current.label
+        vaults = body.vaults if body.vaults is not None else list(current.vaults)
+        stash = body.stash if body.stash is not None else current.stash
+        try:
+            ProfileConfig(path=profile_path, label=label, vaults=vaults, stash=stash)
+        except ValidationError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        try:
+            # `auth=None`: this path already has a verifier from creation
+            # (or none, in locked mode) — an edit never changes that.
+            await dynamic_gateway.upsert_profile(
+                profile_path, vaults, label=label, stash=stash, auth=None
+            )
+        except GatewayConfigError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except AuthPolicyError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        _persist()
+        result = next(p for p in dynamic_gateway.config.profiles if p.path == profile_path)
+        _publish(
+            "gateway.profile.updated",
+            {"path": result.path, "vaults": list(result.vaults), "stash": result.stash},
+        )
+        return _out(result)
+
+    @router.delete("/api/gateway/profiles/{profile_path}", status_code=204)
+    async def delete_profile(profile_path: str) -> None:
+        _require_editable(profile_path)
+        try:
+            await dynamic_gateway.remove_profile(profile_path)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        _persist()
+        _publish("gateway.profile.deleted", {"path": profile_path})
+
+    return router
+
+
+__all__ = [
+    "CreateGatewayProfileRequest",
+    "GatewayProfileOut",
+    "UpdateGatewayProfileRequest",
+    "build_gateway_profiles_router",
+]

--- a/v3/server/src/palaia_hub/gateway/build.py
+++ b/v3/server/src/palaia_hub/gateway/build.py
@@ -36,6 +36,7 @@ from fastmcp.server.middleware import Middleware
 from fastmcp.utilities.lifespan import combine_lifespans
 from starlette.types import ASGIApp
 
+from ..stash.service import StashService
 from .apps.recall_app import RESOURCE_URI as RECALL_EXPLORER_URI
 from .apps.recall_app import render_recall_explorer_html
 from .apps.review_app import RESOURCE_URI as REVIEW_QUEUE_URI
@@ -43,6 +44,7 @@ from .apps.review_app import render_review_queue_html
 from .config import GatewayConfig, ProfileConfig
 from .memory_tools import build_vault_server, vault_identity_block
 from .naming import resolve_tool_names
+from .stash_tools import build_stash_server
 from .vault_protocol import VaultService
 
 # `combine_lifespans`'s return type is generic over the ASGI app it will be
@@ -105,6 +107,7 @@ def _build_profile_server(
     vault_servers: Mapping[str, FastMCP],
     auth: TokenVerifier | None,
     middleware: Sequence[Middleware] = (),
+    stash_service: StashService | None = None,
 ) -> FastMCP:
     # `mount()` does not propagate a mounted server's `instructions` to its
     # parent, so a real client connecting to this profile would otherwise
@@ -140,6 +143,15 @@ def _build_profile_server(
             namespace=vault_config.namespace,
             tool_names=tool_names or None,
         )
+    # `profile.stash` (SPEC-301): mount the stash tool family's five tools
+    # (unnamespaced — see gateway/stash_tools.py's module docstring) into
+    # *this* profile too, alongside its vaults, so one MCP connection
+    # carries both. `stash_service is None` (no hub-wide stash configured
+    # at all) silently mounts nothing, same as a profile with `stash: false`
+    # — a profile never fails to build just because the flag is set ahead
+    # of the service existing.
+    if profile.stash and stash_service is not None:
+        server.mount(build_stash_server(stash_service))
     _attach_app_resources(server)
     return server
 
@@ -175,6 +187,7 @@ def build_gateway(
     *,
     token_verifiers: Mapping[str, TokenVerifier] | None = None,
     profile_middleware: Mapping[str, Sequence[Middleware]] | None = None,
+    stash_service: StashService | None = None,
 ) -> GatewayASGI:
     """Build the full gateway from a validated config and its backing services.
 
@@ -193,6 +206,11 @@ def build_gateway(
             server is built, so a later rebuild of that profile carries the
             same middleware. A profile with no entry is built exactly as
             before this parameter existed.
+        stash_service: the hub-wide stash (SPEC-202), mounted into any
+            profile whose ``stash`` flag is set (SPEC-301). ``None`` (the
+            default) leaves every profile exactly as before this parameter
+            existed, even one with ``stash: true`` — the flag only takes
+            effect once a service exists to back it.
 
     Raises :class:`GatewayConfigError` if a configured vault has no entry in
     ``vault_services``. Structural config problems (duplicate keys, unknown
@@ -207,7 +225,9 @@ def build_gateway(
     for profile in config.profiles:
         auth = (token_verifiers or {}).get(profile.path)
         middleware = (profile_middleware or {}).get(profile.path, ())
-        server = _build_profile_server(profile, config, vault_servers, auth, middleware)
+        server = _build_profile_server(
+            profile, config, vault_servers, auth, middleware, stash_service
+        )
         profile_servers[profile.path] = server
         asgi_app = server.http_app(path="/")
         mounts[f"/mcp/{profile.path}"] = asgi_app

--- a/v3/server/src/palaia_hub/gateway/config.py
+++ b/v3/server/src/palaia_hub/gateway/config.py
@@ -82,13 +82,49 @@ class VaultMountConfig(BaseModel):
         return f"{sanitize_tool_name(self.name).value}_memory"
 
 
+#: The gateway profile a vault is mounted under when nothing more specific
+#: is configured — the "every vault on one profile" shape this SPEC's
+#: zero-config default preserves byte-for-byte (SPEC-301 deliverable #1).
+#: Lives here (the schema module) rather than in ``dashboard_api`` (its
+#: previous home): every module that resolves or persists gateway config —
+#: ``dashboard_api``, ``serve``, ``cli``, ``gateway.settings_bridge`` — needs
+#: this same literal, and importing it from the schema is the one direction
+#: that adds no cycle.
+DEFAULT_GATEWAY_PROFILE = "default"
+
+
 class ProfileConfig(BaseModel):
-    """One addressable profile: a URL path segment and which vaults it exposes."""
+    """One addressable profile: a URL path segment and which vaults it exposes.
+
+    ``path`` is the profile's identity: it is the MCP mount segment
+    (``/mcp/<path>``) a client connects to *and* the OAuth resource audience
+    it is granted a token for (SPEC-203's ``<issuer>/<path>``) — renaming it
+    would silently move every already-connected client and invalidate every
+    already-minted token's audience. So ``path`` is set once, at creation,
+    and never changed again (SPEC-301 deliverable #2): the runtime profile
+    CRUD surface (``palaia_hub.gateway.api``) can create or delete a profile
+    by its path, and can edit its ``label``/``vaults``/``stash``, but has no
+    "rename path" operation at all — a client that wants a new URL gets a
+    new profile, not a mutated one.
+
+    ``label`` is the free-text display name shown in the dashboard's profile
+    editor (SPEC-305) — purely cosmetic, defaults to ``path`` when unset, and
+    safe to change at any time since nothing outside the dashboard reads it.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
     path: str
+    label: str | None = None
     vaults: list[str] = Field(default_factory=list)
+    #: Mount the stash tool family (``stash_set``/``stash_get``/...,
+    #: SPEC-202) inside this profile too, alongside its vaults' memory
+    #: tools — SPEC-301 deliverable #1's "enabled built-ins like stash".
+    #: ``False`` (default) leaves a profile exactly as before this field
+    #: existed; the hub-wide ``/mcp/stash`` mount (SPEC-202) is unaffected
+    #: either way — this only decides whether *this* profile's own MCP
+    #: connection also carries those five tools.
+    stash: bool = False
 
     @field_validator("path")
     @classmethod
@@ -101,6 +137,11 @@ class ProfileConfig(BaseModel):
         if any(not v for v in value):
             raise ValueError("profile vaults list must not contain empty entries")
         return value
+
+    @property
+    def display_label(self) -> str:
+        """``label`` if set, else ``path`` — what a UI should show."""
+        return self.label or self.path
 
 
 class GatewayConfig(BaseModel):

--- a/v3/server/src/palaia_hub/gateway/dynamic.py
+++ b/v3/server/src/palaia_hub/gateway/dynamic.py
@@ -96,6 +96,7 @@ from starlette.routing import Mount, Router
 from starlette.types import ASGIApp
 
 from ..auth.policy import check_gateway_auth_policy
+from ..stash.service import StashService
 from .build import GatewayConfigError, _build_profile_server, _build_vault_servers
 from .config import GatewayConfig, ProfileConfig, VaultMountConfig
 from .vault_protocol import VaultService
@@ -111,6 +112,23 @@ class _MountCommand:
     profile_path: str
     server: FastMCP
     asgi_app: StarletteWithLifespan
+    done: asyncio.Future[None]
+
+
+@dataclass
+class _UnmountCommand:
+    """One "drop this profile from the router" request to the background
+    task (SPEC-301's ``DELETE /api/gateway/profiles/{path}``).
+
+    Unlike :class:`_MountCommand`, there is no ASGI app to enter a lifespan
+    for — only a route to remove. The profile's already-entered lifespan
+    stays in the background task's exit stack regardless (the same
+    deliberate-leak rule the class docstring's "old FastMCP app" bullet
+    describes for a rebuild: an in-flight request or open session against
+    it keeps running until :meth:`DynamicGateway.aclose`).
+    """
+
+    profile_path: str
     done: asyncio.Future[None]
 
 
@@ -135,6 +153,9 @@ class DynamicGateway:
             same contract as :func:`~.build.build_gateway` — re-applied on
             every rebuild of that profile (SPEC-206: the curator profile's
             policy must survive a vault being added at runtime).
+        stash_service: the hub-wide stash (SPEC-202), mounted into any
+            profile whose ``stash`` flag is set (SPEC-301) — same contract
+            as :func:`~.build.build_gateway`.
     """
 
     def __init__(
@@ -145,6 +166,7 @@ class DynamicGateway:
         mode: str = "locked",
         token_verifiers: Mapping[str, TokenVerifier] | None = None,
         profile_middleware: Mapping[str, Sequence[Middleware]] | None = None,
+        stash_service: StashService | None = None,
     ) -> None:
         self._config = config
         self._vault_services: dict[str, VaultService] = dict(vault_services)
@@ -154,13 +176,14 @@ class DynamicGateway:
         self._profile_middleware: dict[str, Sequence[Middleware]] = dict(
             profile_middleware or {}
         )
+        self._stash_service = stash_service
         self.router = Router(routes=[])
         self._profile_servers: dict[str, FastMCP] = {}
         self._lock = asyncio.Lock()
         # See the class docstring's "cancel-scope finding": every lifespan
         # enter/exit happens inside `_lifecycle_task`, via `_queue`, never
         # directly in the caller's own task.
-        self._queue: asyncio.Queue[_MountCommand | object] = asyncio.Queue()
+        self._queue: asyncio.Queue[_MountCommand | _UnmountCommand | object] = asyncio.Queue()
         self._lifecycle_task: asyncio.Task[None] | None = None
         self._stopped = asyncio.Event()
 
@@ -173,6 +196,12 @@ class DynamicGateway:
     def profile_servers(self) -> Mapping[str, FastMCP]:
         """Snapshot of every currently-mounted profile's :class:`FastMCP` server."""
         return dict(self._profile_servers)
+
+    @property
+    def config(self) -> GatewayConfig:
+        """The gateway's current shape — a snapshot, safe to read from
+        anywhere (SPEC-301's ``GET /api/gateway/profiles`` reads this)."""
+        return self._config
 
     async def start(self) -> None:
         """Start the background lifecycle task and mount every configured profile."""
@@ -228,6 +257,81 @@ class DynamicGateway:
 
         check_gateway_auth_policy(self._mode, self._profile_servers)
 
+    async def upsert_profile(
+        self,
+        path: str,
+        vault_keys: Sequence[str],
+        *,
+        label: str | None = None,
+        stash: bool = False,
+        auth: TokenVerifier | None = None,
+    ) -> None:
+        """Create a new profile, or fully replace an existing one's shape.
+
+        The runtime profile-editor's create/edit operations (SPEC-301
+        deliverable #2) — unlike :meth:`add_vault` (adds one vault to
+        already-relevant profiles), this replaces the *whole* vault set,
+        label and stash flag for one profile path. ``path`` itself is never
+        edited this way (see :class:`~.config.ProfileConfig`'s docstring
+        for why) — a caller wanting a new URL creates a new profile.
+
+        Args:
+            path: the profile to create, or the existing one to rebuild.
+            vault_keys: every vault this profile should mount, replacing
+                whatever it mounted before (an edit that only adds one
+                vault to an existing list must pass the whole new list).
+            label: the display name; ``None`` clears it back to "use the
+                path".
+            stash: whether this profile also carries the stash tool family.
+            auth: the verifier this path should use for every future
+                rebuild, recorded into ``self._token_verifiers``. Pass this
+                for a genuinely new path if the hub's mode requires auth
+                (:func:`~palaia_hub.auth.policy.check_gateway_auth_policy`
+                refuses an unauthenticated profile in cloud/open, same as
+                at startup). ``None`` leaves an existing path's verifier
+                untouched — the normal case for editing only the vault
+                list of an already-authenticated profile.
+
+        Raises:
+            GatewayConfigError: a vault key in ``vault_keys`` is not
+                mounted at this gateway at all (create the vault first).
+            palaia_hub.auth.policy.AuthPolicyError: the resulting profile
+                would be unauthenticated in cloud/open mode.
+        """
+        async with self._lock:
+            missing = [k for k in vault_keys if k not in self._vault_services]
+            if missing:
+                raise GatewayConfigError(
+                    f"cannot mount profile {path!r}: vault key(s) {missing} are not "
+                    "mounted at this gateway. Fix: create the vault first."
+                )
+            if auth is not None:
+                self._token_verifiers[path] = auth
+            new_profile = ProfileConfig(
+                path=path, label=label, vaults=list(vault_keys), stash=stash
+            )
+            profiles_by_path = {p.path: p for p in self._config.profiles}
+            profiles_by_path[path] = new_profile
+            self._config = self._config.model_copy(
+                update={"profiles": list(profiles_by_path.values())}
+            )
+            await self._request_mount(new_profile)
+        check_gateway_auth_policy(self._mode, self._profile_servers)
+
+    async def remove_profile(self, path: str) -> None:
+        """Unmount ``path`` (SPEC-301's ``DELETE /api/gateway/profiles/{path}``).
+
+        Raises:
+            KeyError: no profile named ``path`` is currently mounted.
+        """
+        async with self._lock:
+            if path not in {p.path for p in self._config.profiles}:
+                raise KeyError(f"no profile {path!r} mounted at this gateway")
+            self._config = self._config.model_copy(
+                update={"profiles": [p for p in self._config.profiles if p.path != path]}
+            )
+            await self._request_unmount(path)
+
     async def _request_mount(self, profile: ProfileConfig) -> None:
         """Build one profile's FastMCP app (plain construction — safe in the
         caller's own task) and hand it to the lifecycle task to actually
@@ -235,13 +339,21 @@ class DynamicGateway:
         auth = self._token_verifiers.get(profile.path)
         middleware = self._profile_middleware.get(profile.path, ())
         server = _build_profile_server(
-            profile, self._config, self._vault_servers, auth, middleware
+            profile, self._config, self._vault_servers, auth, middleware, self._stash_service
         )
         asgi_app = server.http_app(path="/")
         done: asyncio.Future[None] = asyncio.get_running_loop().create_future()
         await self._queue.put(_MountCommand(profile.path, server, asgi_app, done))
         await done
         self._profile_servers[profile.path] = server
+
+    async def _request_unmount(self, path: str) -> None:
+        """Ask the lifecycle task to drop ``path`` from the router. Caller
+        holds ``self._lock``."""
+        done: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+        await self._queue.put(_UnmountCommand(path, done))
+        await done
+        self._profile_servers.pop(path, None)
 
     async def _lifecycle(self) -> None:
         """The one task that ever enters or exits a profile's ASGI lifespan.
@@ -258,6 +370,21 @@ class DynamicGateway:
                 item = await self._queue.get()
                 if item is _STOP:
                     break
+                if isinstance(item, _UnmountCommand):
+                    # No lifespan to enter or exit here — its already-
+                    # entered generation (if any) stays in `stack`,
+                    # unwound only at `aclose`, same deliberate-leak rule
+                    # a rebuild's retired generation follows (class
+                    # docstring). Only the route disappears, atomically.
+                    target = f"/{item.profile_path}"
+                    self.router.routes = [
+                        route
+                        for route in self.router.routes
+                        if getattr(route, "path", None) != target
+                    ]
+                    if not item.done.done():
+                        item.done.set_result(None)
+                    continue
                 command = item
                 assert isinstance(command, _MountCommand)
                 try:

--- a/v3/server/src/palaia_hub/gateway/settings_bridge.py
+++ b/v3/server/src/palaia_hub/gateway/settings_bridge.py
@@ -1,0 +1,175 @@
+"""Bridges the ``config.yaml`` ``gateway:`` section into the gateway's own
+runtime shapes, and back (SPEC-301).
+
+:mod:`palaia_hub.config` defines :class:`~palaia_hub.config.GatewaySettings`
+as a *duplicate*, fastmcp-free schema (see that class's docstring) — this
+module is the one place that converts between it and
+:class:`~.config.GatewayConfig`/:class:`~.config.ProfileConfig`/
+:class:`~.config.VaultMountConfig`, in both directions:
+
+- :func:`apply_vault_overrides` / :func:`resolve_profiles` /
+  :func:`resolve_full_gateway_profiles` — config.yaml → the shapes
+  :func:`palaia_hub.serve.build_production_app` and ``palaia_hub.cli`` hand
+  to the gateway and the OAuth server. Both call sites use the *same*
+  functions, so "which resources exist" (SPEC-301 deliverable #3) is one
+  computation, not two that could drift.
+- :func:`persist_gateway_settings` — the reverse, for the runtime profile
+  CRUD surface (:mod:`palaia_hub.gateway.api`): after a live edit, write the
+  new shape back to ``config.yaml`` using the same surgical, comment-
+  preserving text patch :mod:`palaia_hub.modes.patch` already established.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+import yaml
+
+from ..config import GatewaySettings, HubConfig
+from ..modes.patch import replace_config_section
+from .config import ProfileConfig, VaultMountConfig
+
+
+class GatewaySettingsError(ValueError):
+    """``config.yaml``'s ``gateway:`` section is structurally fine (it is
+    already a valid :class:`~palaia_hub.config.GatewaySettings`) but
+    disagrees with reality — e.g. a profile names a vault key that is not
+    actually registered. Distinct from the :class:`pydantic.ValidationError`
+    the settings model itself already raises for a malformed section.
+    """
+
+
+def apply_vault_overrides(
+    mounts: Sequence[VaultMountConfig], settings: GatewaySettings | None
+) -> list[VaultMountConfig]:
+    """Overlay ``gateway.vaults`` identity overrides onto ``mounts``.
+
+    A mount whose key has no entry in ``settings.vaults`` (or ``settings``
+    is ``None``) passes through unchanged. A field left ``None`` on the
+    override (``name``/``purpose``) keeps the mount's own value; an empty
+    ``tool_renames`` on the override is *not* special-cased — an operator
+    who lists a vault under ``gateway.vaults`` with no ``tool_renames`` at
+    all still gets the default empty dict, same as omitting it entirely.
+    """
+    if settings is None or not settings.vaults:
+        return list(mounts)
+    overrides = {v.key: v for v in settings.vaults}
+    resolved: list[VaultMountConfig] = []
+    for mount in mounts:
+        override = overrides.get(mount.key)
+        if override is None:
+            resolved.append(mount)
+            continue
+        resolved.append(
+            mount.model_copy(
+                update={
+                    "name": override.name if override.name is not None else mount.name,
+                    "purpose": (
+                        override.purpose if override.purpose is not None else mount.purpose
+                    ),
+                    "tool_renames": dict(override.tool_renames),
+                }
+            )
+        )
+    return resolved
+
+
+def resolve_profiles(
+    settings: GatewaySettings | None,
+    vault_keys: Sequence[str],
+    *,
+    default_profile: str,
+) -> list[ProfileConfig]:
+    """The ordinary (non-curator) profiles this hub serves.
+
+    No ``gateway:`` section, or one with an empty ``profiles`` list:
+    today's zero-config default — one profile (``default_profile``) over
+    every vault in ``vault_keys``, or no profiles at all when there are no
+    vaults yet. A populated ``profiles`` list is authoritative instead.
+
+    Raises:
+        GatewaySettingsError: a configured profile names a vault key not in
+            ``vault_keys`` (a vault that either never existed or was
+            renamed/removed since the section was written).
+    """
+    if settings is None or not settings.profiles:
+        if not vault_keys:
+            return []
+        return [ProfileConfig(path=default_profile, vaults=list(vault_keys))]
+
+    known = set(vault_keys)
+    resolved: list[ProfileConfig] = []
+    for profile in settings.profiles:
+        unknown = [v for v in profile.vaults if v not in known]
+        if unknown:
+            raise GatewaySettingsError(
+                f"config.yaml: gateway.profiles[path={profile.path!r}] references "
+                f"vault key(s) {unknown} that are not registered on this hub (it "
+                f"has: {sorted(known) or 'none'}). Fix: create the vault first, or "
+                f"remove it from this profile's `vaults` list in config.yaml."
+            )
+        resolved.append(
+            ProfileConfig(
+                path=profile.path,
+                label=profile.label,
+                vaults=list(profile.vaults),
+                stash=profile.stash,
+            )
+        )
+    return resolved
+
+
+def resolve_full_gateway_profiles(
+    config: HubConfig,
+    vault_keys: Sequence[str],
+    *,
+    default_profile: str,
+) -> list[ProfileConfig]:
+    """:func:`resolve_profiles` plus the curator's own profile, when it runs.
+
+    The one function both ``palaia_hub.cli`` (building the OAuth server,
+    which needs to know every resource up front) and
+    ``palaia_hub.serve.build_production_app`` (building the real gateway)
+    call, so the two never compute a different profile list for the same
+    config (SPEC-301 deliverable #3's "one source of truth").
+    """
+    profiles = resolve_profiles(config.gateway, vault_keys, default_profile=default_profile)
+    if config.curator.enabled and vault_keys:
+        # Deferred import: the curator package pulls in fastmcp, which this
+        # module otherwise has no need for (it only touches config.py's
+        # fastmcp-free settings and gateway.config's plain pydantic models).
+        from ..curator.profile import curator_profile
+
+        profiles = [*profiles, curator_profile(list(vault_keys))]
+    return profiles
+
+
+def render_gateway_section(settings: GatewaySettings) -> str:
+    """Render the ``gateway:`` section body exactly as ``config.yaml``
+    expects it: everything indented two spaces under the header, header
+    itself excluded (:func:`~palaia_hub.modes.patch.replace_config_section`
+    supplies that)."""
+    payload = settings.model_dump(mode="json")
+    dumped = yaml.safe_dump({"gateway": payload}, default_flow_style=False, sort_keys=False)
+    _, _, body = dumped.partition("\n")
+    if body and not body.endswith("\n"):
+        body += "\n"
+    return body or "  vaults: []\n  profiles: []\n"
+
+
+def persist_gateway_settings(path: Path, settings: GatewaySettings) -> None:
+    """Write ``settings`` back to ``config.yaml`` at ``path``, preserving
+    every other line (comments included) exactly as it was — the runtime
+    profile CRUD surface's write-back half (SPEC-301 deliverable #2)."""
+    replace_config_section(path, "gateway", render_gateway_section(settings))
+
+
+__all__ = [
+    "GatewaySettingsError",
+    "apply_vault_overrides",
+    "persist_gateway_settings",
+    "render_gateway_section",
+    "resolve_full_gateway_profiles",
+    "resolve_profiles",
+]

--- a/v3/server/src/palaia_hub/modes/patch.py
+++ b/v3/server/src/palaia_hub/modes/patch.py
@@ -107,6 +107,41 @@ def _patch_nested_section(text: str, section: str, updates: dict[str, Any]) -> s
     return text[:start] + body + text[end:]
 
 
+def replace_config_section(path: Path, section: str, rendered_body: str) -> None:
+    """Replace a whole top-level section's body, preserving every other
+    line — including every comment outside that section — untouched.
+
+    Unlike :func:`patch_config_values` (one flat scalar key at a time),
+    this is for a section whose *value* is itself structured (SPEC-301's
+    ``gateway:`` list of profile/vault objects): PyYAML has no comment-
+    preserving way to patch inside a list, so the whole section is
+    round-tripped as one block instead. ``rendered_body`` is that block's
+    already-rendered text — every line indented, one trailing newline — the
+    same shape :func:`_patch_nested_section` above builds by hand for a
+    flat mapping; a caller with a structured value (e.g.
+    :func:`palaia_hub.gateway.settings_bridge.render_gateway_section`)
+    renders it via ``yaml.safe_dump`` instead.
+
+    A ``section:`` header with no existing body is added if the section is
+    entirely absent; an existing section's body (everything indented under
+    its header, comments included) is replaced outright — a section this
+    function writes is expected to be edited only through the API that
+    calls it, not by hand, so no attempt is made to preserve comments
+    *inside* it, only around it.
+    """
+    text = path.read_text(encoding="utf-8") if path.exists() else ""
+    span = _section_span(text, section)
+    if span is None:
+        if text and not text.endswith("\n"):
+            text += "\n"
+        text += f"{section}:\n{rendered_body}"
+    else:
+        start, end = span
+        text = text[:start] + rendered_body + text[end:]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(path, text)
+
+
 def patch_config_values(path: Path, updates: dict[str, Any]) -> None:
     """Rewrite ``path`` with ``updates`` applied, preserving everything else.
 
@@ -134,4 +169,4 @@ def patch_config_values(path: Path, updates: dict[str, Any]) -> None:
     atomic_write_text(path, text)
 
 
-__all__ = ["patch_config_values"]
+__all__ = ["patch_config_values", "replace_config_section"]

--- a/v3/server/src/palaia_hub/serve.py
+++ b/v3/server/src/palaia_hub/serve.py
@@ -15,8 +15,10 @@ a parallel stand-in of it.
 
 Every vault the registry already knows about gets a real
 :class:`~palaia_hub.index.VaultIndex` opened (SPEC-104's background embed
-worker included) and is mounted under
-:data:`~palaia_hub.dashboard_api.DEFAULT_GATEWAY_PROFILE` on a
+worker included) and is mounted under whichever profile(s)
+``config.yaml``'s ``gateway:`` section names — or the single
+:data:`~palaia_hub.gateway.config.DEFAULT_GATEWAY_PROFILE` profile over
+every vault, when that section is absent (SPEC-301) — on a
 :class:`~palaia_hub.gateway.dynamic.DynamicGateway`. A vault created later,
 through the wizard, is added to that same running gateway by
 :func:`palaia_hub.dashboard_api.build_dashboard_router`'s ``create_vault``
@@ -32,19 +34,21 @@ from typing import Any
 from fastapi import FastAPI
 
 from .app import create_app
-from .auth import TokenStore, build_profile_verifiers
-from .config import HubConfig
-from .curator import curator_profile
-from .curator.wiring import CuratorWiring, build_curator
-from .dashboard_api import DEFAULT_GATEWAY_PROFILE
+from .auth import TokenStore
+from .config import HubConfig, palaia_home
+from .curator.wiring import STASH_FILENAME, CuratorWiring, build_curator
 from .events import EventBus, publish_from_hook
 from .events.schema import HubEventHook
 from .gateway import DynamicGateway, VaultService
-from .gateway.config import GatewayConfig, ProfileConfig, VaultMountConfig
+from .gateway.config import DEFAULT_GATEWAY_PROFILE, GatewayConfig, VaultMountConfig
+from .gateway.settings_bridge import apply_vault_overrides, resolve_full_gateway_profiles
 from .gateway.wiring import EngineVaultService
 from .hooks import HookStore
 from .index import VaultIndex
 from .oauth import AuthorizationServer
+from .oauth.verifier import build_profile_auth
+from .stash.service import StashService
+from .stash.store import StashStore
 from .vault import EventBus as VaultEventBus
 from .vault import VaultEngine, VaultRegistry
 
@@ -64,6 +68,10 @@ class ProductionApp:
     #: ``curator.enabled`` is off. Its scheduler is started and stopped by
     #: the app's own lifespan; its stash handle is closed here.
     curator: CuratorWiring | None = None
+    #: The hub's one stash store (SPEC-202/301), backing both the
+    #: ``/mcp/stash`` tool family and, when the curator is on, its audit
+    #: trail. Closed at shutdown, same as ``registry``/``indexes``.
+    stash_store: StashStore | None = None
 
 
 def _index_event_hook(event_bus: EventBus, vault_key: str) -> HubEventHook:
@@ -137,11 +145,31 @@ async def build_production_app(
             )
         )
 
-    profiles = (
-        [ProfileConfig(path=DEFAULT_GATEWAY_PROFILE, vaults=[m.key for m in mounts])]
-        if mounts
-        else []
+    # SPEC-301: `gateway.vaults` identity overrides, then `gateway.profiles`
+    # (or the zero-config default: one `default` profile over every vault)
+    # plus the curator's own profile when it runs — the *same* resolution
+    # `palaia_hub.cli._maybe_oauth_server` uses to decide which resources
+    # the OAuth server issues tokens for, so the two never disagree about
+    # what this hub serves (deliverable #3's "one source of truth").
+    mounts = apply_vault_overrides(mounts, config.gateway)
+    profiles = resolve_full_gateway_profiles(
+        config, [m.key for m in mounts], default_profile=DEFAULT_GATEWAY_PROFILE
     )
+
+    # One stash for the whole hub (SPEC-202/301): backs the hub-wide
+    # `/mcp/stash` mount, any profile with `stash: true`, and — when the
+    # curator is on — its own audit trail, all through the one store so a
+    # client's `stash_list` and the curator's audit entries never race two
+    # SQLite connections on the same file.
+    # `palaia_home()` (not `Path.cwd()`): the same "PALAIA_HOME env, else
+    # the platform data dir" resolution every other store in this function
+    # already gets from its own constructor (`VaultRegistry`, `TokenStore`,
+    # `HookStore`) — `cli.py`'s `serve()` never passes `home` explicitly, so
+    # falling back to the process's current directory here would put
+    # `stash.db` wherever the daemon happened to be launched from.
+    stash_home = Path(home) if home is not None else palaia_home()
+    stash_store = StashStore(stash_home / STASH_FILENAME)
+    stash_service = StashService(stash_store)
 
     # SPEC-206: the curator gets its own profile over the same vaults —
     # narrowed to seven actions and guarded by its own middleware (see
@@ -156,26 +184,32 @@ async def build_production_app(
             mounts,
             home=home,
             publish=_curator_event_hook(event_bus),
+            stash_service=stash_service,
             subscribe=event_bus.on,
         )
-        profiles.append(curator_profile([m.key for m in mounts]))
 
     gateway_config = GatewayConfig(vaults=mounts, profiles=profiles)
     # `auth_enabled` (config.py): mandatory in cloud/open (already enforced
     # at config-load time), on by default in locked mode too — see that
-    # field's docstring. Building verifiers here, unconditionally on the
-    # flag rather than on `mode`, matches that documented behavior exactly.
-    token_verifiers = (
-        build_profile_verifiers([p.path for p in profiles], token_store)
-        if config.auth_enabled
-        else {}
+    # field's docstring. SPEC-301: combine it with the OAuth server's own
+    # JWT verifier (when one is running) via `build_profile_auth` — a
+    # profile accepts OAuth access tokens *and* SPEC-108 `plt_` tokens at
+    # once, instead of only ever the latter (the gap this closes: before
+    # this SPEC, a hub with `oauth.enabled: true` and `auth_enabled: false`
+    # mounted its gateway with no verifier at all).
+    token_verifiers = build_profile_auth(
+        [p.path for p in profiles],
+        key=oauth_server.key if oauth_server is not None else None,
+        resources=oauth_server.resources if oauth_server is not None else None,
+        token_store=token_store if config.auth_enabled else None,
     )
     dynamic_gateway = DynamicGateway(
         gateway_config,
         vault_services,
         mode=config.mode,
-        token_verifiers=token_verifiers,
+        token_verifiers=token_verifiers,  # type: ignore[arg-type]
         profile_middleware=curator.profile_middleware if curator else None,
+        stash_service=stash_service,
     )
 
     app = create_app(
@@ -187,8 +221,10 @@ async def build_production_app(
         indexes=indexes,
         event_bus=event_bus,
         oauth_server=oauth_server,
+        stash_service=stash_service,
         hook_store=hook_store,
         curator=curator.scheduler if curator else None,
+        curator_wiring=curator,
         home=home,
     )
     return ProductionApp(
@@ -199,6 +235,7 @@ async def build_production_app(
         event_bus=event_bus,
         token_store=token_store,
         curator=curator,
+        stash_store=stash_store,
     )
 
 

--- a/v3/server/tests/curator/scripted.py
+++ b/v3/server/tests/curator/scripted.py
@@ -26,12 +26,24 @@ Script = Callable[[Client, SessionRequest], Awaitable[None]]
 
 @dataclass
 class ScriptedSessionRunner:
-    """Runs ``script`` against ``server`` instead of spawning a model."""
+    """Runs ``script`` against ``server`` instead of spawning a model.
+
+    ``server_factory``, given, is called fresh on every :meth:`run` instead
+    of connecting to the fixed ``server`` object — for a curator profile
+    that gets *rebuilt* under a :class:`~palaia_hub.gateway.dynamic.
+    DynamicGateway` (SPEC-301 deliverable #4: a vault added at runtime
+    swaps in a brand-new profile server), so the scripted runner always
+    talks to whichever generation is current, exactly the way a real
+    session (HTTP, through a URL that always dispatches to the current
+    mount) already does. ``server`` is still required as a fallback/type
+    anchor and stays the only thing every pre-existing caller sets.
+    """
 
     server: FastMCP
     script: Script
     stdout: str = ""
     exit_code: int = 0
+    server_factory: Callable[[], FastMCP] | None = None
     #: Every request this runner was asked to run, in order — so a test can
     #: assert that an empty inbox launched no session at all.
     requests: list[SessionRequest] = field(default_factory=list)
@@ -40,7 +52,8 @@ class ScriptedSessionRunner:
 
     async def run(self, request: SessionRequest) -> SessionResult:
         self.requests.append(request)
-        async with Client(self.server) as client:
+        server = self.server_factory() if self.server_factory is not None else self.server
+        async with Client(server) as client:
             recorder = _RecordingClient(client, self.calls)
             await self.script(recorder, request)  # type: ignore[arg-type]
         return SessionResult(exit_code=self.exit_code, stdout=self.stdout)

--- a/v3/server/tests/curator/test_runtime_join.py
+++ b/v3/server/tests/curator/test_runtime_join.py
@@ -1,0 +1,102 @@
+"""SPEC-301 deliverable #4 — closing SPEC-206's documented gap: a vault
+created at runtime joins the curator profile (and its guard's tool-action
+map) *and* actually gets curated, without a hub restart.
+
+``test_the_guard_survives_a_profile_rebuild`` in ``test_scheduler_and_wiring.py``
+already covers the raw :class:`~palaia_hub.gateway.dynamic.DynamicGateway`
+behavior when *nothing* tells the curator about the new vault (still
+fail-closed, by design — nobody asked it to know). This file is the other
+half: what happens once the caller — :mod:`palaia_hub.dashboard_api`'s
+``create_vault`` handler, in production — actually calls
+:meth:`~palaia_hub.curator.wiring.CuratorWiring.add_vault`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from scripted import ScriptedSessionRunner, ingest_session
+
+from palaia_hub.config import HubConfig
+from palaia_hub.curator.profile import CURATOR_PROFILE_PATH, curator_profile
+from palaia_hub.curator.wiring import build_curator
+from palaia_hub.gateway.config import GatewayConfig, VaultMountConfig
+from palaia_hub.gateway.dynamic import DynamicGateway
+from palaia_hub.gateway.fake_vault import FakeVaultService
+from palaia_hub.gateway.wiring import EngineVaultService
+from palaia_hub.vault import VaultEngine
+
+
+@pytest.mark.anyio
+async def test_runtime_vault_is_curated_without_restart(
+    engine: VaultEngine, vault_mount: VaultMountConfig, tmp_path: Path
+) -> None:
+    hub_config = HubConfig(curator={"enabled": True})
+    session_runner = ScriptedSessionRunner(server=None, script=lambda *_: None)  # type: ignore[arg-type]
+
+    wiring = build_curator(
+        hub_config,
+        {vault_mount.key: engine},
+        [vault_mount],
+        home=tmp_path,
+        session_runner=session_runner,
+        with_stash=False,
+    )
+    gateway = DynamicGateway(
+        GatewayConfig(vaults=[vault_mount], profiles=[curator_profile([vault_mount.key])]),
+        {vault_mount.key: FakeVaultService()},
+        profile_middleware=wiring.profile_middleware,
+    )
+    await gateway.start()
+    # Same trick production's real HTTP transport gets for free: the
+    # scripted runner always talks to whichever profile generation is
+    # *currently* mounted, not the one that existed when it was built.
+    session_runner.server_factory = lambda: gateway.profile_servers[CURATOR_PROFILE_PATH]
+
+    try:
+        # A second vault, created "at runtime" — after the curator and the
+        # gateway both already exist, exactly like the wizard's
+        # `POST /api/vaults` handler creates one mid-flight.
+        personal_root = tmp_path / "personal"
+        personal_root.mkdir()
+        personal_engine = VaultEngine(personal_root, name="personal")
+        await personal_engine.open(purpose="Personal notes.", create=True)
+        personal_mount = VaultMountConfig(
+            key="personal", name="personal", purpose="Personal notes."
+        )
+        # The same real engine backs both the gateway's mounted tool server
+        # and the runner's own verification pass — a fake here would make
+        # the write and the verification look at two different vaults.
+        personal_service = EngineVaultService(personal_engine)
+
+        # The two calls production makes, in the same order
+        # (palaia_hub.dashboard_api.build_dashboard_router's create_vault):
+        # wire the curator first, then mount the vault on the gateway.
+        await wiring.add_vault(personal_engine, personal_mount)
+        await gateway.add_vault(
+            personal_mount, personal_service, profile_paths=[CURATOR_PROFILE_PATH]
+        )
+
+        assert "personal" in wiring.runners
+        session_runner.script = ingest_session(personal_mount.namespace)
+
+        await personal_service.capture(
+            what_it_concerns="the personal vault's rate limit",
+            why_keep="needed to answer a support question later",
+            content="The personal vault's ingest limit is 100 req/min.",
+        )
+
+        report = await wiring.runners["personal"].run_once()
+    finally:
+        await gateway.aclose()
+        await personal_engine.close()
+
+    assert report.records
+    assert report.records[0].outcome == "ingested"
+    # The curator profile's guard now recognizes the runtime-added vault's
+    # tools (previously unmapped and fail-closed) — the ingest session's
+    # write actually landed, not refused.
+    calls = session_runner.calls
+    write_calls = [c for c in calls if c[0] == "personal_memory_write"]
+    assert write_calls and not write_calls[0][2], "the write must not have been refused"

--- a/v3/server/tests/e2e/support/hub_server_dynamic.py
+++ b/v3/server/tests/e2e/support/hub_server_dynamic.py
@@ -47,6 +47,8 @@ async def _run(*, host: str, port: int, home: Path) -> None:
     finally:
         for index in production.indexes.values():
             await index.close()
+        if production.stash_store is not None:
+            production.stash_store.close()
         await production.registry.aclose()
 
 

--- a/v3/server/tests/gateway/test_api.py
+++ b/v3/server/tests/gateway/test_api.py
@@ -1,0 +1,125 @@
+"""Integration tests for the runtime profile-editor REST surface
+(SPEC-301 deliverable #2): ``/api/gateway/profiles``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from fastapi.testclient import TestClient
+
+from palaia_hub.app import create_app
+from palaia_hub.config import HubConfig, config_file_path
+from palaia_hub.gateway.config import GatewayConfig, ProfileConfig, VaultMountConfig
+from palaia_hub.gateway.dynamic import DynamicGateway
+from palaia_hub.gateway.fake_vault import FakeVaultService
+
+
+def _client(tmp_path: Path, *, gateway: DynamicGateway) -> TestClient:
+    app = create_app(HubConfig(), dynamic_gateway=gateway, home=tmp_path)
+    return TestClient(app)
+
+
+def _gateway() -> DynamicGateway:
+    config = GatewayConfig(
+        vaults=[VaultMountConfig(key="work", name="work", purpose="Work vault.")],
+        profiles=[ProfileConfig(path="default", vaults=["work"])],
+    )
+    return DynamicGateway(config, {"work": FakeVaultService()})
+
+
+def test_list_profiles_reports_the_live_shape(tmp_path: Path) -> None:
+    with _client(tmp_path, gateway=_gateway()) as client:
+        response = client.get("/api/gateway/profiles")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body == [
+        {"path": "default", "label": None, "vaults": ["work"], "stash": False, "managed": False}
+    ]
+
+
+def test_create_profile_is_reachable_immediately_and_persisted(tmp_path: Path) -> None:
+    with _client(tmp_path, gateway=_gateway()) as client:
+        response = client.post(
+            "/api/gateway/profiles",
+            json={"path": "personal", "label": "Personal", "vaults": ["work"], "stash": False},
+        )
+        assert response.status_code == 200
+        assert response.json()["label"] == "Personal"
+
+        mcp_response = client.get("/mcp/personal/")
+        assert mcp_response.status_code != 404
+
+    on_disk = yaml.safe_load((config_file_path(tmp_path)).read_text(encoding="utf-8"))
+    profiles = on_disk["gateway"]["profiles"]
+    assert any(p["path"] == "personal" for p in profiles)
+
+
+def test_create_profile_with_unknown_vault_is_refused(tmp_path: Path) -> None:
+    with _client(tmp_path, gateway=_gateway()) as client:
+        response = client.post(
+            "/api/gateway/profiles", json={"path": "personal", "vaults": ["ghost"]}
+        )
+    assert response.status_code == 400
+
+
+def test_create_profile_with_a_duplicate_path_is_refused(tmp_path: Path) -> None:
+    with _client(tmp_path, gateway=_gateway()) as client:
+        response = client.post(
+            "/api/gateway/profiles", json={"path": "default", "vaults": ["work"]}
+        )
+    assert response.status_code == 400
+
+
+def test_update_profile_changes_vaults_and_stash_live(tmp_path: Path) -> None:
+    gateway = _gateway()
+    with _client(tmp_path, gateway=gateway) as client:
+        response = client.patch(
+            "/api/gateway/profiles/default", json={"stash": True, "label": "Everything"}
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["stash"] is True
+        assert body["label"] == "Everything"
+        assert body["vaults"] == ["work"]  # omitted field keeps its value
+
+
+def test_update_profile_cannot_touch_the_curator_profile(tmp_path: Path) -> None:
+    config = GatewayConfig(
+        vaults=[VaultMountConfig(key="work", name="work")],
+        profiles=[ProfileConfig(path="curator", vaults=["work"])],
+    )
+    gateway = DynamicGateway(config, {"work": FakeVaultService()})
+    with _client(tmp_path, gateway=gateway) as client:
+        response = client.patch("/api/gateway/profiles/curator", json={"stash": True})
+    assert response.status_code == 400
+
+
+def test_delete_profile_unmounts_it_and_persists(tmp_path: Path) -> None:
+    config = GatewayConfig(
+        vaults=[VaultMountConfig(key="work", name="work")],
+        profiles=[
+            ProfileConfig(path="default", vaults=["work"]),
+            ProfileConfig(path="personal", vaults=["work"]),
+        ],
+    )
+    gateway = DynamicGateway(config, {"work": FakeVaultService()})
+    with _client(tmp_path, gateway=gateway) as client:
+        response = client.delete("/api/gateway/profiles/personal")
+        assert response.status_code == 204
+
+        mcp_response = client.get("/mcp/personal/")
+        assert mcp_response.status_code == 404
+
+        listing = client.get("/api/gateway/profiles").json()
+        assert {p["path"] for p in listing} == {"default"}
+
+    on_disk = yaml.safe_load((config_file_path(tmp_path)).read_text(encoding="utf-8"))
+    assert {p["path"] for p in on_disk["gateway"]["profiles"]} == {"default"}
+
+
+def test_delete_unknown_profile_is_404(tmp_path: Path) -> None:
+    with _client(tmp_path, gateway=_gateway()) as client:
+        response = client.delete("/api/gateway/profiles/nope")
+    assert response.status_code == 404

--- a/v3/server/tests/gateway/test_dynamic.py
+++ b/v3/server/tests/gateway/test_dynamic.py
@@ -14,9 +14,12 @@ import pytest
 from fastmcp import Client
 
 from palaia_hub.auth.policy import AuthPolicyError
+from palaia_hub.gateway.build import GatewayConfigError
 from palaia_hub.gateway.config import GatewayConfig, ProfileConfig, VaultMountConfig
 from palaia_hub.gateway.dynamic import DynamicGateway
 from palaia_hub.gateway.fake_vault import FakeVaultService
+from palaia_hub.stash.service import StashService
+from palaia_hub.stash.store import StashStore
 
 pytestmark = pytest.mark.anyio
 
@@ -126,5 +129,153 @@ async def test_add_vault_with_a_duplicate_key_raises() -> None:
             FakeVaultService(),
             profile_paths=["default"],
         )
+
+    await gateway.aclose()
+
+
+# ------------------------------------------------------------------ SPEC-301
+
+
+async def test_upsert_profile_creates_a_brand_new_one() -> None:
+    config = GatewayConfig(vaults=[VaultMountConfig(key="work", name="work")])
+    gateway = DynamicGateway(config, {"work": FakeVaultService()})
+    await gateway.start()
+
+    await gateway.upsert_profile("personal", ["work"], label="Personal")
+
+    assert {p.path for p in gateway.config.profiles} == {"personal"}
+    assert gateway.config.profiles[0].label == "Personal"
+    async with Client(gateway.profile_servers["personal"]) as client:
+        names = {t.name for t in await client.list_tools()}
+    assert "work_memory_search" in names
+
+    await gateway.aclose()
+
+
+async def test_upsert_profile_replaces_an_existing_one_shape() -> None:
+    config = GatewayConfig(
+        vaults=[
+            VaultMountConfig(key="work", name="work"),
+            VaultMountConfig(key="personal", name="personal"),
+        ],
+        profiles=[ProfileConfig(path="default", vaults=["work"])],
+    )
+    gateway = DynamicGateway(
+        config, {"work": FakeVaultService(), "personal": FakeVaultService()}
+    )
+    await gateway.start()
+
+    await gateway.upsert_profile("default", ["work", "personal"], stash=True)
+
+    updated = next(p for p in gateway.config.profiles if p.path == "default")
+    assert set(updated.vaults) == {"work", "personal"}
+    assert updated.stash is True
+    async with Client(gateway.profile_servers["default"]) as client:
+        names = {t.name for t in await client.list_tools()}
+    assert "personal_memory_search" in names
+
+    await gateway.aclose()
+
+
+async def test_upsert_profile_with_unknown_vault_raises() -> None:
+    gateway = DynamicGateway(GatewayConfig(), {})
+    await gateway.start()
+
+    with pytest.raises(GatewayConfigError):
+        await gateway.upsert_profile("default", ["nope"])
+
+    await gateway.aclose()
+
+
+async def test_upsert_profile_in_cloud_mode_without_auth_raises() -> None:
+    gateway = DynamicGateway(GatewayConfig(), {}, mode="cloud")
+    await gateway.start()
+
+    with pytest.raises(AuthPolicyError):
+        await gateway.upsert_profile("default", [])
+
+    await gateway.aclose()
+
+
+async def test_remove_profile_unmounts_it() -> None:
+    config = GatewayConfig(
+        vaults=[VaultMountConfig(key="work", name="work")],
+        profiles=[ProfileConfig(path="default", vaults=["work"])],
+    )
+    gateway = DynamicGateway(config, {"work": FakeVaultService()})
+    await gateway.start()
+
+    await gateway.remove_profile("default")
+
+    assert gateway.config.profiles == []
+    assert "default" not in gateway.profile_servers
+    router = gateway.asgi_app
+    assert not any(getattr(r, "path", None) == "/default" for r in router.routes)  # type: ignore[attr-defined]
+
+    await gateway.aclose()
+
+
+async def test_remove_profile_leaves_an_in_flight_session_running() -> None:
+    """The retiring generation's own already-open session keeps answering —
+    same deliberate-leak rule a rebuild's old generation follows."""
+    config = GatewayConfig(
+        vaults=[VaultMountConfig(key="work", name="work")],
+        profiles=[ProfileConfig(path="default", vaults=["work"])],
+    )
+    gateway = DynamicGateway(config, {"work": FakeVaultService()})
+    await gateway.start()
+
+    old_server = gateway.profile_servers["default"]
+    async with Client(old_server) as old_client:
+        await gateway.remove_profile("default")
+        names = {t.name for t in await old_client.list_tools()}
+    assert "work_memory_search" in names
+
+    await gateway.aclose()
+
+
+async def test_remove_profile_unknown_path_raises() -> None:
+    gateway = DynamicGateway(GatewayConfig(), {})
+    await gateway.start()
+
+    with pytest.raises(KeyError):
+        await gateway.remove_profile("nope")
+
+    await gateway.aclose()
+
+
+async def test_profile_with_stash_true_mounts_the_stash_tools_too() -> None:
+    config = GatewayConfig(
+        vaults=[VaultMountConfig(key="work", name="work")],
+        profiles=[ProfileConfig(path="default", vaults=["work"], stash=True)],
+    )
+    stash_service = StashService(StashStore(":memory:"))
+    gateway = DynamicGateway(
+        config, {"work": FakeVaultService()}, stash_service=stash_service
+    )
+    await gateway.start()
+
+    async with Client(gateway.profile_servers["default"]) as client:
+        names = {t.name for t in await client.list_tools()}
+    assert "stash_set" in names
+    assert "work_memory_search" in names
+
+    await gateway.aclose()
+
+
+async def test_profile_with_stash_false_has_no_stash_tools() -> None:
+    config = GatewayConfig(
+        vaults=[VaultMountConfig(key="work", name="work")],
+        profiles=[ProfileConfig(path="default", vaults=["work"])],
+    )
+    stash_service = StashService(StashStore(":memory:"))
+    gateway = DynamicGateway(
+        config, {"work": FakeVaultService()}, stash_service=stash_service
+    )
+    await gateway.start()
+
+    async with Client(gateway.profile_servers["default"]) as client:
+        names = {t.name for t in await client.list_tools()}
+    assert "stash_set" not in names
 
     await gateway.aclose()

--- a/v3/server/tests/gateway/test_settings_bridge.py
+++ b/v3/server/tests/gateway/test_settings_bridge.py
@@ -1,0 +1,159 @@
+"""SPEC-301: config.yaml's ``gateway:`` section ↔ the gateway's own shapes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from palaia_hub.config import (
+    GatewayProfileSettings,
+    GatewaySettings,
+    GatewayVaultSettings,
+    HubConfig,
+)
+from palaia_hub.gateway.config import ProfileConfig, VaultMountConfig
+from palaia_hub.gateway.settings_bridge import (
+    GatewaySettingsError,
+    apply_vault_overrides,
+    persist_gateway_settings,
+    render_gateway_section,
+    resolve_full_gateway_profiles,
+    resolve_profiles,
+)
+
+
+def test_gateway_vault_settings_matches_vault_mount_config_fields() -> None:
+    """config.py's fastmcp-free duplicate must not drift from the shape it
+    stands in for (see ``GatewayVaultSettings``'s docstring)."""
+    assert set(GatewayVaultSettings.model_fields) == set(VaultMountConfig.model_fields)
+
+
+def test_gateway_profile_settings_matches_profile_config_fields() -> None:
+    assert set(GatewayProfileSettings.model_fields) == set(ProfileConfig.model_fields)
+
+
+def test_apply_vault_overrides_none_settings_is_a_no_op() -> None:
+    mounts = [VaultMountConfig(key="work", name="work", purpose="Work.")]
+    assert apply_vault_overrides(mounts, None) == mounts
+
+
+def test_apply_vault_overrides_overlays_matching_keys() -> None:
+    mounts = [
+        VaultMountConfig(key="work", name="work", purpose="Work."),
+        VaultMountConfig(key="home", name="home", purpose="Home."),
+    ]
+    settings = GatewaySettings(
+        vaults=[
+            GatewayVaultSettings(
+                key="work", name="Work Notes", tool_renames={"search": "find"}
+            )
+        ]
+    )
+
+    result = apply_vault_overrides(mounts, settings)
+
+    work = next(m for m in result if m.key == "work")
+    home = next(m for m in result if m.key == "home")
+    assert work.name == "Work Notes"
+    assert work.purpose == "Work."  # untouched (override left purpose unset)
+    assert work.tool_renames == {"search": "find"}
+    assert home.name == "home"  # untouched: no override for this key
+
+
+def test_resolve_profiles_default_when_no_section() -> None:
+    profiles = resolve_profiles(None, ["work", "home"], default_profile="default")
+    assert profiles == [ProfileConfig(path="default", vaults=["work", "home"])]
+
+
+def test_resolve_profiles_default_when_no_vaults_yet() -> None:
+    assert resolve_profiles(None, [], default_profile="default") == []
+
+
+def test_resolve_profiles_uses_configured_shape() -> None:
+    settings = GatewaySettings(
+        profiles=[
+            GatewayProfileSettings(path="alpha", vaults=["work"], stash=True),
+            GatewayProfileSettings(path="beta", vaults=["home"]),
+        ]
+    )
+
+    profiles = resolve_profiles(settings, ["work", "home"], default_profile="default")
+
+    assert [p.path for p in profiles] == ["alpha", "beta"]
+    assert profiles[0].stash is True
+    assert profiles[1].stash is False
+
+
+def test_resolve_profiles_unknown_vault_raises() -> None:
+    settings = GatewaySettings(
+        profiles=[GatewayProfileSettings(path="alpha", vaults=["ghost"])]
+    )
+
+    with pytest.raises(GatewaySettingsError, match="ghost"):
+        resolve_profiles(settings, ["work"], default_profile="default")
+
+
+def test_resolve_full_gateway_profiles_adds_curator_profile_when_enabled() -> None:
+    config = HubConfig(curator={"enabled": True})
+
+    profiles = resolve_full_gateway_profiles(config, ["work"], default_profile="default")
+
+    paths = {p.path for p in profiles}
+    assert paths == {"default", "curator"}
+
+
+def test_resolve_full_gateway_profiles_no_curator_profile_without_vaults() -> None:
+    config = HubConfig(curator={"enabled": True})
+    assert resolve_full_gateway_profiles(config, [], default_profile="default") == []
+
+
+def test_render_and_persist_round_trips(tmp_path: Path) -> None:
+    settings = GatewaySettings(
+        vaults=[GatewayVaultSettings(key="work", tool_renames={"search": "find"})],
+        profiles=[GatewayProfileSettings(path="default", vaults=["work"], stash=True)],
+    )
+    path = tmp_path / "config.yaml"
+    path.write_text("mode: locked\n# a comment that must survive\n", encoding="utf-8")
+
+    persist_gateway_settings(path, settings)
+    text = path.read_text(encoding="utf-8")
+
+    assert "# a comment that must survive" in text
+    reloaded = yaml.safe_load(text)
+    assert reloaded["gateway"]["vaults"][0]["key"] == "work"
+    assert reloaded["gateway"]["profiles"][0]["stash"] is True
+    # Re-parses cleanly as a real HubConfig too.
+    from palaia_hub.config import load_config
+
+    config = load_config(home=tmp_path)
+    assert config.gateway is not None
+    assert config.gateway.profiles[0].path == "default"
+
+
+def test_persist_gateway_settings_replaces_an_existing_section(tmp_path: Path) -> None:
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        "mode: locked\ngateway:\n  vaults: []\n  profiles:\n    - path: old\n      vaults: []\n"
+        "curator:\n  enabled: false\n",
+        encoding="utf-8",
+    )
+
+    persist_gateway_settings(
+        path,
+        GatewaySettings(profiles=[GatewayProfileSettings(path="new", vaults=[])]),
+    )
+    text = path.read_text(encoding="utf-8")
+
+    assert "path: old" not in text
+    assert "path: new" in text
+    # Sections after the one being replaced are untouched.
+    assert "curator:" in text
+    assert "enabled: false" in text
+
+
+def test_render_gateway_section_empty_settings_is_valid_yaml() -> None:
+    body = render_gateway_section(GatewaySettings())
+    parsed = yaml.safe_load(f"gateway:\n{body}")
+    assert parsed == {"gateway": {"vaults": [], "profiles": []}}

--- a/v3/server/tests/modes/test_patch.py
+++ b/v3/server/tests/modes/test_patch.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import yaml
 
 from palaia_hub.config import load_config
-from palaia_hub.modes.patch import patch_config_values
+from palaia_hub.modes.patch import patch_config_values, replace_config_section
 
 
 def test_top_level_key_is_replaced_in_place(tmp_path: Path) -> None:
@@ -98,3 +98,42 @@ def test_boolean_and_null_scalars_render_as_yaml_literals(tmp_path: Path) -> Non
     parsed = yaml.safe_load(text)
     assert parsed["auth_enabled"] is False
     assert parsed["exposure"]["tunnel"] is None
+
+
+def test_replace_config_section_creates_it_when_absent(tmp_path: Path) -> None:
+    path = tmp_path / "config.yaml"
+    path.write_text("mode: locked\n", encoding="utf-8")
+
+    replace_config_section(path, "gateway", "  vaults: []\n  profiles: []\n")
+
+    parsed = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert parsed["gateway"] == {"vaults": [], "profiles": []}
+    assert parsed["mode"] == "locked"
+
+
+def test_replace_config_section_replaces_it_wholesale(tmp_path: Path) -> None:
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        "mode: locked\n"
+        "gateway:\n"
+        "  vaults: []\n"
+        "  profiles:\n"
+        "    - path: old\n"
+        "      vaults: []\n"
+        "curator:\n"
+        "  enabled: false\n",
+        encoding="utf-8",
+    )
+
+    replace_config_section(
+        path, "gateway", "  vaults: []\n  profiles:\n  - path: new\n    vaults: []\n"
+    )
+    text = path.read_text(encoding="utf-8")
+    parsed = yaml.safe_load(text)
+
+    assert parsed["gateway"]["profiles"][0]["path"] == "new"
+    assert "path: old" not in text
+    # Everything outside the section, including the section after it, is
+    # left byte-for-byte alone.
+    assert "curator:\n  enabled: false\n" in text
+    assert "mode: locked\n" in text

--- a/v3/server/tests/oauth/test_gateway_config_spec301.py
+++ b/v3/server/tests/oauth/test_gateway_config_spec301.py
@@ -1,0 +1,142 @@
+"""SPEC-301 acceptance criterion: "OAuth resources follow gateway profiles:
+token minted for a new profile's audience verifies on it e2e; `oauth.profiles`
+in an old config still works but warns."
+
+Unlike ``test_flow_e2e.py`` (which builds its harness by hand, wiring the
+gateway and the OAuth server together itself), this goes through the real
+production path — ``palaia_hub.cli._maybe_oauth_server`` +
+``palaia_hub.serve.build_production_app`` — with a ``config.yaml`` that sets
+**no** ``oauth.profiles`` at all: the whole point is that the AS learns
+which resources exist from the gateway's own ``gateway:`` section.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+from auth._asgi_mcp_client import mcp_client_transport
+from fastmcp import Client
+
+from palaia_hub.cli import _maybe_oauth_server
+from palaia_hub.config import load_config
+from palaia_hub.oauth import provision_machine_client
+from palaia_hub.serve import build_production_app
+from palaia_hub.vault import VaultRegistry
+
+BASE_URL = "https://testserver"
+SCOPES = ("vault:alpha:read", "vault:alpha:write")
+
+
+async def _registered_vault(home: Path, key: str) -> None:
+    registry = VaultRegistry(home)
+    await registry.create(key, home / "vaults" / key, purpose=f"{key} vault.")
+
+
+def _write_config(home: Path) -> None:
+    (home / "config.yaml").write_text(
+        "mode: locked\n"
+        "oauth:\n"
+        "  enabled: true\n"
+        "  issuer: https://testserver\n"
+        "gateway:\n"
+        "  profiles:\n"
+        "    - path: alpha\n"
+        "      vaults: [alpha]\n"
+        "    - path: beta\n"
+        "      vaults: [beta]\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.anyio
+async def test_oauth_resources_follow_gateway_profiles_with_no_oauth_profiles_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # `_maybe_oauth_server` reads the registry via `VaultRegistry()` (no
+    # explicit home, same as `palaia_hub.cli.serve()` itself) — point it at
+    # this test's isolated home the same way the real CLI is pointed at a
+    # real one.
+    monkeypatch.setenv("PALAIA_HOME", str(tmp_path))
+    await _registered_vault(tmp_path, "alpha")
+    await _registered_vault(tmp_path, "beta")
+    _write_config(tmp_path)
+    config = load_config(home=tmp_path, create_if_missing=False)
+    assert config.oauth.profiles == []  # the deprecated field is not set at all
+
+    oauth_server = _maybe_oauth_server(config)
+    assert oauth_server is not None
+    # The AS learned about both profiles from `gateway:`, with no
+    # `oauth.profiles` in sight — deliverable #3's "one source of truth".
+    assert set(oauth_server.resources.profiles) == {"alpha", "beta"}
+
+    production = await build_production_app(config, home=tmp_path, oauth_server=oauth_server)
+    app = production.app
+    try:
+        async with app.router.lifespan_context(app):
+            provisioned = provision_machine_client(
+                oauth_server.store,
+                client_name="ci job",
+                audience=oauth_server.resources.audience("alpha"),
+                scopes=list(SCOPES),
+                now=oauth_server.now(),
+            )
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app), base_url=BASE_URL
+            ) as http:
+                token_response = await http.post(
+                    "/oauth/token",
+                    data={
+                        "grant_type": "client_credentials",
+                        "client_id": provisioned.client.client_id,
+                        "client_secret": provisioned.client_secret,
+                    },
+                )
+                assert token_response.status_code == 200, token_response.text
+                access_token = str(token_response.json()["access_token"])
+
+                # Verifies on the profile it was minted for.
+                transport = mcp_client_transport(
+                    app, f"{BASE_URL}/mcp/alpha/", token=access_token
+                )
+                async with Client(transport) as client:
+                    result = await client.call_tool_mcp(
+                        "alpha_memory_search", {"query": "anything"}
+                    )
+                assert result.isError is not True
+
+                # And is rejected by the other profile (aud isolation) —
+                # both profiles came from the same `gateway:` section, with
+                # no OAuth-specific config naming them individually.
+                rejected = await http.get(
+                    "/mcp/beta/", headers={"Authorization": f"Bearer {access_token}"}
+                )
+                assert rejected.status_code == 401
+    finally:
+        await production.dynamic_gateway.aclose()
+        if production.stash_store is not None:
+            production.stash_store.close()
+        for index in production.indexes.values():
+            await index.close()
+
+
+@pytest.mark.anyio
+async def test_old_oauth_profiles_config_still_works_with_no_gateway_section(
+    tmp_path: Path,
+) -> None:
+    """An old ``config.yaml`` (``oauth.profiles`` set, no vault registered
+    yet, no ``gateway:`` section) still starts the AS — "still works" — but
+    warns that the field is deprecated."""
+    (tmp_path / "config.yaml").write_text(
+        "mode: locked\noauth:\n  enabled: true\n  issuer: https://testserver\n"
+        "  profiles: [legacy]\n",
+        encoding="utf-8",
+    )
+
+    with pytest.warns(DeprecationWarning, match="oauth.profiles"):
+        config = load_config(home=tmp_path, create_if_missing=False)
+
+    oauth_server = _maybe_oauth_server(config)
+    assert oauth_server is not None
+    assert set(oauth_server.resources.profiles) == {"legacy"}

--- a/v3/server/tests/test_config.py
+++ b/v3/server/tests/test_config.py
@@ -264,3 +264,75 @@ def test_an_unknown_recall_key_is_rejected(tmp_path: Path) -> None:
 
     with pytest.raises(ConfigError):
         load_config(home=tmp_path)
+
+
+# --------------------------------------------------------------- SPEC-301
+
+
+def test_no_gateway_section_means_none(tmp_path: Path) -> None:
+    config = load_config(home=tmp_path)
+    assert config.gateway is None
+
+
+def test_gateway_section_parses_vaults_and_profiles(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text(
+        "gateway:\n"
+        "  vaults:\n"
+        "    - key: work\n"
+        "      name: Work\n"
+        "      purpose: Work notes.\n"
+        "      tool_renames:\n"
+        "        search: find\n"
+        "  profiles:\n"
+        "    - path: default\n"
+        "      label: Default\n"
+        "      vaults: [work]\n"
+        "      stash: true\n",
+        encoding="utf-8",
+    )
+
+    config = load_config(home=tmp_path)
+
+    assert config.gateway is not None
+    assert config.gateway.vaults[0].key == "work"
+    assert config.gateway.vaults[0].tool_renames == {"search": "find"}
+    assert config.gateway.profiles[0].path == "default"
+    assert config.gateway.profiles[0].label == "Default"
+    assert config.gateway.profiles[0].vaults == ["work"]
+    assert config.gateway.profiles[0].stash is True
+
+
+def test_gateway_section_rejects_unknown_keys(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text(
+        "gateway:\n  profiles:\n    - path: default\n      renmae: oops\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ConfigError):
+        load_config(home=tmp_path)
+
+
+def test_oauth_profiles_is_deprecated_but_still_parses(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text(
+        "oauth:\n  enabled: true\n  issuer: https://hub.test\n  profiles: [alpha]\n",
+        encoding="utf-8",
+    )
+
+    with pytest.warns(DeprecationWarning, match="oauth.profiles"):
+        config = load_config(home=tmp_path)
+
+    # Honored (parses, does not error) — just no longer read by anything.
+    assert config.oauth.profiles == ["alpha"]
+
+
+def test_oauth_without_profiles_set_warns_nothing(tmp_path: Path) -> None:
+    import warnings
+
+    (tmp_path / "config.yaml").write_text(
+        "oauth:\n  enabled: true\n  issuer: https://hub.test\n", encoding="utf-8"
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        load_config(home=tmp_path)
+    assert not any(issubclass(w.category, DeprecationWarning) for w in caught)

--- a/v3/server/tests/test_dashboard_api_curator_spec301.py
+++ b/v3/server/tests/test_dashboard_api_curator_spec301.py
@@ -1,0 +1,83 @@
+"""SPEC-301 deliverable #4, at the dashboard-router layer: the wizard's
+``POST /api/vaults`` handler actually wires a runtime-created vault into
+the curator (not just the gateway) when one is running.
+
+``tests/curator/test_runtime_join.py`` proves the underlying mechanism end
+to end (a scripted curation session actually curates the new vault); this
+file proves :mod:`palaia_hub.dashboard_api` actually calls it, through the
+same ``create_app``/``build_dashboard_router`` wiring production uses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from palaia_hub.app import create_app
+from palaia_hub.config import HubConfig
+from palaia_hub.curator.middleware import CuratorScopeMiddleware
+from palaia_hub.curator.profile import CURATOR_PROFILE_PATH
+from palaia_hub.curator.wiring import build_curator
+from palaia_hub.gateway.config import GatewayConfig, ProfileConfig, VaultMountConfig
+from palaia_hub.gateway.dynamic import DynamicGateway
+from palaia_hub.gateway.fake_vault import FakeVaultService
+from palaia_hub.vault import VaultEngine, VaultRegistry
+
+
+def test_vault_created_via_the_wizard_joins_the_curator_profile(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    registry = VaultRegistry(home)
+
+    vault_root = home / "vaults" / "work"
+    vault_root.parent.mkdir(parents=True, exist_ok=True)
+    engine = VaultEngine(vault_root, name="work")
+    # `.open()` does no loop-bound background work of its own — safe to run
+    # to completion on a throwaway loop, unlike `DynamicGateway.start()`
+    # below, which must run on the same loop `TestClient` drives.
+    asyncio.run(engine.open(purpose="Work vault.", create=True))
+
+    mount = VaultMountConfig(key="work", name="work", purpose="Work vault.")
+    hub_config = HubConfig(curator={"enabled": True})
+    curator = build_curator(
+        hub_config, {"work": engine}, [mount], home=home, with_stash=False
+    )
+    gateway = DynamicGateway(
+        GatewayConfig(
+            vaults=[mount],
+            profiles=[
+                ProfileConfig(path="default", vaults=["work"]),
+                ProfileConfig(path=CURATOR_PROFILE_PATH, vaults=["work"]),
+            ],
+        ),
+        {"work": FakeVaultService()},
+        profile_middleware=curator.profile_middleware,
+    )
+    # Not started here — `create_app`'s own lifespan (run inside
+    # `TestClient`'s `with` block below) starts it on the loop that will
+    # actually serve requests, which is what its background lifecycle task
+    # must be bound to (see `DynamicGateway`'s own docstring).
+
+    app = create_app(
+        hub_config,
+        vault_registry=registry,
+        dynamic_gateway=gateway,
+        curator_wiring=curator,  # type: ignore[arg-type]
+    )
+    with TestClient(app) as client:
+        response = client.post("/api/vaults", json={"key": "personal", "purpose": "Personal."})
+        assert response.status_code == 200
+
+        # The dashboard's create_vault handler wired the curator too —
+        # SPEC-206's documented gap, closed.
+        assert "personal" in curator.runners  # type: ignore[attr-defined]
+
+        mcp_response = client.get(f"/mcp/{CURATOR_PROFILE_PATH}/")
+        assert mcp_response.status_code != 404
+
+    middleware = curator.profile_middleware[CURATOR_PROFILE_PATH][0]  # type: ignore[index]
+    assert isinstance(middleware, CuratorScopeMiddleware)
+    # The guard's tool-action map recognizes the runtime-added vault's
+    # tools now — previously unmapped and fail-closed until a restart.
+    assert middleware.action_for("personal_memory_write") == "write"

--- a/v3/server/tests/test_serve_gateway_config_spec301.py
+++ b/v3/server/tests/test_serve_gateway_config_spec301.py
@@ -1,0 +1,102 @@
+"""SPEC-301: ``build_production_app`` actually builds the gateway from
+``config.yaml``'s ``gateway:`` section — vault identity overrides
+(including tool renames, sanitized per SPEC-105) and custom profiles — and
+a profile created at runtime through the REST editor survives a restart
+(persisted, then re-resolved from the same file)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+from fastmcp import Client
+
+from palaia_hub.config import load_config
+from palaia_hub.serve import build_production_app
+from palaia_hub.vault import VaultRegistry
+
+BASE_URL = "https://testserver"
+
+
+async def _registered_vault(home: Path, key: str) -> None:
+    registry = VaultRegistry(home)
+    await registry.create(key, home / "vaults" / key, purpose=f"{key} vault.")
+
+
+@pytest.mark.anyio
+async def test_configured_tool_rename_is_applied_and_sanitized(tmp_path: Path) -> None:
+    await _registered_vault(tmp_path, "work")
+    (tmp_path / "config.yaml").write_text(
+        "mode: locked\n"
+        "auth_enabled: false\n"
+        "gateway:\n"
+        "  vaults:\n"
+        "    - key: work\n"
+        "      tool_renames:\n"
+        "        search: find!!\n"  # invalid chars — must be sanitized, not rejected
+        "  profiles:\n"
+        "    - path: default\n"
+        "      vaults: [work]\n",
+        encoding="utf-8",
+    )
+    config = load_config(home=tmp_path, create_if_missing=False)
+
+    production = await build_production_app(config, home=tmp_path)
+    try:
+        async with production.app.router.lifespan_context(production.app):
+            async with Client(production.dynamic_gateway.profile_servers["default"]) as client:
+                names = {t.name for t in await client.list_tools()}
+    finally:
+        await production.dynamic_gateway.aclose()
+        assert production.stash_store is not None
+        production.stash_store.close()
+        for index in production.indexes.values():
+            await index.close()
+
+    # Sanitized (SPEC-105: invalid chars stripped, not a hard error) rather
+    # than the plain `work_memory_search`.
+    assert "work_memory_find" in names
+    assert "work_memory_search" not in names
+
+
+@pytest.mark.anyio
+async def test_a_profile_created_via_rest_survives_a_restart(tmp_path: Path) -> None:
+    await _registered_vault(tmp_path, "work")
+    config = load_config(home=tmp_path)  # zero-config: writes the default template
+
+    production = await build_production_app(config, home=tmp_path)
+    try:
+        async with production.app.router.lifespan_context(production.app):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=production.app), base_url=BASE_URL
+            ) as http:
+                response = await http.post(
+                    "/api/gateway/profiles", json={"path": "personal", "vaults": ["work"]}
+                )
+                assert response.status_code == 200
+    finally:
+        await production.dynamic_gateway.aclose()
+        assert production.stash_store is not None
+        production.stash_store.close()
+        for index in production.indexes.values():
+            await index.close()
+
+    # "Restart": reload config from the same file, rebuild the app fresh.
+    restarted_config = load_config(home=tmp_path, create_if_missing=False)
+    assert restarted_config.gateway is not None
+    assert any(p.path == "personal" for p in restarted_config.gateway.profiles)
+
+    restarted = await build_production_app(restarted_config, home=tmp_path)
+    try:
+        async with restarted.app.router.lifespan_context(restarted.app):
+            assert "personal" in restarted.dynamic_gateway.profile_servers
+            async with Client(restarted.dynamic_gateway.profile_servers["personal"]) as client:
+                names = {t.name for t in await client.list_tools()}
+            assert "work_memory_search" in names
+    finally:
+        await restarted.dynamic_gateway.aclose()
+        assert restarted.stash_store is not None
+        restarted.stash_store.close()
+        for index in restarted.indexes.values():
+            await index.close()

--- a/v3/server/tests/test_serve_stash_spec301.py
+++ b/v3/server/tests/test_serve_stash_spec301.py
@@ -1,0 +1,87 @@
+"""SPEC-301: ``build_production_app`` wires one hub-wide stash, shared by
+the ``/mcp/stash`` tool family and any profile with ``stash: true`` —
+closing a pre-existing gap where production never wired a stash service at
+all (SPEC-202 built the tool family; nothing before this SPEC ever
+constructed one in ``build_production_app``)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastmcp import Client
+
+from palaia_hub.config import load_config
+from palaia_hub.serve import build_production_app
+from palaia_hub.vault import VaultRegistry
+
+sys.path.insert(0, str(Path(__file__).parent / "auth"))
+from _asgi_mcp_client import mcp_client_transport  # noqa: E402
+
+BASE_URL = "https://testserver"
+
+
+async def _registered_vault(home: Path, key: str) -> None:
+    registry = VaultRegistry(home)
+    await registry.create(key, home / "vaults" / key, purpose=f"{key} vault.")
+
+
+@pytest.mark.anyio
+async def test_hub_wide_stash_is_mounted(tmp_path: Path) -> None:
+    config = load_config(home=tmp_path)
+    production = await build_production_app(config, home=tmp_path)
+    try:
+        async with production.app.router.lifespan_context(production.app):
+            transport = mcp_client_transport(production.app, f"{BASE_URL}/mcp/stash/")
+            async with Client(transport) as client:
+                names = {t.name for t in await client.list_tools()}
+        assert "stash_set" in names
+    finally:
+        await production.dynamic_gateway.aclose()
+        assert production.stash_store is not None
+        production.stash_store.close()
+
+
+@pytest.mark.anyio
+async def test_profile_with_stash_true_shares_the_hub_wide_stash(tmp_path: Path) -> None:
+    await _registered_vault(tmp_path, "work")
+    (tmp_path / "config.yaml").write_text(
+        "mode: locked\n"
+        "auth_enabled: false\n"
+        "gateway:\n"
+        "  profiles:\n"
+        "    - path: default\n"
+        "      vaults: [work]\n"
+        "      stash: true\n",
+        encoding="utf-8",
+    )
+    config = load_config(home=tmp_path, create_if_missing=False)
+    production = await build_production_app(config, home=tmp_path)
+    try:
+        async with production.app.router.lifespan_context(production.app):
+            # Set through the profile-mounted copy, read through the
+            # hub-wide `/mcp/stash` mount — same store, so the value
+            # round-trips.
+            profile_transport = mcp_client_transport(
+                production.app, f"{BASE_URL}/mcp/default/"
+            )
+            async with Client(profile_transport) as profile_client:
+                await profile_client.call_tool(
+                    "stash_set", {"namespace": "ns", "key": "k", "value": "v"}
+                )
+
+            stash_transport = mcp_client_transport(production.app, f"{BASE_URL}/mcp/stash/")
+            async with Client(stash_transport) as stash_client:
+                result = await stash_client.call_tool(
+                    "stash_get", {"namespace": "ns", "key": "k"}
+                )
+        assert not result.is_error
+        text = result.content[0].text if result.content else ""  # type: ignore[union-attr]
+        assert "v" in text
+    finally:
+        await production.dynamic_gateway.aclose()
+        assert production.stash_store is not None
+        production.stash_store.close()
+        for index in production.indexes.values():
+            await index.close()


### PR DESCRIPTION
## Summary

Implements SPEC-301: the gateway's shape (profiles, vault mounts, tool
renames, per-profile stash) becomes durable, operator-editable
`config.yaml` configuration instead of code-side assembly, and retires the
three documented Phase-2 bridges/debts it names: `oauth.profiles`, the
"enable OAuth needs a manual config.yaml edit" seam, and the "a
wizard-created vault is not curated until restart" gap.

## Acceptance criteria

- [x] zero-config hub behaves byte-identically to today (golden tools
      snapshot untouched; default profile serves every vault) — verified:
      the full pre-existing suite (1436 tests) passes unchanged.
- [x] a profile created via REST is MCP-reachable without restart and
      survives a restart (persisted to config.yaml)
- [x] OAuth resources follow gateway profiles: token minted for a new
      profile's audience verifies on it e2e; `oauth.profiles` in an old
      config still works but warns
- [x] wizard-created vault: curator curates a capture into it without
      restart (regression test on SPEC-206's documented gap)
- [x] tool renames from config are applied and sanitized (SPEC-105 rules)

## What changed

- `config.py`: new `gateway:` section (`GatewaySettings` /
  `GatewayVaultSettings` / `GatewayProfileSettings`) — duplicated,
  fastmcp-free schema mirroring the gateway's own shapes (same rule as the
  existing curator-command duplication), with a drift test. `oauth.profiles`
  is deprecated (parses, warns, is otherwise ignored) and dropped from the
  fresh template.
- `gateway/config.py`: `ProfileConfig` gains `label` (display name; `path`
  stays permanent/never-renamed — documented why) and `stash` (mount the
  stash tool family inside the profile). `DEFAULT_GATEWAY_PROFILE` moved
  here from `dashboard_api` (its natural home; every resolver imports it).
- `gateway/settings_bridge.py` (new): the one place that resolves
  `config.gateway` + the registered vaults into real `GatewayConfig`
  profiles (`resolve_full_gateway_profiles`), used identically by
  `serve.build_production_app` and `cli._maybe_oauth_server` — one source
  of truth for "what this hub serves." Also the config.yaml write-back
  (`persist_gateway_settings`, via a new `modes.patch.replace_config_section`
  general-purpose helper).
- `gateway/api.py` (new): `/api/gateway/profiles` — GET/POST/PATCH/DELETE,
  applied live to the running `DynamicGateway` and persisted back to
  `config.yaml`. The curator's own profile is protected (400) since it is
  synthesized from `curator.enabled`, not a `gateway.profiles` entry.
- `gateway/dynamic.py`: `DynamicGateway.upsert_profile` /
  `remove_profile` (create/edit/delete a profile live, same rebuild-and-
  swap discipline as `add_vault`), a `config` property, and stash-service
  threading.
- `gateway/build.py`: profiles with `stash: true` also mount the stash
  tool family (unnamespaced) alongside their vaults.
- `serve.py`: `build_production_app` now resolves the gateway from
  `config.gateway` (or the zero-config default), builds one hub-wide
  `StashService`/`StashStore` (shared by `/mcp/stash`, any `stash: true`
  profile, and the curator's audit trail), and wires `build_profile_auth`
  (OAuth JWT + SPEC-108 `plt_` tokens together) into the gateway's
  `token_verifiers` — closing a real gap where a hub with
  `oauth.enabled: true` and `auth_enabled: false` previously mounted its
  MCP profiles with **no verifier at all**.
- `cli.py`: `_maybe_oauth_server`/`_oauth_machine_client` resolve profiles
  from the gateway (via the shared resolver) instead of `oauth.profiles`,
  with a narrow fallback to the deprecated field only when nothing else
  resolves at all (no vaults, no `gateway:` section) — keeps the existing
  CLI test suite's "old config" scenarios working unchanged.
- `curator/`: `CuratorWiring.add_vault` (+ `CuratorScopeMiddleware.
  add_tool_actions`, `CuratorScheduler.add_vault`, and a real mutation-
  during-iteration bug fix in `CuratorScheduler.run_all`) — the mechanism
  that closes SPEC-206's documented "known limitation, deliberately
  fail-closed" gap. `build_curator` accepts an externally-built
  `stash_service` so the curator's audit trail and the hub-wide stash are
  the same store.
- `dashboard_api.py`: `create_vault` now also calls `curator.add_vault`
  and mounts the new vault on the curator profile, when a curator is
  running.
- `events/schema.py` / `docs/events.md`: additive
  `gateway.profile.created/updated/deleted`.

## Honest scope notes / deviations

- **Tool-rename editing is config-only, not a live REST verb.** Deliverable
  #2 says "edit mounts/renames." Editing which vaults a profile mounts is
  fully live (`PATCH /api/gateway/profiles/{path}`). Editing an *already-
  mounted* vault's `tool_renames`/`name`/`purpose` (`gateway.vaults` in
  config.yaml) is declarative only in this PR — it takes effect on the next
  restart, the same way a mode/host change does (`palaia_hub.modes.api`'s
  existing `restart_required` precedent). Rebuilding *every* profile that
  mounts a given vault key live, plus its underlying vault tool server, was
  judged out of scope for this pass; a follow-up can add it as a `PATCH
  /api/gateway/vaults/{key}` route using the same rebuild-and-swap
  machinery. Config-driven renames (a fresh `gateway.vaults` entry applied
  at startup) are fully live-applied and tested end to end.
- **Deliverable #5 (exposure wizard can enable OAuth without a manual
  edit)** is satisfied as a *consequence* of deliverable #3 rather than new
  code: `palaia_hub.modes.api`'s existing `POST /api/mode`
  (`oauth_enabled`/`oauth_issuer`) already covered "set issuer, enable
  flag"; the only manual step was `oauth.profiles`, which is now retired.
  No changes were made to `modes/api.py` itself.
- A vault created at runtime joins the curator profile only when the
  dashboard's wizard is the one creating it (`dashboard_api.create_vault`,
  which now calls both `dynamic_gateway.add_vault` and
  `curator.add_vault`). A vault added straight through
  `DynamicGateway.add_vault` without going through the curator wiring stays
  fail-closed for the curator until restart — unchanged, and still covered
  by the pre-existing `test_the_guard_survives_a_profile_rebuild` test.
- The pre-existing "every vault on the `default` profile" convention for a
  wizard-created vault is unchanged: it does not generalize to "any
  profile configured to mean all vaults" (SPEC-305's job).

## Verification

From `v3/`:

- `uv sync`
- `uv run ruff check server` → all checks passed
- `uv run mypy server/src` → success, no issues found in 131 source files
- `uv run pytest server/tests -q` → 1481 passed, 10 skipped (pre-existing
  baseline was 1436 passed, 10 skipped; net +45 new tests, zero
  regressions, zero changes to any golden snapshot file)

New/changed test files:
`server/tests/test_config.py`, `server/tests/modes/test_patch.py`,
`server/tests/gateway/test_dynamic.py`,
`server/tests/gateway/test_settings_bridge.py` (new),
`server/tests/gateway/test_api.py` (new),
`server/tests/curator/scripted.py`,
`server/tests/curator/test_runtime_join.py` (new),
`server/tests/oauth/test_gateway_config_spec301.py` (new),
`server/tests/test_dashboard_api_curator_spec301.py` (new),
`server/tests/test_serve_stash_spec301.py` (new),
`server/tests/test_serve_gateway_config_spec301.py` (new),
`server/tests/e2e/support/hub_server_dynamic.py`.

## Scope

v3-only (`v3/server`, `v3/docs/events.md`). No v2 root files touched. No
`v3/web` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790162827&installation_model_id=428086&pr_number=239&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F239&signature=9fb33864e403a0a6a26c7b7c0406af3c4be563a9d54c5fba3f521825d287e768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->