### PR TITLE
fix(v3): refuse 'open' mode until the dashboard sign-in exists

### DIFF
--- a/v3/server/src/palaia_hub/config.py
+++ b/v3/server/src/palaia_hub/config.py
@@ -815,6 +815,25 @@ def load_config(home: Path | None = None, *, create_if_missing: bool = True) -> 
     merged: dict[str, Any] = {**file_values, **env_values}
 
     try:
-        return HubConfig.model_validate(merged)
+        config = HubConfig.model_validate(merged)
     except ValidationError as exc:
         raise ConfigError(_format_validation_error(path, exc)) from exc
+    # Issue #242: `open` mode's contract (masterplan mode table) is a PUBLIC
+    # dashboard with mandatory sign-in — and the dashboard's owner sign-in
+    # does not exist yet. Until it does, an operator choosing `open` (here
+    # or via the dashboard's mode endpoint, which enforces the same rule)
+    # would put every admin endpoint — token minting, profile editing, mode
+    # changes, vault contents — on the public internet with no check at all.
+    # Refused at the operator entry points rather than in HubConfig's own
+    # validator, so the mode's internal semantics (rate limiting, policy,
+    # tunnel handling) stay implemented and tested for the SPEC that adds
+    # the admin-session gate and lifts this.
+    if config.mode == "open":
+        raise ConfigError(
+            f"{path}: mode 'open' is not available yet: it makes the dashboard "
+            f"itself public, and the dashboard sign-in that this requires is "
+            f"still being built. Fix: use `mode: cloud` — clients like "
+            f"claude.ai and ChatGPT connect exactly the same way there, only "
+            f"the dashboard stays on your own network."
+        )
+    return config

--- a/v3/server/src/palaia_hub/modes/api.py
+++ b/v3/server/src/palaia_hub/modes/api.py
@@ -83,6 +83,22 @@ class ModeChangeRequest(BaseModel):
 def _dotted_updates(body: ModeChangeRequest) -> dict[str, Any]:
     updates: dict[str, Any] = {}
     if body.mode is not None:
+        # Issue #242: same refusal as config.load_config — `open` makes the
+        # dashboard itself public, and the dashboard sign-in that requires
+        # does not exist yet. Refused at both operator entry points so
+        # neither a config edit nor this endpoint can reach an
+        # unauthenticated public admin surface.
+        if body.mode == "open":
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Fully public isn't available yet: it would make this "
+                    "dashboard reachable from the internet, and the sign-in "
+                    "that requires is still being built. Choose 'Reachable "
+                    "for AI services' instead — claude.ai and ChatGPT "
+                    "connect exactly the same way there."
+                ),
+            )
         updates["mode"] = body.mode
     if body.host is not None:
         updates["host"] = body.host

--- a/v3/server/tests/modes/test_api.py
+++ b/v3/server/tests/modes/test_api.py
@@ -159,7 +159,14 @@ def test_comments_in_config_yaml_survive_a_mode_change(tmp_path: Path) -> None:
 
 
 def test_get_exposure_includes_status_detection_and_checklist(tmp_path: Path) -> None:
-    client = _client(HubConfig(mode="open", auth_enabled=True), tmp_path)
+    # Built directly (not via the persisted-config _client): `open` mode is
+    # refused at load_config until the dashboard sign-in exists (issue
+    # #242), but the exposure semantics stay implemented for the SPEC that
+    # lifts that.
+    from palaia_hub.app import create_app
+
+    app = create_app(HubConfig(mode="open", auth_enabled=True), home=tmp_path)
+    client = TestClient(app)
 
     response = client.get("/api/exposure")
 
@@ -175,7 +182,10 @@ def test_get_exposure_includes_status_detection_and_checklist(tmp_path: Path) ->
 def test_exposure_checklist_reflects_rate_limiting_being_active_in_open_mode(
     tmp_path: Path,
 ) -> None:
-    client = _client(HubConfig(mode="open", auth_enabled=True), tmp_path)
+    # Direct construction — see the previous test's comment (issue #242).
+    from palaia_hub.app import create_app
+
+    client = TestClient(create_app(HubConfig(mode="open", auth_enabled=True), home=tmp_path))
 
     body = client.get("/api/exposure").json()
 

--- a/v3/server/tests/modes/test_api.py
+++ b/v3/server/tests/modes/test_api.py
@@ -212,13 +212,16 @@ def test_tunnel_guidance_scopes_to_mcp_and_oauth_paths_in_cloud_mode(tmp_path: P
     assert "only the MCP endpoint" in body["note"]
 
 
-def test_tunnel_guidance_forwards_everything_in_open_mode(tmp_path: Path) -> None:
-    client = _client(HubConfig(mode="open", auth_enabled=True), tmp_path)
+def test_tunnel_guidance_forwards_everything_in_open_mode() -> None:
+    # Unit-level rather than through a persisted hub: `open` mode is refused
+    # at the operator entry points until the dashboard sign-in exists
+    # (issue #242, test_open_mode_refused.py), but the guidance semantics
+    # stay implemented for the SPEC that lifts that.
+    from palaia_hub.modes.tunnel import tailscale_guidance
 
-    response = client.post("/api/exposure/tunnel", json={"kind": "tailscale"})
+    guidance = tailscale_guidance(mode="open", local_port=8420)
 
-    assert response.status_code == 200
-    assert "including the dashboard" in response.json()["note"]
+    assert "including the dashboard" in guidance.note
 
 
 # ------------------------------------------------------- POST /api/exposure/selftest

--- a/v3/server/tests/modes/test_open_mode_refused.py
+++ b/v3/server/tests/modes/test_open_mode_refused.py
@@ -1,0 +1,35 @@
+"""Issue #242: `open` mode is refused at both operator entry points until
+the dashboard's own sign-in exists (the masterplan mode table makes that
+sign-in mandatory for a public dashboard). HubConfig itself still accepts
+mode="open" so the mode's internal semantics stay implemented and tested."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from palaia_hub.app import create_app
+from palaia_hub.config import ConfigError, HubConfig, load_config
+
+
+def test_load_config_refuses_open_mode(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text(
+        "mode: open\nhost: 0.0.0.0\nauth_enabled: true\n", encoding="utf-8"
+    )
+    with pytest.raises(ConfigError, match="not available yet"):
+        load_config(tmp_path)
+
+
+def test_mode_endpoint_refuses_open_mode(tmp_path: Path) -> None:
+    app = create_app(HubConfig(), home=tmp_path)
+    with TestClient(app) as client:
+        response = client.post("/api/mode", json={"mode": "open"})
+    assert response.status_code == 400
+    assert "isn't available yet" in response.json()["detail"]
+
+
+def test_hub_config_itself_still_models_open_mode() -> None:
+    config = HubConfig(mode="open", auth_enabled=True)
+    assert config.mode == "open"

--- a/v3/server/tests/test_config.py
+++ b/v3/server/tests/test_config.py
@@ -4,6 +4,7 @@ import pytest
 
 from palaia_hub.config import (
     ConfigError,
+    HubConfig,
     RecallSettings,
     config_file_path,
     load_config,

--- a/v3/server/tests/test_config.py
+++ b/v3/server/tests/test_config.py
@@ -36,12 +36,12 @@ def test_file_overrides_defaults(tmp_path: Path) -> None:
 def test_env_overrides_file_which_overrides_defaults(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    (tmp_path / "config.yaml").write_text("mode: cloud\nport: 9000\n", encoding="utf-8")
-    monkeypatch.setenv("PALAIA_MODE", "open")
+    (tmp_path / "config.yaml").write_text("mode: locked\nport: 9000\n", encoding="utf-8")
+    monkeypatch.setenv("PALAIA_MODE", "cloud")
 
     config = load_config(home=tmp_path)
 
-    assert config.mode == "open"  # env wins over file
+    assert config.mode == "cloud"  # env wins over file
     assert config.port == 9000  # file still wins over default (no env override)
 
 
@@ -199,9 +199,10 @@ def test_cloud_mode_with_tailscale_range_host_is_allowed(tmp_path: Path) -> None
 
 
 def test_open_mode_with_wildcard_bind_host_is_allowed(tmp_path: Path) -> None:
-    (tmp_path / "config.yaml").write_text("mode: open\nhost: 0.0.0.0\n", encoding="utf-8")
-
-    config = load_config(home=tmp_path)
+    # HubConfig itself still models the mode's semantics (no bind
+    # restriction); load_config refuses it until the dashboard sign-in
+    # exists (issue #242) — see test_open_mode_refused.py.
+    config = HubConfig(mode="open", host="0.0.0.0", auth_enabled=True)
 
     assert config.mode == "open"
     assert config.host == "0.0.0.0"


### PR DESCRIPTION
## Summary

Issue #242, part 1. The masterplan's mode table defines Open mode as a **public dashboard with mandatory sign-in** — and that sign-in isn't built yet. Until it is, choosing Open would put every admin endpoint (token minting, profile editing, mode changes, vault contents) on the public internet with no check at all.

- `load_config` refuses `mode: open` (config file or `PALAIA_MODE`) with a plain-language message pointing at Cloud mode — claude.ai/ChatGPT connect identically there, only the dashboard stays private.
- The dashboard's mode endpoint refuses the same switch with jargon-free copy.
- `HubConfig` itself still models `open`, so the mode's internal semantics (rate limiting, tunnel guidance, exposure checklist) stay implemented and tested for the SPEC that adds the admin-session gate and lifts this — those tests now exercise the semantics at the unit/direct-construction level instead of through a persisted config.

Part 2 (the real owner-session gate on `/api/*`) stays tracked in #242.

## Verification

```
uv run ruff check server    All checks passed!
uv run mypy server/src      Success (154 files)
uv run pytest server/tests  1593 passed, 15 skipped
```

## Scope

`v3/server/**` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790168623&installation_model_id=428086&pr_number=243&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F243&signature=7e1a7aa4c5396b34845d4b890739458734a24660b6c11bdb8fbb15b4d45990a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->