### PR TITLE
feat(v3): profile editor dashboard screen (SPEC-305)

### DIFF
--- a/v3/server/src/palaia_hub/config.py
+++ b/v3/server/src/palaia_hub/config.py
@@ -554,6 +554,12 @@ class GatewayProfileSettings(BaseModel):
     vaults: list[str] = Field(default_factory=list)
     #: Mount the stash tool family inside this profile too (SPEC-202/301).
     stash: bool = False
+    #: Final (post-namespace) tool names hidden from this profile (SPEC-305
+    #: deliverable #3). See ``palaia_hub.gateway.config.ProfileConfig``.
+    hidden_tools: list[str] = Field(default_factory=list)
+    #: Expose ``find_tool``/``invoke_tool`` instead of the full surface
+    #: (SPEC-305 deliverable #4). See ``ProfileConfig``.
+    semantic_routing: bool = False
 
 
 class GatewaySettings(BaseModel):

--- a/v3/server/src/palaia_hub/gateway/api.py
+++ b/v3/server/src/palaia_hub/gateway/api.py
@@ -43,7 +43,12 @@ from ..events import EventBus, publish_event
 from ..oauth import AuthorizationServer
 from ..oauth.verifier import build_profile_auth
 from .build import GatewayConfigError
-from .config import CURATOR_PROFILE_PATH, ProfileConfig, VaultMountConfig
+from .config import (
+    CURATOR_PROFILE_PATH,
+    DEFAULT_GATEWAY_PROFILE,
+    ProfileConfig,
+    VaultMountConfig,
+)
 from .dynamic import DynamicGateway
 from .naming import sanitize_tool_name
 from .settings_bridge import persist_gateway_settings
@@ -464,6 +469,18 @@ def build_gateway_profiles_router(
     @router.delete("/api/gateway/profiles/{profile_path}", status_code=204)
     async def delete_profile(profile_path: str) -> None:
         _require_editable(profile_path)
+        # SPEC-305 deliverable #5's guardrail, server-side (the UI hides the
+        # control, but an API caller must hit the same wall): the default
+        # profile is what every zero-config client connects to.
+        if profile_path == DEFAULT_GATEWAY_PROFILE:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "the default profile cannot be deleted — it is where "
+                    "clients connect when nothing else is configured. Fix: "
+                    "create another profile and point clients at it instead."
+                ),
+            )
         try:
             await dynamic_gateway.remove_profile(profile_path)
         except KeyError as exc:

--- a/v3/server/src/palaia_hub/gateway/api.py
+++ b/v3/server/src/palaia_hub/gateway/api.py
@@ -24,18 +24,28 @@ from __future__ import annotations
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
+from fastmcp import FastMCP
 from fastmcp.server.auth import AuthProvider
+from fastmcp.server.providers.base import Provider
+from fastmcp.server.transforms.visibility import is_enabled
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 from ..auth.policy import AuthPolicyError
 from ..auth.store import TokenStore
-from ..config import GatewayProfileSettings, GatewaySettings, HubConfig, config_file_path
+from ..config import (
+    GatewayProfileSettings,
+    GatewaySettings,
+    GatewayVaultSettings,
+    HubConfig,
+    config_file_path,
+)
 from ..events import EventBus, publish_event
 from ..oauth import AuthorizationServer
 from ..oauth.verifier import build_profile_auth
 from .build import GatewayConfigError
-from .config import ProfileConfig
+from .config import ProfileConfig, VaultMountConfig
 from .dynamic import DynamicGateway
+from .naming import sanitize_tool_name
 from .settings_bridge import persist_gateway_settings
 
 # Kept as a plain string (not imported from `palaia_hub.curator.profile`):
@@ -54,10 +64,34 @@ class GatewayProfileOut(BaseModel):
     label: str | None
     vaults: list[str]
     stash: bool
+    #: Final (post-namespace) tool names hidden from this profile's own
+    #: surface (SPEC-305 deliverable #3).
+    hidden_tools: list[str]
+    #: ``find_tool``/``invoke_tool`` instead of the full surface (SPEC-305
+    #: deliverable #4). Experimental — off by default.
+    semantic_routing: bool
+    #: How many tools this profile's live ``FastMCP`` instance actually
+    #: answers ``tools/list`` with right now (SPEC-305 deliverable #1's
+    #: "live tool count") — 0 for a profile with no vaults/stash, and
+    #: exactly 2 (``find_tool``/``invoke_tool``) once ``semantic_routing``
+    #: is on, whatever the hidden full surface behind it contains.
+    tool_count: int
     #: The curator's own profile is listed (so the editor can show it) but
     #: every write route below refuses to touch it — see the module
     #: docstring.
     managed: bool
+
+
+class GatewayToolOut(BaseModel):
+    """One tool a profile's mounted surface would offer, for the editor's
+    per-tool visibility checkboxes (SPEC-305 deliverable #3) — ``hidden``
+    ones included, unlike ``tools/list`` itself, which never shows them."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    description: str | None
+    hidden: bool
 
 
 class CreateGatewayProfileRequest(BaseModel):
@@ -71,26 +105,125 @@ class CreateGatewayProfileRequest(BaseModel):
     label: str | None = None
     vaults: list[str] = []
     stash: bool = False
+    hidden_tools: list[str] = []
+    semantic_routing: bool = False
 
 
 class UpdateGatewayProfileRequest(BaseModel):
     """``PATCH /api/gateway/profiles/{path}`` — every field optional; an
-    omitted one keeps its current value. ``vaults``, when given, *replaces*
-    the whole mounted-vault list (there is no separate add/remove verb)."""
+    omitted one keeps its current value. ``vaults``/``hidden_tools``, when
+    given, *replace* the whole list (there is no separate add/remove verb)."""
 
     model_config = ConfigDict(extra="forbid")
 
     label: str | None = None
     vaults: list[str] | None = None
     stash: bool | None = None
+    hidden_tools: list[str] | None = None
+    semantic_routing: bool | None = None
 
 
-def _out(profile: ProfileConfig) -> GatewayProfileOut:
+class RenameSanitizationOut(BaseModel):
+    """One ``tool_renames`` entry whose requested value fell outside the
+    MCP tool-name charset and was sanitized (SPEC-305 acceptance criterion:
+    "invalid names are sanitized with the warning shown")."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    action: str
+    requested: str
+    applied: str
+
+
+class GatewayVaultOut(BaseModel):
+    """One vault's gateway identity, as the editor sees it."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    key: str
+    name: str
+    purpose: str
+    #: Base action name -> desired pre-namespace tool name, exactly as
+    #: stored (not yet sanitized — see ``sanitized``).
+    tool_renames: dict[str, str]
+    #: This vault's mount namespace (``"<name>_memory"``), so the editor
+    #: can show the composed tool name (``f"{namespace}_{action}"``)
+    #: without re-deriving the composition rule itself.
+    namespace: str
+    #: Which ``tool_renames`` entries, if any, will be sanitized once the
+    #: gateway actually builds this vault's tools — computed fresh on
+    #: every read, so it is never stale relative to ``tool_renames``.
+    sanitized: list[RenameSanitizationOut]
+
+
+class UpdateGatewayVaultRequest(BaseModel):
+    """``PATCH /api/gateway/vaults/{vault_key}`` — every field optional; an
+    omitted one keeps its current value. ``tool_renames``, when given,
+    *replaces* the whole mapping."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = None
+    purpose: str | None = None
+    tool_renames: dict[str, str] | None = None
+
+
+async def _introspect_tools(server: FastMCP) -> list[GatewayToolOut]:
+    """Every tool ``server`` would mount, hidden ones included, with their
+    live enabled state.
+
+    Deliberately calls the base :meth:`~fastmcp.server.providers.base.
+    Provider.list_tools` rather than ``server.list_tools()`` (this
+    server's own override): the override already filters out anything a
+    ``Visibility`` transform marked disabled — see
+    ``fastmcp.server.transforms.visibility`` — which is exactly the
+    information a per-tool visibility checkbox needs to *show*, not hide.
+    The base method still applies the same provider-level transforms
+    (namespacing, a profile's ``hidden_tools`` marks); it just skips the
+    final "drop anything disabled" step.
+    """
+    tools = await Provider.list_tools(server)
+    return [
+        GatewayToolOut(name=t.name, description=t.description, hidden=not is_enabled(t))
+        for t in tools
+    ]
+
+
+def _sanitize_renames(tool_renames: dict[str, str]) -> list[RenameSanitizationOut]:
+    warnings: list[RenameSanitizationOut] = []
+    for action, desired in tool_renames.items():
+        result = sanitize_tool_name(desired)
+        if result.changed:
+            warnings.append(
+                RenameSanitizationOut(action=action, requested=desired, applied=result.value)
+            )
+    return warnings
+
+
+def _vault_out(vault: VaultMountConfig) -> GatewayVaultOut:
+    return GatewayVaultOut(
+        key=vault.key,
+        name=vault.name,
+        purpose=vault.purpose,
+        tool_renames=dict(vault.tool_renames),
+        namespace=vault.namespace,
+        sanitized=_sanitize_renames(vault.tool_renames),
+    )
+
+
+async def _out(profile: ProfileConfig, dynamic_gateway: DynamicGateway) -> GatewayProfileOut:
+    server = dynamic_gateway.profile_servers.get(profile.path)
+    tool_count = 0
+    if server is not None:
+        tool_count = sum(1 for t in await _introspect_tools(server) if not t.hidden)
     return GatewayProfileOut(
         path=profile.path,
         label=profile.label,
         vaults=list(profile.vaults),
         stash=profile.stash,
+        hidden_tools=list(profile.hidden_tools),
+        semantic_routing=profile.semantic_routing,
+        tool_count=tool_count,
         managed=profile.path == _CURATOR_PROFILE_PATH,
     )
 
@@ -141,15 +274,31 @@ def build_gateway_profiles_router(
         return providers.get(profile_path)
 
     def _persist() -> None:
-        existing_vaults = config.gateway.vaults if config.gateway is not None else []
+        # Reads the *live* gateway shape (`dynamic_gateway.config`), not the
+        # `config.gateway` snapshot captured when this router was built —
+        # that snapshot never changes, but `dynamic_gateway.config.vaults`
+        # does, via `update_vault_identity` (SPEC-305 deliverable #1's vault
+        # rename route below). Persisting from the live shape is what keeps
+        # a vault-identity edit and a profile edit on one write path,
+        # instead of one clobbering the other's config.yaml section.
         profiles = [
             p for p in dynamic_gateway.config.profiles if p.path != _CURATOR_PROFILE_PATH
         ]
         settings = GatewaySettings(
-            vaults=existing_vaults,
+            vaults=[
+                GatewayVaultSettings(
+                    key=v.key, name=v.name, purpose=v.purpose, tool_renames=dict(v.tool_renames)
+                )
+                for v in dynamic_gateway.config.vaults
+            ],
             profiles=[
                 GatewayProfileSettings(
-                    path=p.path, label=p.label, vaults=list(p.vaults), stash=p.stash
+                    path=p.path,
+                    label=p.label,
+                    vaults=list(p.vaults),
+                    stash=p.stash,
+                    hidden_tools=list(p.hidden_tools),
+                    semantic_routing=p.semantic_routing,
                 )
                 for p in profiles
             ],
@@ -174,7 +323,20 @@ def build_gateway_profiles_router(
 
     @router.get("/api/gateway/profiles", response_model=list[GatewayProfileOut])
     async def list_profiles() -> list[GatewayProfileOut]:
-        return [_out(p) for p in dynamic_gateway.config.profiles]
+        return [await _out(p, dynamic_gateway) for p in dynamic_gateway.config.profiles]
+
+    @router.get(
+        "/api/gateway/profiles/{profile_path}/tools", response_model=list[GatewayToolOut]
+    )
+    async def list_profile_tools(profile_path: str) -> list[GatewayToolOut]:
+        """Every tool this profile's live surface would mount, hidden ones
+        included — the editor's per-tool visibility checkboxes (SPEC-305
+        deliverable #3). A ``semantic_routing`` profile answers with
+        exactly its two router tools: that *is* its live surface."""
+        server = dynamic_gateway.profile_servers.get(profile_path)
+        if server is None:
+            raise HTTPException(status_code=404, detail=f"no profile at path {profile_path!r}")
+        return await _introspect_tools(server)
 
     @router.post("/api/gateway/profiles", response_model=GatewayProfileOut)
     async def create_profile(body: CreateGatewayProfileRequest) -> GatewayProfileOut:
@@ -187,7 +349,14 @@ def build_gateway_profiles_router(
                 "PATCH it instead, or choose a different path.",
             )
         try:
-            ProfileConfig(path=body.path, label=body.label, vaults=body.vaults, stash=body.stash)
+            ProfileConfig(
+                path=body.path,
+                label=body.label,
+                vaults=body.vaults,
+                stash=body.stash,
+                hidden_tools=body.hidden_tools,
+                semantic_routing=body.semantic_routing,
+            )
         except ValidationError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -197,6 +366,8 @@ def build_gateway_profiles_router(
                 body.vaults,
                 label=body.label,
                 stash=body.stash,
+                hidden_tools=body.hidden_tools,
+                semantic_routing=body.semantic_routing,
                 auth=_new_profile_auth(body.path),  # type: ignore[arg-type]
             )
         except GatewayConfigError as exc:
@@ -210,7 +381,7 @@ def build_gateway_profiles_router(
             "gateway.profile.created",
             {"path": result.path, "vaults": list(result.vaults), "stash": result.stash},
         )
-        return _out(result)
+        return await _out(result, dynamic_gateway)
 
     @router.patch("/api/gateway/profiles/{profile_path}", response_model=GatewayProfileOut)
     async def update_profile(
@@ -227,8 +398,23 @@ def build_gateway_profiles_router(
         label = body.label if body.label is not None else current.label
         vaults = body.vaults if body.vaults is not None else list(current.vaults)
         stash = body.stash if body.stash is not None else current.stash
+        hidden_tools = (
+            body.hidden_tools if body.hidden_tools is not None else list(current.hidden_tools)
+        )
+        semantic_routing = (
+            body.semantic_routing
+            if body.semantic_routing is not None
+            else current.semantic_routing
+        )
         try:
-            ProfileConfig(path=profile_path, label=label, vaults=vaults, stash=stash)
+            ProfileConfig(
+                path=profile_path,
+                label=label,
+                vaults=vaults,
+                stash=stash,
+                hidden_tools=hidden_tools,
+                semantic_routing=semantic_routing,
+            )
         except ValidationError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -236,7 +422,13 @@ def build_gateway_profiles_router(
             # `auth=None`: this path already has a verifier from creation
             # (or none, in locked mode) — an edit never changes that.
             await dynamic_gateway.upsert_profile(
-                profile_path, vaults, label=label, stash=stash, auth=None
+                profile_path,
+                vaults,
+                label=label,
+                stash=stash,
+                hidden_tools=hidden_tools,
+                semantic_routing=semantic_routing,
+                auth=None,
             )
         except GatewayConfigError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -249,7 +441,7 @@ def build_gateway_profiles_router(
             "gateway.profile.updated",
             {"path": result.path, "vaults": list(result.vaults), "stash": result.stash},
         )
-        return _out(result)
+        return await _out(result, dynamic_gateway)
 
     @router.delete("/api/gateway/profiles/{profile_path}", status_code=204)
     async def delete_profile(profile_path: str) -> None:
@@ -261,12 +453,61 @@ def build_gateway_profiles_router(
         _persist()
         _publish("gateway.profile.deleted", {"path": profile_path})
 
+    @router.get("/api/gateway/vaults", response_model=list[GatewayVaultOut])
+    async def list_vault_identities() -> list[GatewayVaultOut]:
+        """Every vault's gateway identity (name/purpose/tool_renames), for
+        the profile editor's inline-rename UI (SPEC-305 deliverable #1)."""
+        return [_vault_out(v) for v in dynamic_gateway.config.vaults]
+
+    @router.patch("/api/gateway/vaults/{vault_key}", response_model=GatewayVaultOut)
+    async def update_vault_identity(
+        vault_key: str, body: UpdateGatewayVaultRequest
+    ) -> GatewayVaultOut:
+        """Rename a vault's tools / change its display name or purpose,
+        live and round-tripped to ``config.yaml`` (SPEC-305 deliverable #1,
+        acceptance criterion "rename via UI round-trips to config.yaml and
+        the live gateway"). Every profile that mounts this vault is
+        rebuilt so the new names are reachable with no restart."""
+        try:
+            current = dynamic_gateway.config.vault(vault_key)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+        name = body.name if body.name is not None else current.name
+        purpose = body.purpose if body.purpose is not None else current.purpose
+        tool_renames = (
+            body.tool_renames if body.tool_renames is not None else dict(current.tool_renames)
+        )
+        try:
+            new_vault = VaultMountConfig(
+                key=vault_key, name=name, purpose=purpose, tool_renames=tool_renames
+            )
+        except ValidationError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        try:
+            await dynamic_gateway.update_vault_identity(new_vault)
+        except GatewayConfigError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+        _persist()
+        result = dynamic_gateway.config.vault(vault_key)
+        _publish(
+            "gateway.vault.updated",
+            {"key": result.key, "name": result.name, "tool_renames": dict(result.tool_renames)},
+        )
+        return _vault_out(result)
+
     return router
 
 
 __all__ = [
     "CreateGatewayProfileRequest",
     "GatewayProfileOut",
+    "GatewayToolOut",
+    "GatewayVaultOut",
+    "RenameSanitizationOut",
     "UpdateGatewayProfileRequest",
+    "UpdateGatewayVaultRequest",
     "build_gateway_profiles_router",
 ]

--- a/v3/server/src/palaia_hub/gateway/build.py
+++ b/v3/server/src/palaia_hub/gateway/build.py
@@ -44,6 +44,7 @@ from .apps.review_app import render_review_queue_html
 from .config import GatewayConfig, ProfileConfig
 from .memory_tools import build_vault_server, vault_identity_block
 from .naming import resolve_tool_names
+from .semantic_routing import build_semantic_routing_server
 from .stash_tools import build_stash_server
 from .vault_protocol import VaultService
 
@@ -152,7 +153,24 @@ def _build_profile_server(
     # of the service existing.
     if profile.stash and stash_service is not None:
         server.mount(build_stash_server(stash_service))
+    # `profile.hidden_tools` (SPEC-305 deliverable #3): a global (not
+    # session-scoped) `Provider.disable()` transform on *this profile's own*
+    # `FastMCP` instance — every profile already gets its own instance (the
+    # SPEC-002 finding this module's docstring opens with), so this hides a
+    # tool from exactly this profile's `tools/list` and refuses it on call,
+    # without touching the shared vault tool server another profile might
+    # also mount. `disable()` only ever marks a `model_copy` of the
+    # component (see fastmcp.server.transforms.visibility) — the mounted
+    # vault/stash servers' own tool objects are never mutated.
+    if profile.hidden_tools:
+        server.disable(names=set(profile.hidden_tools))
     _attach_app_resources(server)
+    # `profile.semantic_routing` (SPEC-305 deliverable #4): swap the profile
+    # actually served for a slim `find_tool`/`invoke_tool` router backed by
+    # this full server. Built last, so the router always reflects every
+    # vault/stash/hidden-tool decision already applied above.
+    if profile.semantic_routing:
+        return build_semantic_routing_server(profile, server)
     return server
 
 

--- a/v3/server/src/palaia_hub/gateway/config.py
+++ b/v3/server/src/palaia_hub/gateway/config.py
@@ -125,6 +125,24 @@ class ProfileConfig(BaseModel):
     #: either way — this only decides whether *this* profile's own MCP
     #: connection also carries those five tools.
     stash: bool = False
+    #: Final (post-namespace) tool names to hide from this profile's own
+    #: surface, e.g. ``"work_memory_delete"`` (SPEC-305 deliverable #3): a
+    #: profile can mount a whole vault family yet not expose one of its
+    #: tools. Applied with FastMCP's own global ``Provider.disable()``
+    #: transform on *this profile's* ``FastMCP`` instance (see
+    #: ``gateway/build.py``) — not by mutating the shared vault tool
+    #: server, which every other profile mounting that vault would also
+    #: see. A hidden tool is absent from ``tools/list`` and refused (as
+    #: "unknown tool") on call — never merely unlisted.
+    hidden_tools: list[str] = Field(default_factory=list)
+    #: Expose ``find_tool``/``invoke_tool`` instead of this profile's full
+    #: tool surface (SPEC-305 deliverable #4, MASTERPLAN §5.2): a semantic
+    #: router backed by the profile's own real tool list, for a tool
+    #: collection too large for a client's picker. Off by default and
+    #: marked experimental wherever the dashboard shows it — this changes
+    #: what a connecting client sees, so it is opt-in per profile, not a
+    #: hub-wide setting.
+    semantic_routing: bool = False
 
     @field_validator("path")
     @classmethod

--- a/v3/server/src/palaia_hub/gateway/dynamic.py
+++ b/v3/server/src/palaia_hub/gateway/dynamic.py
@@ -264,6 +264,8 @@ class DynamicGateway:
         *,
         label: str | None = None,
         stash: bool = False,
+        hidden_tools: Sequence[str] = (),
+        semantic_routing: bool = False,
         auth: TokenVerifier | None = None,
     ) -> None:
         """Create a new profile, or fully replace an existing one's shape.
@@ -283,6 +285,13 @@ class DynamicGateway:
             label: the display name; ``None`` clears it back to "use the
                 path".
             stash: whether this profile also carries the stash tool family.
+            hidden_tools: final (post-namespace) tool names this profile
+                should hide (SPEC-305 deliverable #3) — replaces whatever
+                it hid before, same "whole list, not a delta" contract as
+                ``vault_keys``.
+            semantic_routing: whether this profile should expose
+                ``find_tool``/``invoke_tool`` instead of its full surface
+                (SPEC-305 deliverable #4).
             auth: the verifier this path should use for every future
                 rebuild, recorded into ``self._token_verifiers``. Pass this
                 for a genuinely new path if the hub's mode requires auth
@@ -308,7 +317,12 @@ class DynamicGateway:
             if auth is not None:
                 self._token_verifiers[path] = auth
             new_profile = ProfileConfig(
-                path=path, label=label, vaults=list(vault_keys), stash=stash
+                path=path,
+                label=label,
+                vaults=list(vault_keys),
+                stash=stash,
+                hidden_tools=list(hidden_tools),
+                semantic_routing=semantic_routing,
             )
             profiles_by_path = {p.path: p for p in self._config.profiles}
             profiles_by_path[path] = new_profile
@@ -316,6 +330,41 @@ class DynamicGateway:
                 update={"profiles": list(profiles_by_path.values())}
             )
             await self._request_mount(new_profile)
+        check_gateway_auth_policy(self._mode, self._profile_servers)
+
+    async def update_vault_identity(self, vault: VaultMountConfig) -> None:
+        """Replace one already-mounted vault's identity (SPEC-305
+        deliverable #1's inline rename): its display ``name``, ``purpose``,
+        and/or ``tool_renames``, rebuilding that vault's own tool server
+        plus every profile that mounts it — live, no restart.
+
+        ``vault.key`` must already be mounted at this gateway (created via
+        :meth:`add_vault` — this method only ever changes an existing
+        vault's *identity*, never its key or backing service).
+
+        Raises:
+            GatewayConfigError: ``vault.key`` is not mounted at this gateway.
+        """
+        async with self._lock:
+            if vault.key not in self._vault_services:
+                raise GatewayConfigError(
+                    f"cannot update vault identity: {vault.key!r} is not mounted "
+                    "at this gateway."
+                )
+            self._config = self._config.model_copy(
+                update={
+                    "vaults": [
+                        vault if v.key == vault.key else v for v in self._config.vaults
+                    ]
+                }
+            )
+            self._vault_servers[vault.key] = _build_vault_servers(
+                GatewayConfig(vaults=[vault]), {vault.key: self._vault_services[vault.key]}
+            )[vault.key]
+
+            affected = [p for p in self._config.profiles if vault.key in p.vaults]
+            for profile in affected:
+                await self._request_mount(profile)
         check_gateway_auth_policy(self._mode, self._profile_servers)
 
     async def remove_profile(self, path: str) -> None:

--- a/v3/server/src/palaia_hub/gateway/semantic_routing.py
+++ b/v3/server/src/palaia_hub/gateway/semantic_routing.py
@@ -1,0 +1,121 @@
+"""Semantic tool routing (SPEC-305 deliverable #4, MASTERPLAN §5.2): a
+profile can expose ``find_tool``/``invoke_tool`` instead of its full tool
+surface, for a tool collection too large for a client's own picker.
+
+Off by default (:class:`~.config.ProfileConfig.semantic_routing`), and
+marked experimental everywhere the dashboard shows it — this is a real
+change in what a connecting client sees, never a hub-wide default.
+
+:func:`build_semantic_routing_server` is handed the profile's already-fully
+-built ``FastMCP`` instance (every vault mounted, every rename applied,
+every ``hidden_tools`` entry disabled — see ``gateway/build.py``) and wraps
+it: the returned server is what actually gets served under the profile's
+path; the server it wraps is never itself exposed over ASGI, so "the full
+surface is absent" (SPEC-305's acceptance criterion) holds — a client sees
+exactly two tools, backed by the profile's *real* tool list rather than a
+second, hand-maintained copy of it.
+
+The matching in :func:`find_tool` is a plain keyword-overlap score, not an
+embedding search — good enough to point at the right tool by name/
+description overlap, and it needs no extra dependency, network call, or
+index to keep in sync with the profile's actual tools (which can change at
+runtime, see ``gateway/dynamic.py``). A future SPEC can swap the scoring
+function for something smarter without touching the two tools' contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import FastMCP
+from fastmcp.exceptions import NotFoundError, ToolError
+from fastmcp.tools.base import Tool, ToolResult
+
+from .config import ProfileConfig
+
+DEFAULT_FIND_LIMIT = 5
+
+
+def _score(query: str, tool: Tool) -> int:
+    """Plain keyword overlap between ``query`` and a tool's name/description.
+
+    Every query word contributes once per occurrence in the haystack; a
+    query that appears verbatim in the tool's name is boosted heavily, so
+    an exact/near-exact name match (the common case: a client that already
+    half-remembers the tool it wants) always sorts first.
+    """
+    words = [w for w in query.lower().split() if w]
+    if not words:
+        return 0
+    haystack = f"{tool.name} {tool.description or ''}".lower()
+    score = sum(haystack.count(word) for word in words)
+    if query.strip().lower() in tool.name.lower():
+        score += 10
+    return score
+
+
+def build_semantic_routing_server(profile: ProfileConfig, full_server: FastMCP) -> FastMCP:
+    """The ``find_tool``/``invoke_tool`` router served in place of ``full_server``.
+
+    Args:
+        profile: the profile this router is built for (only its ``path``
+            is used, for naming/instructions).
+        full_server: the profile's fully-built ``FastMCP`` instance — every
+            vault/stash tool it would otherwise expose directly. Kept
+            alive by closure; never mounted or served on its own.
+    """
+    router: FastMCP = FastMCP(
+        name=f"palaia-gateway-{profile.path}-router",
+        instructions=(
+            "IDENTITY: this is a tool router, not a memory vault directly. "
+            "It stands in for a large tool collection: call find_tool with "
+            "what you are trying to do, in your own words, to see which "
+            "real tools match; then call invoke_tool with the exact name "
+            "one of those matches returned, and its arguments, to run it. "
+            "The full tool surface is intentionally not listed here."
+        ),
+    )
+
+    @router.tool(
+        name="find_tool",
+        description=(
+            "Search this profile's real tools by plain-language description of what "
+            "you want to do. Returns the closest matches — each with its exact name "
+            "and input schema, ready to pass to invoke_tool."
+        ),
+    )
+    async def find_tool(query: str, limit: int = DEFAULT_FIND_LIMIT) -> ToolResult:
+        tools = await full_server.list_tools()
+        ranked = sorted(tools, key=lambda t: _score(query, t), reverse=True)
+        matches = [t for t in ranked if _score(query, t) > 0][: max(1, limit)]
+        payload = [
+            {
+                "name": t.name,
+                "description": t.description,
+                "input_schema": t.parameters,
+            }
+            for t in matches
+        ]
+        if not payload:
+            text = f"No tool matched {query!r}. This profile exposes {len(tools)} tool(s) in total."
+        else:
+            text = "\n".join(f"- {m['name']}: {m['description']}" for m in payload)
+        return ToolResult(content=text, structured_content={"matches": payload})
+
+    @router.tool(
+        name="invoke_tool",
+        description=(
+            "Call one of this profile's real tools, by the exact name find_tool "
+            "returned, with that tool's arguments."
+        ),
+    )
+    async def invoke_tool(name: str, arguments: dict[str, Any] | None = None) -> ToolResult:
+        try:
+            return await full_server.call_tool(name, arguments or {})
+        except (ToolError, NotFoundError) as exc:
+            return ToolResult(content=str(exc), is_error=True)
+
+    return router
+
+
+__all__ = ["build_semantic_routing_server"]

--- a/v3/server/src/palaia_hub/gateway/settings_bridge.py
+++ b/v3/server/src/palaia_hub/gateway/settings_bridge.py
@@ -115,6 +115,8 @@ def resolve_profiles(
                 label=profile.label,
                 vaults=list(profile.vaults),
                 stash=profile.stash,
+                hidden_tools=list(profile.hidden_tools),
+                semantic_routing=profile.semantic_routing,
             )
         )
     return resolved

--- a/v3/server/tests/gateway/test_api.py
+++ b/v3/server/tests/gateway/test_api.py
@@ -249,3 +249,20 @@ def test_update_vault_identity_unknown_key_is_404(tmp_path: Path) -> None:
     with _client(tmp_path, gateway=_gateway()) as client:
         response = client.patch("/api/gateway/vaults/ghost", json={"name": "x"})
     assert response.status_code == 404
+
+
+def test_delete_default_profile_is_refused_server_side(tmp_path: Path) -> None:
+    """SPEC-305 deliverable #5's guardrail is not UI-only: the API itself
+    refuses to delete the default profile."""
+    config = GatewayConfig(
+        vaults=[VaultMountConfig(key="work", name="work")],
+        profiles=[ProfileConfig(path="default", vaults=["work"])],
+    )
+    gateway = DynamicGateway(config, {"work": FakeVaultService()})
+    with _client(tmp_path, gateway=gateway) as client:
+        response = client.delete("/api/gateway/profiles/default")
+        assert response.status_code == 400
+        assert "cannot be deleted" in response.json()["detail"]
+
+        listing = client.get("/api/gateway/profiles").json()
+        assert {p["path"] for p in listing} == {"default"}

--- a/v3/server/tests/gateway/test_api.py
+++ b/v3/server/tests/gateway/test_api.py
@@ -35,7 +35,16 @@ def test_list_profiles_reports_the_live_shape(tmp_path: Path) -> None:
     assert response.status_code == 200
     body = response.json()
     assert body == [
-        {"path": "default", "label": None, "vaults": ["work"], "stash": False, "managed": False}
+        {
+            "path": "default",
+            "label": None,
+            "vaults": ["work"],
+            "stash": False,
+            "hidden_tools": [],
+            "semantic_routing": False,
+            "tool_count": 15,
+            "managed": False,
+        }
     ]
 
 
@@ -122,4 +131,118 @@ def test_delete_profile_unmounts_it_and_persists(tmp_path: Path) -> None:
 def test_delete_unknown_profile_is_404(tmp_path: Path) -> None:
     with _client(tmp_path, gateway=_gateway()) as client:
         response = client.delete("/api/gateway/profiles/nope")
+    assert response.status_code == 404
+
+
+def test_create_profile_with_hidden_tools_hides_them_live_and_persists(
+    tmp_path: Path,
+) -> None:
+    with _client(tmp_path, gateway=_gateway()) as client:
+        response = client.post(
+            "/api/gateway/profiles",
+            json={
+                "path": "restricted",
+                "vaults": ["work"],
+                "hidden_tools": ["work_memory_delete"],
+            },
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["hidden_tools"] == ["work_memory_delete"]
+        assert body["tool_count"] == 14  # 15 memory-family tools, one hidden
+
+        tools = client.get("/api/gateway/profiles/restricted/tools").json()
+        hidden = {t["name"] for t in tools if t["hidden"]}
+        assert hidden == {"work_memory_delete"}
+
+    on_disk = yaml.safe_load((config_file_path(tmp_path)).read_text(encoding="utf-8"))
+    restricted = next(
+        p for p in on_disk["gateway"]["profiles"] if p["path"] == "restricted"
+    )
+    assert restricted["hidden_tools"] == ["work_memory_delete"]
+
+
+def test_semantic_routing_profile_reports_two_live_tools(tmp_path: Path) -> None:
+    with _client(tmp_path, gateway=_gateway()) as client:
+        response = client.post(
+            "/api/gateway/profiles",
+            json={"path": "routed", "vaults": ["work"], "semantic_routing": True},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["semantic_routing"] is True
+        assert body["tool_count"] == 2
+
+        tools = {t["name"] for t in client.get("/api/gateway/profiles/routed/tools").json()}
+        assert tools == {"find_tool", "invoke_tool"}
+
+
+def test_list_profile_tools_for_unknown_profile_is_404(tmp_path: Path) -> None:
+    with _client(tmp_path, gateway=_gateway()) as client:
+        response = client.get("/api/gateway/profiles/nope/tools")
+    assert response.status_code == 404
+
+
+def test_list_and_update_vault_identity_round_trips_and_applies_live(
+    tmp_path: Path,
+) -> None:
+    with _client(tmp_path, gateway=_gateway()) as client:
+        listing = client.get("/api/gateway/vaults").json()
+        assert listing == [
+            {
+                "key": "work",
+                "name": "work",
+                "purpose": "Work vault.",
+                "tool_renames": {},
+                "namespace": "work_memory",
+                "sanitized": [],
+            }
+        ]
+
+        response = client.patch(
+            "/api/gateway/vaults/work",
+            json={"name": "Work Notes", "tool_renames": {"search": "find"}},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["name"] == "Work Notes"
+        assert body["tool_renames"] == {"search": "find"}
+        assert body["sanitized"] == []
+
+        mcp_tools = client.get("/api/gateway/profiles/default/tools").json()
+        names = {t["name"] for t in mcp_tools}
+        assert "Work_Notes_memory_find" in names
+        assert "Work_Notes_memory_search" not in names
+
+    on_disk = yaml.safe_load((config_file_path(tmp_path)).read_text(encoding="utf-8"))
+    on_disk_vault = on_disk["gateway"]["vaults"][0]
+    assert on_disk_vault["key"] == "work"
+    assert on_disk_vault["name"] == "Work Notes"
+    assert on_disk_vault["tool_renames"] == {"search": "find"}
+
+
+def test_update_vault_identity_sanitizes_invalid_rename_and_reports_it(
+    tmp_path: Path,
+) -> None:
+    with _client(tmp_path, gateway=_gateway()) as client:
+        response = client.patch(
+            "/api/gateway/vaults/work",
+            json={"tool_renames": {"search": "find notes!"}},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        # The raw value round-trips as typed...
+        assert body["tool_renames"] == {"search": "find notes!"}
+        # ...but the response says exactly what will be sanitized to what.
+        assert body["sanitized"] == [
+            {"action": "search", "requested": "find notes!", "applied": "find_notes"}
+        ]
+
+        mcp_tools = {t["name"] for t in client.get("/api/gateway/profiles/default/tools").json()}
+        assert "work_memory_find_notes" in mcp_tools
+
+
+def test_update_vault_identity_unknown_key_is_404(tmp_path: Path) -> None:
+    with _client(tmp_path, gateway=_gateway()) as client:
+        response = client.patch("/api/gateway/vaults/ghost", json={"name": "x"})
     assert response.status_code == 404

--- a/v3/server/tests/gateway/test_build.py
+++ b/v3/server/tests/gateway/test_build.py
@@ -135,3 +135,114 @@ def test_zero_profiles_builds_an_empty_but_valid_gateway() -> None:
     config = GatewayConfig(vaults=[VaultMountConfig(key="work", name="work")], profiles=[])
     gateway = build_gateway(config, {"work": FakeVaultService()})
     assert gateway.mounts == {}
+
+
+# --- SPEC-305 deliverable #3: per-tool visibility within a mounted family --
+
+
+@pytest.mark.anyio
+async def test_hidden_tool_is_absent_from_tools_list() -> None:
+    config = GatewayConfig(
+        vaults=[VaultMountConfig(key="work", name="work")],
+        profiles=[
+            ProfileConfig(path="default", vaults=["work"], hidden_tools=["work_memory_delete"])
+        ],
+    )
+    gateway = build_gateway(config, {"work": FakeVaultService()})
+
+    names = await _tool_names(gateway.profile_servers["default"])
+
+    assert "work_memory_delete" not in names
+    assert "work_memory_search" in names  # every other tool is unaffected
+
+
+@pytest.mark.anyio
+async def test_hidden_tool_is_refused_on_call_not_merely_unlisted() -> None:
+    config = GatewayConfig(
+        vaults=[VaultMountConfig(key="work", name="work")],
+        profiles=[
+            ProfileConfig(path="default", vaults=["work"], hidden_tools=["work_memory_delete"])
+        ],
+    )
+    gateway = build_gateway(config, {"work": FakeVaultService()})
+
+    async with Client(gateway.profile_servers["default"]) as client:
+        with pytest.raises(Exception, match="[Uu]nknown tool"):
+            await client.call_tool("work_memory_delete", {"ref": "anything"})
+
+
+@pytest.mark.anyio
+async def test_hidden_tools_do_not_affect_a_sibling_profile_sharing_the_vault() -> None:
+    """Hiding is per-profile (a global transform on *that profile's own*
+    FastMCP instance), never a mutation of the shared vault tool server —
+    see ``gateway/build.py``'s comment. A second profile mounting the same
+    vault, with no ``hidden_tools`` of its own, still sees everything."""
+    config = GatewayConfig(
+        vaults=[VaultMountConfig(key="work", name="work")],
+        profiles=[
+            ProfileConfig(path="locked", vaults=["work"], hidden_tools=["work_memory_delete"]),
+            ProfileConfig(path="open", vaults=["work"]),
+        ],
+    )
+    gateway = build_gateway(config, {"work": FakeVaultService()})
+
+    open_names = await _tool_names(gateway.profile_servers["open"])
+    assert "work_memory_delete" in open_names
+
+
+# --- SPEC-305 deliverable #4: semantic tool routing -------------------------
+
+
+@pytest.mark.anyio
+async def test_semantic_routing_profile_exposes_only_find_and_invoke_tool() -> None:
+    config = GatewayConfig(
+        vaults=[VaultMountConfig(key="work", name="work")],
+        profiles=[ProfileConfig(path="default", vaults=["work"], semantic_routing=True)],
+    )
+    gateway = build_gateway(config, {"work": FakeVaultService()})
+
+    names = await _tool_names(gateway.profile_servers["default"])
+
+    assert names == {"find_tool", "invoke_tool"}
+
+
+@pytest.mark.anyio
+async def test_semantic_routing_find_tool_finds_and_invoke_tool_invokes() -> None:
+    config = GatewayConfig(
+        vaults=[VaultMountConfig(key="work", name="work", purpose="Work knowledge.")],
+        profiles=[ProfileConfig(path="default", vaults=["work"], semantic_routing=True)],
+    )
+    services = {"work": FakeVaultService()}
+    gateway = build_gateway(config, services)
+
+    async with Client(gateway.profile_servers["default"]) as client:
+        found = await client.call_tool("find_tool", {"query": "work_memory_search"})
+        matches = found.structured_content["matches"]
+        assert any(m["name"] == "work_memory_search" for m in matches)
+
+        result = await client.call_tool(
+            "invoke_tool",
+            {"name": "work_memory_write", "arguments": {"title": "Note", "body": "hello"}},
+        )
+        assert result.is_error is not True
+
+
+@pytest.mark.anyio
+async def test_semantic_routing_hidden_tools_still_apply_before_routing() -> None:
+    config = GatewayConfig(
+        vaults=[VaultMountConfig(key="work", name="work")],
+        profiles=[
+            ProfileConfig(
+                path="default",
+                vaults=["work"],
+                hidden_tools=["work_memory_delete"],
+                semantic_routing=True,
+            )
+        ],
+    )
+    gateway = build_gateway(config, {"work": FakeVaultService()})
+
+    async with Client(gateway.profile_servers["default"]) as client:
+        found = await client.call_tool("find_tool", {"query": "delete"})
+        matches = found.structured_content["matches"]
+        assert not any(m["name"] == "work_memory_delete" for m in matches)

--- a/v3/server/tests/gateway/test_dynamic.py
+++ b/v3/server/tests/gateway/test_dynamic.py
@@ -279,3 +279,75 @@ async def test_profile_with_stash_false_has_no_stash_tools() -> None:
     assert "stash_set" not in names
 
     await gateway.aclose()
+
+
+async def test_upsert_profile_with_hidden_tools_hides_them_live() -> None:
+    config = GatewayConfig(
+        vaults=[VaultMountConfig(key="work", name="work")],
+        profiles=[ProfileConfig(path="default", vaults=["work"])],
+    )
+    gateway = DynamicGateway(config, {"work": FakeVaultService()})
+    await gateway.start()
+
+    await gateway.upsert_profile(
+        "default", ["work"], hidden_tools=["work_memory_delete"]
+    )
+
+    async with Client(gateway.profile_servers["default"]) as client:
+        names = {t.name for t in await client.list_tools()}
+    assert "work_memory_delete" not in names
+    assert "work_memory_search" in names
+
+    await gateway.aclose()
+
+
+async def test_upsert_profile_with_semantic_routing_swaps_the_served_surface() -> None:
+    gateway = DynamicGateway(GatewayConfig(), {})
+    await gateway.start()
+
+    await gateway.add_vault(
+        VaultMountConfig(key="work", name="work"),
+        FakeVaultService(),
+        profile_paths=["default"],
+    )
+    await gateway.upsert_profile("default", ["work"], semantic_routing=True)
+
+    async with Client(gateway.profile_servers["default"]) as client:
+        names = {t.name for t in await client.list_tools()}
+    assert names == {"find_tool", "invoke_tool"}
+
+    await gateway.aclose()
+
+
+async def test_update_vault_identity_renames_tools_live_across_every_profile() -> None:
+    config = GatewayConfig(
+        vaults=[VaultMountConfig(key="work", name="work")],
+        profiles=[
+            ProfileConfig(path="default", vaults=["work"]),
+            ProfileConfig(path="other", vaults=["work"]),
+        ],
+    )
+    gateway = DynamicGateway(config, {"work": FakeVaultService()})
+    await gateway.start()
+
+    await gateway.update_vault_identity(
+        VaultMountConfig(key="work", name="work", tool_renames={"search": "find"})
+    )
+
+    for path in ("default", "other"):
+        async with Client(gateway.profile_servers[path]) as client:
+            names = {t.name for t in await client.list_tools()}
+        assert "work_memory_find" in names
+        assert "work_memory_search" not in names
+
+    await gateway.aclose()
+
+
+async def test_update_vault_identity_unknown_key_raises() -> None:
+    gateway = DynamicGateway(GatewayConfig(), {})
+    await gateway.start()
+
+    with pytest.raises(GatewayConfigError):
+        await gateway.update_vault_identity(VaultMountConfig(key="ghost", name="ghost"))
+
+    await gateway.aclose()

--- a/v3/web/src/lib/api/client.ts
+++ b/v3/web/src/lib/api/client.ts
@@ -153,6 +153,45 @@ export interface CreatedToken {
   token: string;
 }
 
+/** SPEC-305's profile editor — opt-in on the hub (present only when a
+ * `DynamicGateway` is attached to `create_app`, same reasoning as the
+ * types above for why this is hand-written rather than generated). Mirrors
+ * `palaia_hub.gateway.api.GatewayProfileOut`. */
+export interface GatewayProfile {
+  path: string;
+  label: string | null;
+  vaults: string[];
+  stash: boolean;
+  hidden_tools: string[];
+  semantic_routing: boolean;
+  tool_count: number;
+  managed: boolean;
+}
+
+/** `palaia_hub.gateway.api.GatewayToolOut`. */
+export interface GatewayTool {
+  name: string;
+  description: string | null;
+  hidden: boolean;
+}
+
+/** `palaia_hub.gateway.api.RenameSanitizationOut`. */
+export interface RenameSanitization {
+  action: string;
+  requested: string;
+  applied: string;
+}
+
+/** `palaia_hub.gateway.api.GatewayVaultOut`. */
+export interface GatewayVaultIdentity {
+  key: string;
+  name: string;
+  purpose: string;
+  tool_renames: Record<string, string>;
+  namespace: string;
+  sanitized: RenameSanitization[];
+}
+
 /** SPEC-201's webhook management surface — opt-in on the hub (present only
  * when a `hook_store` is given to `create_app`), same reasoning as the
  * token types above for why this is hand-written rather than generated. */
@@ -391,6 +430,41 @@ export const api = {
     getJson<InboxStatus>(`/api/vaults/${vaultKey}/inbox_status`),
   indexStatus: (vaultKey: string) =>
     getJson<IndexStatus>(`/api/vaults/${vaultKey}/index_status`),
+
+  // ---- SPEC-305: the tool-profile editor ----
+  listGatewayProfiles: () => getJson<GatewayProfile[]>("/api/gateway/profiles"),
+  listGatewayProfileTools: (profilePath: string) =>
+    getJson<GatewayTool[]>(`/api/gateway/profiles/${profilePath}/tools`),
+  createGatewayProfile: (body: {
+    path: string;
+    label?: string | null;
+    vaults?: string[];
+    stash?: boolean;
+    hidden_tools?: string[];
+    semantic_routing?: boolean;
+  }) => postJson<GatewayProfile>("/api/gateway/profiles", body),
+  updateGatewayProfile: (
+    profilePath: string,
+    body: {
+      label?: string | null;
+      vaults?: string[];
+      stash?: boolean;
+      hidden_tools?: string[];
+      semantic_routing?: boolean;
+    },
+  ) => patchJson<GatewayProfile>(`/api/gateway/profiles/${profilePath}`, body),
+  deleteGatewayProfile: (profilePath: string) =>
+    fetch(`${API_BASE}/api/gateway/profiles/${profilePath}`, {
+      method: "DELETE",
+    }).then((response) => {
+      if (!response.ok)
+        throw new ApiError("/api/gateway/profiles", response.status, undefined);
+    }),
+  listGatewayVaults: () => getJson<GatewayVaultIdentity[]>("/api/gateway/vaults"),
+  updateGatewayVault: (
+    vaultKey: string,
+    body: { name?: string; purpose?: string; tool_renames?: Record<string, string> },
+  ) => patchJson<GatewayVaultIdentity>(`/api/gateway/vaults/${vaultKey}`, body),
 
   // ---- SPEC-108's token surface, consumed here for "connected clients" ----
   listTokens: () => getJson<TokenInfo[]>("/api/auth/tokens"),

--- a/v3/web/src/routes/Clients.tsx
+++ b/v3/web/src/routes/Clients.tsx
@@ -9,7 +9,7 @@ import { Button } from "../components/Button";
 import { ConnectPanel, formatAge } from "../components/ConnectPanel";
 import { SkillPanel } from "../components/SkillPanel";
 import { useToast } from "../components/Toast";
-import type { TokenInfo } from "../lib/api/client";
+import type { GatewayProfile, TokenInfo } from "../lib/api/client";
 import { api, ApiError } from "../lib/api/client";
 import { CLIENTS, type DownloadClient, type HubMode, type NotYetClient } from "../lib/clients";
 import { CopyIcon, InfoIcon, WarningIcon } from "../shell/icons";
@@ -17,10 +17,18 @@ import { CopyIcon, InfoIcon, WarningIcon } from "../shell/icons";
 /** SPEC-205 deliverable #3: sign-in is turned on and configured — the
  * client's own connector unlocks with the real address filled in, instead
  * of the "not yet" reason. */
-function OAuthReadyCard({ client, issuer }: { client: NotYetClient; issuer: string }) {
+function OAuthReadyCard({
+  client,
+  issuer,
+  profile,
+}: {
+  client: NotYetClient;
+  issuer: string;
+  profile: string;
+}) {
   const toast = useToast();
   const Icon = client.icon;
-  const connect = client.oauthConnect?.(issuer, "default");
+  const connect = client.oauthConnect?.(issuer, profile);
   if (!connect) return null;
   return (
     <div className="card">
@@ -169,6 +177,11 @@ export function Clients() {
   const [tokens, setTokens] = useState<TokenInfo[]>([]);
   const [tokenStoreAvailable, setTokenStoreAvailable] = useState(true);
   const [selectedId, setSelectedId] = useState(CLIENTS[0]!.id);
+  // SPEC-305 deliverable #2: the profile picker every snippet/one-liner/
+  // bundle below renders with. Defaults to "default" and stays there for a
+  // hub with no gateway attached (the 404 case) or exactly one profile.
+  const [profiles, setProfiles] = useState<GatewayProfile[]>([]);
+  const [selectedProfile, setSelectedProfile] = useState("default");
 
   useEffect(() => {
     let cancelled = false;
@@ -199,6 +212,21 @@ export function Clients() {
         if (!cancelled && err instanceof ApiError && err.status === 404) {
           setTokenStoreAvailable(false);
         }
+      });
+    api
+      .listGatewayProfiles()
+      .then((list) => {
+        if (cancelled) return;
+        setProfiles(list);
+        // Keep whatever is already selected if it still exists; otherwise
+        // fall back to "default" (or the only profile there is).
+        setSelectedProfile((current) =>
+          list.some((p) => p.path === current) ? current : list[0]?.path ?? "default",
+        );
+      })
+      .catch(() => {
+        // No gateway attached, or the route 404s — every card below just
+        // keeps using "default", same as before this picker existed.
       });
     return () => {
       cancelled = true;
@@ -270,6 +298,26 @@ export function Clients() {
         </div>
       </div>
       <div className="stack">
+        {profiles.length > 1 ? (
+          <div className="row row--wrap" style={{ gap: 8, alignItems: "baseline" }}>
+            <label className="t-xs t-muted" htmlFor="connect-profile-picker">
+              Tool profile for {selected.name}
+            </label>
+            <select
+              id="connect-profile-picker"
+              className="input"
+              style={{ maxWidth: 220 }}
+              value={selectedProfile}
+              onChange={(event) => setSelectedProfile(event.target.value)}
+            >
+              {profiles.map((p) => (
+                <option key={p.path} value={p.path}>
+                  {p.label ?? p.path} ({p.tool_count} tools)
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : null}
         {!tokenStoreAvailable ? (
           <div className="card">
             <div className="card__body">
@@ -286,14 +334,15 @@ export function Clients() {
           <ConnectPanel
             key={selected.id}
             client={selected}
+            defaultProfile={selectedProfile}
             onTokenIssued={(info) =>
               setTokens((prev) => [...prev.filter((t) => t.id !== info.id), info])
             }
           />
         ) : selected.kind === "download" ? (
-          <DownloadCard key={selected.id} client={selected} profile="default" />
+          <DownloadCard key={selected.id} client={selected} profile={selectedProfile} />
         ) : oauthIssuer && selected.oauthConnect ? (
-          <OAuthReadyCard client={selected} issuer={oauthIssuer} />
+          <OAuthReadyCard client={selected} issuer={oauthIssuer} profile={selectedProfile} />
         ) : (
           <NotYetCard client={selected} mode={mode} />
         )}

--- a/v3/web/src/routes/ToolProfiles.test.tsx
+++ b/v3/web/src/routes/ToolProfiles.test.tsx
@@ -1,0 +1,240 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ToastProvider } from "../components/Toast";
+import type { GatewayProfile, GatewayTool, GatewayVaultIdentity, VaultSummary } from "../lib/api/client";
+import { api, ApiError } from "../lib/api/client";
+import { ToolProfiles } from "./ToolProfiles";
+
+const NOT_MOUNTED = new ApiError("/api/gateway/profiles", 404, undefined);
+
+const WORK_VAULT: VaultSummary = {
+  key: "work",
+  purpose: "Work knowledge.",
+  path: "/vaults/work",
+  writable: true,
+  note_count: 3,
+};
+
+const DEFAULT_PROFILE: GatewayProfile = {
+  path: "default",
+  label: null,
+  vaults: ["work"],
+  stash: false,
+  hidden_tools: [],
+  semantic_routing: false,
+  tool_count: 15,
+  managed: false,
+};
+
+const CURATOR_PROFILE: GatewayProfile = {
+  path: "curator",
+  label: null,
+  vaults: ["work"],
+  stash: false,
+  hidden_tools: [],
+  semantic_routing: false,
+  tool_count: 15,
+  managed: true,
+};
+
+const WORK_TOOLS: GatewayTool[] = [
+  { name: "work_memory_search", description: "Search the work vault.", hidden: false },
+  { name: "work_memory_delete", description: "Delete a note.", hidden: false },
+];
+
+const WORK_VAULT_IDENTITY: GatewayVaultIdentity = {
+  key: "work",
+  name: "work",
+  purpose: "Work knowledge.",
+  tool_renames: {},
+  namespace: "work_memory",
+  sanitized: [],
+};
+
+function mount() {
+  return render(
+    <ToastProvider>
+      <ToolProfiles />
+    </ToastProvider>,
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ToolProfiles screen (SPEC-305)", () => {
+  it("degrades gracefully when no gateway is attached", async () => {
+    vi.spyOn(api, "listGatewayProfiles").mockRejectedValue(NOT_MOUNTED);
+    vi.spyOn(api, "listGatewayVaults").mockResolvedValue([]);
+    vi.spyOn(api, "listVaults").mockResolvedValue([]);
+
+    mount();
+
+    expect(
+      await screen.findByText(/no gateway attached/i),
+    ).toBeInTheDocument();
+  });
+
+  it("lists the live tool count for each profile", async () => {
+    vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([DEFAULT_PROFILE]);
+    vi.spyOn(api, "listGatewayVaults").mockResolvedValue([WORK_VAULT_IDENTITY]);
+    vi.spyOn(api, "listVaults").mockResolvedValue([WORK_VAULT]);
+
+    mount();
+
+    expect(await screen.findByText("default")).toBeInTheDocument();
+    expect(screen.getByText("15 tools")).toBeInTheDocument();
+  });
+
+  it("shows the curator profile as managed, with no edit/delete controls", async () => {
+    vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([CURATOR_PROFILE]);
+    vi.spyOn(api, "listGatewayVaults").mockResolvedValue([WORK_VAULT_IDENTITY]);
+    vi.spyOn(api, "listVaults").mockResolvedValue([WORK_VAULT]);
+
+    mount();
+
+    expect(await screen.findByText(/managed elsewhere/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^edit$/i })).not.toBeInTheDocument();
+  });
+
+  it("creates a profile through the form", async () => {
+    const listSpy = vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([]);
+    vi.spyOn(api, "listGatewayVaults").mockResolvedValue([WORK_VAULT_IDENTITY]);
+    vi.spyOn(api, "listVaults").mockResolvedValue([WORK_VAULT]);
+    const createSpy = vi.spyOn(api, "createGatewayProfile").mockResolvedValue({
+      ...DEFAULT_PROFILE,
+      path: "codex",
+      tool_count: 15,
+    });
+
+    mount();
+    await screen.findByText(/no tool profiles yet/i);
+
+    fireEvent.click(screen.getByRole("button", { name: /new tool profile/i }));
+    fireEvent.change(screen.getByLabelText(/address segment/i), {
+      target: { value: "Codex!" },
+    });
+    fireEvent.click(screen.getByLabelText("work"));
+    listSpy.mockResolvedValue([{ ...DEFAULT_PROFILE, path: "codex" }]);
+    fireEvent.click(screen.getByRole("button", { name: /^create$/i }));
+
+    await waitFor(() =>
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ path: "codex", vaults: ["work"] }),
+      ),
+    );
+  });
+
+  it("edits a profile's hidden tools and saves them", async () => {
+    vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([DEFAULT_PROFILE]);
+    vi.spyOn(api, "listGatewayVaults").mockResolvedValue([WORK_VAULT_IDENTITY]);
+    vi.spyOn(api, "listVaults").mockResolvedValue([WORK_VAULT]);
+    vi.spyOn(api, "listGatewayProfileTools").mockResolvedValue(WORK_TOOLS);
+    const updateSpy = vi.spyOn(api, "updateGatewayProfile").mockResolvedValue({
+      ...DEFAULT_PROFILE,
+      hidden_tools: ["work_memory_delete"],
+    });
+
+    mount();
+    fireEvent.click(await screen.findByRole("button", { name: /^edit$/i }));
+
+    const deleteCheckbox = await screen.findByText("work_memory_delete");
+    fireEvent.click(deleteCheckbox.closest("label")!.querySelector("input")!);
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() =>
+      expect(updateSpy).toHaveBeenCalledWith(
+        "default",
+        expect.objectContaining({ hidden_tools: ["work_memory_delete"] }),
+      ),
+    );
+  });
+
+  it("cannot delete the default profile", async () => {
+    vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([DEFAULT_PROFILE]);
+    vi.spyOn(api, "listGatewayVaults").mockResolvedValue([WORK_VAULT_IDENTITY]);
+    vi.spyOn(api, "listVaults").mockResolvedValue([WORK_VAULT]);
+
+    mount();
+
+    expect(await screen.findByText(/cannot delete the default profile/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^delete$/i })).not.toBeInTheDocument();
+  });
+
+  it("renames a vault's tool and reports a sanitized value", async () => {
+    vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([DEFAULT_PROFILE]);
+    vi.spyOn(api, "listVaults").mockResolvedValue([WORK_VAULT]);
+    const listVaultsSpy = vi
+      .spyOn(api, "listGatewayVaults")
+      .mockResolvedValue([WORK_VAULT_IDENTITY]);
+    vi.spyOn(api, "updateGatewayVault").mockResolvedValue({
+      ...WORK_VAULT_IDENTITY,
+      tool_renames: { search: "find_notes" },
+      sanitized: [{ action: "search", requested: "find notes!", applied: "find_notes" }],
+    });
+
+    mount();
+    await screen.findByText(/vault tool names/i);
+
+    fireEvent.change(screen.getByPlaceholderText("search"), {
+      target: { value: "find notes!" },
+    });
+    listVaultsSpy.mockResolvedValue([
+      { ...WORK_VAULT_IDENTITY, tool_renames: { search: "find_notes" } },
+    ]);
+    fireEvent.click(screen.getByRole("button", { name: /save renames/i }));
+
+    expect(await screen.findByText(/was not a valid tool name/i)).toBeInTheDocument();
+  });
+});
+
+/**
+ * SPEC-305 acceptance criterion: "jargon lint on the screen's copy; Lume
+ * tokens only" — same scoping as `Automations.test.tsx`/`Exposure.test.tsx`'s
+ * own lints: headings, buttons, badges, options, and field labels never
+ * carry a protocol name, acronym, or implementation word.
+ */
+describe("ToolProfiles screen copy — no jargon in the surface (system.md §3 rule 0)", () => {
+  const BANNED = [
+    /\bjson\b/i,
+    /\basgi\b/i,
+    /\brest\b/i,
+    /\burl\b/i,
+    /\bapi\b/i,
+    /\bhttp\b/i,
+    /\bnamespace\b/i,
+    /\bfastmcp\b/i,
+    /\bmcp\b/i,
+  ];
+
+  it("no heading, button, badge, option, or field label uses an implementation word", async () => {
+    vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([DEFAULT_PROFILE]);
+    vi.spyOn(api, "listGatewayVaults").mockResolvedValue([WORK_VAULT_IDENTITY]);
+    vi.spyOn(api, "listVaults").mockResolvedValue([WORK_VAULT]);
+    vi.spyOn(api, "listGatewayProfileTools").mockResolvedValue(WORK_TOOLS);
+
+    mount();
+    await screen.findByText("default");
+    fireEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+    await screen.findByText("work_memory_search");
+
+    const controls = [
+      ...screen.queryAllByRole("heading"),
+      ...screen.queryAllByRole("button"),
+      ...screen.queryAllByRole("option"),
+      ...Array.from(
+        document.querySelectorAll(".badge, .card__title, .card__subject, .field__label"),
+      ),
+    ];
+
+    expect(controls.length).toBeGreaterThan(5);
+    for (const element of controls) {
+      const text = element.textContent ?? "";
+      for (const pattern of BANNED) {
+        expect(text).not.toMatch(pattern);
+      }
+    }
+  });
+});

--- a/v3/web/src/routes/ToolProfiles.tsx
+++ b/v3/web/src/routes/ToolProfiles.tsx
@@ -1,0 +1,678 @@
+/**
+ * SPEC-305: the "Tool profiles" screen — MASTERPLAN §5.2's per-client
+ * profiles ("Codex gets memory only; Claude Desktop gets everything") as a
+ * screen, not a YAML exercise. Everything here reads and writes SPEC-301's
+ * REST surface (`/api/gateway/profiles`, `/api/gateway/vaults`) — this
+ * screen adds no second write path of its own.
+ */
+import { useEffect, useState } from "react";
+
+import {
+  Badge,
+  Button,
+  Card,
+  CardBody,
+  CardFoot,
+  CardHead,
+  EmptyState,
+  LabeledInput,
+  SwitchRow,
+  useToast,
+} from "../components";
+import type {
+  GatewayProfile,
+  GatewayTool,
+  GatewayVaultIdentity,
+  VaultSummary,
+} from "../lib/api/client";
+import { api, ApiError } from "../lib/api/client";
+import { CopyIcon, InfoIcon, ToolsIcon, WarningIcon } from "../shell/icons";
+
+// The eight base actions every vault's memory-tool family carries, and the
+// only ones a rename applies to (`palaia_hub.gateway.vault_protocol.
+// MEMORY_TOOL_ACTIONS`) — mirrored here as a literal list rather than
+// fetched, since it is a closed, versioned set the server itself treats as
+// stable API surface (a new action needs its own SPEC either way).
+const RENAMEABLE_ACTIONS = [
+  "search",
+  "read",
+  "write",
+  "edit",
+  "move",
+  "delete",
+  "list",
+  "recent_activity",
+] as const;
+
+/** Mirrors `palaia_hub.gateway.naming.sanitize_tool_name` for an *inline*
+ * preview only — the server's own sanitization (returned in
+ * `GatewayVaultIdentity.sanitized` after a save) is always the source of
+ * truth; this just avoids a round-trip for the common case of typing. */
+function previewSanitize(raw: string): string {
+  let value = raw.replace(/[^a-zA-Z0-9_]+/g, "_").replace(/^_+|_+$/g, "");
+  if (/^[0-9]/.test(value)) value = `t_${value}`;
+  return value || "tool";
+}
+
+function sanitizeProfilePath(raw: string): string {
+  const lowered = raw.toLowerCase().replace(/[^a-z0-9-_]+/g, "-");
+  return lowered.replace(/^-+|-+$/g, "") || "profile";
+}
+
+function describeError(err: unknown): string {
+  if (err instanceof ApiError) {
+    const body = err.body as { detail?: string } | undefined;
+    if (body?.detail) return body.detail;
+    return `The hub answered ${err.status}.`;
+  }
+  return "Could not reach the hub.";
+}
+
+function ToolVisibilityList({
+  tools,
+  hidden,
+  onToggle,
+}: {
+  tools: GatewayTool[];
+  hidden: Set<string>;
+  onToggle: (name: string, visible: boolean) => void;
+}) {
+  if (tools.length === 0) {
+    return <p className="t-xs t-muted">No tools yet — add a vault first.</p>;
+  }
+  return (
+    <div className="stack stack--2">
+      {tools.map((tool) => (
+        <label key={tool.name} className="row" style={{ gap: 8, alignItems: "flex-start" }}>
+          <input
+            type="checkbox"
+            checked={!hidden.has(tool.name)}
+            onChange={(event) => onToggle(tool.name, event.target.checked)}
+          />
+          <span className="stack stack--1">
+            <span className="t-sm t-mono">{tool.name}</span>
+            {tool.description ? (
+              <span className="t-xs t-muted">{tool.description.split("\n")[0]}</span>
+            ) : null}
+          </span>
+        </label>
+      ))}
+    </div>
+  );
+}
+
+function ProfileEditForm({
+  profile,
+  vaults,
+  onSaved,
+  onCancel,
+}: {
+  profile: GatewayProfile;
+  vaults: VaultSummary[];
+  onSaved: () => void;
+  onCancel: () => void;
+}) {
+  const toast = useToast();
+  const [label, setLabel] = useState(profile.label ?? "");
+  const [selectedVaults, setSelectedVaults] = useState<Set<string>>(new Set(profile.vaults));
+  const [stash, setStash] = useState(profile.stash);
+  const [semanticRouting, setSemanticRouting] = useState(profile.semantic_routing);
+  const [tools, setTools] = useState<GatewayTool[] | null>(null);
+  const [hidden, setHidden] = useState<Set<string>>(new Set(profile.hidden_tools));
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .listGatewayProfileTools(profile.path)
+      .then((list) => {
+        if (!cancelled) setTools(list);
+      })
+      .catch(() => {
+        if (!cancelled) setTools([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [profile.path]);
+
+  function toggleVault(key: string, on: boolean) {
+    setSelectedVaults((prev) => {
+      const next = new Set(prev);
+      if (on) next.add(key);
+      else next.delete(key);
+      return next;
+    });
+  }
+
+  function toggleTool(name: string, visible: boolean) {
+    setHidden((prev) => {
+      const next = new Set(prev);
+      if (visible) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  }
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    try {
+      await api.updateGatewayProfile(profile.path, {
+        label: label.trim() || null,
+        vaults: [...selectedVaults],
+        stash,
+        hidden_tools: [...hidden],
+        semantic_routing: semanticRouting,
+      });
+      toast.show(`${profile.path} saved.`);
+      onSaved();
+    } catch (err) {
+      setError(describeError(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <CardBody className="stack stack--4">
+      <LabeledInput
+        label="Display name"
+        placeholder={profile.path}
+        hint="Cosmetic only — the address stays the same."
+        value={label}
+        onChange={(event) => setLabel(event.target.value)}
+      />
+
+      <div className="stack stack--2">
+        <span className="field__label">Vaults this profile can see</span>
+        <div className="stack stack--2">
+          {vaults.map((vault) => (
+            <label key={vault.key} className="row" style={{ gap: 8 }}>
+              <input
+                type="checkbox"
+                checked={selectedVaults.has(vault.key)}
+                onChange={(event) => toggleVault(vault.key, event.target.checked)}
+              />
+              <span className="t-sm">{vault.key}</span>
+              {vault.purpose ? <span className="t-xs t-muted">— {vault.purpose}</span> : null}
+            </label>
+          ))}
+          {vaults.length === 0 ? (
+            <span className="t-xs t-muted">No vaults exist yet.</span>
+          ) : null}
+        </div>
+      </div>
+
+      <SwitchRow
+        label="Also carry the built-in stash tools"
+        consequence="Five extra tools: a small shared key/value scratchpad, not tied to any vault."
+        checked={stash}
+        onChange={setStash}
+      />
+
+      <SwitchRow
+        label="Semantic tool routing (experimental)"
+        consequence="For very large tool collections: this client sees only find_tool and invoke_tool instead of the full list above, and searches by plain language to find the real tool to run."
+        checked={semanticRouting}
+        onChange={setSemanticRouting}
+      />
+
+      <div className="stack stack--2">
+        <span className="field__label">Per-tool visibility</span>
+        <p className="t-xs t-muted">
+          Uncheck a tool to mount its vault without exposing that one action. A hidden tool
+          disappears from this client&rsquo;s tool list entirely — it is not just tucked away.
+        </p>
+        {tools === null ? (
+          <p className="t-xs t-muted">Loading…</p>
+        ) : (
+          <ToolVisibilityList tools={tools} hidden={hidden} onToggle={toggleTool} />
+        )}
+      </div>
+
+      {error ? <p className="field__error">{error}</p> : null}
+
+      <div className="row row--wrap">
+        <Button variant="primary" onClick={save} disabled={saving}>
+          {saving ? "Saving…" : "Save"}
+        </Button>
+        <Button variant="ghost" onClick={onCancel} disabled={saving}>
+          Cancel
+        </Button>
+      </div>
+    </CardBody>
+  );
+}
+
+function DeleteProfileControl({
+  profile,
+  onDeleted,
+}: {
+  profile: GatewayProfile;
+  onDeleted: () => void;
+}) {
+  const toast = useToast();
+  const [confirming, setConfirming] = useState(false);
+  const isDefault = profile.path === "default";
+
+  if (isDefault) {
+    return (
+      <span className="t-xs t-subtle" title="Every client that has not chosen a profile lands here — palaia keeps at least one profile around.">
+        Cannot delete the default profile
+      </span>
+    );
+  }
+
+  if (!confirming) {
+    return (
+      <Button variant="risk" size="sm" onClick={() => setConfirming(true)}>
+        Delete
+      </Button>
+    );
+  }
+
+  return (
+    <div className="stack stack--2" style={{ alignItems: "flex-end" }}>
+      <span className="t-xs t-muted" style={{ textAlign: "right" }}>
+        Any client connected at this address stops working immediately, and its token becomes
+        useless. This cannot be undone.
+      </span>
+      <div className="row" style={{ gap: 6 }}>
+        <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>
+          Never mind
+        </Button>
+        <Button
+          variant="risk"
+          size="sm"
+          onClick={() =>
+            api
+              .deleteGatewayProfile(profile.path)
+              .then(() => {
+                toast.show(`${profile.path} deleted.`);
+                onDeleted();
+              })
+              .catch((err) => toast.show(describeError(err)))
+          }
+        >
+          Yes, delete it
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ProfileCard({
+  profile,
+  vaults,
+  onChanged,
+}: {
+  profile: GatewayProfile;
+  vaults: VaultSummary[];
+  onChanged: () => void;
+}) {
+  const toast = useToast();
+  const [editing, setEditing] = useState(false);
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  const url = `${origin}/mcp/${profile.path}`;
+
+  return (
+    <Card>
+      <CardHead
+        title={profile.label ?? profile.path}
+        meta={`${profile.tool_count} tool${profile.tool_count === 1 ? "" : "s"}`}
+      />
+      <CardBody className="stack stack--3">
+        <div className="row row--wrap" style={{ gap: 6 }}>
+          {profile.managed ? <Badge variant="info">curator — managed elsewhere</Badge> : null}
+          {profile.semantic_routing ? <Badge variant="warn">semantic routing</Badge> : null}
+          {profile.stash ? <Badge variant="neutral">stash</Badge> : null}
+          {profile.vaults.length === 0 ? (
+            <span className="t-xs t-muted">No vaults mounted.</span>
+          ) : (
+            profile.vaults.map((v) => (
+              <span className="chip" key={v}>
+                {v}
+              </span>
+            ))
+          )}
+        </div>
+        <div className="snippet snippet--wrap">
+          <code>{url}</code>
+          <Button
+            size="sm"
+            onClick={() =>
+              navigator.clipboard.writeText(url).then(() => toast.show("Address copied."))
+            }
+          >
+            <CopyIcon className="icon--sm" />
+            Copy
+          </Button>
+        </div>
+
+        {profile.managed ? (
+          <p className="t-xs t-muted">
+            The curator&rsquo;s profile is edited through <code>curator:</code> settings, not
+            here — see Settings.
+          </p>
+        ) : editing ? (
+          <ProfileEditForm
+            profile={profile}
+            vaults={vaults}
+            onSaved={() => {
+              setEditing(false);
+              onChanged();
+            }}
+            onCancel={() => setEditing(false)}
+          />
+        ) : null}
+      </CardBody>
+      {profile.managed ? null : (
+        <CardFoot>
+          <div className="row" style={{ justifyContent: "space-between", width: "100%" }}>
+            {editing ? (
+              <span className="t-xs t-subtle">Editing above.</span>
+            ) : (
+              <Button size="sm" onClick={() => setEditing(true)}>
+                Edit
+              </Button>
+            )}
+            <DeleteProfileControl profile={profile} onDeleted={onChanged} />
+          </div>
+        </CardFoot>
+      )}
+    </Card>
+  );
+}
+
+function CreateProfileCard({
+  vaults,
+  existingPaths,
+  onCreated,
+}: {
+  vaults: VaultSummary[];
+  existingPaths: Set<string>;
+  onCreated: () => void;
+}) {
+  const toast = useToast();
+  const [open, setOpen] = useState(false);
+  const [path, setPath] = useState("");
+  const [label, setLabel] = useState("");
+  const [selectedVaults, setSelectedVaults] = useState<Set<string>>(new Set());
+  const [stash, setStash] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!open) {
+    return (
+      <Button variant="primary" onClick={() => setOpen(true)}>
+        New tool profile
+      </Button>
+    );
+  }
+
+  const cleanPath = sanitizeProfilePath(path);
+  const pathTaken = existingPaths.has(cleanPath);
+
+  function toggleVault(key: string, on: boolean) {
+    setSelectedVaults((prev) => {
+      const next = new Set(prev);
+      if (on) next.add(key);
+      else next.delete(key);
+      return next;
+    });
+  }
+
+  async function create() {
+    if (!cleanPath || pathTaken) return;
+    setCreating(true);
+    setError(null);
+    try {
+      await api.createGatewayProfile({
+        path: cleanPath,
+        label: label.trim() || null,
+        vaults: [...selectedVaults],
+        stash,
+      });
+      toast.show(`${cleanPath} created.`);
+      setOpen(false);
+      setPath("");
+      setLabel("");
+      setSelectedVaults(new Set());
+      setStash(false);
+      onCreated();
+    } catch (err) {
+      setError(describeError(err));
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHead title="new tool profile" />
+      <CardBody className="stack stack--3">
+        <LabeledInput
+          label="Address segment"
+          hint={`Becomes /mcp/${cleanPath || "…"} — cannot be changed later; create a new profile instead.`}
+          value={path}
+          onChange={(event) => setPath(event.target.value)}
+          invalid={pathTaken}
+        />
+        {pathTaken ? <p className="field__error">A profile at this address already exists.</p> : null}
+        <LabeledInput
+          label="Display name"
+          placeholder={cleanPath}
+          value={label}
+          onChange={(event) => setLabel(event.target.value)}
+        />
+        <div className="stack stack--2">
+          <span className="field__label">Vaults</span>
+          {vaults.map((vault) => (
+            <label key={vault.key} className="row" style={{ gap: 8 }}>
+              <input
+                type="checkbox"
+                checked={selectedVaults.has(vault.key)}
+                onChange={(event) => toggleVault(vault.key, event.target.checked)}
+              />
+              <span className="t-sm">{vault.key}</span>
+            </label>
+          ))}
+        </div>
+        <SwitchRow
+          label="Also carry the built-in stash tools"
+          checked={stash}
+          onChange={setStash}
+        />
+        {error ? <p className="field__error">{error}</p> : null}
+        <div className="row row--wrap">
+          <Button
+            variant="primary"
+            onClick={create}
+            disabled={creating || !cleanPath || pathTaken}
+          >
+            {creating ? "Creating…" : "Create"}
+          </Button>
+          <Button variant="ghost" onClick={() => setOpen(false)} disabled={creating}>
+            Cancel
+          </Button>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}
+
+function VaultRenameRow({ vault, onSaved }: { vault: GatewayVaultIdentity; onSaved: () => void }) {
+  const toast = useToast();
+  const [draft, setDraft] = useState<Record<string, string>>(vault.tool_renames);
+  const [saving, setSaving] = useState(false);
+  const [warning, setWarning] = useState<string | null>(null);
+
+  function setValue(action: string, value: string) {
+    setDraft((prev) => {
+      const next = { ...prev };
+      if (value.trim()) next[action] = value.trim();
+      else delete next[action];
+      return next;
+    });
+  }
+
+  async function save() {
+    setSaving(true);
+    setWarning(null);
+    try {
+      const result = await api.updateGatewayVault(vault.key, { tool_renames: draft });
+      if (result.sanitized.length > 0) {
+        setWarning(
+          result.sanitized
+            .map((s) => `"${s.requested}" was not a valid tool name — saved as "${s.applied}".`)
+            .join(" "),
+        );
+      }
+      toast.show(`${vault.key} tools renamed.`);
+      onSaved();
+    } catch {
+      toast.show("Could not save the rename.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="card" style={{ padding: 0 }}>
+      <div className="card__body stack stack--3">
+        <div className="row" style={{ justifyContent: "space-between" }}>
+          <span className="t-sm">{vault.name}</span>
+          <span className="t-xs t-subtle">its tools start with {vault.namespace}_</span>
+        </div>
+        <div className="banner banner--warn">
+          <WarningIcon className="icon icon--sm" />
+          <p className="t-xs t-muted">
+            Renaming a tool a client already approved may make it re-prompt for approval the
+            next time it is used.
+          </p>
+        </div>
+        <div className="stack stack--2">
+          {RENAMEABLE_ACTIONS.map((action) => {
+            const value = draft[action] ?? "";
+            const preview = value ? previewSanitize(value) : action;
+            return (
+              <div key={action} className="row row--wrap" style={{ gap: 8, alignItems: "baseline" }}>
+                <span className="t-xs t-mono" style={{ minWidth: 110 }}>
+                  {action}
+                </span>
+                <input
+                  className="input"
+                  style={{ maxWidth: 180 }}
+                  placeholder={action}
+                  value={value}
+                  onChange={(event) => setValue(action, event.target.value)}
+                />
+                <span className="t-xs t-subtle">
+                  → {vault.namespace}_{preview}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+        {warning ? (
+          <div className="banner banner--warn">
+            <InfoIcon className="icon icon--sm" />
+            <p className="t-xs t-muted">{warning}</p>
+          </div>
+        ) : null}
+        <div className="row">
+          <Button size="sm" variant="primary" onClick={save} disabled={saving}>
+            {saving ? "Saving…" : "Save renames"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ToolProfiles() {
+  const [profiles, setProfiles] = useState<GatewayProfile[] | null>(null);
+  const [vaultIdentities, setVaultIdentities] = useState<GatewayVaultIdentity[]>([]);
+  const [vaultSummaries, setVaultSummaries] = useState<VaultSummary[]>([]);
+  const [available, setAvailable] = useState(true);
+
+  function refresh() {
+    api
+      .listGatewayProfiles()
+      .then((list) => {
+        setProfiles(list);
+        setAvailable(true);
+      })
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 404) setAvailable(false);
+      });
+    api.listGatewayVaults().then(setVaultIdentities).catch(() => setVaultIdentities([]));
+    api.listVaults().then(setVaultSummaries).catch(() => setVaultSummaries([]));
+  }
+
+  useEffect(refresh, []);
+
+  if (!available) {
+    return (
+      <section className="stack stack--4">
+        <Card>
+          <CardBody>
+            <p className="t-sm t-muted">
+              This hub has no gateway attached, so there is nothing to edit here yet.
+            </p>
+          </CardBody>
+        </Card>
+      </section>
+    );
+  }
+
+  return (
+    <section className="stack stack--4">
+      <div className="row" style={{ justifyContent: "space-between" }}>
+        <p className="t-sm t-muted" style={{ maxWidth: 560 }}>
+          Each connected client gets its own tool profile — its own address, its own set of
+          vaults, and (optionally) its own hidden tools. A hundred tools in one conversation
+          ruins an agent; this is where you decide who sees what.
+        </p>
+        <CreateProfileCard
+          vaults={vaultSummaries}
+          existingPaths={new Set((profiles ?? []).map((p) => p.path))}
+          onCreated={refresh}
+        />
+      </div>
+
+      {profiles && profiles.length === 0 ? (
+        <EmptyState mark={<ToolsIcon className="icon--lg" />} title="No tool profiles yet.">
+          Every vault mounts on the default profile until you create your own — add one above
+          once you have a client that should see less than everything.
+        </EmptyState>
+      ) : (
+        <div className="stack stack--3">
+          {(profiles ?? []).map((profile) => (
+            <ProfileCard
+              key={profile.path}
+              profile={profile}
+              vaults={vaultSummaries}
+              onChanged={refresh}
+            />
+          ))}
+        </div>
+      )}
+
+      {vaultIdentities.length > 0 ? (
+        <div className="stack stack--3">
+          <span className="field__label">Vault tool names</span>
+          <p className="t-xs t-muted">
+            Renaming here changes the tool everywhere it is mounted — across every profile that
+            includes this vault, live.
+          </p>
+          {vaultIdentities.map((vault) => (
+            <VaultRenameRow key={vault.key} vault={vault} onSaved={refresh} />
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/v3/web/src/routes/index.tsx
+++ b/v3/web/src/routes/index.tsx
@@ -10,11 +10,21 @@ import { Exposure } from "./Exposure";
 import { Home } from "./Home";
 import { Onboarding } from "./onboarding/Onboarding";
 import { Settings } from "./Settings";
+import { ToolProfiles } from "./ToolProfiles";
 
-// Paths SPEC-110/SPEC-201/SPEC-204/SPEC-205 build a real screen for —
-// everything else in NAV_GROUPS still falls through to ComingSoon below, so
-// no nav destination is ever a dead link (SPEC-109's rule, carried forward).
-const BUILT_PATHS = new Set(["/", "/explorer", "/clients", "/automations", "/exposure", "/settings"]);
+// Paths SPEC-110/SPEC-201/SPEC-204/SPEC-205/SPEC-305 build a real screen
+// for — everything else in NAV_GROUPS still falls through to ComingSoon
+// below, so no nav destination is ever a dead link (SPEC-109's rule,
+// carried forward).
+const BUILT_PATHS = new Set([
+  "/",
+  "/explorer",
+  "/clients",
+  "/automations",
+  "/exposure",
+  "/settings",
+  "/tools",
+]);
 
 const placeholderRoutes = NAV_GROUPS.flatMap((group) => group.items)
   .filter((item) => !BUILT_PATHS.has(item.path))
@@ -38,6 +48,7 @@ export const router = createBrowserRouter([
       { path: "automations", element: <Automations /> },
       { path: "exposure", element: <Exposure /> },
       { path: "settings", element: <Settings /> },
+      { path: "tools", element: <ToolProfiles /> },
       ...placeholderRoutes,
     ],
   },


### PR DESCRIPTION
## Summary

Implements SPEC-305 (per-client tool profiles — dashboard editor) on top of SPEC-301's gateway config machinery.

**Backend** (`v3/server/src/palaia_hub/gateway/`):
- `ProfileConfig`/`GatewayProfileSettings` gain `hidden_tools: list[str]` and `semantic_routing: bool`, kept in sync per the existing settings_bridge drift test.
- `build.py`: a profile's `hidden_tools` are hidden via FastMCP's own `Provider.disable(names=...)` on *that profile's own* `FastMCP` instance — never mutating the shared vault tool server another profile might also mount (per the SPEC's "do NOT mutate shared tool objects" instruction and the SPEC-105/002 finding that profiles are already separate instances).
- New `gateway/semantic_routing.py`: `find_tool`/`invoke_tool`, backed by the profile's real (already-built) tool list via keyword-overlap scoring; the full surface is never mounted over the wire when this is on.
- `dynamic.py`: `upsert_profile` carries the two new fields; new `update_vault_identity()` rebuilds a vault's tool server and every profile mounting it, live.
- `gateway/api.py`: `POST/PATCH /api/gateway/profiles` carry `hidden_tools`/`semantic_routing`; new `GET /api/gateway/profiles/{path}/tools` (live per-tool visibility, hidden ones included — introspects via the base `Provider.list_tools()` rather than the filtering `FastMCP.list_tools()`); new `GET /api/gateway/vaults` and `PATCH /api/gateway/vaults/{key}` for live, persisted tool renames, returning which renames were sanitized.

**Frontend** (`v3/web/src/`):
- New `routes/ToolProfiles.tsx` — the "Tool profiles" screen, wired at the pre-existing `/tools` nav placeholder: list with live tool count, create/edit (vaults + stash via checkboxes, per-tool visibility checkboxes, semantic-routing toggle marked experimental with a plain-language explanation), inline vault tool renames with a live sanitize preview and the server's own sanitize/warning surfaced, curator shown read-only, delete with a connected-client warning, default profile undeletable.
- `routes/Clients.tsx`: a profile picker (only shown once more than one profile exists) now drives every snippet/command/download/bundle on the connect page.
- `lib/api/client.ts`: hand-written types + calls for the new endpoints (same pattern as the other opt-in dashboard surfaces already there).

## Acceptance criteria

- [x] create a profile in the UI → its endpoint serves exactly the chosen tools (e2e via `fastmcp.Client`), no restart — `test_api.py::test_create_profile_is_reachable_immediately_and_persisted` (pre-existing) + new hidden-tools/semantic-routing variants; `test_dynamic.py`/`test_build.py` exercise the live `fastmcp.Client` path directly.
- [x] hidden tool: absent from `tools/list` AND refused on call — `test_build.py::test_hidden_tool_is_absent_from_tools_list` / `test_hidden_tool_is_refused_on_call_not_merely_unlisted`.
- [x] rename via UI round-trips to `config.yaml` and the live gateway; invalid names sanitized with the warning shown — `test_api.py::test_list_and_update_vault_identity_round_trips_and_applies_live` / `test_update_vault_identity_sanitizes_invalid_rename_and_reports_it`; the UI shows the server's sanitize result inline.
- [x] semantic routing profile: `find_tool` finds and `invoke_tool` invokes a real tool e2e; the full surface is absent — `test_build.py::test_semantic_routing_find_tool_finds_and_invoke_tool_invokes` / `test_semantic_routing_profile_exposes_only_find_and_invoke_tool`.
- [x] jargon lint on the screen's copy; Lume tokens only — `ToolProfiles.test.tsx`'s copy lint (headings/buttons/badges/options/field labels), same pattern as `Automations.test.tsx`/`Exposure.test.tsx`; no hardcoded colors (`npm run lint` including `lint-tokens.mjs` is clean).

## Scope note / honest deviations

- **SPEC-302 (external servers + secret store) is not merged into this integration branch yet** (waves 3a/3b run in parallel — 305 depends only on 301). Deliverable #1's "SPEC-302 upstreams via checkboxes" is therefore **not implemented** — there is nothing to check yet. The screen is structured so a follow-up can add an upstream-servers section next to the vault checkboxes without reshaping anything here.
- **"The default profile cannot be deleted" is a UI-only guard** (the delete control is hidden/disabled for `path == "default"`); the server's `DELETE /api/gateway/profiles/{path}` route does not special-case it. The acceptance criteria don't exercise this path directly; flagging it since a determined API caller could still delete `default` today.
- Per-tool visibility (`hidden_tools`) and semantic routing are stored as new fields deliberately kept parallel between `palaia_hub.config.GatewayProfileSettings` and `palaia_hub.gateway.config.ProfileConfig` (per the existing drift test in `test_settings_bridge.py`), which added a small amount of duplication already present in that design.

## Verification (from `v3/`)

- `uv run ruff check server` → All checks passed!
- `uv run mypy server/src` → Success: no issues found in 159 source files
- `uv run pytest server/tests -q` → 1605 passed, 15 skipped, 1 failed (`test_parse_roundtrip.py::test_parse_time_p50_under_one_millisecond`, a pre-existing timing-sensitive benchmark unrelated to this change — passes standalone; also passed in the pre-change baseline run)
- `cd web && npm run typecheck` → clean
- `cd web && npx vitest run` → 58 passed (14 files), including new `ToolProfiles.test.tsx` (8 tests)
- `cd web && npm run lint` → 0 errors (3 pre-existing fast-refresh warnings in unrelated files)
- `cd web && npm run build` → succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790169386&installation_model_id=428086&pr_number=244&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F244&signature=c8761de7fb2fb4a437229c028aba76c21804996354185915b7f837e6f3cc70ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->