### PR TITLE
feat(v3): external MCP servers + encrypted secret store

### DIFF
--- a/v3/README.md
+++ b/v3/README.md
@@ -16,6 +16,7 @@ v2 hotfixes happen on the `v2-maintenance` branch.
 | [research/](research/) | Research dossiers the plan is grounded in |
 | [decisions/](decisions/) | Architecture Decision Records (ADRs) for v3 |
 | [docs/design/](docs/design/) | UX north star: design system, principles, and HTML mockups of the key screens |
+| [docs/external-servers.md](docs/external-servers.md) | Connecting other people's MCP servers, and where their credentials live |
 
 ## Dev setup
 

--- a/v3/docs/events.md
+++ b/v3/docs/events.md
@@ -100,21 +100,34 @@ of them ignores them.
 | `curator.proposal.apply_failed` | same shape | An operation failed mid-plan; the proposal is stamped `apply-failed` and a `doctor.finding` is raised. |
 | `curator.proposal.manual` | same shape | The proposal carries no executable plan (or an unparseable one) — a human has to apply it. |
 
-<<<<<<< HEAD
 ### 3.2 Marketplace event (SPEC-303, additive)
 
 | Event | Origin | `data` fields | Fires when |
 |---|---|---|---|
 | `market.index.updated` | `market` | `generated_at`, `entry_count`, `stale`, `warning` | The curated add-on index (`palaia_hub.market.curated.CuratedIndexClient`) is (re)fetched — on a fresh, verified document `stale` is `false` and `warning` empty; on a refused/tampered document or an offline network, `stale` is `true` and `warning` names the exact reason (the same reason logged as a WARNING), and `generated_at`/`entry_count` describe whichever copy (last-verified, or none) was served instead. |
-=======
-### 3.2 Gateway profile events (SPEC-301, additive)
+
+### 3.3 Gateway profile events (SPEC-301, additive)
 
 | Event | Origin | `data` fields | Fires when |
 |---|---|---|---|
 | `gateway.profile.created` | `gateway` | `path`, `vaults`, `stash` | `POST /api/gateway/profiles` creates a new MCP profile. |
 | `gateway.profile.updated` | `gateway` | `path`, `vaults`, `stash` | `PATCH /api/gateway/profiles/{path}` changes an existing profile's label, mounted vaults, or stash flag. |
 | `gateway.profile.deleted` | `gateway` | `path` | `DELETE /api/gateway/profiles/{path}` removes a profile. |
->>>>>>> origin/claude/palaia-major-rewrite-lj5v9x
+
+### 3.4 External MCP server events (SPEC-302, additive)
+
+Reachability is reported only when it **changes** — a healthy external server
+is silent, so these are safe to route to a phone. No event here ever carries a
+credential: an upstream's stored secrets are referenced by name and never
+included in `data` at all.
+
+| Event | Origin | `data` fields | Fires when |
+|---|---|---|---|
+| `gateway.upstream.up` | `gateway` | `upstream`, `display_name`, `namespace`, `kind`, `detail`, `tool_count` | A probe (periodic or `POST /api/gateway/upstreams/{key}/probe`) reaches an external server that was previously unreachable or never checked. `detail` is the same one-line status the REST surface shows. |
+| `gateway.upstream.down` | `gateway` | same shape (`tool_count` is `0`) | A probe cannot reach a server that was up, or the first check of a server fails. `detail` says why, in plain language. |
+| `gateway.upstream.connected` | `gateway` | `upstream`, `display_name`, `kind`, `namespace`, `profiles` | `POST /api/gateway/upstreams` connects a new external server. |
+| `gateway.upstream.updated` | `gateway` | `upstream`, `display_name`, `enabled`, `profiles` | `PATCH /api/gateway/upstreams/{key}` changes one (including switching it off). |
+| `gateway.upstream.disconnected` | `gateway` | `upstream` | `DELETE /api/gateway/upstreams/{key}` removes one; every profile that mounted it is rebuilt without it. |
 
 `health` also travels the same bus and wire format (SSE only; it is not a
 webhook-filterable v1 name — see §6) — it is the dashboard's periodic

--- a/v3/docs/external-servers.md
+++ b/v3/docs/external-servers.md
@@ -1,0 +1,128 @@
+# External MCP servers and the secret store (SPEC-302)
+
+> One endpoint, many tools (MASTERPLAN §5.2). Connect somebody else's MCP
+> server to palaia once, and it appears — named, renamable, health-checked —
+> on whichever profiles you put it on. Its API key lives in palaia's
+> encrypted store, not in every client's config file.
+
+## What a connected server is
+
+An entry under `gateway.upstreams` in `config.yaml`, of one of two kinds:
+
+| Kind | What it is | What palaia does |
+|---|---|---|
+| `http` | A server on the internet (or your network) speaking streamable HTTP | Connects to its URL, adding a header from the secret store if you configured one |
+| `stdio` | A program on this machine | Starts it, talks over its pipes, injects the secrets you named into its environment, and stops it when the hub stops |
+
+Listing a server connects it. Listing it in a **profile's** `upstreams` is
+what exposes its tools to the clients using that profile — the two steps are
+separate on purpose, so connecting something does not hand it to everything.
+
+Its tools appear as `<namespace>_<tool>` (default namespace: the server's
+key), and any of them can be renamed. Renames are stored **pre-namespace** —
+you write the part after the prefix, palaia composes the rest (the reason is
+FINDINGS Q4 in `v3/spikes/gateway/FINDINGS.md`: fastmcp applies a rename
+before adding the prefix, so storing the full displayed name double-prefixes
+it).
+
+The profile's own instructions carry one line per connected server —
+*"tools named `linear_*` come from Linear — an outside service, connected by
+you"* — so a model reading the tool surface can tell palaia's own memory
+tools apart from a third party's. The servers' own tool descriptions pass
+through unchanged; palaia does not rewrite or vouch for them.
+
+## Credentials: what goes where
+
+**Nothing secret goes in `config.yaml`.** An entry names the secret it
+needs; the value lives encrypted in the store.
+
+```yaml
+gateway:
+  upstreams:
+    - key: linear
+      kind: http
+      display_name: Linear
+      url: https://mcp.linear.app/mcp
+      auth:
+        header: Authorization          # default
+        value_template: "Bearer {secret}"   # default
+        secret_name: linear-token      # ← a name, never a value
+    - key: weather
+      kind: stdio
+      display_name: Weather box
+      command: /usr/local/bin/weather-mcp
+      args: ["--stdio"]
+      env_secrets:
+        WEATHER_API_KEY: weather-key   # ← env var: secret name
+```
+
+For an API key in a custom header, set `header: X-API-Key` and
+`value_template: "{secret}"`.
+
+### The store
+
+- `<home>/secrets.sqlite3` — values encrypted with Fernet, file mode `0600`.
+- `<home>/secrets.key` — the encryption key, `0600`, inside the `0700` home,
+  created with `O_CREAT | O_EXCL` and never overwritten. Both are re-narrowed
+  every time the hub opens them, so a file widened by a `chmod` or an
+  `rsync -a` from a laxer machine is quietly fixed.
+- Copying the database without its key makes every value unreadable — by
+  design. palaia says so by name (*"secret `linear-token` cannot be decrypted
+  with the current secrets.key"*) rather than failing vaguely.
+
+### Write-only, by construction
+
+| Route | Does |
+|---|---|
+| `PUT /api/secrets/{name}` | Stores a value (replacing any previous one) |
+| `GET /api/secrets` | Lists **names and timestamps** |
+| `DELETE /api/secrets/{name}` | Removes one |
+
+There is no route that returns a value, and no response model in the hub has
+a field one could be placed in. A value is decrypted only inside the hub
+process, at the moment a header or a child process's environment is built. It
+is never logged, never included in an error message, and never part of an
+event payload — asserted by
+`server/tests/upstream/test_secret_never_leaks.py`.
+
+### OAuth against a third party: what this is not
+
+palaia does **not** run an OAuth login flow against somebody else's
+authorization server. If a service issues you a token, paste it into the
+secret store and reference it by name. That is the whole v1 path, stated
+plainly rather than implied away. (palaia's *own* OAuth server — the one your
+clients log into to reach palaia — is a different thing entirely; see
+SPEC-203.)
+
+## Health
+
+Each server is probed (connect → initialize → `tools/list`) on a bounded
+timeout, on a background pass roughly every minute, and on demand via
+`POST /api/gateway/upstreams/{key}/probe`. `GET /api/gateway/upstreams`
+reports every server with one plain-language status line.
+
+What happens when one is unreachable:
+
+- Its tools are **absent** from the profiles that mount it. Everything else
+  on those profiles keeps working exactly as before.
+- Nothing waits on it. Hub startup never probes (so a dead server cannot
+  delay a start), and a profile never holds a mount that would time out on
+  every `tools/list`.
+- It comes back on its own: the pass that finds it reachable again rebuilds
+  the profiles that mount it, with no restart and nothing to click.
+- `gateway.upstream.up` / `gateway.upstream.down` fire **only on a change**,
+  so a healthy server is silent. See [events.md](events.md) §3.4.
+
+## Two fences
+
+**The curator never mounts an external server.** It runs a model over your
+own notes; an outside tool inside that session could carry them out. The
+refusal is in three places — the profile schema will not hold it, the builder
+will not mount it, and the REST route will not accept it — because one of
+them is not enough (`server/tests/upstream/test_curator_fence.py`).
+
+**Name collisions are refused, loudly, at config time.** Two servers cannot
+claim one tool prefix, and no server can claim a vault's (`work_memory`) —
+that would silently shadow your memory tools. The error names both claimants
+and the fix. A switched-off server still owns its prefix, so turning it back
+on later cannot surprise you.

--- a/v3/server/src/palaia_hub/app.py
+++ b/v3/server/src/palaia_hub/app.py
@@ -56,6 +56,14 @@ from .oauth import AuthorizationServer, build_oauth_router
 from .stash.service import StashService
 from .stash_api import build_stash_router
 from .static import mount_dashboard
+from .upstream.api import (
+    build_secret_change_hook,
+    build_secrets_router,
+    build_upstreams_router,
+)
+from .upstream.monitor import UpstreamHealthMonitor
+from .upstream.secrets import SecretStore
+from .upstream.service import UpstreamService
 from .vault import VaultNotFoundError, VaultRegistry
 
 # Name of the env var that, when set to a positive number of seconds, adds a
@@ -86,6 +94,9 @@ def create_app(
     automation_outbox: AutomationOutbox | None = None,
     notification_store: NotificationStore | None = None,
     curator_wiring: CuratorWiring | None = None,
+    upstream_service: UpstreamService | None = None,
+    upstream_monitor: UpstreamHealthMonitor | None = None,
+    secret_store: SecretStore | None = None,
     home: Path | None = None,
 ) -> FastAPI:
     """Build the hub's ASGI app.
@@ -201,6 +212,22 @@ def create_app(
             wired into :mod:`palaia_hub.dashboard_api`'s ``create_vault``).
             Omitted, a wizard-created vault stays off the curator until a
             restart, exactly as before this parameter existed.
+        upstream_service: the external-server registry (SPEC-302). Given
+            together with ``dynamic_gateway``, mounts
+            ``/api/gateway/upstreams`` and every connection it holds
+            (including a ``stdio`` upstream's child process) is closed by
+            this app's own lifespan. Omitted, the hub serves no external
+            servers at all, same as before this parameter existed.
+        upstream_monitor: the periodic reachability probe for those servers
+            (:class:`~palaia_hub.upstream.monitor.UpstreamHealthMonitor`).
+            Started at the *end* of startup — deliberately after the gateway
+            has mounted its profiles, so a hub whose external server is
+            unreachable still starts instantly (SPEC-302 deliverable #4) —
+            and stopped before the connections are reaped.
+        secret_store: the encrypted credential store (SPEC-302). Given,
+            mounts the write-only ``/api/secrets`` surface — independent of
+            ``dynamic_gateway`` on purpose, so a credential can be entered
+            before anything is connected — and is closed at shutdown.
         hook_outbox: the durable delivery queue backing ``hook_store``.
             Defaults to :class:`~palaia_hub.hooks.HookOutbox` at its
             standard path under the hub's data directory when ``hook_store``
@@ -356,6 +383,12 @@ def create_app(
             tasks.append(asyncio.create_task(automation_dispatcher.run_forever()))
         if curator is not None:
             await curator.start()
+        # SPEC-302: the first external-server probe pass runs here, in the
+        # background — after the gateway has already mounted every profile,
+        # so a hub whose upstream is unreachable still starts instantly and
+        # the profile picks the server up on the pass that finds it.
+        if upstream_monitor is not None:
+            await upstream_monitor.start()
         publish_event(
             event_bus,
             "hub.started",
@@ -375,6 +408,16 @@ def create_app(
             await stop_background_tasks(tasks)
             if curator is not None:
                 await curator.aclose()
+            # Stop probing before the gateway goes away, then reap every
+            # upstream connection — for a `stdio` upstream that is what
+            # kills its child process (SPEC-302 acceptance: "process reaped
+            # on hub shutdown").
+            if upstream_monitor is not None:
+                await upstream_monitor.aclose()
+            if upstream_service is not None:
+                await upstream_service.aclose()
+            if secret_store is not None:
+                secret_store.close()
             if dynamic_gateway is not None:
                 await dynamic_gateway.aclose()
             if indexes is not None:
@@ -512,6 +555,32 @@ def create_app(
                 event_bus=event_bus,
                 oauth_server=oauth_server,
                 token_store=token_store,
+            )
+        )
+    # SPEC-302: external MCP servers, and the write-only secret store their
+    # credentials live in. The upstream surface needs a live gateway to
+    # mount onto (same gate as the profile editor above); the secret surface
+    # only needs the store, so a credential can be entered before anything
+    # is connected.
+    if secret_store is not None:
+        app.include_router(
+            build_secrets_router(
+                secret_store,
+                on_secret_changed=(
+                    build_secret_change_hook(upstream_service, dynamic_gateway)
+                    if upstream_service is not None and dynamic_gateway is not None
+                    else None
+                ),
+            )
+        )
+    if dynamic_gateway is not None and upstream_service is not None:
+        app.include_router(
+            build_upstreams_router(
+                dynamic_gateway,
+                upstream_service,
+                home=hub_home,
+                config=config,
+                event_bus=event_bus,
             )
         )
     # SPEC-306: the Claude Desktop connect-page "Download bundle" button.

--- a/v3/server/src/palaia_hub/config.py
+++ b/v3/server/src/palaia_hub/config.py
@@ -18,6 +18,12 @@ import yaml
 from platformdirs import user_data_dir
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
+# SPEC-302: the external-server schema, imported rather than duplicated.
+# `palaia_hub.upstream.models` (and its package `__init__`) import nothing
+# from the rest of `palaia_hub` and nothing from fastmcp, precisely so this
+# module can use it while still loading before any transport layer exists.
+from .upstream.models import UpstreamConfig as GatewayUpstreamSettings
+
 APP_NAME = "palaia-hub"
 
 # The default curator runner command, duplicated here as a plain tuple rather
@@ -210,6 +216,39 @@ exposure:
 #       label: Default
 #       vaults: [work]
 #       stash: false
+#       # Other MCP servers this profile also offers, by key (see below).
+#       upstreams: [linear]
+#   # Other people's MCP servers, connected once here instead of in every
+#   # client's own config file. `kind: http` is a server on the internet;
+#   # `kind: stdio` is a program palaia starts on this machine and talks to.
+#   # Their tools appear as `<namespace>_<tool>` on whichever profiles list
+#   # them above, and you can rename any of them.
+#   #
+#   # API keys and tokens NEVER go in this file. Store the value once (the
+#   # dashboard, or `PUT /api/secrets/<name>`) and refer to it by name here;
+#   # it is encrypted in secrets.sqlite3 and never shown again.
+#   #
+#   # palaia does not log in to other services for you: if a service issues
+#   # you a token, paste it in yourself. (palaia's own `oauth:` server above
+#   # is a different thing — that is how your clients log in to palaia.)
+#   upstreams:
+#     - key: linear
+#       kind: http
+#       display_name: Linear
+#       url: https://mcp.linear.app/mcp
+#       namespace: linear
+#       enabled: true
+#       auth:
+#         header: Authorization
+#         value_template: "Bearer {secret}"
+#         secret_name: linear-token
+#     - key: weather
+#       kind: stdio
+#       display_name: Weather box
+#       command: /usr/local/bin/weather-mcp
+#       args: ["--stdio"]
+#       env_secrets:
+#         WEATHER_API_KEY: weather-key
 
 # The curator (SPEC-206): the background job that turns inbox captures into
 # well-placed vault notes. Off by default — it runs a model, which costs
@@ -554,6 +593,11 @@ class GatewayProfileSettings(BaseModel):
     vaults: list[str] = Field(default_factory=list)
     #: Mount the stash tool family inside this profile too (SPEC-202/301).
     stash: bool = False
+    #: External MCP servers (SPEC-302) mounted into this profile, by key —
+    #: each has to appear in ``gateway.upstreams`` below. Listing a server
+    #: there connects it; listing it *here* is what exposes its tools to the
+    #: clients using this profile.
+    upstreams: list[str] = Field(default_factory=list)
 
 
 class GatewaySettings(BaseModel):
@@ -581,6 +625,20 @@ class GatewaySettings(BaseModel):
 
     vaults: list[GatewayVaultSettings] = Field(default_factory=list)
     profiles: list[GatewayProfileSettings] = Field(default_factory=list)
+    #: External MCP servers this hub connects (SPEC-302). Unlike the two
+    #: lists above, this one is **not** duplicated from the gateway package
+    #: — :class:`palaia_hub.upstream.models.UpstreamConfig` is imported
+    #: directly, because that module was written to be import-free with
+    #: respect to the rest of ``palaia_hub`` for exactly this reason (see
+    #: its docstring). One shape, no twin to keep in sync; the "duplicate it
+    #: to stay fastmcp-free" rule the two settings classes above follow is
+    #: satisfied here by the *model* being fastmcp-free instead.
+    #:
+    #: Credentials are never stored here: an entry names the secret it needs
+    #: (:class:`~palaia_hub.upstream.models.UpstreamAuthConfig.secret_name`,
+    #: ``env_secrets``) and the value lives encrypted in
+    #: ``<home>/secrets.sqlite3``.
+    upstreams: list[GatewayUpstreamSettings] = Field(default_factory=list)
 
 
 class CuratorSettings(BaseModel):

--- a/v3/server/src/palaia_hub/curator/profile.py
+++ b/v3/server/src/palaia_hub/curator/profile.py
@@ -30,7 +30,7 @@ from collections.abc import Iterable, Sequence
 
 from fastmcp.server.middleware import Middleware
 
-from ..gateway.config import ProfileConfig, VaultMountConfig
+from ..gateway.config import CURATOR_PROFILE_PATH, ProfileConfig, VaultMountConfig
 from ..gateway.naming import compose_tool_name, resolve_tool_names
 from ..gateway.vault_protocol import (
     INBOX_TOOL_ACTIONS,
@@ -41,8 +41,10 @@ from .middleware import CuratorScopeMiddleware
 from .policy import CURATOR_TOOL_ACTIONS, ActiveCaptures
 from .session import MCP_SERVER_NAME
 
-#: The profile path the curator connects to: ``/mcp/curator``.
-CURATOR_PROFILE_PATH = "curator"
+# `CURATOR_PROFILE_PATH` (``"curator"``) is imported above and re-exported
+# here for every existing caller. The literal itself now lives in
+# `palaia_hub.gateway.config`, so `ProfileConfig` can fence this path against
+# external servers (SPEC-302 deliverable #6) without importing this module.
 
 #: Every action the memory tool family exposes, curator-relevant or not. The
 #: middleware needs all of them: mapping a *forbidden* tool name to its

--- a/v3/server/src/palaia_hub/events/schema.py
+++ b/v3/server/src/palaia_hub/events/schema.py
@@ -71,6 +71,15 @@ EventName = Literal[
     "gateway.profile.created",
     "gateway.profile.updated",
     "gateway.profile.deleted",
+    # SPEC-302 (external servers): one pair for reachability — emitted only
+    # when it *changes*, so a healthy server is silent — plus one per
+    # connect/edit/disconnect through `/api/gateway/upstreams`. Additive to
+    # the v1 vocabulary.
+    "gateway.upstream.up",
+    "gateway.upstream.down",
+    "gateway.upstream.connected",
+    "gateway.upstream.updated",
+    "gateway.upstream.disconnected",
     # SPEC-303: the curated marketplace index was (re)fetched — fresh or a
     # refused/offline fallback, named honestly in the event's own data.
     # Additive to the v1 vocabulary, same rule as the curator events above.

--- a/v3/server/src/palaia_hub/gateway/api.py
+++ b/v3/server/src/palaia_hub/gateway/api.py
@@ -34,15 +34,14 @@ from ..events import EventBus, publish_event
 from ..oauth import AuthorizationServer
 from ..oauth.verifier import build_profile_auth
 from .build import GatewayConfigError
-from .config import ProfileConfig
+from .config import CURATOR_PROFILE_PATH, ProfileConfig
 from .dynamic import DynamicGateway
 from .settings_bridge import persist_gateway_settings
 
-# Kept as a plain string (not imported from `palaia_hub.curator.profile`):
-# this module has no other reason to pull in the curator package, and the
-# path itself is what matters here — protecting it from the generic CRUD
-# below, see the module docstring.
-_CURATOR_PROFILE_PATH = "curator"
+# `CURATOR_PROFILE_PATH` is imported from `.config` (not from
+# `palaia_hub.curator.profile`): this module has no other reason to pull in
+# the curator package, and the path itself is what matters here — protecting
+# it from the generic CRUD below, see the module docstring.
 
 
 class GatewayProfileOut(BaseModel):
@@ -54,6 +53,10 @@ class GatewayProfileOut(BaseModel):
     label: str | None
     vaults: list[str]
     stash: bool
+    #: External MCP servers this profile mounts (SPEC-302), by key. The
+    #: profile editor (SPEC-305) assigns them through this same surface
+    #: rather than a second write path.
+    upstreams: list[str]
     #: The curator's own profile is listed (so the editor can show it) but
     #: every write route below refuses to touch it — see the module
     #: docstring.
@@ -71,6 +74,7 @@ class CreateGatewayProfileRequest(BaseModel):
     label: str | None = None
     vaults: list[str] = []
     stash: bool = False
+    upstreams: list[str] = []
 
 
 class UpdateGatewayProfileRequest(BaseModel):
@@ -83,6 +87,9 @@ class UpdateGatewayProfileRequest(BaseModel):
     label: str | None = None
     vaults: list[str] | None = None
     stash: bool | None = None
+    #: Same whole-list contract as ``vaults`` (SPEC-302): given, it replaces
+    #: the profile's external-server list entirely.
+    upstreams: list[str] | None = None
 
 
 def _out(profile: ProfileConfig) -> GatewayProfileOut:
@@ -91,7 +98,8 @@ def _out(profile: ProfileConfig) -> GatewayProfileOut:
         label=profile.label,
         vaults=list(profile.vaults),
         stash=profile.stash,
-        managed=profile.path == _CURATOR_PROFILE_PATH,
+        upstreams=list(profile.upstreams),
+        managed=profile.path == CURATOR_PROFILE_PATH,
     )
 
 
@@ -143,16 +151,24 @@ def build_gateway_profiles_router(
     def _persist() -> None:
         existing_vaults = config.gateway.vaults if config.gateway is not None else []
         profiles = [
-            p for p in dynamic_gateway.config.profiles if p.path != _CURATOR_PROFILE_PATH
+            p for p in dynamic_gateway.config.profiles if p.path != CURATOR_PROFILE_PATH
         ]
         settings = GatewaySettings(
             vaults=existing_vaults,
             profiles=[
                 GatewayProfileSettings(
-                    path=p.path, label=p.label, vaults=list(p.vaults), stash=p.stash
+                    path=p.path,
+                    label=p.label,
+                    vaults=list(p.vaults),
+                    stash=p.stash,
+                    upstreams=list(p.upstreams),
                 )
                 for p in profiles
             ],
+            # SPEC-302: carried through from the live gateway, not from
+            # `config` — a profile edit must never blank out the external
+            # servers someone connected since this process started.
+            upstreams=list(dynamic_gateway.config.upstreams),
         )
         persist_gateway_settings(path, settings)
 
@@ -161,7 +177,7 @@ def build_gateway_profiles_router(
             publish_event(event_bus, event, origin="gateway", data=data)
 
     def _require_editable(profile_path: str) -> None:
-        if profile_path == _CURATOR_PROFILE_PATH:
+        if profile_path == CURATOR_PROFILE_PATH:
             raise HTTPException(
                 status_code=400,
                 detail=(
@@ -187,7 +203,13 @@ def build_gateway_profiles_router(
                 "PATCH it instead, or choose a different path.",
             )
         try:
-            ProfileConfig(path=body.path, label=body.label, vaults=body.vaults, stash=body.stash)
+            ProfileConfig(
+                path=body.path,
+                label=body.label,
+                vaults=body.vaults,
+                stash=body.stash,
+                upstreams=body.upstreams,
+            )
         except ValidationError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -197,6 +219,7 @@ def build_gateway_profiles_router(
                 body.vaults,
                 label=body.label,
                 stash=body.stash,
+                upstreams=body.upstreams,
                 auth=_new_profile_auth(body.path),  # type: ignore[arg-type]
             )
         except GatewayConfigError as exc:
@@ -227,8 +250,15 @@ def build_gateway_profiles_router(
         label = body.label if body.label is not None else current.label
         vaults = body.vaults if body.vaults is not None else list(current.vaults)
         stash = body.stash if body.stash is not None else current.stash
+        upstreams = body.upstreams if body.upstreams is not None else list(current.upstreams)
         try:
-            ProfileConfig(path=profile_path, label=label, vaults=vaults, stash=stash)
+            ProfileConfig(
+                path=profile_path,
+                label=label,
+                vaults=vaults,
+                stash=stash,
+                upstreams=upstreams,
+            )
         except ValidationError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -236,7 +266,12 @@ def build_gateway_profiles_router(
             # `auth=None`: this path already has a verifier from creation
             # (or none, in locked mode) — an edit never changes that.
             await dynamic_gateway.upsert_profile(
-                profile_path, vaults, label=label, stash=stash, auth=None
+                profile_path,
+                vaults,
+                label=label,
+                stash=stash,
+                upstreams=upstreams,
+                auth=None,
             )
         except GatewayConfigError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/v3/server/src/palaia_hub/gateway/build.py
+++ b/v3/server/src/palaia_hub/gateway/build.py
@@ -16,12 +16,14 @@ Binding findings this module follows exactly (SPEC-002,
   loudly.
 - **``tool_names`` renames are pre-namespace** (Q4) — handled once, in
   :mod:`palaia_hub.gateway.naming`, not re-derived here.
-- No ``FastMCP.as_proxy()`` / ``create_proxy()`` appears here because vault
-  tool servers are mounted in-process (no remote upstream in this SPEC's
-  scope — external upstreams are Phase 3, MASTERPLAN §5.2/§5.3). If a
-  future SPEC proxies a remote MCP server into a profile, it MUST use
-  ``fastmcp.server.create_proxy()`` — ``FastMCP.as_proxy()`` is deprecated
-  (Q1).
+- Vault tool servers are mounted in-process (no network hop). **External**
+  MCP servers (SPEC-302) arrive here as already-built client-backed proxies
+  in :class:`UpstreamMount` — created by
+  :meth:`palaia_hub.upstream.service.UpstreamService.proxy_for` with
+  ``fastmcp.server.create_proxy()``, never the deprecated
+  ``FastMCP.as_proxy()`` (Q1). Building them is the async caller's job so
+  that this function stays synchronous and, more importantly, so that no
+  network round-trip can ever happen inside a profile build.
 """
 
 from __future__ import annotations
@@ -37,11 +39,12 @@ from fastmcp.utilities.lifespan import combine_lifespans
 from starlette.types import ASGIApp
 
 from ..stash.service import StashService
+from ..upstream.models import UpstreamConfig
 from .apps.recall_app import RESOURCE_URI as RECALL_EXPLORER_URI
 from .apps.recall_app import render_recall_explorer_html
 from .apps.review_app import RESOURCE_URI as REVIEW_QUEUE_URI
 from .apps.review_app import render_review_queue_html
-from .config import GatewayConfig, ProfileConfig
+from .config import CURATOR_PROFILE_PATH, GatewayConfig, ProfileConfig
 from .memory_tools import build_vault_server, vault_identity_block
 from .naming import resolve_tool_names
 from .stash_tools import build_stash_server
@@ -54,6 +57,39 @@ from .vault_protocol import VaultService
 # that shape is exactly what `combine_lifespans` already produces (verified
 # against `FastAPI(lifespan=...)` directly; see the module docstring).
 Lifespan = Any
+
+
+@dataclass(frozen=True)
+class UpstreamMount:
+    """One external MCP server, ready to mount (SPEC-302 deliverable #1).
+
+    ``server`` is the client-backed proxy
+    (:func:`fastmcp.server.create_proxy`) whose every tool call is forwarded
+    over its own MCP connection to the real upstream. Constructing it costs
+    no I/O, and a proxy whose upstream is unreachable mounts perfectly well
+    — fastmcp 3.4.7's tool aggregator logs and skips a provider whose
+    ``list_tools`` fails, so the profile serves everything else. That is
+    exactly the degradation SPEC-302 deliverable #4 asks for.
+    """
+
+    config: UpstreamConfig
+    server: FastMCP
+
+
+def upstream_identity_block(config: UpstreamConfig) -> str:
+    """The IDENTITY line marking an upstream's tools as somebody else's.
+
+    SPEC-302 deliverable #6: an upstream's own tool descriptions pass
+    through untouched, so the profile's instructions are where provenance
+    gets stated — in plain language, naming who connected it, so a model
+    reading the surface can tell palaia's own memory tools apart from a
+    third party's.
+    """
+    return (
+        f"IDENTITY: tools named {config.mount_namespace}_* come from "
+        f"{config.display_name} — an outside service, connected by you. palaia "
+        "passes their descriptions through unchanged and does not vouch for them."
+    )
 
 
 class GatewayConfigError(ValueError):
@@ -108,18 +144,34 @@ def _build_profile_server(
     auth: TokenVerifier | None,
     middleware: Sequence[Middleware] = (),
     stash_service: StashService | None = None,
+    upstream_mounts: Mapping[str, UpstreamMount] | None = None,
 ) -> FastMCP:
+    # SPEC-302 deliverable #6, second half of the fence: `ProfileConfig`
+    # already refuses to *hold* upstreams on the curator path, so reaching
+    # this line means a caller built the profile some other way. Fail
+    # closed and loudly rather than mount anything.
+    if profile.path == CURATOR_PROFILE_PATH and profile.upstreams:
+        raise GatewayConfigError(
+            "refusing to mount an external server on the curator profile: the "
+            "curator runs a model over your own notes, and an outside tool in "
+            f"that session could exfiltrate them (asked for: {sorted(profile.upstreams)})"
+        )
     # `mount()` does not propagate a mounted server's `instructions` to its
     # parent, so a real client connecting to this profile would otherwise
     # see none at all (SPEC-105 deliverable #4: "server instructions with
     # an IDENTITY line per vault"). Compose one IDENTITY block per mounted
     # vault into *this* server's own instructions instead.
     vault_configs = [config.vault(key) for key in profile.vaults]
-    instructions = (
-        "\n\n".join(vault_identity_block(v) for v in vault_configs)
-        if vault_configs
-        else None
-    )
+    # Only upstreams the caller actually built a proxy for are mounted: a
+    # disabled or unreachable one is simply absent from `upstream_mounts`,
+    # which is how a down external server degrades to absent tools instead
+    # of a broken profile (SPEC-302 deliverable #4).
+    mounted_upstreams = [
+        (upstream_mounts or {})[key] for key in profile.upstreams if key in (upstream_mounts or {})
+    ]
+    identity_blocks = [vault_identity_block(v) for v in vault_configs]
+    identity_blocks += [upstream_identity_block(m.config) for m in mounted_upstreams]
+    instructions = "\n\n".join(identity_blocks) if identity_blocks else None
     # `auth` (SPEC-108): a TokenVerifier here makes FastMCP wrap this
     # profile's HTTP endpoint in its own RequireAuthMiddleware/
     # BearerAuthBackend — every request needs a bearer token this verifier
@@ -152,6 +204,17 @@ def _build_profile_server(
     # of the service existing.
     if profile.stash and stash_service is not None:
         server.mount(build_stash_server(stash_service))
+    # SPEC-302: external servers, namespaced and renamable exactly like a
+    # vault's tool family. `tool_names` values are pre-namespace (FINDINGS
+    # Q4) — the one composition rule `gateway.naming` owns, applied here
+    # through the same helper the vault mounts use.
+    for mount in mounted_upstreams:
+        renames = resolve_tool_names(mount.config.mount_namespace, mount.config.tool_renames)
+        server.mount(
+            mount.server,
+            namespace=mount.config.mount_namespace,
+            tool_names=renames or None,
+        )
     _attach_app_resources(server)
     return server
 
@@ -188,6 +251,7 @@ def build_gateway(
     token_verifiers: Mapping[str, TokenVerifier] | None = None,
     profile_middleware: Mapping[str, Sequence[Middleware]] | None = None,
     stash_service: StashService | None = None,
+    upstream_mounts: Mapping[str, UpstreamMount] | None = None,
 ) -> GatewayASGI:
     """Build the full gateway from a validated config and its backing services.
 
@@ -211,6 +275,13 @@ def build_gateway(
             default) leaves every profile exactly as before this parameter
             existed, even one with ``stash: true`` — the flag only takes
             effect once a service exists to back it.
+        upstream_mounts: external MCP servers ready to mount (SPEC-302),
+            keyed by upstream key — built by the async caller via
+            :meth:`palaia_hub.upstream.service.UpstreamService.proxy_for`.
+            A profile's ``upstreams`` entry with no key here contributes no
+            tools, which is how a switched-off or unreachable server
+            degrades. ``None`` (the default) leaves every profile exactly as
+            before this parameter existed.
 
     Raises :class:`GatewayConfigError` if a configured vault has no entry in
     ``vault_services``. Structural config problems (duplicate keys, unknown
@@ -226,7 +297,7 @@ def build_gateway(
         auth = (token_verifiers or {}).get(profile.path)
         middleware = (profile_middleware or {}).get(profile.path, ())
         server = _build_profile_server(
-            profile, config, vault_servers, auth, middleware, stash_service
+            profile, config, vault_servers, auth, middleware, stash_service, upstream_mounts
         )
         profile_servers[profile.path] = server
         asgi_app = server.http_app(path="/")
@@ -245,4 +316,10 @@ def build_gateway(
     )
 
 
-__all__ = ["GatewayASGI", "GatewayConfigError", "build_gateway"]
+__all__ = [
+    "GatewayASGI",
+    "GatewayConfigError",
+    "UpstreamMount",
+    "build_gateway",
+    "upstream_identity_block",
+]

--- a/v3/server/src/palaia_hub/gateway/config.py
+++ b/v3/server/src/palaia_hub/gateway/config.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from ..upstream.models import UpstreamConfig, check_namespace_conflicts
 from .vault_protocol import MEMORY_TOOL_ACTIONS
 
 # MCP profile path segments and vault keys share the tool-name charset
@@ -92,6 +93,15 @@ class VaultMountConfig(BaseModel):
 #: that adds no cycle.
 DEFAULT_GATEWAY_PROFILE = "default"
 
+#: The curator's own profile path (SPEC-206). Defined here, in the schema
+#: module, because three unrelated modules need the same literal to *fence*
+#: it: :mod:`palaia_hub.curator.profile` (which synthesizes the profile),
+#: :mod:`palaia_hub.gateway.api` (which refuses to edit it), and
+#: :class:`ProfileConfig` below (which refuses to let an external server be
+#: mounted on it at all — SPEC-302 deliverable #6). Importing it from the
+#: schema is the one direction that adds no cycle.
+CURATOR_PROFILE_PATH = "curator"
+
 
 class ProfileConfig(BaseModel):
     """One addressable profile: a URL path segment and which vaults it exposes.
@@ -125,11 +135,38 @@ class ProfileConfig(BaseModel):
     #: either way — this only decides whether *this* profile's own MCP
     #: connection also carries those five tools.
     stash: bool = False
+    #: External MCP servers (SPEC-302) mounted into this profile, by their
+    #: :attr:`palaia_hub.upstream.models.UpstreamConfig.key`. An upstream
+    #: that is disabled or currently unreachable contributes no tools and
+    #: does not stop the profile from building — see
+    #: :func:`palaia_hub.gateway.build.build_gateway`.
+    upstreams: list[str] = Field(default_factory=list)
 
     @field_validator("path")
     @classmethod
     def _check_path(cls, value: str) -> str:
         return _validate_key(value, what="profile path")
+
+    @model_validator(mode="after")
+    def _no_upstreams_on_the_curator(self) -> ProfileConfig:
+        """The curator never sees an external server (SPEC-302 deliverable #6).
+
+        Enforced in the schema, not only at mount time, so there is no way
+        to *express* the mistake — a config.yaml, a REST payload and a
+        runtime rebuild all fail the same way, with the same reason. The
+        second half of the fence lives in
+        :func:`palaia_hub.gateway.build._build_profile_server`, which
+        refuses to mount an upstream onto this path even if a future caller
+        ever constructed the profile some other way.
+        """
+        if self.path == CURATOR_PROFILE_PATH and self.upstreams:
+            raise ValueError(
+                "the curator profile never mounts an external server: it runs a "
+                "model over your own notes, and an outside tool in that session "
+                "could exfiltrate them. Fix: mount "
+                f"{sorted(self.upstreams)} on a profile your clients use instead."
+            )
+        return self
 
     @field_validator("vaults")
     @classmethod
@@ -151,6 +188,10 @@ class GatewayConfig(BaseModel):
 
     vaults: list[VaultMountConfig] = Field(default_factory=list)
     profiles: list[ProfileConfig] = Field(default_factory=list)
+    #: External MCP servers this hub knows about (SPEC-302). Listing one
+    #: here does not expose it — a profile has to name it in its own
+    #: ``upstreams`` list.
+    upstreams: list[UpstreamConfig] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def _check_references(self) -> GatewayConfig:
@@ -160,13 +201,31 @@ class GatewayConfig(BaseModel):
         profile_paths = [p.path for p in self.profiles]
         if len(set(profile_paths)) != len(profile_paths):
             raise ValueError(f"duplicate profile paths in gateway config: {profile_paths}")
+        upstream_keys = [u.key for u in self.upstreams]
+        if len(set(upstream_keys)) != len(upstream_keys):
+            raise ValueError(f"duplicate upstream keys in gateway config: {upstream_keys}")
         known = set(vault_keys)
+        known_upstreams = set(upstream_keys)
         for profile in self.profiles:
             unknown = [v for v in profile.vaults if v not in known]
             if unknown:
                 raise ValueError(
                     f"profile {profile.path!r} references unknown vault key(s) {unknown}"
                 )
+            unknown_up = [u for u in profile.upstreams if u not in known_upstreams]
+            if unknown_up:
+                raise ValueError(
+                    f"profile {profile.path!r} references unknown external server(s) "
+                    f"{unknown_up}"
+                )
+        # SPEC-302 deliverable #5: two upstreams (or an upstream and a
+        # vault's memory tool family) claiming the same tool-name prefix is
+        # refused here, at config time — never resolved by letting whichever
+        # mounted last win.
+        check_namespace_conflicts(
+            self.upstreams,
+            reserved={v.namespace: f"vault {v.key!r}" for v in self.vaults},
+        )
         return self
 
     def vault(self, key: str) -> VaultMountConfig:
@@ -174,3 +233,9 @@ class GatewayConfig(BaseModel):
             if vault.key == key:
                 return vault
         raise KeyError(f"no vault configured with key {key!r}")
+
+    def upstream(self, key: str) -> UpstreamConfig:
+        for upstream in self.upstreams:
+            if upstream.key == key:
+                return upstream
+        raise KeyError(f"no external server configured with key {key!r}")

--- a/v3/server/src/palaia_hub/gateway/dynamic.py
+++ b/v3/server/src/palaia_hub/gateway/dynamic.py
@@ -84,6 +84,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import logging
 from collections.abc import Mapping, Sequence
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
@@ -97,9 +98,18 @@ from starlette.types import ASGIApp
 
 from ..auth.policy import check_gateway_auth_policy
 from ..stash.service import StashService
-from .build import GatewayConfigError, _build_profile_server, _build_vault_servers
+from ..upstream.models import UpstreamConfig
+from ..upstream.service import UpstreamCredentialError, UpstreamService
+from .build import (
+    GatewayConfigError,
+    UpstreamMount,
+    _build_profile_server,
+    _build_vault_servers,
+)
 from .config import GatewayConfig, ProfileConfig, VaultMountConfig
 from .vault_protocol import VaultService
+
+logger = logging.getLogger("palaia_hub.gateway.dynamic")
 
 #: Sentinel telling the background task to stop and close everything.
 _STOP = object()
@@ -156,6 +166,18 @@ class DynamicGateway:
         stash_service: the hub-wide stash (SPEC-202), mounted into any
             profile whose ``stash`` flag is set (SPEC-301) — same contract
             as :func:`~.build.build_gateway`.
+        upstream_service: the external-server registry (SPEC-302). Given,
+            a profile's ``upstreams`` entries are mounted **only while the
+            upstream's last probe said it was reachable** — a down or
+            switched-off server contributes no tools and, crucially, no
+            wait: nothing in a profile build or a ``tools/list`` reaches
+            for an unreachable endpoint. :meth:`start` deliberately does
+            **not** probe (SPEC-302 deliverable #4: "the mount must not
+            block hub startup"), so a freshly started hub mounts no
+            upstream at all until
+            :class:`palaia_hub.upstream.monitor.UpstreamHealthMonitor`'s
+            first pass reports one up and calls
+            :meth:`refresh_upstreams`.
     """
 
     def __init__(
@@ -167,8 +189,10 @@ class DynamicGateway:
         token_verifiers: Mapping[str, TokenVerifier] | None = None,
         profile_middleware: Mapping[str, Sequence[Middleware]] | None = None,
         stash_service: StashService | None = None,
+        upstream_service: UpstreamService | None = None,
     ) -> None:
         self._config = config
+        self._upstream_service = upstream_service
         self._vault_services: dict[str, VaultService] = dict(vault_services)
         self._vault_servers: dict[str, FastMCP] = _build_vault_servers(config, self._vault_services)
         self._mode = mode
@@ -232,6 +256,19 @@ class DynamicGateway:
                 raise GatewayConfigError(
                     f"vault key {vault.key!r} is already mounted at this gateway"
                 )
+            # SPEC-302 deliverable #5, the other direction: a *vault* created
+            # at runtime must not silently shadow an already-connected
+            # external server's tool prefix either. `model_copy` below does
+            # not re-run GatewayConfig's validators, so the check is explicit.
+            clashing = [u for u in self._config.upstreams if u.mount_namespace == vault.namespace]
+            if clashing:
+                raise GatewayConfigError(
+                    f"vault {vault.key!r} would use the tool prefix "
+                    f"{vault.namespace!r}, which the connected external server "
+                    f"{clashing[0].key!r} ({clashing[0].display_name}) already "
+                    "uses. Fix: name the vault differently, or give that server "
+                    "another namespace."
+                )
             self._config = self._config.model_copy(update={"vaults": [*self._config.vaults, vault]})
             self._vault_services[vault.key] = service
             self._vault_servers[vault.key] = _build_vault_servers(
@@ -257,6 +294,29 @@ class DynamicGateway:
 
         check_gateway_auth_policy(self._mode, self._profile_servers)
 
+    async def refresh_upstreams(self, keys: Sequence[str] | None = None) -> list[str]:
+        """Rebuild every profile that mounts one of ``keys`` (SPEC-302).
+
+        Called whenever an external server's *mountability* changed — it
+        came up, went down, was switched off, had its renames edited, or was
+        just added. ``None`` refreshes every profile that mounts any
+        upstream at all.
+
+        Returns the profile paths that were actually rebuilt, so a caller
+        can log or report it. A profile that mounts no affected upstream is
+        left completely alone (no rebuild, no retired session manager).
+        """
+        async with self._lock:
+            affected = [
+                profile
+                for profile in self._config.profiles
+                if profile.upstreams
+                and (keys is None or any(key in profile.upstreams for key in keys))
+            ]
+            for profile in affected:
+                await self._request_mount(profile)
+        return [profile.path for profile in affected]
+
     async def upsert_profile(
         self,
         path: str,
@@ -264,6 +324,7 @@ class DynamicGateway:
         *,
         label: str | None = None,
         stash: bool = False,
+        upstreams: Sequence[str] | None = None,
         auth: TokenVerifier | None = None,
     ) -> None:
         """Create a new profile, or fully replace an existing one's shape.
@@ -283,6 +344,12 @@ class DynamicGateway:
             label: the display name; ``None`` clears it back to "use the
                 path".
             stash: whether this profile also carries the stash tool family.
+            upstreams: every external server (SPEC-302) this profile should
+                mount, by key — replacing whatever it mounted before, the
+                same whole-list contract ``vault_keys`` follows. ``None``
+                keeps an existing profile's list untouched (and means "none"
+                for a brand-new one), so a caller editing only the vault
+                list never silently unmounts a connected server.
             auth: the verifier this path should use for every future
                 rebuild, recorded into ``self._token_verifiers``. Pass this
                 for a genuinely new path if the hub's mode requires auth
@@ -307,10 +374,30 @@ class DynamicGateway:
                 )
             if auth is not None:
                 self._token_verifiers[path] = auth
-            new_profile = ProfileConfig(
-                path=path, label=label, vaults=list(vault_keys), stash=stash
-            )
             profiles_by_path = {p.path: p for p in self._config.profiles}
+            if upstreams is None:
+                previous = profiles_by_path.get(path)
+                resolved_upstreams = list(previous.upstreams) if previous is not None else []
+            else:
+                resolved_upstreams = list(upstreams)
+            unknown_upstreams = [
+                key
+                for key in resolved_upstreams
+                if key not in {u.key for u in self._config.upstreams}
+            ]
+            if unknown_upstreams:
+                raise GatewayConfigError(
+                    f"cannot mount profile {path!r}: no external server is "
+                    f"configured under {unknown_upstreams}. Fix: connect the "
+                    "server first."
+                )
+            new_profile = ProfileConfig(
+                path=path,
+                label=label,
+                vaults=list(vault_keys),
+                stash=stash,
+                upstreams=resolved_upstreams,
+            )
             profiles_by_path[path] = new_profile
             self._config = self._config.model_copy(
                 update={"profiles": list(profiles_by_path.values())}
@@ -332,14 +419,102 @@ class DynamicGateway:
             )
             await self._request_unmount(path)
 
+    async def register_upstream(self, upstream: UpstreamConfig) -> None:
+        """Add or replace an external server in this gateway's own config.
+
+        Only the *registry* changes here — no profile mounts it until a
+        caller names it in :meth:`upsert_profile`'s ``upstreams``. The
+        replacement is validated by :class:`~.config.GatewayConfig` itself,
+        so a namespace that collides with a vault or another upstream is
+        refused here rather than at mount time (SPEC-302 deliverable #5).
+        """
+        async with self._lock:
+            others = [u for u in self._config.upstreams if u.key != upstream.key]
+            # A fresh `GatewayConfig(...)` rather than `model_copy(update=...)`:
+            # only the constructor re-runs the model validators, which is
+            # where the namespace-conflict refusal lives.
+            self._config = GatewayConfig(
+                vaults=list(self._config.vaults),
+                profiles=list(self._config.profiles),
+                upstreams=[*others, upstream],
+            )
+
+    async def remove_upstream(self, key: str) -> list[str]:
+        """Drop an external server and rebuild every profile that mounted it.
+
+        Returns the profile paths rebuilt. Raises :class:`KeyError` when no
+        such upstream is configured.
+        """
+        async with self._lock:
+            if key not in {u.key for u in self._config.upstreams}:
+                raise KeyError(f"no external server configured under {key!r}")
+            profiles = [
+                profile.model_copy(
+                    update={"upstreams": [k for k in profile.upstreams if k != key]}
+                )
+                if key in profile.upstreams
+                else profile
+                for profile in self._config.profiles
+            ]
+            affected = [
+                profile.path
+                for profile, before in zip(profiles, self._config.profiles, strict=True)
+                if profile.upstreams != before.upstreams
+            ]
+            self._config = GatewayConfig(
+                vaults=list(self._config.vaults),
+                profiles=profiles,
+                upstreams=[u for u in self._config.upstreams if u.key != key],
+            )
+            for profile in profiles:
+                if profile.path in affected:
+                    await self._request_mount(profile)
+        return affected
+
+    async def _upstream_mounts_for(self, profile: ProfileConfig) -> dict[str, UpstreamMount]:
+        """The subset of ``profile.upstreams`` that is actually mountable now.
+
+        An upstream is mounted only when it is enabled *and* its last probe
+        found it reachable — see the class docstring's ``upstream_service``
+        note for why an unreachable one is left out entirely rather than
+        mounted and allowed to time out on every ``tools/list``.
+        """
+        service = self._upstream_service
+        if service is None or not profile.upstreams:
+            return {}
+        mounts: dict[str, UpstreamMount] = {}
+        for key in profile.upstreams:
+            config = service.configs.get(key)
+            if config is None or not config.enabled or not service.is_up(key):
+                continue
+            try:
+                proxy = await service.proxy_for(key)
+            except UpstreamCredentialError as exc:
+                logger.warning(
+                    "not mounting external server %r on profile %r: %s",
+                    key,
+                    profile.path,
+                    exc,
+                )
+                continue
+            mounts[key] = UpstreamMount(config=config, server=proxy)
+        return mounts
+
     async def _request_mount(self, profile: ProfileConfig) -> None:
         """Build one profile's FastMCP app (plain construction — safe in the
         caller's own task) and hand it to the lifecycle task to actually
         mount. Caller holds ``self._lock``."""
         auth = self._token_verifiers.get(profile.path)
         middleware = self._profile_middleware.get(profile.path, ())
+        upstream_mounts = await self._upstream_mounts_for(profile)
         server = _build_profile_server(
-            profile, self._config, self._vault_servers, auth, middleware, self._stash_service
+            profile,
+            self._config,
+            self._vault_servers,
+            auth,
+            middleware,
+            self._stash_service,
+            upstream_mounts,
         )
         asgi_app = server.http_app(path="/")
         done: asyncio.Future[None] = asyncio.get_running_loop().create_future()

--- a/v3/server/src/palaia_hub/gateway/settings_bridge.py
+++ b/v3/server/src/palaia_hub/gateway/settings_bridge.py
@@ -28,6 +28,7 @@ import yaml
 
 from ..config import GatewaySettings, HubConfig
 from ..modes.patch import replace_config_section
+from ..upstream.models import UpstreamConfig
 from .config import ProfileConfig, VaultMountConfig
 
 
@@ -99,6 +100,7 @@ def resolve_profiles(
         return [ProfileConfig(path=default_profile, vaults=list(vault_keys))]
 
     known = set(vault_keys)
+    known_upstreams = {u.key for u in settings.upstreams}
     resolved: list[ProfileConfig] = []
     for profile in settings.profiles:
         unknown = [v for v in profile.vaults if v not in known]
@@ -109,15 +111,41 @@ def resolve_profiles(
                 f"has: {sorted(known) or 'none'}). Fix: create the vault first, or "
                 f"remove it from this profile's `vaults` list in config.yaml."
             )
+        unknown_upstreams = [u for u in profile.upstreams if u not in known_upstreams]
+        if unknown_upstreams:
+            raise GatewaySettingsError(
+                f"config.yaml: gateway.profiles[path={profile.path!r}] references "
+                f"external server(s) {unknown_upstreams} that are not listed under "
+                f"`gateway.upstreams` (it lists: {sorted(known_upstreams) or 'none'}). "
+                "Fix: add the server there, or remove it from this profile's "
+                "`upstreams` list."
+            )
         resolved.append(
             ProfileConfig(
                 path=profile.path,
                 label=profile.label,
                 vaults=list(profile.vaults),
                 stash=profile.stash,
+                upstreams=list(profile.upstreams),
             )
         )
     return resolved
+
+
+def resolve_upstreams(settings: GatewaySettings | None) -> list[UpstreamConfig]:
+    """The external servers ``config.yaml`` connects (SPEC-302 deliverable #1).
+
+    No ``gateway:`` section, or one with no ``upstreams``: an empty list —
+    a hub with no external servers, which is every hub until someone
+    connects one. The models are already validated (they *are*
+    :class:`~palaia_hub.upstream.models.UpstreamConfig` — see
+    :class:`palaia_hub.config.GatewaySettings`), so this is a pass-through
+    that exists to keep every caller reading the section through this one
+    module rather than reaching into ``config.gateway`` themselves.
+    """
+    if settings is None:
+        return []
+    return list(settings.upstreams)
 
 
 def resolve_full_gateway_profiles(
@@ -172,4 +200,5 @@ __all__ = [
     "render_gateway_section",
     "resolve_full_gateway_profiles",
     "resolve_profiles",
+    "resolve_upstreams",
 ]

--- a/v3/server/src/palaia_hub/serve.py
+++ b/v3/server/src/palaia_hub/serve.py
@@ -27,6 +27,7 @@ handler — no restart, per that module's ``dynamic_gateway`` parameter.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -43,7 +44,11 @@ from .events import EventBus, publish_from_hook
 from .events.schema import HubEventHook
 from .gateway import DynamicGateway, VaultService
 from .gateway.config import DEFAULT_GATEWAY_PROFILE, GatewayConfig, VaultMountConfig
-from .gateway.settings_bridge import apply_vault_overrides, resolve_full_gateway_profiles
+from .gateway.settings_bridge import (
+    apply_vault_overrides,
+    resolve_full_gateway_profiles,
+    resolve_upstreams,
+)
 from .gateway.wiring import EngineVaultService
 from .hooks import HookStore
 from .index import VaultIndex
@@ -55,6 +60,9 @@ from .oauth.verifier import build_profile_auth
 from .registry import RegistryClient
 from .stash.service import StashService
 from .stash.store import StashStore
+from .upstream.monitor import UpstreamHealthMonitor
+from .upstream.secrets import SecretStore
+from .upstream.service import UpstreamService
 from .vault import EventBus as VaultEventBus
 from .vault import VaultEngine, VaultRegistry
 
@@ -78,6 +86,13 @@ class ProductionApp:
     #: ``/mcp/stash`` tool family and, when the curator is on, its audit
     #: trail. Closed at shutdown, same as ``registry``/``indexes``.
     stash_store: StashStore | None = None
+    #: The external-server registry (SPEC-302). Its connections — including
+    #: any ``stdio`` child process — are closed by the app's own lifespan;
+    #: the handle is here so a caller can inspect health.
+    upstream_service: UpstreamService | None = None
+    #: The encrypted credential store backing those servers. Closed here,
+    #: same as ``stash_store``.
+    secret_store: SecretStore | None = None
 
 
 def _index_event_hook(event_bus: EventBus, vault_key: str) -> HubEventHook:
@@ -103,6 +118,19 @@ def _curator_event_hook(event_bus: EventBus) -> HubEventHook:
         publish_from_hook(event_bus, event, data, origin="curator")
 
     return _hook
+
+
+def _upstream_event_hook(event_bus: EventBus) -> Callable[[str, dict[str, Any]], None]:
+    """Promote ``gateway.upstream.up``/``down`` onto the public bus (SPEC-302).
+
+    :class:`~palaia_hub.upstream.service.UpstreamService` publishes only on a
+    *change* of reachability, so this is quiet for a healthy hub.
+    """
+
+    def _publish(event: str, data: dict[str, Any]) -> None:
+        publish_from_hook(event_bus, event, data, origin="gateway")
+
+    return _publish
 
 
 async def build_production_app(
@@ -221,7 +249,23 @@ async def build_production_app(
             subscribe=event_bus.on,
         )
 
-    gateway_config = GatewayConfig(vaults=mounts, profiles=profiles)
+    # SPEC-302: external MCP servers. The secret store is opened
+    # unconditionally (it creates its own key/db, 0600, on first use — and
+    # the dashboard can store a credential before any server is connected);
+    # the service starts with whatever `gateway.upstreams` names. Nothing
+    # here touches the network: the first reachability probe happens in the
+    # background, from the health monitor started by the app's lifespan, so
+    # a hub whose upstream is down still starts instantly.
+    secret_store = SecretStore(stash_home)
+    upstream_service = UpstreamService(
+        resolve_upstreams(config.gateway),
+        secret_store=secret_store,
+        publish=_upstream_event_hook(event_bus),
+    )
+
+    gateway_config = GatewayConfig(
+        vaults=mounts, profiles=profiles, upstreams=resolve_upstreams(config.gateway)
+    )
     # `auth_enabled` (config.py): mandatory in cloud/open (already enforced
     # at config-load time), on by default in locked mode too — see that
     # field's docstring. SPEC-301: combine it with the OAuth server's own
@@ -243,6 +287,10 @@ async def build_production_app(
         token_verifiers=token_verifiers,  # type: ignore[arg-type]
         profile_middleware=curator.profile_middleware if curator else None,
         stash_service=stash_service,
+        upstream_service=upstream_service,
+    )
+    upstream_monitor = UpstreamHealthMonitor(
+        upstream_service, on_change=dynamic_gateway.refresh_upstreams
     )
 
     app = create_app(
@@ -262,6 +310,9 @@ async def build_production_app(
         automation_outbox=automation_outbox,
         notification_store=notification_store,
         curator_wiring=curator,
+        upstream_service=upstream_service,
+        upstream_monitor=upstream_monitor,
+        secret_store=secret_store,
         home=home,
     )
     return ProductionApp(
@@ -273,6 +324,8 @@ async def build_production_app(
         token_store=token_store,
         curator=curator,
         stash_store=stash_store,
+        upstream_service=upstream_service,
+        secret_store=secret_store,
     )
 
 

--- a/v3/server/src/palaia_hub/upstream/__init__.py
+++ b/v3/server/src/palaia_hub/upstream/__init__.py
@@ -1,0 +1,17 @@
+"""External MCP servers behind the gateway (SPEC-302).
+
+**No imports here, on purpose.** :mod:`palaia_hub.config` imports
+:class:`palaia_hub.upstream.models.UpstreamConfig` directly, and config
+loading must never drag fastmcp or a transport layer in behind it (see
+``models.py``'s docstring). Importing this package therefore costs nothing;
+callers reach for the submodule they actually need:
+
+- :mod:`palaia_hub.upstream.models` — the config schema (fastmcp-free).
+- :mod:`palaia_hub.upstream.secrets` — the encrypted credential store.
+- :mod:`palaia_hub.upstream.service` — connecting, probing and proxying
+  (this one pulls fastmcp).
+- :mod:`palaia_hub.upstream.monitor` — the periodic health probe.
+- :mod:`palaia_hub.upstream.api` — the REST surface.
+"""
+
+from __future__ import annotations

--- a/v3/server/src/palaia_hub/upstream/api.py
+++ b/v3/server/src/palaia_hub/upstream/api.py
@@ -1,0 +1,464 @@
+"""REST for external servers and the secret store (SPEC-302 #2/#4).
+
+Two surfaces, one rule between them.
+
+``/api/gateway/upstreams`` — connect, edit, disconnect and health-check an
+external MCP server. Every write does the same three things in the same
+order as SPEC-301's profile editor: validate against the gateway actually
+running, apply it live to the :class:`~palaia_hub.gateway.dynamic.
+DynamicGateway` (no restart), then write the new shape back to
+``config.yaml`` (so it survives one).
+
+``/api/secrets`` — **write-only, names-only.** There is no route that returns
+a secret value, and no response model in this module has a field one could be
+placed in: :class:`SecretOut` carries a name and two timestamps. That is the
+SPEC's fixed design, implemented structurally rather than by remembering not
+to fill a field in. The value goes in through ``PUT`` and comes out only
+inside the hub, when :mod:`palaia_hub.upstream.service` builds a header or a
+child process's environment.
+
+Error messages here name secrets and servers by *name*, never by value, and
+never echo a request body back (a 422 from pydantic on a ``PUT`` body would
+otherwise quote the value it rejected — which is why
+:class:`SecretPutRequest` accepts any non-empty string and does its own
+checking in the handler).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from ..config import GatewayProfileSettings, GatewaySettings, HubConfig, config_file_path
+from ..events import EventBus, publish_event
+from ..gateway.build import GatewayConfigError
+from ..gateway.config import CURATOR_PROFILE_PATH
+from ..gateway.dynamic import DynamicGateway
+from ..gateway.settings_bridge import persist_gateway_settings
+from .models import UpstreamConfig, UpstreamConflictError
+from .secrets import SecretStore, SecretStoreError, validate_secret_name
+from .service import UpstreamNotConfiguredError, UpstreamService
+
+logger = logging.getLogger("palaia_hub.upstream.api")
+
+
+class UpstreamOut(BaseModel):
+    """One external server as the dashboard sees it — credential-free.
+
+    ``secret_names`` lists which stored secrets this server *uses*, so a UI
+    can show "needs a token you have not entered yet". It never carries a
+    value, and neither does anything else here.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    key: str
+    kind: str
+    display_name: str
+    namespace: str
+    enabled: bool
+    #: Where it points: the URL, or the command line. Credential-free by
+    #: construction — a token lives in the secret store, never in either.
+    target: str
+    #: Profiles that mount this server (SPEC-301 profile shapes).
+    profiles: list[str]
+    up: bool
+    #: One plain-language line: connected and how many tools, or why not.
+    status: str
+    checked_at: float | None
+    tools: list[str]
+    secret_names: list[str]
+    tool_renames: dict[str, str]
+
+
+class ConnectUpstreamRequest(BaseModel):
+    """``POST /api/gateway/upstreams`` — the config, plus where to mount it.
+
+    ``profiles`` is a convenience: naming them here mounts the server on
+    them in the same call instead of requiring a follow-up PATCH per
+    profile. The curator profile is refused (SPEC-302 deliverable #6).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    upstream: UpstreamConfig
+    profiles: list[str] = Field(default_factory=list)
+
+
+class UpdateUpstreamRequest(BaseModel):
+    """``PATCH /api/gateway/upstreams/{key}`` — every field optional.
+
+    ``key``, ``kind`` and ``namespace`` are absent on purpose: the first two
+    are identity, and changing the third renames every tool a connected
+    client already approved. Disconnect and reconnect for those.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    display_name: str | None = None
+    enabled: bool | None = None
+    url: str | None = None
+    command: str | None = None
+    args: list[str] | None = None
+    tool_renames: dict[str, str] | None = None
+    profiles: list[str] | None = None
+
+
+class SecretOut(BaseModel):
+    """A stored secret's *metadata*. There is no value field, by design."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    created_at: float
+    updated_at: float
+
+
+class SecretPutRequest(BaseModel):
+    """``PUT /api/secrets/{name}`` — the one place a value travels inbound."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    value: str
+
+
+def build_secret_change_hook(
+    upstream_service: UpstreamService, dynamic_gateway: DynamicGateway
+) -> Callable[[str], Awaitable[None]]:
+    """The "a secret's value changed" reaction (SPEC-302 deliverable #3).
+
+    An external server's credential is baked into its transport when the
+    connection is built — a ``stdio`` child's environment at spawn time, an
+    HTTP transport's headers at construction time — so replacing a stored
+    value has no effect on a server that is already connected until that
+    connection is thrown away. This hook does exactly that, for the servers
+    that actually reference the changed name, and then lets the profiles
+    mounting them be rebuilt around the fresh connection. A name nothing
+    references costs one dictionary scan and nothing else.
+    """
+
+    async def _on_change(name: str) -> None:
+        affected = [
+            config.key
+            for config in upstream_service.configs.values()
+            if name in _secret_names(config)
+        ]
+        if not affected:
+            return
+        for key in affected:
+            await upstream_service.register(upstream_service.config(key))
+        await dynamic_gateway.refresh_upstreams(affected)
+
+    return _on_change
+
+
+def build_secrets_router(
+    secret_store: SecretStore,
+    *,
+    on_secret_changed: Callable[[str], Awaitable[None]] | None = None,
+) -> APIRouter:
+    """The write-only secret surface (SPEC-302 deliverable #2).
+
+    Args:
+        secret_store: the encrypted store.
+        on_secret_changed: awaited with a secret's name after its value is
+            replaced or removed — normally
+            :func:`build_secret_change_hook`, so a connected server picks up
+            a rotated credential without a restart. Omitted, writes still
+            work; a server already connected keeps using the old value until
+            it is edited or the hub restarts.
+    """
+    router = APIRouter(tags=["secrets"])
+
+    @router.get("/api/secrets", response_model=list[SecretOut])
+    async def list_secrets() -> list[SecretOut]:
+        """Names and timestamps only — never values."""
+        return [
+            SecretOut(name=info.name, created_at=info.created_at, updated_at=info.updated_at)
+            for info in secret_store.names()
+        ]
+
+    @router.put("/api/secrets/{name}", response_model=SecretOut)
+    async def put_secret(name: str, body: SecretPutRequest) -> SecretOut:
+        """Store a value under ``name``, replacing any previous one.
+
+        The response confirms *that* it was stored, never *what* was
+        stored — there is nowhere in :class:`SecretOut` to put it.
+        """
+        try:
+            validate_secret_name(name)
+            info = secret_store.put(name, body.value)
+        except SecretStoreError as exc:
+            # `str(exc)` is safe: every SecretStoreError message names the
+            # secret and the fix, and none of them interpolates a value.
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if on_secret_changed is not None:
+            await on_secret_changed(name)
+        return SecretOut(
+            name=info.name, created_at=info.created_at, updated_at=info.updated_at
+        )
+
+    @router.delete("/api/secrets/{name}", status_code=204)
+    async def delete_secret(name: str) -> None:
+        if not secret_store.delete(name):
+            raise HTTPException(status_code=404, detail=f"no secret stored under {name!r}")
+        if on_secret_changed is not None:
+            await on_secret_changed(name)
+
+    return router
+
+
+def _secret_names(config: UpstreamConfig) -> list[str]:
+    names = sorted(config.env_secrets.values())
+    if config.auth is not None:
+        names = sorted({*names, config.auth.secret_name})
+    return names
+
+
+def build_upstreams_router(
+    dynamic_gateway: DynamicGateway,
+    upstream_service: UpstreamService,
+    *,
+    home: Path,
+    config: HubConfig,
+    event_bus: EventBus | None = None,
+    refresh: Callable[[list[str]], Awaitable[object]] | None = None,
+) -> APIRouter:
+    """Build the external-server router (SPEC-302 deliverables #1/#3/#4).
+
+    Args:
+        dynamic_gateway: the live gateway every write applies to.
+        upstream_service: the registry that owns connections and health.
+        home: where ``config.yaml`` lives, for the write-back.
+        config: the running config — only its ``gateway.vaults``/
+            ``gateway.profiles`` identity overrides are read (never
+            mutated); the authoritative profile/upstream shape is the
+            gateway's own.
+        event_bus: publishes ``gateway.upstream.up``/``down`` transitions
+            triggered by a probe from here. Omitted, probes still work.
+        refresh: how a mountability change is applied — normally
+            :meth:`DynamicGateway.refresh_upstreams`. Injected rather than
+            called directly so a test can observe it.
+    """
+    router = APIRouter(tags=["gateway"])
+    config_path = config_file_path(home)
+    apply_refresh = refresh or dynamic_gateway.refresh_upstreams
+
+    def _profiles_mounting(key: str) -> list[str]:
+        return sorted(
+            profile.path
+            for profile in dynamic_gateway.config.profiles
+            if key in profile.upstreams
+        )
+
+    def _out(key: str) -> UpstreamOut:
+        upstream = upstream_service.config(key)
+        status = upstream_service.status(key)
+        return UpstreamOut(
+            key=upstream.key,
+            kind=upstream.kind,
+            display_name=upstream.display_name,
+            namespace=upstream.mount_namespace,
+            enabled=upstream.enabled,
+            target=upstream.target,
+            profiles=_profiles_mounting(key),
+            up=status.up,
+            status=status.detail,
+            checked_at=status.checked_at,
+            tools=list(status.tools),
+            secret_names=_secret_names(upstream),
+            tool_renames=dict(upstream.tool_renames),
+        )
+
+    def _persist() -> None:
+        """Write the gateway's current shape back to ``config.yaml``.
+
+        Same contract as SPEC-301's profile editor: the curator profile is
+        excluded (it is synthesized from ``curator:``, not stored here), and
+        the per-vault identity overrides already in the file are carried
+        through untouched.
+        """
+        existing_vaults = config.gateway.vaults if config.gateway is not None else []
+        profiles = [
+            p for p in dynamic_gateway.config.profiles if p.path != CURATOR_PROFILE_PATH
+        ]
+        persist_gateway_settings(
+            config_path,
+            GatewaySettings(
+                vaults=existing_vaults,
+                profiles=[
+                    GatewayProfileSettings(
+                        path=p.path,
+                        label=p.label,
+                        vaults=list(p.vaults),
+                        stash=p.stash,
+                        upstreams=list(p.upstreams),
+                    )
+                    for p in profiles
+                ],
+                upstreams=list(dynamic_gateway.config.upstreams),
+            ),
+        )
+
+    def _publish(event: str, data: dict[str, object]) -> None:
+        if event_bus is not None:
+            publish_event(event_bus, event, origin="gateway", data=data)
+
+    async def _mount_on(key: str, profile_paths: list[str]) -> None:
+        """Add ``key`` to each named profile's ``upstreams`` list, live."""
+        for path in profile_paths:
+            if path == CURATOR_PROFILE_PATH:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "the curator profile never mounts an external server: it "
+                        "runs a model over your own notes, and an outside tool in "
+                        "that session could exfiltrate them."
+                    ),
+                )
+            current = next(
+                (p for p in dynamic_gateway.config.profiles if p.path == path), None
+            )
+            if current is None:
+                raise HTTPException(status_code=404, detail=f"no profile at path {path!r}")
+            if key in current.upstreams:
+                continue
+            await dynamic_gateway.upsert_profile(
+                path,
+                list(current.vaults),
+                label=current.label,
+                stash=current.stash,
+                upstreams=[*current.upstreams, key],
+            )
+
+    async def _unmount_from(key: str, keep: list[str]) -> None:
+        """Make exactly ``keep`` mount ``key`` — remove it everywhere else."""
+        for profile in list(dynamic_gateway.config.profiles):
+            if key in profile.upstreams and profile.path not in keep:
+                await dynamic_gateway.upsert_profile(
+                    profile.path,
+                    list(profile.vaults),
+                    label=profile.label,
+                    stash=profile.stash,
+                    upstreams=[k for k in profile.upstreams if k != key],
+                )
+
+    @router.get("/api/gateway/upstreams", response_model=list[UpstreamOut])
+    async def list_upstreams() -> list[UpstreamOut]:
+        """Every connected server with its last known health (deliverable #4)."""
+        return [_out(status.key) for status in upstream_service.statuses()]
+
+    @router.post("/api/gateway/upstreams", response_model=UpstreamOut)
+    async def connect_upstream(body: ConnectUpstreamRequest) -> UpstreamOut:
+        upstream = body.upstream
+        if upstream.key in upstream_service.configs:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"an external server is already connected under {upstream.key!r}. "
+                    "Fix: PATCH it, or pick a different key."
+                ),
+            )
+        try:
+            await dynamic_gateway.register_upstream(upstream)
+        except (UpstreamConflictError, ValidationError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        await upstream_service.register(upstream)
+        try:
+            await _mount_on(upstream.key, body.profiles)
+        except GatewayConfigError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        await apply_refresh([upstream.key])
+        _persist()
+        _publish(
+            "gateway.upstream.connected",
+            {
+                "upstream": upstream.key,
+                "display_name": upstream.display_name,
+                "kind": upstream.kind,
+                "namespace": upstream.mount_namespace,
+                "profiles": _profiles_mounting(upstream.key),
+            },
+        )
+        return _out(upstream.key)
+
+    @router.patch("/api/gateway/upstreams/{key}", response_model=UpstreamOut)
+    async def update_upstream(key: str, body: UpdateUpstreamRequest) -> UpstreamOut:
+        try:
+            current = upstream_service.config(key)
+        except UpstreamNotConfiguredError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        updates = body.model_dump(exclude_unset=True, exclude_none=True)
+        updates.pop("profiles", None)
+        try:
+            updated = current.model_copy(update=updates)
+            # `model_copy` skips validators; re-construct so a now-invalid
+            # combination (an http upstream with its url blanked, say) is
+            # refused rather than mounted.
+            updated = UpstreamConfig.model_validate(updated.model_dump())
+        except (ValidationError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        try:
+            await dynamic_gateway.register_upstream(updated)
+        except (UpstreamConflictError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        await upstream_service.register(updated)
+        if body.profiles is not None:
+            try:
+                await _mount_on(key, body.profiles)
+                await _unmount_from(key, body.profiles)
+            except GatewayConfigError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+        await apply_refresh([key])
+        _persist()
+        _publish(
+            "gateway.upstream.updated",
+            {
+                "upstream": key,
+                "display_name": updated.display_name,
+                "enabled": updated.enabled,
+                "profiles": _profiles_mounting(key),
+            },
+        )
+        return _out(key)
+
+    @router.post("/api/gateway/upstreams/{key}/probe", response_model=UpstreamOut)
+    async def probe_upstream(key: str) -> UpstreamOut:
+        """Check reachability now (deliverable #4's on-demand half)."""
+        try:
+            before = upstream_service.status(key).up
+            await upstream_service.probe(key)
+        except UpstreamNotConfiguredError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        if upstream_service.status(key).up != before:
+            await apply_refresh([key])
+        return _out(key)
+
+    @router.delete("/api/gateway/upstreams/{key}", status_code=204)
+    async def disconnect_upstream(key: str) -> None:
+        try:
+            upstream_service.config(key)
+        except UpstreamNotConfiguredError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        await dynamic_gateway.remove_upstream(key)
+        await upstream_service.unregister(key)
+        _persist()
+        _publish("gateway.upstream.disconnected", {"upstream": key})
+
+    return router
+
+
+__all__ = [
+    "ConnectUpstreamRequest",
+    "SecretOut",
+    "SecretPutRequest",
+    "UpdateUpstreamRequest",
+    "UpstreamOut",
+    "build_secret_change_hook",
+    "build_secrets_router",
+    "build_upstreams_router",
+]

--- a/v3/server/src/palaia_hub/upstream/models.py
+++ b/v3/server/src/palaia_hub/upstream/models.py
@@ -1,0 +1,281 @@
+"""The upstream-server registry's schema (SPEC-302 deliverable #1).
+
+One external MCP server the operator connected: a remote HTTP endpoint, or a
+local command palaia spawns. Deliberately **import-free** with respect to the
+rest of ``palaia_hub``:
+
+- :mod:`palaia_hub.config` imports :class:`UpstreamConfig` directly (as
+  ``GatewayUpstreamSettings``) rather than keeping a hand-maintained twin of
+  it, and that module must stay importable without pulling in fastmcp — so
+  nothing here may import :mod:`palaia_hub.gateway` (whose package
+  ``__init__`` does) or :mod:`palaia_hub.upstream.service` (which does too).
+  The namespace/key charset rules are therefore re-stated here as local
+  regexes rather than borrowed from ``gateway.config``/``gateway.naming``.
+- The parent package's ``__init__`` is deliberately empty of imports for the
+  same reason: ``import palaia_hub.upstream.models`` must not drag a
+  transport layer in behind it.
+
+Credentials never appear in this model. An ``http`` upstream names the
+*secret* that holds its bearer token or API key
+(:class:`UpstreamAuthConfig.secret_name`); a ``stdio`` upstream names which
+secrets to inject into which environment variables
+(:attr:`UpstreamConfig.env_secrets`). Both are looked up at connect time
+through :class:`palaia_hub.upstream.secrets.SecretStore`, so this model — and
+therefore ``config.yaml``, which is plain text — carries names only.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+#: An upstream's config identity: the key REST addresses it by, a profile
+#: lists in its ``upstreams``, and ``config.yaml`` stores it under.
+_KEY_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+#: An upstream's tool-name prefix. Narrower than the key charset (``-`` is
+#: not a legal MCP tool-name character), and a *loud* error rather than a
+#: silent sanitization: a mis-typed namespace changes every tool name a
+#: connected client sees, which is not something to fix behind the
+#: operator's back.
+_NAMESPACE_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+
+#: How long a connect/initialize/tools-list probe may take before the
+#: upstream is called down. Bounded by construction (SPEC-302 deliverable
+#: #4: "bounded connect timeouts; the mount must not block hub startup").
+DEFAULT_CONNECT_TIMEOUT = 8.0
+
+UpstreamKind = Literal["http", "stdio"]
+
+
+class UpstreamAuthConfig(BaseModel):
+    """Static header auth for an ``http`` upstream (SPEC-302 deliverable #3).
+
+    ``secret_name`` names an entry in the encrypted secret store; its value
+    is substituted into ``value_template`` at connect time. The default
+    template produces the ordinary ``Authorization: Bearer <token>``; an
+    upstream wanting ``X-API-Key: <key>`` sets ``header: X-API-Key`` and
+    ``value_template: "{secret}"``.
+
+    Full OAuth *client* flows against a third-party authorization server are
+    an explicit non-goal of this SPEC: the v1 path is pasting a token into
+    the secret store by hand, which the dashboard says plainly rather than
+    implying an automatic login.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    header: str = "Authorization"
+    value_template: str = "Bearer {secret}"
+    secret_name: str
+
+    @field_validator("header")
+    @classmethod
+    def _check_header(cls, value: str) -> str:
+        if not value or any(ch.isspace() or ch == ":" for ch in value):
+            raise ValueError(
+                f"auth header name {value!r} must be a single HTTP header name, "
+                "with no spaces or ':'"
+            )
+        return value
+
+    @field_validator("value_template")
+    @classmethod
+    def _check_template(cls, value: str) -> str:
+        if "{secret}" not in value:
+            raise ValueError(
+                "auth value_template must contain '{secret}' — that is where the "
+                "stored secret is substituted (e.g. 'Bearer {secret}')"
+            )
+        return value
+
+
+class UpstreamConfig(BaseModel):
+    """One external MCP server, as configured.
+
+    Args:
+        key: config identity (``[a-z0-9_-]``), set once.
+        kind: ``http`` for a remote streamable-HTTP endpoint, ``stdio`` for a
+            local command palaia spawns and talks to over its pipes.
+        display_name: what a person calls this server ("Linear", "My
+            weather box"). Shown in the dashboard and in the provenance line
+            a profile's IDENTITY block carries.
+        namespace: the tool-name prefix its tools appear under
+            (``<namespace>_<tool>``). Defaults to ``key`` with ``-`` turned
+            into ``_``.
+        enabled: ``False`` keeps the entry but mounts nothing — the way to
+            switch a server off without losing how it was configured.
+        url: the endpoint, for ``kind: http``.
+        command / args / cwd: the process to spawn, for ``kind: stdio``.
+        env: plain (non-secret) environment for a ``stdio`` child.
+        env_secrets: ``{ENV_VAR: secret name}`` — each named secret is
+            decrypted and injected into the child's environment at spawn
+            time, so a token never appears in ``config.yaml`` or in a
+            process listing's arguments.
+        headers: plain (non-secret) extra headers for an ``http`` upstream.
+        auth: static header auth from the secret store, for ``http``.
+        tool_renames: ``{upstream tool name: pre-namespace replacement}`` —
+            the same pre-namespace contract every rename in this repository
+            uses (SPEC-002 FINDINGS Q4; see
+            :mod:`palaia_hub.gateway.naming`).
+        connect_timeout: seconds a probe or connect may take.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    key: str
+    kind: UpstreamKind
+    display_name: str
+    namespace: str | None = None
+    enabled: bool = True
+
+    url: str | None = None
+
+    command: str | None = None
+    args: list[str] = Field(default_factory=list)
+    cwd: str | None = None
+    env: dict[str, str] = Field(default_factory=dict)
+    env_secrets: dict[str, str] = Field(default_factory=dict)
+
+    headers: dict[str, str] = Field(default_factory=dict)
+    auth: UpstreamAuthConfig | None = None
+
+    tool_renames: dict[str, str] = Field(default_factory=dict)
+    connect_timeout: float = DEFAULT_CONNECT_TIMEOUT
+
+    @field_validator("key")
+    @classmethod
+    def _check_key(cls, value: str) -> str:
+        if not _KEY_RE.match(value):
+            raise ValueError(
+                f"upstream key {value!r} must be 1-64 characters of lowercase "
+                "letters, digits, '-' or '_', starting with a letter or digit"
+            )
+        return value
+
+    @field_validator("namespace")
+    @classmethod
+    def _check_namespace(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if not _NAMESPACE_RE.match(value):
+            raise ValueError(
+                f"upstream namespace {value!r} must be 1-64 characters of "
+                "lowercase letters, digits or '_', starting with a letter — it "
+                "becomes the prefix of every tool name this server contributes"
+            )
+        return value
+
+    @field_validator("display_name")
+    @classmethod
+    def _check_display_name(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("display_name must not be empty — it is what a person reads")
+        return value
+
+    @field_validator("connect_timeout")
+    @classmethod
+    def _check_timeout(cls, value: float) -> float:
+        if not 0.1 <= value <= 120:
+            raise ValueError("connect_timeout must be between 0.1 and 120 seconds")
+        return value
+
+    @model_validator(mode="after")
+    def _check_kind_fields(self) -> UpstreamConfig:
+        if self.kind == "http":
+            if not self.url:
+                raise ValueError(f"upstream {self.key!r} is kind 'http' and needs a `url`")
+            if self.command:
+                raise ValueError(
+                    f"upstream {self.key!r} is kind 'http' but also sets `command`; "
+                    "pick one (use kind 'stdio' for a local command)"
+                )
+            if self.env_secrets or self.env:
+                raise ValueError(
+                    f"upstream {self.key!r} is kind 'http'; `env`/`env_secrets` only "
+                    "apply to a 'stdio' upstream (use `auth`/`headers` instead)"
+                )
+        else:
+            if not self.command:
+                raise ValueError(f"upstream {self.key!r} is kind 'stdio' and needs a `command`")
+            if self.url:
+                raise ValueError(
+                    f"upstream {self.key!r} is kind 'stdio' but also sets `url`; "
+                    "pick one (use kind 'http' for a remote endpoint)"
+                )
+            if self.auth or self.headers:
+                raise ValueError(
+                    f"upstream {self.key!r} is kind 'stdio'; `auth`/`headers` only "
+                    "apply to an 'http' upstream (use `env_secrets` instead)"
+                )
+        for env_var in self.env_secrets:
+            if not env_var or not env_var.replace("_", "").isalnum():
+                raise ValueError(
+                    f"upstream {self.key!r}: {env_var!r} is not a usable environment "
+                    "variable name (letters, digits and '_' only)"
+                )
+        return self
+
+    @property
+    def mount_namespace(self) -> str:
+        """The tool-name prefix actually used: ``namespace``, else ``key``."""
+        return self.namespace or self.key.replace("-", "_")
+
+    @property
+    def target(self) -> str:
+        """A one-line, credential-free description of where this points."""
+        if self.kind == "http":
+            return self.url or ""
+        return " ".join([self.command or "", *self.args]).strip()
+
+
+class UpstreamConflictError(ValueError):
+    """Two upstreams (or an upstream and a vault) claim the same namespace,
+    or two upstream tools would land on the same final name.
+
+    Raised at config time — never resolved by letting the last write win
+    (SPEC-302 deliverable #5: "conflicts refused loudly at config time, not
+    silently last-write-wins").
+    """
+
+
+def check_namespace_conflicts(
+    upstreams: list[UpstreamConfig], *, reserved: dict[str, str] | None = None
+) -> None:
+    """Refuse a set of upstreams whose namespaces collide.
+
+    Args:
+        upstreams: every configured upstream (enabled or not — a disabled
+            entry still owns its namespace, so enabling it later can never
+            surprise anyone with a conflict).
+        reserved: ``{namespace: what already owns it}`` — the vault
+            namespaces (``<vault>_memory``) and any built-in prefix, so an
+            upstream cannot shadow a memory tool family.
+
+    Raises:
+        UpstreamConflictError: naming both claimants and the namespace.
+    """
+    owners: dict[str, str] = dict(reserved or {})
+    for upstream in upstreams:
+        namespace = upstream.mount_namespace
+        existing = owners.get(namespace)
+        if existing is not None:
+            raise UpstreamConflictError(
+                f"namespace {namespace!r} is claimed by both {existing} and "
+                f"upstream {upstream.key!r} ({upstream.display_name!r}). Every "
+                "tool from both would collide. Fix: give one of them a different "
+                "`namespace`."
+            )
+        owners[namespace] = f"upstream {upstream.key!r}"
+
+
+__all__ = [
+    "DEFAULT_CONNECT_TIMEOUT",
+    "UpstreamAuthConfig",
+    "UpstreamConfig",
+    "UpstreamConflictError",
+    "UpstreamKind",
+    "check_namespace_conflicts",
+]

--- a/v3/server/src/palaia_hub/upstream/monitor.py
+++ b/v3/server/src/palaia_hub/upstream/monitor.py
@@ -1,0 +1,116 @@
+"""Periodic reachability probing for external servers (SPEC-302 #4).
+
+Why a loop at all, rather than probing when someone asks: an upstream that
+was down when the hub started, and comes back five minutes later, has to
+start serving tools again *without* anybody clicking anything — and an
+upstream that dies has to stop being offered before a model tries to call it
+and waits out a timeout. Both are state changes nobody is watching for.
+
+The loop is deliberately dumb: probe everything, publish
+``gateway.upstream.up``/``down`` for whatever *changed*
+(:class:`~palaia_hub.upstream.service.UpstreamService` owns that comparison),
+and hand the changed keys to one callback — in production
+:meth:`palaia_hub.gateway.dynamic.DynamicGateway.refresh_upstreams`, which
+rebuilds only the profiles that mount them. Nothing here knows what a
+profile is.
+
+The first pass runs immediately on :meth:`UpstreamHealthMonitor.start`, in
+the background: this is what mounts an upstream after a hub start that
+deliberately mounted none (see ``DynamicGateway``'s ``upstream_service``
+note — startup must not block on a network round-trip).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Awaitable, Callable, Sequence
+
+from .service import UpstreamService
+
+logger = logging.getLogger("palaia_hub.upstream.monitor")
+
+#: Seconds between probe passes. Human-paced: an external server coming back
+#: within a minute is fast enough, and a shorter interval only adds traffic
+#: to somebody else's service.
+DEFAULT_PROBE_INTERVAL = 60.0
+
+OnChange = Callable[[Sequence[str]], Awaitable[object]]
+
+
+class UpstreamHealthMonitor:
+    """Probes every configured upstream on an interval.
+
+    Args:
+        service: the registry to probe.
+        on_change: awaited with the keys whose reachability changed since
+            the previous pass (never with an empty list). Exceptions from it
+            are logged, never propagated — a failed rebuild must not stop
+            the monitor.
+        interval: seconds between passes.
+    """
+
+    def __init__(
+        self,
+        service: UpstreamService,
+        *,
+        on_change: OnChange | None = None,
+        interval: float = DEFAULT_PROBE_INTERVAL,
+    ) -> None:
+        self._service = service
+        self._on_change = on_change
+        self._interval = max(1.0, interval)
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        """Start the loop (idempotent). Returns immediately — the first
+        probe pass runs in the background."""
+        if self._task is not None:
+            return
+        self._task = asyncio.create_task(self._run())
+
+    async def aclose(self) -> None:
+        """Stop the loop and wait for the current pass to unwind."""
+        if self._task is None:
+            return
+        self._task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await self._task
+        self._task = None
+
+    async def probe_once(self) -> list[str]:
+        """One pass. Returns the keys whose ``up`` state changed."""
+        before = {status.key: status.up for status in self._service.statuses()}
+        unchecked = {
+            status.key for status in self._service.statuses() if status.checked_at is None
+        }
+        await self._service.probe_all()
+        after = {status.key: status.up for status in self._service.statuses()}
+        changed = sorted(
+            key
+            for key, up in after.items()
+            # A first-ever check counts as a change even when it confirms
+            # "down": that is the pass that decides whether the profile
+            # rebuild after hub startup mounts anything at all.
+            if before.get(key) != up or key in unchecked
+        )
+        if changed and self._on_change is not None:
+            try:
+                await self._on_change(changed)
+            except Exception as exc:  # noqa: BLE001 — a failed rebuild must not stop the loop
+                logger.warning("reacting to an external-server change failed: %s", exc)
+        return changed
+
+    async def _run(self) -> None:
+        while True:
+            try:
+                await self.probe_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001 — the loop outlives one bad pass
+                logger.warning("external-server health pass failed: %s", exc)
+            await asyncio.sleep(self._interval)
+
+
+__all__ = ["DEFAULT_PROBE_INTERVAL", "OnChange", "UpstreamHealthMonitor"]

--- a/v3/server/src/palaia_hub/upstream/secrets.py
+++ b/v3/server/src/palaia_hub/upstream/secrets.py
@@ -1,0 +1,266 @@
+"""The encrypted secret store (SPEC-302 deliverable #2 — fixed design).
+
+Upstream API keys, bearer tokens and OAuth client secrets live here, and
+nowhere else: not in ``config.yaml`` (which is plain text, edited by hand and
+often copied around), not in a client's own configuration file, and never in
+a log line or a REST response.
+
+**On-disk shape** (fixed by the SPEC, implemented verbatim):
+
+- ``<home>/secrets.sqlite3`` — one table, ``secrets(name, ciphertext,
+  created_at, updated_at)``. Created ``0600`` inside the ``0700`` hub home.
+- ``<home>/secrets.key`` — a single Fernet key (``cryptography``, already a
+  dependency), created ``0600`` with ``O_CREAT | O_EXCL`` so the material is
+  never briefly world-readable between ``open`` and ``chmod``, and never
+  overwrites an existing key.
+
+Both are re-narrowed on every load via
+:func:`palaia_hub.oauth.keys.enforce_private_mode` — the exact pattern
+SPEC-203's signing key established, reused rather than re-derived (the SPEC
+names that reuse explicitly).
+
+**The never-return-values rule.** :meth:`SecretStore.get` exists because the
+hub itself must decrypt a value to build an upstream's ``Authorization``
+header or a child process's environment. That is the *only* consumer. No
+REST response model in this repository has a field a secret value could be
+placed in (see :mod:`palaia_hub.upstream.api` — the listing model carries
+``name``/``created_at``/``updated_at`` and nothing else), and nothing in this
+module logs a value, an exception message containing one, or a ciphertext.
+Errors name the *secret's name* only. A test asserts all three halves of
+that (``tests/upstream/test_secrets.py``,
+``tests/upstream/test_secret_never_leaks.py``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from ..oauth.keys import DIR_MODE, FILE_MODE, enforce_private_mode
+
+logger = logging.getLogger("palaia_hub.upstream.secrets")
+
+#: The encrypted store, in the hub home.
+SECRETS_DB_NAME = "secrets.sqlite3"
+#: The Fernet key that store is encrypted under, in the same home.
+SECRETS_KEY_NAME = "secrets.key"
+
+#: Secret names are operator-chosen identifiers that travel through URLs
+#: (``PUT /api/secrets/{name}``) and into ``config.yaml`` as plain
+#: references. Narrow, boring charset — a bad name is a loud error, never
+#: silently sanitized (the same posture ``gateway/config.py`` takes for
+#: vault keys and profile paths).
+_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$")
+
+
+class SecretStoreError(RuntimeError):
+    """A secret could not be stored or read back.
+
+    Its message names the secret by *name* and says what went wrong — never
+    the value, never the ciphertext.
+    """
+
+
+def validate_secret_name(name: str) -> str:
+    """Return ``name`` if it is a legal secret name, else raise.
+
+    Raises:
+        SecretStoreError: the name is empty, too long, or uses characters
+            outside ``[A-Za-z0-9._-]``.
+    """
+    if not _NAME_RE.match(name):
+        raise SecretStoreError(
+            f"{name!r} is not a usable secret name. Use 1-128 characters from "
+            "letters, digits, '.', '_' or '-', starting with a letter or digit."
+        )
+    return name
+
+
+@dataclass(frozen=True, slots=True)
+class SecretInfo:
+    """What a listing may reveal about a stored secret: never its value."""
+
+    name: str
+    created_at: float
+    updated_at: float
+
+
+def load_or_create_key(home: Path) -> bytes:
+    """Load ``<home>/secrets.key``, generating it if absent.
+
+    The home directory is created ``0700`` if missing and re-narrowed if it
+    was widened; the key file is created with ``O_CREAT | O_EXCL`` and an
+    explicit ``0600`` mode, then re-narrowed on every load.
+    """
+    directory = Path(home)
+    directory.mkdir(parents=True, exist_ok=True)
+    enforce_private_mode(directory, DIR_MODE)
+    path = directory / SECRETS_KEY_NAME
+    if path.exists():
+        enforce_private_mode(path, FILE_MODE)
+        material = path.read_bytes().strip()
+        try:
+            Fernet(material)
+        except (ValueError, TypeError) as exc:
+            raise SecretStoreError(
+                f"{path} does not contain a usable encryption key. Fix: move the "
+                "file aside and re-enter your upstream secrets — palaia will "
+                "generate a new key. (Every stored secret becomes unreadable, "
+                "which is why the file is never overwritten automatically.)"
+            ) from exc
+        return material
+    material = Fernet.generate_key()
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, FILE_MODE)
+    try:
+        os.write(fd, material)
+    finally:
+        os.close(fd)
+    enforce_private_mode(path, FILE_MODE)
+    logger.info("generated a new secret-store encryption key at %s", path)
+    return material
+
+
+class SecretStore:
+    """Write-mostly encrypted key/value store for upstream credentials.
+
+    Args:
+        home: the hub home. ``<home>/secrets.sqlite3`` and
+            ``<home>/secrets.key`` are created there, both ``0600``.
+
+    The API is deliberately tiny and matches the SPEC exactly:
+    :meth:`put`, :meth:`get`, :meth:`delete`, :meth:`names`.
+    """
+
+    def __init__(self, home: Path) -> None:
+        self._home = Path(home)
+        self._key = load_or_create_key(self._home)
+        self._fernet = Fernet(self._key)
+        self._path = self._home / SECRETS_DB_NAME
+        existed = self._path.exists()
+        self._conn = sqlite3.connect(self._path, check_same_thread=False)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS secrets (
+                name        TEXT PRIMARY KEY,
+                ciphertext  BLOB NOT NULL,
+                created_at  REAL NOT NULL,
+                updated_at  REAL NOT NULL
+            )
+            """
+        )
+        self._conn.commit()
+        if not existed:
+            # WAL mode leaves -wal/-shm siblings; narrowing the main file is
+            # what matters (the sidecars carry the same pages and are
+            # created with the same umask-independent mode by SQLite as the
+            # db itself once the db is 0600 — re-narrowed on every open
+            # below regardless).
+            enforce_private_mode(self._path, FILE_MODE)
+        enforce_private_mode(self._path, FILE_MODE)
+        enforce_private_mode(self._home, DIR_MODE)
+
+    # ------------------------------------------------------------------ API
+
+    def put(self, name: str, value: str) -> SecretInfo:
+        """Store (or replace) the secret called ``name``.
+
+        Returns the metadata a caller may safely echo back — never the
+        value it just wrote.
+        """
+        validate_secret_name(name)
+        if not value:
+            raise SecretStoreError(
+                f"secret {name!r} would be empty. Fix: send the actual value, or "
+                "delete the secret instead of blanking it."
+            )
+        now = time.time()
+        ciphertext = self._fernet.encrypt(value.encode("utf-8"))
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO secrets (name, ciphertext, created_at, updated_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(name) DO UPDATE SET
+                    ciphertext = excluded.ciphertext,
+                    updated_at = excluded.updated_at
+                """,
+                (name, ciphertext, now, now),
+            )
+        logger.info("stored secret %r (%d bytes of ciphertext)", name, len(ciphertext))
+        info = self.info(name)
+        assert info is not None  # just written
+        return info
+
+    def get(self, name: str) -> str | None:
+        """Decrypt and return the secret called ``name``, or ``None``.
+
+        **In-process callers only** — see this module's docstring. The only
+        consumers in this repository are
+        :mod:`palaia_hub.upstream.service` (building an upstream's auth
+        header or a child process's environment).
+        """
+        row = self._conn.execute(
+            "SELECT ciphertext FROM secrets WHERE name = ?", (name,)
+        ).fetchone()
+        if row is None:
+            return None
+        try:
+            return self._fernet.decrypt(row[0]).decode("utf-8")
+        except InvalidToken as exc:
+            raise SecretStoreError(
+                f"secret {name!r} cannot be decrypted with the current "
+                f"{SECRETS_KEY_NAME}. Fix: re-enter it (the key changed, or the "
+                "database was copied without its key)."
+            ) from exc
+
+    def delete(self, name: str) -> bool:
+        """Remove the secret called ``name``. ``True`` if it existed."""
+        with self._conn:
+            cursor = self._conn.execute("DELETE FROM secrets WHERE name = ?", (name,))
+        deleted = cursor.rowcount > 0
+        if deleted:
+            logger.info("deleted secret %r", name)
+        return deleted
+
+    def names(self) -> list[SecretInfo]:
+        """Every stored secret's name and timestamps, sorted by name."""
+        rows = self._conn.execute(
+            "SELECT name, created_at, updated_at FROM secrets ORDER BY name"
+        ).fetchall()
+        return [SecretInfo(name=r[0], created_at=r[1], updated_at=r[2]) for r in rows]
+
+    def info(self, name: str) -> SecretInfo | None:
+        """One secret's metadata, or ``None`` — never its value."""
+        row = self._conn.execute(
+            "SELECT name, created_at, updated_at FROM secrets WHERE name = ?", (name,)
+        ).fetchone()
+        if row is None:
+            return None
+        return SecretInfo(name=row[0], created_at=row[1], updated_at=row[2])
+
+    def has(self, name: str) -> bool:
+        """Whether a secret called ``name`` exists."""
+        return self.info(name) is not None
+
+    def close(self) -> None:
+        """Close the SQLite handle."""
+        self._conn.close()
+
+
+__all__ = [
+    "SECRETS_DB_NAME",
+    "SECRETS_KEY_NAME",
+    "SecretInfo",
+    "SecretStore",
+    "SecretStoreError",
+    "load_or_create_key",
+    "validate_secret_name",
+]

--- a/v3/server/src/palaia_hub/upstream/service.py
+++ b/v3/server/src/palaia_hub/upstream/service.py
@@ -1,0 +1,427 @@
+"""Connecting to an upstream: probes, proxies, credentials, teardown.
+
+This is the only module that decrypts a secret (through
+:class:`~palaia_hub.upstream.secrets.SecretStore`) and the only one that
+builds a :class:`fastmcp.Client`. Two rules shape all of it:
+
+**1. Mounting must never block hub startup, and a dead upstream must never
+hang a profile** (SPEC-302 deliverable #4). Every client is built with an
+explicit, bounded ``timeout``/``init_timeout``
+(:attr:`~palaia_hub.upstream.models.UpstreamConfig.connect_timeout`), and
+:meth:`UpstreamService.probe` swallows every connection failure into an
+:class:`UpstreamStatus` with ``up=False`` and a one-line ``detail`` instead of
+raising. Nothing in the mount path awaits a network round-trip: building a
+proxy is plain object construction (verified against fastmcp 3.4.7 — a proxy
+to an unreachable endpoint mounts fine), and fastmcp's own tool aggregator
+already logs-and-skips a provider whose ``list_tools`` fails, so a profile
+that mounts a down upstream still serves every other tool it has.
+
+**2. The proxy uses the current client-backed-server mount**, not
+``FastMCP.as_proxy()`` — deprecated in 3.4.7 (SPEC-002 FINDINGS Q1/Q2).
+:func:`fastmcp.server.create_proxy` takes the (disconnected)
+:class:`fastmcp.Client` this module builds and forwards every call over it.
+
+A ``stdio`` upstream's :class:`~fastmcp.client.transports.StdioTransport` is
+created **once per upstream** and cached, so repeated tool calls reuse one
+child process rather than spawning one each time (fastmcp's
+``keep_alive=True`` default). :meth:`UpstreamService.aclose` closes every
+cached transport, which is what reaps those children at hub shutdown.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+
+from fastmcp import Client
+from fastmcp.client.transports import ClientTransport, StdioTransport, StreamableHttpTransport
+from fastmcp.server import create_proxy
+from fastmcp.server.providers.proxy import FastMCPProxy
+
+from .models import UpstreamConfig
+from .secrets import SecretStore, SecretStoreError
+
+logger = logging.getLogger("palaia_hub.upstream.service")
+
+#: Published on the event bus when an upstream's reachability changes.
+EVENT_UP = "gateway.upstream.up"
+EVENT_DOWN = "gateway.upstream.down"
+
+#: What a status looks like before the first probe has run.
+UNKNOWN_DETAIL = "Not checked yet."
+
+
+class UpstreamNotConfiguredError(KeyError):
+    """No upstream is registered under that key."""
+
+
+class UpstreamCredentialError(RuntimeError):
+    """An upstream references a secret that is missing or unreadable.
+
+    Its message names the *secret's name* and what to do about it — never
+    the value.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class UpstreamStatus:
+    """One upstream's last known reachability — the shape REST returns.
+
+    ``detail`` is the "clear one-line status" the SPEC asks for: plain
+    language, no stack trace, and never a credential (the probe's own
+    exception text is normalized by :func:`_one_line` before it lands here).
+    """
+
+    key: str
+    display_name: str
+    namespace: str
+    kind: str
+    enabled: bool
+    target: str
+    up: bool
+    detail: str
+    checked_at: float | None = None
+    tools: tuple[str, ...] = ()
+
+    @property
+    def tool_count(self) -> int:
+        return len(self.tools)
+
+
+@dataclass
+class _Connection:
+    """Cached per-upstream transport + client, so one child process serves
+    every call to a ``stdio`` upstream."""
+
+    transport: ClientTransport
+    client: Client[ClientTransport]
+    proxy: FastMCPProxy | None = None
+
+
+def _one_line(exc: BaseException) -> str:
+    """Collapse an exception into one plain-language line, credential-free.
+
+    Only the exception *type* and its own message are used — never a repr of
+    the client, transport or headers, any of which could carry a token.
+    """
+    message = str(exc).strip().splitlines()
+    text = message[0] if message else exc.__class__.__name__
+    if len(text) > 200:
+        text = text[:197] + "..."
+    return text or exc.__class__.__name__
+
+
+class UpstreamService:
+    """The upstream registry: configs, credentials, proxies and health.
+
+    Args:
+        upstreams: every configured upstream (see
+            :func:`palaia_hub.upstream.models.check_namespace_conflicts` —
+            the caller validates the set before handing it over).
+        secret_store: where an ``http`` upstream's bearer token and a
+            ``stdio`` upstream's injected environment come from. ``None``
+            means no upstream may reference a secret; one that does is
+            reported down with a plain-language reason rather than
+            crashing the hub.
+        publish: optional ``(event name, data)`` sink for
+            ``gateway.upstream.up``/``down`` — called only on a *change*
+            of state, so a healthy upstream does not emit an event per
+            probe.
+    """
+
+    def __init__(
+        self,
+        upstreams: Iterable[UpstreamConfig] = (),
+        *,
+        secret_store: SecretStore | None = None,
+        publish: Callable[[str, dict[str, object]], None] | None = None,
+    ) -> None:
+        self._configs: dict[str, UpstreamConfig] = {u.key: u for u in upstreams}
+        self._secret_store = secret_store
+        self._publish = publish
+        self._status: dict[str, UpstreamStatus] = {
+            key: self._unknown_status(cfg) for key, cfg in self._configs.items()
+        }
+        self._connections: dict[str, _Connection] = {}
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------- registry
+
+    @property
+    def configs(self) -> Mapping[str, UpstreamConfig]:
+        """Snapshot of every configured upstream, keyed by ``key``."""
+        return dict(self._configs)
+
+    def config(self, key: str) -> UpstreamConfig:
+        try:
+            return self._configs[key]
+        except KeyError as exc:
+            raise UpstreamNotConfiguredError(
+                f"no external server configured under {key!r}"
+            ) from exc
+
+    def statuses(self) -> list[UpstreamStatus]:
+        """Every upstream's last known status, ordered by key."""
+        return [self._status[key] for key in sorted(self._status)]
+
+    def status(self, key: str) -> UpstreamStatus:
+        self.config(key)  # raises UpstreamNotConfiguredError for an unknown key
+        return self._status[key]
+
+    def is_up(self, key: str) -> bool:
+        """Whether ``key`` was reachable at its last probe."""
+        status = self._status.get(key)
+        return status is not None and status.up
+
+    async def register(self, upstream: UpstreamConfig) -> UpstreamStatus:
+        """Add or replace an upstream, dropping any cached connection to it."""
+        async with self._lock:
+            await self._drop_connection(upstream.key)
+            self._configs[upstream.key] = upstream
+            self._status[upstream.key] = self._unknown_status(upstream)
+        return await self.probe(upstream.key)
+
+    async def unregister(self, key: str) -> None:
+        """Remove an upstream and reap its connection (if any)."""
+        async with self._lock:
+            self._configs.pop(key, None)
+            self._status.pop(key, None)
+            await self._drop_connection(key)
+
+    # ---------------------------------------------------------------- health
+
+    async def probe(self, key: str) -> UpstreamStatus:
+        """Reachability probe: connect, initialize, ``tools/list``.
+
+        Never raises for an unreachable upstream — the failure becomes the
+        returned status's ``detail``. Publishes
+        ``gateway.upstream.up``/``down`` when the state changed.
+        """
+        config = self.config(key)
+        if not config.enabled:
+            status = self._replace_status(
+                key, up=False, detail="Switched off — nothing is connected.", tools=()
+            )
+            return status
+        started = time.time()
+        try:
+            client = await self._client_for(config)
+        except SecretStoreError as exc:
+            return self._replace_status(key, up=False, detail=_one_line(exc), tools=())
+        except UpstreamCredentialError as exc:
+            return self._replace_status(key, up=False, detail=_one_line(exc), tools=())
+        try:
+            async with asyncio.timeout(config.connect_timeout + 2):
+                async with client:
+                    tools = await client.list_tools()
+        except TimeoutError:
+            return self._replace_status(
+                key,
+                up=False,
+                detail=(
+                    f"Did not answer within {config.connect_timeout:g} seconds. "
+                    "Check that it is running and reachable."
+                ),
+                tools=(),
+            )
+        except Exception as exc:  # noqa: BLE001 — every failure is "down", with a reason
+            return self._replace_status(key, up=False, detail=_one_line(exc), tools=())
+        names = tuple(sorted(tool.name for tool in tools))
+        elapsed = time.time() - started
+        detail = (
+            f"Connected — {len(names)} tool{'' if len(names) == 1 else 's'} "
+            f"({elapsed * 1000:.0f} ms)."
+        )
+        return self._replace_status(key, up=True, detail=detail, tools=names)
+
+    async def probe_all(self) -> list[UpstreamStatus]:
+        """Probe every configured upstream concurrently."""
+        keys = sorted(self._configs)
+        if not keys:
+            return []
+        await asyncio.gather(*(self.probe(key) for key in keys), return_exceptions=False)
+        return self.statuses()
+
+    # ---------------------------------------------------------------- mounts
+
+    async def proxy_for(self, key: str) -> FastMCPProxy:
+        """The client-backed proxy server for ``key``, built once and cached.
+
+        Plain object construction — no network round-trip, so a caller may
+        mount this into a profile without risking a blocked startup even
+        when the upstream is down (see the module docstring).
+        """
+        config = self.config(key)
+        async with self._lock:
+            connection = self._connections.get(key)
+            if connection is None:
+                connection = await self._build_connection(config)
+                self._connections[key] = connection
+            if connection.proxy is None:
+                connection.proxy = create_proxy(
+                    connection.client, name=f"palaia-upstream-{config.key}"
+                )
+            return connection.proxy
+
+    # ------------------------------------------------------------- teardown
+
+    async def aclose(self) -> None:
+        """Close every cached transport — this is what reaps ``stdio`` children."""
+        async with self._lock:
+            for key in list(self._connections):
+                await self._drop_connection(key)
+
+    # ------------------------------------------------------------- internals
+
+    def _unknown_status(self, config: UpstreamConfig) -> UpstreamStatus:
+        return UpstreamStatus(
+            key=config.key,
+            display_name=config.display_name,
+            namespace=config.mount_namespace,
+            kind=config.kind,
+            enabled=config.enabled,
+            target=config.target,
+            up=False,
+            detail=UNKNOWN_DETAIL if config.enabled else "Switched off — nothing is connected.",
+        )
+
+    def _replace_status(
+        self, key: str, *, up: bool, detail: str, tools: tuple[str, ...]
+    ) -> UpstreamStatus:
+        config = self._configs[key]
+        previous = self._status.get(key)
+        status = UpstreamStatus(
+            key=config.key,
+            display_name=config.display_name,
+            namespace=config.mount_namespace,
+            kind=config.kind,
+            enabled=config.enabled,
+            target=config.target,
+            up=up,
+            detail=detail,
+            checked_at=time.time(),
+            tools=tools,
+        )
+        self._status[key] = status
+        changed = previous is None or previous.up != up or previous.checked_at is None
+        if changed and self._publish is not None:
+            self._publish(
+                EVENT_UP if up else EVENT_DOWN,
+                {
+                    "upstream": config.key,
+                    "display_name": config.display_name,
+                    "namespace": config.mount_namespace,
+                    "kind": config.kind,
+                    "detail": detail,
+                    "tool_count": len(tools),
+                },
+            )
+        if not up:
+            logger.warning(
+                "external server %r (%s) is unavailable: %s",
+                config.key,
+                config.display_name,
+                detail,
+            )
+        else:
+            logger.info(
+                "external server %r (%s) is available: %s",
+                config.key,
+                config.display_name,
+                detail,
+            )
+        return status
+
+    async def _client_for(self, config: UpstreamConfig) -> Client[ClientTransport]:
+        """The cached client for ``config``, built on first use.
+
+        Deliberately *not* rebuilt per call, even though a ``stdio`` child's
+        environment and an HTTP transport's headers are fixed at construction
+        time and would therefore keep serving a rotated secret: rebuilding
+        here would respawn the child process on every health probe, and the
+        proxy already mounted into a profile would still be holding the old
+        client anyway. Invalidation is an explicit event instead —
+        :meth:`register` (a server edited through REST) and
+        :func:`palaia_hub.upstream.api.build_secret_change_hook` (a secret's
+        value replaced) both drop the connection and let the profile be
+        rebuilt around a fresh one.
+        """
+        async with self._lock:
+            connection = self._connections.get(config.key)
+            if connection is not None:
+                return connection.client
+            connection = await self._build_connection(config)
+            self._connections[config.key] = connection
+            return connection.client
+
+    async def _build_connection(self, config: UpstreamConfig) -> _Connection:
+        if config.kind == "http":
+            headers = dict(config.headers)
+            if config.auth is not None:
+                secret = self._require_secret(config, config.auth.secret_name)
+                headers[config.auth.header] = config.auth.value_template.format(secret=secret)
+            assert config.url is not None  # guaranteed by UpstreamConfig's validator
+            transport: ClientTransport = StreamableHttpTransport(
+                config.url, headers=headers or None
+            )
+        else:
+            env = dict(config.env)
+            for env_var, secret_name in sorted(config.env_secrets.items()):
+                env[env_var] = self._require_secret(config, secret_name)
+            assert config.command is not None  # guaranteed by UpstreamConfig's validator
+            transport = StdioTransport(
+                command=config.command,
+                args=list(config.args),
+                env=env or None,
+                cwd=config.cwd,
+            )
+        client: Client[ClientTransport] = Client(
+            transport,
+            timeout=config.connect_timeout,
+            init_timeout=config.connect_timeout,
+        )
+        return _Connection(transport=transport, client=client)
+
+    def _require_secret(self, config: UpstreamConfig, name: str) -> str:
+        if self._secret_store is None:
+            raise UpstreamCredentialError(
+                f"{config.display_name} needs the stored secret {name!r}, but this "
+                "hub has no secret store. Fix: run the hub with a home directory "
+                "it can write to."
+            )
+        value = self._secret_store.get(name)
+        if value is None:
+            raise UpstreamCredentialError(
+                f"{config.display_name} needs a secret called {name!r}, which is "
+                "not stored yet. Fix: add it under Settings (it is written once "
+                "and never shown again)."
+            )
+        return value
+
+    async def _drop_connection(self, key: str) -> None:
+        """Close and forget ``key``'s cached transport. Caller holds the lock."""
+        connection = self._connections.pop(key, None)
+        if connection is None:
+            return
+        try:
+            # `ClientTransport.close()` carries no annotations in fastmcp
+            # 3.4.7 (it is `async def close(self):`), so mypy's strict mode
+            # calls this an untyped call. It is the documented teardown —
+            # for a StdioTransport it is what terminates the child process.
+            await connection.transport.close()  # type: ignore[no-untyped-call]
+        except Exception as exc:  # noqa: BLE001 — shutdown must not raise
+            logger.warning("closing the connection to %r did not finish cleanly: %s", key, exc)
+
+
+__all__ = [
+    "EVENT_DOWN",
+    "EVENT_UP",
+    "UNKNOWN_DETAIL",
+    "UpstreamCredentialError",
+    "UpstreamNotConfiguredError",
+    "UpstreamService",
+    "UpstreamStatus",
+]

--- a/v3/server/tests/gateway/test_api.py
+++ b/v3/server/tests/gateway/test_api.py
@@ -35,7 +35,16 @@ def test_list_profiles_reports_the_live_shape(tmp_path: Path) -> None:
     assert response.status_code == 200
     body = response.json()
     assert body == [
-        {"path": "default", "label": None, "vaults": ["work"], "stash": False, "managed": False}
+        {
+            "path": "default",
+            "label": None,
+            "vaults": ["work"],
+            "stash": False,
+            # SPEC-302: external servers this profile mounts — empty until
+            # one is connected, which is every hub until someone does.
+            "upstreams": [],
+            "managed": False,
+        }
     ]
 
 

--- a/v3/server/tests/gateway/test_settings_bridge.py
+++ b/v3/server/tests/gateway/test_settings_bridge.py
@@ -156,4 +156,7 @@ def test_persist_gateway_settings_replaces_an_existing_section(tmp_path: Path) -
 def test_render_gateway_section_empty_settings_is_valid_yaml() -> None:
     body = render_gateway_section(GatewaySettings())
     parsed = yaml.safe_load(f"gateway:\n{body}")
-    assert parsed == {"gateway": {"vaults": [], "profiles": []}}
+    # `upstreams` joined the section in SPEC-302; an empty list means
+    # "no external servers connected", which is every hub until someone
+    # connects one.
+    assert parsed == {"gateway": {"vaults": [], "profiles": [], "upstreams": []}}

--- a/v3/server/tests/upstream/conftest.py
+++ b/v3/server/tests/upstream/conftest.py
@@ -1,0 +1,109 @@
+"""Fixtures for SPEC-302: a real HTTP upstream in its own process, a real
+stdio upstream command, and a hub home with a secret store.
+"""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+import pytest
+
+from palaia_hub.upstream.secrets import SecretStore
+
+HERE = Path(__file__).parent
+HTTP_SERVER = HERE / "fixture_http_server.py"
+STDIO_SERVER = HERE / "fixture_stdio_server.py"
+
+#: The token ``http_upstream`` demands when started with one. Test-only.
+FIXTURE_BEARER_TOKEN = "fixture-upstream-token"  # noqa: S105 - test fixture, not a credential
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@dataclass
+class HttpUpstream:
+    """A running fixture MCP server in its own process."""
+
+    url: str
+    process: subprocess.Popen[bytes]
+
+    def stop(self) -> None:
+        self.process.terminate()
+        try:
+            self.process.wait(timeout=10)
+        except subprocess.TimeoutExpired:  # pragma: no cover - stubborn child
+            self.process.kill()
+            self.process.wait(timeout=10)
+
+
+def _start_http_upstream(*, require_token: str | None) -> HttpUpstream:
+    port = _free_port()
+    command = [sys.executable, str(HTTP_SERVER), "--port", str(port)]
+    if require_token:
+        command += ["--require-token", require_token]
+    process = subprocess.Popen(command)
+    url = f"http://127.0.0.1:{port}/"
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        if process.poll() is not None:  # pragma: no cover - fixture start failure
+            raise RuntimeError("the fixture upstream exited before becoming reachable")
+        try:
+            # Any answer at all (including 401/406) proves the socket is up;
+            # the MCP handshake itself is what the tests exercise.
+            httpx.post(url, timeout=1.0)
+            return HttpUpstream(url=url, process=process)
+        except httpx.HTTPError:
+            time.sleep(0.1)
+    process.terminate()  # pragma: no cover - fixture start failure
+    raise RuntimeError("the fixture upstream never became reachable")  # pragma: no cover
+
+
+@pytest.fixture
+def http_upstream() -> Iterator[HttpUpstream]:
+    """An unauthenticated fixture MCP server, in its own process."""
+    upstream = _start_http_upstream(require_token=None)
+    try:
+        yield upstream
+    finally:
+        upstream.stop()
+
+
+@pytest.fixture
+def http_upstream_with_token() -> Iterator[HttpUpstream]:
+    """A fixture MCP server that requires :data:`FIXTURE_BEARER_TOKEN`."""
+    upstream = _start_http_upstream(require_token=FIXTURE_BEARER_TOKEN)
+    try:
+        yield upstream
+    finally:
+        upstream.stop()
+
+
+@pytest.fixture
+def secret_store(tmp_path: Path) -> Iterator[SecretStore]:
+    store = SecretStore(tmp_path / "home")
+    try:
+        yield store
+    finally:
+        store.close()
+
+
+@pytest.fixture
+def stdio_command() -> list[str]:
+    """The command line for the stdio fixture upstream."""
+    return [sys.executable, str(STDIO_SERVER)]

--- a/v3/server/tests/upstream/fixture_http_server.py
+++ b/v3/server/tests/upstream/fixture_http_server.py
@@ -1,0 +1,53 @@
+"""A real second FastMCP server, served over streamable HTTP, as an
+``http`` upstream fixture (SPEC-302 acceptance criterion #1: "a real second
+FastMCP server (test fixture) connected as an upstream").
+
+Started as a subprocess by ``conftest.py``'s ``http_upstream`` fixture — a
+separate OS process, so a call that comes back through it has demonstrably
+left the hub. When ``--require-token`` is passed it rejects any request whose
+``Authorization`` header does not carry that exact bearer token, which is how
+``test_http_upstream.py`` proves the secret store's value reached the wire.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import uvicorn
+from fastmcp import FastMCP
+from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+
+
+def build_server(required_token: str | None) -> FastMCP:
+    auth = (
+        StaticTokenVerifier(tokens={required_token: {"client_id": "fixture", "scopes": []}})
+        if required_token
+        else None
+    )
+    server: FastMCP = FastMCP(name="fixture-http-upstream", auth=auth)
+
+    @server.tool
+    def echo(text: str) -> str:
+        """Echo text back, prefixed so the caller can prove where it came from."""
+        return f"fixture-http-upstream echo: {text}"
+
+    @server.tool
+    def ping() -> str:
+        """Liveness check."""
+        return "pong"
+
+    return server
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--require-token", default=None)
+    args = parser.parse_args()
+    server = build_server(args.require_token)
+    uvicorn.run(server.http_app(path="/"), host=args.host, port=args.port, log_level="warning")
+
+
+if __name__ == "__main__":
+    main()

--- a/v3/server/tests/upstream/fixture_stdio_server.py
+++ b/v3/server/tests/upstream/fixture_stdio_server.py
@@ -1,0 +1,33 @@
+"""A real, standalone FastMCP server used as a ``stdio`` upstream fixture.
+
+Run as a subprocess by palaia itself (``sys.executable
+fixture_stdio_server.py``) — the same interpreter/venv pytest runs in, so
+``fastmcp`` is importable. It echoes back the value of ``FIXTURE_TOKEN``,
+which is how ``test_stdio_upstream.py`` proves an env-var secret really
+reached the child process rather than being dropped somewhere in the
+transport.
+"""
+
+from __future__ import annotations
+
+import os
+
+from fastmcp import FastMCP
+
+server: FastMCP = FastMCP(name="fixture-stdio-upstream")
+
+
+@server.tool
+def whoami() -> str:
+    """Report which credential this process was started with."""
+    return f"token={os.environ.get('FIXTURE_TOKEN', 'MISSING')}"
+
+
+@server.tool
+def add(a: int, b: int) -> int:
+    """Add two numbers (a plain tool, no credential involved)."""
+    return a + b
+
+
+if __name__ == "__main__":
+    server.run()

--- a/v3/server/tests/upstream/test_api.py
+++ b/v3/server/tests/upstream/test_api.py
@@ -1,0 +1,328 @@
+"""SPEC-302 deliverables #2/#4 over REST, through the real production app.
+
+``build_production_app`` is used rather than a hand-assembled router, so
+these exercise the same wiring ``palaia-hub serve`` runs: connect a server,
+see its health, have its tools appear on a profile without a restart, and —
+the security half — never get a stored value back out of any endpoint.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import httpx
+import pytest
+from fastmcp import Client
+
+from palaia_hub.config import load_config
+from palaia_hub.serve import ProductionApp, build_production_app
+from palaia_hub.vault import VaultRegistry
+
+from .conftest import FIXTURE_BEARER_TOKEN, HttpUpstream
+
+pytestmark = pytest.mark.anyio
+
+BASE_URL = "https://testserver"
+SECRET = "sk-never-echo-this-back-8123"
+
+
+async def _hub(tmp_path: Path) -> ProductionApp:
+    registry = VaultRegistry(tmp_path)
+    await registry.create("work", tmp_path / "vaults" / "work", purpose="Work vault.")
+    config = load_config(home=tmp_path)
+    return await build_production_app(config, home=tmp_path)
+
+
+@asynccontextmanager
+async def _running(production: ProductionApp) -> AsyncIterator[httpx.AsyncClient]:
+    try:
+        async with production.app.router.lifespan_context(production.app):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=production.app), base_url=BASE_URL
+            ) as http:
+                yield http
+    finally:
+        await production.dynamic_gateway.aclose()
+        if production.stash_store is not None:
+            production.stash_store.close()
+        for index in production.indexes.values():
+            await index.close()
+
+
+def _connect_body(url: str, *, secret_name: str | None = None) -> dict[str, object]:
+    upstream: dict[str, object] = {
+        "key": "fixture",
+        "kind": "http",
+        "display_name": "Fixture server",
+        "url": url,
+    }
+    if secret_name is not None:
+        upstream["auth"] = {"secret_name": secret_name}
+    return {"upstream": upstream, "profiles": ["default"]}
+
+
+async def test_connect_probe_and_call_without_a_restart(
+    tmp_path: Path, http_upstream: HttpUpstream
+) -> None:
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        response = await http.post(
+            "/api/gateway/upstreams", json=_connect_body(http_upstream.url)
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["key"] == "fixture"
+        assert body["namespace"] == "fixture"
+        assert body["profiles"] == ["default"]
+        assert body["up"] is True
+        assert "fixture_echo" not in body["tools"]  # upstream-side names
+        assert "echo" in body["tools"]
+
+        listing = (await http.get("/api/gateway/upstreams")).json()
+        assert [item["key"] for item in listing] == ["fixture"]
+        assert listing[0]["status"]
+
+        # Live on the profile, no restart.
+        async with Client(production.dynamic_gateway.profile_servers["default"]) as client:
+            names = {tool.name for tool in await client.list_tools()}
+            assert "fixture_echo" in names
+            result = await client.call_tool("fixture_echo", {"text": "over rest"})
+        assert "fixture-http-upstream echo: over rest" in str(result.content)
+
+
+async def test_a_connected_server_survives_a_restart(
+    tmp_path: Path, http_upstream: HttpUpstream
+) -> None:
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        assert (
+            await http.post("/api/gateway/upstreams", json=_connect_body(http_upstream.url))
+        ).status_code == 200
+
+    restarted_config = load_config(home=tmp_path, create_if_missing=False)
+    assert restarted_config.gateway is not None
+    assert [u.key for u in restarted_config.gateway.upstreams] == ["fixture"]
+    assert restarted_config.gateway.profiles[0].upstreams == ["fixture"]
+
+    restarted = await build_production_app(restarted_config, home=tmp_path)
+    async with _running(restarted) as http:
+        # The monitor's own first pass is asynchronous; probing explicitly is
+        # the deterministic equivalent.
+        probed = (await http.post("/api/gateway/upstreams/fixture/probe")).json()
+        assert probed["up"] is True
+        async with Client(restarted.dynamic_gateway.profile_servers["default"]) as client:
+            assert "fixture_echo" in {tool.name for tool in await client.list_tools()}
+
+
+async def test_switching_a_server_off_removes_its_tools_and_persists(
+    tmp_path: Path, http_upstream: HttpUpstream
+) -> None:
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        await http.post("/api/gateway/upstreams", json=_connect_body(http_upstream.url))
+        patched = await http.patch(
+            "/api/gateway/upstreams/fixture", json={"enabled": False}
+        )
+        assert patched.status_code == 200
+        assert patched.json()["enabled"] is False
+        assert patched.json()["up"] is False
+
+        async with Client(production.dynamic_gateway.profile_servers["default"]) as client:
+            names = {tool.name for tool in await client.list_tools()}
+        assert not any(name.startswith("fixture_") for name in names)
+        assert "work_memory_search" in names
+
+    reloaded = load_config(home=tmp_path, create_if_missing=False)
+    assert reloaded.gateway is not None
+    assert reloaded.gateway.upstreams[0].enabled is False
+
+
+async def test_renaming_an_upstream_tool_over_rest(
+    tmp_path: Path, http_upstream: HttpUpstream
+) -> None:
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        await http.post("/api/gateway/upstreams", json=_connect_body(http_upstream.url))
+        patched = await http.patch(
+            "/api/gateway/upstreams/fixture", json={"tool_renames": {"echo": "say"}}
+        )
+        assert patched.status_code == 200
+        assert patched.json()["tool_renames"] == {"echo": "say"}
+
+        async with Client(production.dynamic_gateway.profile_servers["default"]) as client:
+            names = {tool.name for tool in await client.list_tools()}
+        assert "fixture_say" in names
+        assert "fixture_echo" not in names
+
+
+async def test_disconnecting_removes_it_from_every_profile(
+    tmp_path: Path, http_upstream: HttpUpstream
+) -> None:
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        await http.post("/api/gateway/upstreams", json=_connect_body(http_upstream.url))
+        assert (
+            await http.delete("/api/gateway/upstreams/fixture")
+        ).status_code == 204
+        assert (await http.get("/api/gateway/upstreams")).json() == []
+        profiles = (await http.get("/api/gateway/profiles")).json()
+        assert all(profile["upstreams"] == [] for profile in profiles)
+
+        async with Client(production.dynamic_gateway.profile_servers["default"]) as client:
+            names = {tool.name for tool in await client.list_tools()}
+        assert not any(name.startswith("fixture_") for name in names)
+
+    reloaded = load_config(home=tmp_path, create_if_missing=False)
+    assert reloaded.gateway is not None
+    assert reloaded.gateway.upstreams == []
+
+
+async def test_connecting_the_same_key_twice_is_refused(
+    tmp_path: Path, http_upstream: HttpUpstream
+) -> None:
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        await http.post("/api/gateway/upstreams", json=_connect_body(http_upstream.url))
+        second = await http.post(
+            "/api/gateway/upstreams", json=_connect_body(http_upstream.url)
+        )
+        assert second.status_code == 400
+        assert "already connected" in second.json()["detail"]
+
+
+async def test_a_namespace_clash_with_a_vault_is_refused_loudly(tmp_path: Path) -> None:
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        response = await http.post(
+            "/api/gateway/upstreams",
+            json={
+                "upstream": {
+                    "key": "clash",
+                    "kind": "http",
+                    "display_name": "Clashing server",
+                    "url": "https://example.invalid/mcp",
+                    "namespace": "work_memory",
+                },
+                "profiles": [],
+            },
+        )
+        assert response.status_code == 400
+        assert "work_memory" in response.json()["detail"]
+
+
+async def test_mounting_on_the_curator_profile_is_refused_over_rest(
+    tmp_path: Path, http_upstream: HttpUpstream
+) -> None:
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        body = _connect_body(http_upstream.url)
+        body["profiles"] = ["curator"]
+        response = await http.post("/api/gateway/upstreams", json=body)
+        assert response.status_code == 400
+        assert "curator" in response.json()["detail"]
+
+
+# ------------------------------------------------------------------ secrets
+
+
+async def test_a_stored_secret_value_never_comes_back_out(tmp_path: Path) -> None:
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        stored = await http.put("/api/secrets/fixture-token", json={"value": SECRET})
+        assert stored.status_code == 200
+        assert stored.json() == {
+            "name": "fixture-token",
+            "created_at": stored.json()["created_at"],
+            "updated_at": stored.json()["updated_at"],
+        }
+        assert SECRET not in stored.text
+
+        listing = await http.get("/api/secrets")
+        assert [item["name"] for item in listing.json()] == ["fixture-token"]
+        assert SECRET not in listing.text
+
+        # There is no endpoint that returns a value — the obvious guesses
+        # are not routes at all.
+        for path in (
+            "/api/secrets/fixture-token",
+            "/api/secrets/fixture-token/value",
+        ):
+            assert (await http.get(path)).status_code == 405 or (
+                await http.get(path)
+            ).status_code == 404
+
+        # Nor does the upstream surface leak it: it names the secret only.
+        await http.post(
+            "/api/gateway/upstreams",
+            json=_connect_body("https://example.invalid/mcp", secret_name="fixture-token"),
+        )
+        upstreams = await http.get("/api/gateway/upstreams")
+        assert upstreams.json()[0]["secret_names"] == ["fixture-token"]
+        assert SECRET not in upstreams.text
+
+        # …and neither does the config file it persisted to.
+        assert SECRET not in (tmp_path / "config.yaml").read_text(encoding="utf-8")
+
+        assert (await http.delete("/api/secrets/fixture-token")).status_code == 204
+        assert (await http.get("/api/secrets")).json() == []
+
+
+async def test_a_secret_written_over_rest_is_the_one_the_upstream_uses(
+    tmp_path: Path, http_upstream_with_token: HttpUpstream
+) -> None:
+    """The full loop: the dashboard writes the token, the hub connects with
+    it, and the (token-demanding) fixture answers."""
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        await http.put("/api/secrets/fixture-token", json={"value": FIXTURE_BEARER_TOKEN})
+        response = await http.post(
+            "/api/gateway/upstreams",
+            json=_connect_body(http_upstream_with_token.url, secret_name="fixture-token"),
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["up"] is True
+
+        async with Client(production.dynamic_gateway.profile_servers["default"]) as client:
+            result = await client.call_tool("fixture_echo", {"text": "with a real token"})
+        assert "fixture-http-upstream echo: with a real token" in str(result.content)
+
+
+async def test_replacing_a_secret_reconnects_the_servers_using_it(
+    tmp_path: Path, http_upstream_with_token: HttpUpstream
+) -> None:
+    """A rotated credential reaches an already-connected server without a
+    restart: the wrong value leaves it down, and writing the right one over
+    the same name brings it up and its tools back."""
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        await http.put("/api/secrets/fixture-token", json={"value": "the-wrong-token"})
+        connected = await http.post(
+            "/api/gateway/upstreams",
+            json=_connect_body(http_upstream_with_token.url, secret_name="fixture-token"),
+        )
+        assert connected.status_code == 200
+        assert connected.json()["up"] is False
+
+        await http.put("/api/secrets/fixture-token", json={"value": FIXTURE_BEARER_TOKEN})
+
+        assert (await http.get("/api/gateway/upstreams")).json()[0]["up"] is True
+        async with Client(production.dynamic_gateway.profile_servers["default"]) as client:
+            assert "fixture_echo" in {tool.name for tool in await client.list_tools()}
+
+
+async def test_a_bad_secret_name_is_refused_without_echoing_the_value(
+    tmp_path: Path,
+) -> None:
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        response = await http.put("/api/secrets/has%20space", json={"value": SECRET})
+        assert response.status_code == 400
+        assert SECRET not in response.text
+
+        empty = await http.put("/api/secrets/token", json={"value": ""})
+        assert empty.status_code == 400
+
+        missing = await http.delete("/api/secrets/never-stored")
+        assert missing.status_code == 404

--- a/v3/server/tests/upstream/test_config_section.py
+++ b/v3/server/tests/upstream/test_config_section.py
@@ -1,0 +1,107 @@
+"""SPEC-302 deliverable #1: the ``gateway.upstreams`` config.yaml section —
+loaded, resolved, mounted, and written back without losing anything.
+
+Also asserts the provenance line deliverable #6 asks for: a profile's
+instructions say whose tools those are.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from palaia_hub.config import load_config
+from palaia_hub.gateway.build import upstream_identity_block
+from palaia_hub.gateway.settings_bridge import (
+    GatewaySettingsError,
+    persist_gateway_settings,
+    resolve_profiles,
+    resolve_upstreams,
+)
+from palaia_hub.upstream.models import UpstreamConfig
+
+CONFIG = """\
+mode: locked
+auth_enabled: false
+gateway:
+  profiles:
+    - path: default
+      vaults: [work]
+      upstreams: [linear]
+  upstreams:
+    - key: linear
+      kind: http
+      display_name: Linear
+      url: https://mcp.example.invalid/mcp
+      namespace: linear
+      auth:
+        secret_name: linear-token
+"""
+
+
+def test_the_section_loads_and_resolves(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text(CONFIG, encoding="utf-8")
+    config = load_config(home=tmp_path, create_if_missing=False)
+
+    upstreams = resolve_upstreams(config.gateway)
+    assert [u.key for u in upstreams] == ["linear"]
+    assert upstreams[0].mount_namespace == "linear"
+    assert upstreams[0].auth is not None
+    assert upstreams[0].auth.secret_name == "linear-token"
+
+    profiles = resolve_profiles(config.gateway, ["work"], default_profile="default")
+    assert profiles[0].upstreams == ["linear"]
+
+
+def test_no_gateway_section_means_no_external_servers(tmp_path: Path) -> None:
+    config = load_config(home=tmp_path)  # zero-config default template
+    assert resolve_upstreams(config.gateway) == []
+
+
+def test_a_profile_naming_an_unlisted_server_fails_with_the_fix(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text(
+        "gateway:\n  profiles:\n    - path: default\n      vaults: [work]\n"
+        "      upstreams: [ghost]\n",
+        encoding="utf-8",
+    )
+    config = load_config(home=tmp_path, create_if_missing=False)
+    with pytest.raises(GatewaySettingsError) as excinfo:
+        resolve_profiles(config.gateway, ["work"], default_profile="default")
+    assert "ghost" in str(excinfo.value)
+    assert "Fix:" in str(excinfo.value)
+
+
+def test_writing_the_section_back_preserves_every_field(tmp_path: Path) -> None:
+    path = tmp_path / "config.yaml"
+    path.write_text(CONFIG, encoding="utf-8")
+    config = load_config(home=tmp_path, create_if_missing=False)
+    assert config.gateway is not None
+
+    persist_gateway_settings(path, config.gateway)
+
+    reloaded = load_config(home=tmp_path, create_if_missing=False)
+    assert reloaded.gateway is not None
+    assert reloaded.gateway.upstreams == config.gateway.upstreams
+    assert reloaded.gateway.profiles == config.gateway.profiles
+    # And nothing that looks like a credential ended up in the file — only
+    # the secret's name.
+    text = path.read_text(encoding="utf-8")
+    assert "linear-token" in text
+    parsed = yaml.safe_load(text)
+    assert parsed["gateway"]["upstreams"][0]["kind"] == "http"
+
+
+def test_the_identity_block_names_the_source_in_plain_language() -> None:
+    block = upstream_identity_block(
+        UpstreamConfig(
+            key="linear",
+            kind="http",
+            display_name="Linear",
+            url="https://mcp.example.invalid/mcp",
+        )
+    )
+    assert "linear_*" in block
+    assert "Linear" in block
+    assert "connected by you" in block

--- a/v3/server/tests/upstream/test_curator_fence.py
+++ b/v3/server/tests/upstream/test_curator_fence.py
@@ -1,0 +1,146 @@
+"""SPEC-302 acceptance criterion #5 / deliverable #6: the curator profile
+provably cannot see or call an external server's tools.
+
+Three independent layers, each asserted on its own, because the fence has to
+hold even if a future change routes around one of them:
+
+1. **Schema.** :class:`ProfileConfig` refuses to *hold* upstreams on the
+   curator path at all — a config.yaml, a REST body and a runtime rebuild all
+   fail identically.
+2. **Builder.** ``_build_profile_server`` refuses even if a caller
+   constructed the profile some other way (``model_construct``, a future
+   code path).
+3. **Live gateway.** With an upstream up and mounted on an ordinary profile,
+   the curator profile's own tool surface carries none of it, and calling one
+   of its tool names there fails — which is also the fail-closed behavior
+   SPEC-206's middleware map already guarantees for an unmapped name.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client
+from pydantic import ValidationError
+
+from palaia_hub.curator.policy import ActiveCaptures
+from palaia_hub.curator.profile import (
+    CURATOR_PROFILE_PATH,
+    curator_profile,
+    curator_profile_middleware,
+    curator_tool_actions,
+)
+from palaia_hub.gateway.build import GatewayConfigError, _build_profile_server
+from palaia_hub.gateway.config import GatewayConfig, ProfileConfig, VaultMountConfig
+from palaia_hub.gateway.dynamic import DynamicGateway
+from palaia_hub.gateway.fake_vault import FakeVaultService
+from palaia_hub.upstream.models import UpstreamConfig
+from palaia_hub.upstream.service import UpstreamService
+
+from .conftest import HttpUpstream
+
+pytestmark = pytest.mark.anyio
+
+VAULT = VaultMountConfig(key="work", name="work", purpose="Work vault.")
+
+
+def _upstream(url: str) -> UpstreamConfig:
+    return UpstreamConfig(
+        key="fixture", kind="http", display_name="Fixture server", url=url
+    )
+
+
+def test_the_schema_refuses_upstreams_on_the_curator_profile() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        ProfileConfig(path=CURATOR_PROFILE_PATH, vaults=["work"], upstreams=["fixture"])
+    assert "curator" in str(excinfo.value)
+
+
+def test_the_builder_refuses_even_a_profile_built_around_the_schema() -> None:
+    upstream = _upstream("http://127.0.0.1:9/mcp/")
+    config = GatewayConfig(vaults=[VAULT], profiles=[], upstreams=[upstream])
+    # `model_construct` skips validators — the only way to express the
+    # mistake at all. The builder still refuses.
+    sneaky = ProfileConfig.model_construct(
+        path=CURATOR_PROFILE_PATH,
+        label=None,
+        vaults=["work"],
+        stash=False,
+        upstreams=["fixture"],
+    )
+    with pytest.raises(GatewayConfigError) as excinfo:
+        _build_profile_server(sneaky, config, {}, None)
+    assert "curator" in str(excinfo.value)
+
+
+async def test_the_live_curator_profile_carries_no_upstream_tools(
+    http_upstream: HttpUpstream,
+) -> None:
+    upstream = _upstream(http_upstream.url)
+    service = UpstreamService([upstream])
+    config = GatewayConfig(
+        vaults=[VAULT],
+        profiles=[
+            ProfileConfig(path="default", vaults=["work"], upstreams=["fixture"]),
+            curator_profile(["work"]),
+        ],
+        upstreams=[upstream],
+    )
+    gateway = DynamicGateway(
+        config,
+        {"work": FakeVaultService()},
+        upstream_service=service,
+        profile_middleware=curator_profile_middleware(
+            [VAULT], active_captures=ActiveCaptures()
+        ),
+    )
+    await gateway.start()
+    await service.probe_all()
+    await gateway.refresh_upstreams()
+    try:
+        async with Client(gateway.profile_servers["default"]) as client:
+            ordinary = {tool.name for tool in await client.list_tools()}
+        assert "fixture_echo" in ordinary  # it really is connected and up
+
+        async with Client(gateway.profile_servers[CURATOR_PROFILE_PATH]) as client:
+            curator_tools = {tool.name for tool in await client.list_tools()}
+            assert not any(name.startswith("fixture_") for name in curator_tools)
+
+            # And it is refused on call, not merely unlisted.
+            result = await client.call_tool(
+                "fixture_echo", {"text": "should never happen"}, raise_on_error=False
+            )
+        assert result.is_error is True
+    finally:
+        await gateway.aclose()
+        await service.aclose()
+
+
+def test_the_curator_action_map_never_learns_an_upstream_tool() -> None:
+    """SPEC-206's map is fail-closed: an upstream tool name is not in it, so
+    the middleware refuses it with "unknown tool" rather than waving it
+    through."""
+    mapping = curator_tool_actions([VAULT])
+    assert not any(name.startswith("fixture_") for name in mapping)
+
+
+async def test_refresh_upstreams_never_rebuilds_the_curator_profile(
+    http_upstream: HttpUpstream,
+) -> None:
+    upstream = _upstream(http_upstream.url)
+    service = UpstreamService([upstream])
+    config = GatewayConfig(
+        vaults=[VAULT],
+        profiles=[
+            ProfileConfig(path="default", vaults=["work"], upstreams=["fixture"]),
+            curator_profile(["work"]),
+        ],
+        upstreams=[upstream],
+    )
+    gateway = DynamicGateway(config, {"work": FakeVaultService()}, upstream_service=service)
+    await gateway.start()
+    try:
+        await service.probe_all()
+        assert await gateway.refresh_upstreams() == ["default"]
+    finally:
+        await gateway.aclose()
+        await service.aclose()

--- a/v3/server/tests/upstream/test_down_upstream.py
+++ b/v3/server/tests/upstream/test_down_upstream.py
@@ -1,0 +1,193 @@
+"""SPEC-302 acceptance criterion #3: a down upstream — the profile still
+initializes, its other tools still work, and the status endpoint says which
+server is down and why.
+
+Also covers the recovery direction: an upstream that was down when the hub
+started is picked up by the health monitor's pass and appears without a
+restart, and the reverse (it goes away again) removes its tools rather than
+leaving a mount that times out on every ``tools/list``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client
+
+from palaia_hub.gateway.config import GatewayConfig, ProfileConfig, VaultMountConfig
+from palaia_hub.gateway.dynamic import DynamicGateway
+from palaia_hub.gateway.fake_vault import FakeVaultService
+from palaia_hub.upstream.models import UpstreamConfig
+from palaia_hub.upstream.monitor import UpstreamHealthMonitor
+from palaia_hub.upstream.service import UpstreamService
+
+from .conftest import HttpUpstream
+
+pytestmark = pytest.mark.anyio
+
+#: Port 9 ("discard") refuses connections immediately on every platform the
+#: hub targets — a fast, dependency-free "this endpoint is down".
+DEAD_URL = "http://127.0.0.1:9/mcp/"
+
+
+def _config(upstreams: list[UpstreamConfig]) -> GatewayConfig:
+    return GatewayConfig(
+        vaults=[VaultMountConfig(key="work", name="work", purpose="Work vault.")],
+        profiles=[
+            ProfileConfig(
+                path="default", vaults=["work"], upstreams=[u.key for u in upstreams]
+            )
+        ],
+        upstreams=upstreams,
+    )
+
+
+async def test_a_down_upstream_leaves_the_rest_of_the_profile_working() -> None:
+    dead = UpstreamConfig(
+        key="dead",
+        kind="http",
+        display_name="Unplugged service",
+        url=DEAD_URL,
+        connect_timeout=2.0,
+    )
+    service = UpstreamService([dead])
+    gateway = DynamicGateway(
+        _config([dead]), {"work": FakeVaultService()}, upstream_service=service
+    )
+    await gateway.start()
+    monitor = UpstreamHealthMonitor(service, on_change=gateway.refresh_upstreams)
+    try:
+        changed = await monitor.probe_once()
+        assert changed == ["dead"]
+
+        async with Client(gateway.profile_servers["default"]) as client:
+            names = {tool.name for tool in await client.list_tools()}
+            # The vault's own tools are all there…
+            assert "work_memory_search" in names
+            # …and the unreachable server simply contributes nothing.
+            assert not any(name.startswith("dead_") for name in names)
+            result = await client.call_tool("work_memory_search", {"query": "anything"})
+        assert result.content is not None
+
+        status = service.status("dead")
+        assert status.up is False
+        assert status.display_name == "Unplugged service"
+        assert status.detail  # one line, naming why
+        assert len(status.detail.splitlines()) == 1
+    finally:
+        await monitor.aclose()
+        await gateway.aclose()
+        await service.aclose()
+
+
+async def test_an_upstream_that_comes_up_later_appears_without_a_restart(
+    http_upstream: HttpUpstream,
+) -> None:
+    """The hub-start case: nothing is mounted until a probe says it is up."""
+    upstream = UpstreamConfig(
+        key="fixture", kind="http", display_name="Fixture server", url=http_upstream.url
+    )
+    service = UpstreamService([upstream])
+    gateway = DynamicGateway(
+        _config([upstream]), {"work": FakeVaultService()}, upstream_service=service
+    )
+    await gateway.start()
+    monitor = UpstreamHealthMonitor(service, on_change=gateway.refresh_upstreams)
+    try:
+        # Startup itself never probes (deliverable #4: it must not block), so
+        # the profile begins with no upstream tools at all.
+        async with Client(gateway.profile_servers["default"]) as client:
+            before = {tool.name for tool in await client.list_tools()}
+        assert not any(name.startswith("fixture_") for name in before)
+
+        await monitor.probe_once()
+
+        async with Client(gateway.profile_servers["default"]) as client:
+            after = {tool.name for tool in await client.list_tools()}
+        assert "fixture_echo" in after
+    finally:
+        await monitor.aclose()
+        await gateway.aclose()
+        await service.aclose()
+
+
+async def test_an_upstream_that_dies_stops_being_offered(
+    http_upstream: HttpUpstream,
+) -> None:
+    upstream = UpstreamConfig(
+        key="fixture",
+        kind="http",
+        display_name="Fixture server",
+        url=http_upstream.url,
+        connect_timeout=2.0,
+    )
+    service = UpstreamService([upstream])
+    gateway = DynamicGateway(
+        _config([upstream]), {"work": FakeVaultService()}, upstream_service=service
+    )
+    await gateway.start()
+    monitor = UpstreamHealthMonitor(service, on_change=gateway.refresh_upstreams)
+    try:
+        await monitor.probe_once()
+        async with Client(gateway.profile_servers["default"]) as client:
+            assert "fixture_echo" in {tool.name for tool in await client.list_tools()}
+
+        http_upstream.stop()
+        assert await monitor.probe_once() == ["fixture"]
+
+        async with Client(gateway.profile_servers["default"]) as client:
+            names = {tool.name for tool in await client.list_tools()}
+        assert not any(name.startswith("fixture_") for name in names)
+        assert "work_memory_search" in names
+        assert service.status("fixture").up is False
+    finally:
+        await monitor.aclose()
+        await gateway.aclose()
+        await service.aclose()
+
+
+async def test_reachability_changes_publish_up_and_down_events(
+    http_upstream: HttpUpstream,
+) -> None:
+    published: list[tuple[str, dict[str, object]]] = []
+    upstream = UpstreamConfig(
+        key="fixture",
+        kind="http",
+        display_name="Fixture server",
+        url=http_upstream.url,
+        connect_timeout=2.0,
+    )
+    service = UpstreamService(
+        [upstream], publish=lambda event, data: published.append((event, data))
+    )
+    try:
+        await service.probe("fixture")
+        assert published[-1][0] == "gateway.upstream.up"
+        assert published[-1][1]["upstream"] == "fixture"
+
+        # A second successful probe is silent — only changes are published.
+        await service.probe("fixture")
+        assert len(published) == 1
+
+        http_upstream.stop()
+        await service.probe("fixture")
+        assert published[-1][0] == "gateway.upstream.down"
+        assert published[-1][1]["tool_count"] == 0
+    finally:
+        await service.aclose()
+
+
+async def test_a_switched_off_upstream_is_never_connected_at_all() -> None:
+    off = UpstreamConfig(
+        key="off",
+        kind="http",
+        display_name="Paused service",
+        url=DEAD_URL,
+        enabled=False,
+    )
+    service = UpstreamService([off])
+    try:
+        status = await service.probe("off")
+        assert status.up is False
+        assert "off" in status.detail.lower()
+    finally:
+        await service.aclose()

--- a/v3/server/tests/upstream/test_http_upstream.py
+++ b/v3/server/tests/upstream/test_http_upstream.py
@@ -1,0 +1,194 @@
+"""SPEC-302 acceptance criterion #1: a real second FastMCP server, connected
+as an ``http`` upstream, callable through a profile by a real
+``fastmcp.Client``, namespaced, with a working rename.
+
+The fixture upstream runs in **its own OS process** (see ``conftest.py``), so
+a result carrying its literal ``fixture-http-upstream echo:`` prefix proves
+the call actually left the hub. The authenticated variant proves the value
+from the encrypted store reached the wire: the fixture rejects any request
+whose bearer token does not match.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client
+
+from palaia_hub.gateway.config import GatewayConfig, ProfileConfig, VaultMountConfig
+from palaia_hub.gateway.dynamic import DynamicGateway
+from palaia_hub.gateway.fake_vault import FakeVaultService
+from palaia_hub.upstream.models import UpstreamAuthConfig, UpstreamConfig
+from palaia_hub.upstream.secrets import SecretStore
+from palaia_hub.upstream.service import UpstreamService
+
+from .conftest import FIXTURE_BEARER_TOKEN, HttpUpstream
+
+pytestmark = pytest.mark.anyio
+
+
+def _gateway_config(upstream: UpstreamConfig) -> GatewayConfig:
+    return GatewayConfig(
+        vaults=[VaultMountConfig(key="work", name="work", purpose="Work vault.")],
+        profiles=[ProfileConfig(path="default", vaults=["work"], upstreams=[upstream.key])],
+        upstreams=[upstream],
+    )
+
+
+async def _started_gateway(
+    upstream: UpstreamConfig, service: UpstreamService
+) -> DynamicGateway:
+    gateway = DynamicGateway(
+        _gateway_config(upstream),
+        {"work": FakeVaultService()},
+        upstream_service=service,
+    )
+    await gateway.start()
+    # Startup deliberately mounts no upstream (it never probes — see
+    # DynamicGateway's docstring); this is what the health monitor's first
+    # pass does in production.
+    await service.probe_all()
+    await gateway.refresh_upstreams([upstream.key])
+    return gateway
+
+
+async def test_an_http_upstream_is_callable_through_a_profile(
+    http_upstream: HttpUpstream,
+) -> None:
+    upstream = UpstreamConfig(
+        key="fixture",
+        kind="http",
+        display_name="Fixture server",
+        url=http_upstream.url,
+    )
+    service = UpstreamService([upstream])
+    gateway = await _started_gateway(upstream, service)
+    try:
+        async with Client(gateway.profile_servers["default"]) as client:
+            names = {tool.name for tool in await client.list_tools()}
+            assert "fixture_echo" in names
+            assert "fixture_ping" in names
+            # The profile's own memory tools are untouched.
+            assert "work_memory_search" in names
+
+            result = await client.call_tool("fixture_echo", {"text": "through the hub"})
+        assert "fixture-http-upstream echo: through the hub" in str(result.content)
+    finally:
+        await gateway.aclose()
+        await service.aclose()
+
+
+async def test_the_profile_tells_a_client_whose_tools_those_are(
+    http_upstream: HttpUpstream,
+) -> None:
+    """Deliverable #6: descriptions pass through, provenance is in the
+    profile's IDENTITY block — and a real client can read it."""
+    upstream = UpstreamConfig(
+        key="fixture",
+        kind="http",
+        display_name="Fixture server",
+        url=http_upstream.url,
+    )
+    service = UpstreamService([upstream])
+    gateway = await _started_gateway(upstream, service)
+    try:
+        async with Client(gateway.profile_servers["default"]) as client:
+            instructions = client.initialize_result.instructions or ""
+            tools = {tool.name: tool.description or "" for tool in await client.list_tools()}
+        assert "Fixture server" in instructions
+        assert "connected by you" in instructions
+        # The upstream's own description is untouched by palaia.
+        assert "Echo text back" in tools["fixture_echo"]
+    finally:
+        await gateway.aclose()
+        await service.aclose()
+
+
+async def test_an_upstream_tool_can_be_renamed(http_upstream: HttpUpstream) -> None:
+    upstream = UpstreamConfig(
+        key="fixture",
+        kind="http",
+        display_name="Fixture server",
+        url=http_upstream.url,
+        # Pre-namespace value, per FINDINGS Q4 — the mount composes
+        # "fixture_" in front of it. Typing the already-namespaced name here
+        # is the documented foot-gun this contract avoids.
+        tool_renames={"echo": "say"},
+    )
+    service = UpstreamService([upstream])
+    gateway = await _started_gateway(upstream, service)
+    try:
+        async with Client(gateway.profile_servers["default"]) as client:
+            names = {tool.name for tool in await client.list_tools()}
+            assert "fixture_say" in names
+            assert "fixture_echo" not in names
+            assert "fixture_fixture_say" not in names
+
+            result = await client.call_tool("fixture_say", {"text": "renamed"})
+        assert "fixture-http-upstream echo: renamed" in str(result.content)
+    finally:
+        await gateway.aclose()
+        await service.aclose()
+
+
+async def test_a_bearer_token_from_the_secret_store_reaches_the_upstream(
+    http_upstream_with_token: HttpUpstream, secret_store: SecretStore
+) -> None:
+    secret_store.put("fixture-token", FIXTURE_BEARER_TOKEN)
+    upstream = UpstreamConfig(
+        key="fixture",
+        kind="http",
+        display_name="Fixture server",
+        url=http_upstream_with_token.url,
+        auth=UpstreamAuthConfig(secret_name="fixture-token"),
+    )
+    service = UpstreamService([upstream], secret_store=secret_store)
+    gateway = await _started_gateway(upstream, service)
+    try:
+        assert service.status("fixture").up is True
+        async with Client(gateway.profile_servers["default"]) as client:
+            result = await client.call_tool("fixture_echo", {"text": "authenticated"})
+        assert "fixture-http-upstream echo: authenticated" in str(result.content)
+    finally:
+        await gateway.aclose()
+        await service.aclose()
+
+
+async def test_a_wrong_token_leaves_the_upstream_down_with_a_reason(
+    http_upstream_with_token: HttpUpstream, secret_store: SecretStore
+) -> None:
+    secret_store.put("fixture-token", "not-the-right-token")
+    upstream = UpstreamConfig(
+        key="fixture",
+        kind="http",
+        display_name="Fixture server",
+        url=http_upstream_with_token.url,
+        auth=UpstreamAuthConfig(secret_name="fixture-token"),
+    )
+    service = UpstreamService([upstream], secret_store=secret_store)
+    try:
+        status = await service.probe("fixture")
+        assert status.up is False
+        assert status.detail
+        # The rejected credential is never quoted back.
+        assert "not-the-right-token" not in status.detail
+    finally:
+        await service.aclose()
+
+
+async def test_a_missing_secret_is_reported_by_name_not_by_crashing(
+    http_upstream_with_token: HttpUpstream, secret_store: SecretStore
+) -> None:
+    upstream = UpstreamConfig(
+        key="fixture",
+        kind="http",
+        display_name="Fixture server",
+        url=http_upstream_with_token.url,
+        auth=UpstreamAuthConfig(secret_name="never-entered"),
+    )
+    service = UpstreamService([upstream], secret_store=secret_store)
+    try:
+        status = await service.probe("fixture")
+        assert status.up is False
+        assert "never-entered" in status.detail
+    finally:
+        await service.aclose()

--- a/v3/server/tests/upstream/test_models.py
+++ b/v3/server/tests/upstream/test_models.py
@@ -1,0 +1,132 @@
+"""SPEC-302 deliverables #1/#5: the upstream schema and loud conflicts."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from palaia_hub.gateway.config import GatewayConfig, ProfileConfig, VaultMountConfig
+from palaia_hub.upstream.models import (
+    UpstreamAuthConfig,
+    UpstreamConfig,
+    UpstreamConflictError,
+    check_namespace_conflicts,
+)
+
+
+def _http(**kwargs: object) -> UpstreamConfig:
+    payload: dict[str, object] = {
+        "key": "fixture",
+        "kind": "http",
+        "display_name": "Fixture",
+        "url": "https://example.invalid/mcp",
+    }
+    payload.update(kwargs)
+    return UpstreamConfig.model_validate(payload)
+
+
+def test_the_namespace_defaults_to_the_key_with_dashes_turned_into_underscores() -> None:
+    assert _http(key="my-server").mount_namespace == "my_server"
+    assert _http(namespace="linear").mount_namespace == "linear"
+
+
+def test_an_http_upstream_needs_a_url_and_refuses_a_command() -> None:
+    with pytest.raises(ValidationError):
+        UpstreamConfig(key="x", kind="http", display_name="X")
+    with pytest.raises(ValidationError):
+        _http(command="/bin/true")
+
+
+def test_a_stdio_upstream_needs_a_command_and_refuses_url_or_headers() -> None:
+    with pytest.raises(ValidationError):
+        UpstreamConfig(key="x", kind="stdio", display_name="X")
+    with pytest.raises(ValidationError):
+        UpstreamConfig(
+            key="x",
+            kind="stdio",
+            display_name="X",
+            command="/bin/true",
+            url="https://example.invalid/mcp",
+        )
+    with pytest.raises(ValidationError):
+        UpstreamConfig(
+            key="x",
+            kind="stdio",
+            display_name="X",
+            command="/bin/true",
+            auth=UpstreamAuthConfig(secret_name="t"),
+        )
+
+
+def test_env_secrets_are_refused_on_an_http_upstream() -> None:
+    with pytest.raises(ValidationError):
+        _http(env_secrets={"TOKEN": "t"})
+
+
+def test_a_bad_namespace_is_an_error_not_a_silent_sanitization() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        _http(namespace="My Server!")
+    assert "namespace" in str(excinfo.value)
+
+
+def test_an_auth_template_must_say_where_the_secret_goes() -> None:
+    with pytest.raises(ValidationError):
+        UpstreamAuthConfig(secret_name="t", value_template="Bearer nothing-here")
+
+
+def test_the_target_line_is_credential_free() -> None:
+    http = _http(auth=UpstreamAuthConfig(secret_name="linear-token"))
+    assert http.target == "https://example.invalid/mcp"
+    stdio = UpstreamConfig(
+        key="box",
+        kind="stdio",
+        display_name="Box",
+        command="/usr/bin/mcp",
+        args=["--stdio"],
+        env_secrets={"TOKEN": "box-token"},
+    )
+    assert stdio.target == "/usr/bin/mcp --stdio"
+    assert "box-token" not in stdio.target
+
+
+def test_two_upstreams_claiming_one_namespace_are_refused_loudly() -> None:
+    with pytest.raises(UpstreamConflictError) as excinfo:
+        check_namespace_conflicts(
+            [_http(key="a", namespace="shared"), _http(key="b", namespace="shared")]
+        )
+    assert "shared" in str(excinfo.value)
+    assert "'a'" in str(excinfo.value) and "'b'" in str(excinfo.value)
+
+
+def test_an_upstream_may_not_shadow_a_vault_tool_family() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        GatewayConfig(
+            vaults=[VaultMountConfig(key="work", name="work", purpose="Work.")],
+            upstreams=[_http(namespace="work_memory")],
+        )
+    assert "work_memory" in str(excinfo.value)
+
+
+def test_a_disabled_upstream_still_owns_its_namespace() -> None:
+    """Otherwise switching it back on later would surprise someone with a
+    conflict that was not there when they configured the second server."""
+    with pytest.raises(UpstreamConflictError):
+        check_namespace_conflicts(
+            [
+                _http(key="a", namespace="shared", enabled=False),
+                _http(key="b", namespace="shared"),
+            ]
+        )
+
+
+def test_a_profile_may_not_reference_an_unknown_upstream() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        GatewayConfig(
+            profiles=[ProfileConfig(path="default", upstreams=["ghost"])],
+        )
+    assert "ghost" in str(excinfo.value)
+
+
+def test_duplicate_upstream_keys_are_refused() -> None:
+    with pytest.raises(ValidationError):
+        GatewayConfig(upstreams=[_http(key="a"), _http(key="a", namespace="other")])

--- a/v3/server/tests/upstream/test_secret_never_leaks.py
+++ b/v3/server/tests/upstream/test_secret_never_leaks.py
@@ -1,0 +1,136 @@
+"""SPEC-302 acceptance criterion #2, the redaction half: a stored value never
+appears in a log line, an error message, or an event payload.
+
+The hub's own :class:`~palaia_hub.logging.RedactionFilter` is a *second* line
+of defense; the first is that nothing in the upstream package ever passes a
+value to a logger or an exception in the first place. Both are asserted here:
+the raw records captured during a full connect-probe-call cycle, and the same
+records after the production filter has run over them.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from palaia_hub.logging import RedactionFilter, redact
+from palaia_hub.upstream.models import UpstreamAuthConfig, UpstreamConfig
+from palaia_hub.upstream.secrets import SecretStore
+from palaia_hub.upstream.service import UpstreamService
+
+from .conftest import FIXTURE_BEARER_TOKEN, HttpUpstream
+
+pytestmark = pytest.mark.anyio
+
+SECRET = "sk-canary-value-must-never-be-logged-31337"
+
+
+async def test_no_log_line_from_a_full_cycle_contains_the_value(
+    tmp_path: Path, http_upstream_with_token: HttpUpstream, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.DEBUG)
+    store = SecretStore(tmp_path / "home")
+    store.put("fixture-token", FIXTURE_BEARER_TOKEN)
+    upstream = UpstreamConfig(
+        key="fixture",
+        kind="http",
+        display_name="Fixture server",
+        url=http_upstream_with_token.url,
+        auth=UpstreamAuthConfig(secret_name="fixture-token"),
+    )
+    service = UpstreamService([upstream], secret_store=store)
+    try:
+        status = await service.probe("fixture")
+        assert status.up is True
+        await service.proxy_for("fixture")
+    finally:
+        await service.aclose()
+        store.close()
+
+    messages = [record.getMessage() for record in caplog.records]
+    joined = "\n".join(messages)
+    assert FIXTURE_BEARER_TOKEN not in joined
+    # And the production filter would have caught it even if it had been
+    # there — asserted on a deliberately leaky line so the test proves the
+    # filter works rather than merely that nothing leaked.
+    assert FIXTURE_BEARER_TOKEN not in redact(
+        f"Authorization: Bearer {FIXTURE_BEARER_TOKEN}"
+    )
+    filtered = RedactionFilter()
+    for record in caplog.records:
+        assert filtered.filter(record) is True
+        assert FIXTURE_BEARER_TOKEN not in record.getMessage()
+
+
+async def test_a_failure_message_names_the_secret_not_its_value(tmp_path: Path) -> None:
+    store = SecretStore(tmp_path / "home")
+    store.put("fixture-token", SECRET)
+    upstream = UpstreamConfig(
+        key="fixture",
+        kind="http",
+        display_name="Fixture server",
+        # Nothing listening — the failure text is what is under test.
+        url="http://127.0.0.1:9/mcp/",
+        auth=UpstreamAuthConfig(secret_name="fixture-token"),
+        connect_timeout=2.0,
+    )
+    service = UpstreamService([upstream], secret_store=store)
+    try:
+        status = await service.probe("fixture")
+    finally:
+        await service.aclose()
+        store.close()
+
+    assert status.up is False
+    assert SECRET not in status.detail
+
+
+async def test_no_event_payload_carries_a_value(
+    tmp_path: Path, http_upstream_with_token: HttpUpstream
+) -> None:
+    published: list[tuple[str, dict[str, object]]] = []
+    store = SecretStore(tmp_path / "home")
+    store.put("fixture-token", FIXTURE_BEARER_TOKEN)
+    upstream = UpstreamConfig(
+        key="fixture",
+        kind="http",
+        display_name="Fixture server",
+        url=http_upstream_with_token.url,
+        auth=UpstreamAuthConfig(secret_name="fixture-token"),
+    )
+    service = UpstreamService(
+        [upstream],
+        secret_store=store,
+        publish=lambda event, data: published.append((event, data)),
+    )
+    try:
+        await service.probe("fixture")
+    finally:
+        await service.aclose()
+        store.close()
+
+    assert published
+    assert FIXTURE_BEARER_TOKEN not in repr(published)
+
+
+async def test_the_status_shape_has_nowhere_to_put_a_value(
+    tmp_path: Path, http_upstream: HttpUpstream
+) -> None:
+    """Structural, not behavioral: the status dataclass's field set is fixed,
+    so a future change cannot start carrying a credential by accident."""
+    from palaia_hub.upstream.service import UpstreamStatus
+
+    assert set(UpstreamStatus.__dataclass_fields__) == {
+        "key",
+        "display_name",
+        "namespace",
+        "kind",
+        "enabled",
+        "target",
+        "up",
+        "detail",
+        "checked_at",
+        "tools",
+    }

--- a/v3/server/tests/upstream/test_secrets.py
+++ b/v3/server/tests/upstream/test_secrets.py
@@ -1,0 +1,175 @@
+"""SPEC-302 deliverable #2 / acceptance criterion #2: the secret store.
+
+Covers the fixed design point by point: file modes, ``O_CREAT|O_EXCL``
+creation, encryption at rest, the names-only listing, read-back across a
+"restart" (a second :class:`SecretStore` over the same home), and that no
+log line produced while storing or reading a secret contains its value.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import stat
+from pathlib import Path
+
+import pytest
+
+from palaia_hub.upstream.secrets import (
+    SECRETS_DB_NAME,
+    SECRETS_KEY_NAME,
+    SecretInfo,
+    SecretStore,
+    SecretStoreError,
+    validate_secret_name,
+)
+
+SECRET = "sk-live-do-not-log-me-4711"
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+def test_key_and_db_files_are_0600_in_a_0700_home(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    store = SecretStore(home)
+    try:
+        store.put("linear-token", SECRET)
+    finally:
+        store.close()
+
+    assert _mode(home) == 0o700
+    assert _mode(home / SECRETS_KEY_NAME) == 0o600
+    assert _mode(home / SECRETS_DB_NAME) == 0o600
+
+
+def test_widened_modes_are_narrowed_again_on_the_next_open(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    SecretStore(home).close()
+    (home / SECRETS_KEY_NAME).chmod(0o644)
+    home.chmod(0o755)
+
+    SecretStore(home).close()
+
+    assert _mode(home / SECRETS_KEY_NAME) == 0o600
+    assert _mode(home) == 0o700
+
+
+def test_an_existing_key_is_never_overwritten(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    store = SecretStore(home)
+    store.put("token", SECRET)
+    store.close()
+    key_before = (home / SECRETS_KEY_NAME).read_bytes()
+
+    reopened = SecretStore(home)
+    try:
+        # Same key, so the value still decrypts — the O_CREAT|O_EXCL path
+        # was not taken a second time.
+        assert reopened.get("token") == SECRET
+    finally:
+        reopened.close()
+    assert (home / SECRETS_KEY_NAME).read_bytes() == key_before
+
+
+def test_the_value_is_encrypted_at_rest(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    store = SecretStore(home)
+    try:
+        store.put("token", SECRET)
+    finally:
+        store.close()
+
+    # The raw database bytes must not contain the plaintext anywhere.
+    assert SECRET.encode() not in (home / SECRETS_DB_NAME).read_bytes()
+    connection = sqlite3.connect(home / SECRETS_DB_NAME)
+    try:
+        stored = connection.execute("SELECT ciphertext FROM secrets").fetchone()[0]
+    finally:
+        connection.close()
+    assert SECRET.encode() not in bytes(stored)
+
+
+def test_put_get_delete_and_names_only_listing(secret_store: SecretStore) -> None:
+    secret_store.put("b-token", "value-b")
+    secret_store.put("a-token", SECRET)
+
+    assert [info.name for info in secret_store.names()] == ["a-token", "b-token"]
+    # The listing shape has no value field at all — there is nowhere to leak.
+    assert set(SecretInfo.__slots__) == {"name", "created_at", "updated_at"}
+    assert secret_store.get("a-token") == SECRET
+    assert secret_store.get("nope") is None
+
+    assert secret_store.delete("a-token") is True
+    assert secret_store.delete("a-token") is False
+    assert [info.name for info in secret_store.names()] == ["b-token"]
+
+
+def test_replacing_a_value_keeps_the_created_timestamp(secret_store: SecretStore) -> None:
+    first = secret_store.put("token", "one")
+    second = secret_store.put("token", "two")
+
+    assert secret_store.get("token") == "two"
+    assert second.created_at == first.created_at
+    assert second.updated_at >= first.updated_at
+
+
+def test_a_hub_restart_reads_the_secrets_back(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    first = SecretStore(home)
+    first.put("linear-token", SECRET)
+    first.close()
+
+    second = SecretStore(home)
+    try:
+        assert second.get("linear-token") == SECRET
+    finally:
+        second.close()
+
+
+def test_a_value_stored_with_a_different_key_is_refused_by_name(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    store = SecretStore(home)
+    store.put("token", SECRET)
+    store.close()
+    # Simulate "the database was copied without its key".
+    (home / SECRETS_KEY_NAME).unlink()
+
+    reopened = SecretStore(home)
+    try:
+        with pytest.raises(SecretStoreError) as excinfo:
+            reopened.get("token")
+    finally:
+        reopened.close()
+    assert "token" in str(excinfo.value)
+    assert SECRET not in str(excinfo.value)
+
+
+@pytest.mark.parametrize("name", ["", " ", "has space", "a/b", "x" * 129, "-leading"])
+def test_bad_secret_names_are_refused_loudly(name: str) -> None:
+    with pytest.raises(SecretStoreError):
+        validate_secret_name(name)
+
+
+def test_an_empty_value_is_refused_rather_than_stored(secret_store: SecretStore) -> None:
+    with pytest.raises(SecretStoreError):
+        secret_store.put("token", "")
+
+
+def test_nothing_logged_while_storing_or_reading_contains_the_value(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="palaia_hub")
+    store = SecretStore(tmp_path / "home")
+    try:
+        store.put("linear-token", SECRET)
+        assert store.get("linear-token") == SECRET
+        store.delete("linear-token")
+    finally:
+        store.close()
+
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    assert SECRET not in logged
+    # The name, on the other hand, is deliberately loggable.
+    assert "linear-token" in logged

--- a/v3/server/tests/upstream/test_stdio_upstream.py
+++ b/v3/server/tests/upstream/test_stdio_upstream.py
@@ -1,0 +1,144 @@
+"""SPEC-302 acceptance criterion #4: a ``stdio`` upstream — command spawned,
+env-var secret injected, tools callable e2e, process reaped on shutdown.
+
+The fixture server (``fixture_stdio_server.py``) reports the value of
+``FIXTURE_TOKEN`` back through a tool, so "the secret was injected" is proven
+by the call's own result rather than by inspecting our own plumbing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from pathlib import Path
+
+import pytest
+from fastmcp import Client
+
+from palaia_hub.gateway.config import GatewayConfig, ProfileConfig, VaultMountConfig
+from palaia_hub.gateway.dynamic import DynamicGateway
+from palaia_hub.gateway.fake_vault import FakeVaultService
+from palaia_hub.upstream.models import UpstreamConfig
+from palaia_hub.upstream.secrets import SecretStore
+from palaia_hub.upstream.service import UpstreamService
+
+pytestmark = pytest.mark.anyio
+
+STDIO_SECRET = "stdio-secret-value-9182"
+
+
+def _stdio_upstream(stdio_command: list[str]) -> UpstreamConfig:
+    return UpstreamConfig(
+        key="localbox",
+        kind="stdio",
+        display_name="Local box",
+        command=stdio_command[0],
+        args=stdio_command[1:],
+        env_secrets={"FIXTURE_TOKEN": "localbox-token"},
+    )
+
+
+async def test_a_stdio_upstream_spawns_and_serves_tools_with_its_secret(
+    stdio_command: list[str], secret_store: SecretStore
+) -> None:
+    secret_store.put("localbox-token", STDIO_SECRET)
+    upstream = _stdio_upstream(stdio_command)
+    service = UpstreamService([upstream], secret_store=secret_store)
+    gateway = DynamicGateway(
+        GatewayConfig(
+            vaults=[VaultMountConfig(key="work", name="work", purpose="Work vault.")],
+            profiles=[ProfileConfig(path="default", vaults=["work"], upstreams=["localbox"])],
+            upstreams=[upstream],
+        ),
+        {"work": FakeVaultService()},
+        upstream_service=service,
+    )
+    await gateway.start()
+    await service.probe_all()
+    await gateway.refresh_upstreams(["localbox"])
+    try:
+        assert service.status("localbox").up is True
+        async with Client(gateway.profile_servers["default"]) as client:
+            names = {tool.name for tool in await client.list_tools()}
+            assert {"localbox_whoami", "localbox_add"} <= names
+
+            identity = await client.call_tool("localbox_whoami", {})
+            total = await client.call_tool("localbox_add", {"a": 2, "b": 3})
+        assert f"token={STDIO_SECRET}" in str(identity.content)
+        assert "5" in str(total.content)
+    finally:
+        await gateway.aclose()
+        await service.aclose()
+
+
+def _own_children() -> set[int]:
+    """PIDs of this process's direct children, read from ``/proc``.
+
+    Linux-only, which is what the hub's own container target is; the test
+    using it skips elsewhere rather than pretending to check something.
+    """
+    task_dir = Path(f"/proc/{os.getpid()}/task")
+    children: set[int] = set()
+    for task in task_dir.iterdir():
+        try:
+            raw = (task / "children").read_text()
+        except OSError:  # pragma: no cover - task exited mid-read
+            continue
+        children.update(int(pid) for pid in raw.split())
+    return children
+
+
+@pytest.mark.skipif(
+    not Path("/proc/self/task").exists(), reason="needs /proc to observe child processes"
+)
+async def test_the_child_process_is_spawned_and_reaped_on_shutdown(
+    stdio_command: list[str], secret_store: SecretStore
+) -> None:
+    secret_store.put("localbox-token", STDIO_SECRET)
+    upstream = _stdio_upstream(stdio_command)
+    service = UpstreamService([upstream], secret_store=secret_store)
+    before = _own_children()
+
+    await service.probe_all()
+    proxy = await service.proxy_for("localbox")
+    # A real call, so the child is definitely running before we tear down.
+    async with Client(proxy) as client:
+        await client.call_tool("whoami", {})
+    spawned = _own_children() - before
+    assert spawned, "the stdio upstream's command was never spawned"
+
+    await service.aclose()
+
+    # The child is gone — not merely forgotten by us. It may take a moment
+    # for the kernel to reap it after the transport signalled its stop.
+    deadline = time.time() + 15
+    while time.time() < deadline and (_own_children() & spawned):
+        await asyncio.sleep(0.1)
+    assert not (_own_children() & spawned), "the stdio upstream's process outlived shutdown"
+
+    # After aclose the cached transport is gone; asking again builds a fresh
+    # one rather than handing back a dead session.
+    rebuilt = await service.proxy_for("localbox")
+    assert rebuilt is not proxy
+    await service.aclose()
+
+
+async def test_a_stdio_upstream_whose_command_does_not_exist_is_down_not_fatal(
+    secret_store: SecretStore,
+) -> None:
+    upstream = UpstreamConfig(
+        key="ghost",
+        kind="stdio",
+        display_name="Ghost box",
+        command="/nonexistent/palaia-test-binary",
+        connect_timeout=3.0,
+    )
+    service = UpstreamService([upstream], secret_store=secret_store)
+    try:
+        status = await service.probe("ghost")
+        assert status.up is False
+        assert status.detail
+        assert status.tools == ()
+    finally:
+        await service.aclose()


### PR DESCRIPTION
## Summary

SPEC-302 on top of SPEC-301's gateway config: connect somebody else's MCP server to palaia once — a remote HTTP endpoint or a local command — and it appears namespaced, renamable and health-checked on whichever profiles mount it. Its credential lives in palaia's encrypted store, never in a client config file.

New package `palaia_hub.upstream`:

| Module | What it owns |
|---|---|
| `models.py` | The `UpstreamConfig` schema (fastmcp-free, imported directly by `config.py` — see the deviation note) and the loud namespace-conflict check |
| `secrets.py` | The encrypted store: `secrets.sqlite3` + `secrets.key`, both `0600`, `O_CREAT\|O_EXCL`, reusing SPEC-203's `enforce_private_mode` |
| `service.py` | Connections, credential resolution, bounded probes, client-backed proxies via `fastmcp.server.create_proxy`, teardown |
| `monitor.py` | The periodic reachability pass that publishes up/down and triggers profile rebuilds |
| `api.py` | `/api/gateway/upstreams` (list/connect/edit/probe/disconnect) and the write-only `/api/secrets` |

Wired into `gateway/build.py` (mount + provenance IDENTITY line), `gateway/dynamic.py` (mountability-driven rebuild, `refresh_upstreams`), `gateway/settings_bridge.py`, `serve.py` and `app.py` (lifespan start/stop, so a `stdio` child is reaped at shutdown).

Fixed designs implemented verbatim, not redesigned: the secret store's shape and its never-return-values rule; the curator fence.

## Acceptance criteria

- [x] **e2e: a real second FastMCP server (test fixture) connected as an upstream is callable through a profile by a real `fastmcp.Client`, namespaced, and its rename works** — `tests/upstream/test_http_upstream.py`. The fixture runs in its own OS process, so the literal `fixture-http-upstream echo:` prefix in the result proves the call left the hub. Rename asserted both directions (`fixture_say` present, `fixture_echo` and the double-prefixed `fixture_fixture_say` both absent). Also over REST end-to-end in `test_api.py`.
- [x] **secret store: key/db files 0600; a stored value never appears in any REST response, log line (redaction test), or error message; hub restarts read it back** — `tests/upstream/test_secrets.py` (modes, `O_CREAT|O_EXCL`/never-overwrite, encrypted-at-rest against the raw db bytes, restart read-back, widened modes re-narrowed) and `tests/upstream/test_secret_never_leaks.py` (raw log records from a full connect/probe/call cycle, failure messages, event payloads, and the status dataclass's field set). `test_api.py::test_a_stored_secret_value_never_comes_back_out` also asserts the value is absent from the persisted `config.yaml`.
- [x] **a down upstream: profile still initializes, its other tools work, status endpoint says which upstream is down and why** — `tests/upstream/test_down_upstream.py`, plus the recovery direction (an upstream that comes up later appears with no restart) and the reverse (one that dies stops being offered).
- [x] **stdio upstream: command spawned, env-var secret injected, tools callable e2e, process reaped on hub shutdown** — `tests/upstream/test_stdio_upstream.py`. The injected secret is proven by the child's own tool result (`token=…`), and the reaping by watching this process's `/proc` children before and after `aclose()` (skipped honestly where `/proc` is unavailable).
- [x] **curator profile provably cannot see or call upstream tools** — `tests/upstream/test_curator_fence.py`, one test per fence layer: the schema refuses to hold it, the builder refuses even a `model_construct`-ed profile that routed around the schema, the live curator profile carries no `fixture_*` tool and refuses the call, SPEC-206's action map never learns one, and `refresh_upstreams` never rebuilds the curator profile.

## Deviations and judgement calls

1. **`GatewayUpstreamSettings` is an import, not a duplicate.** `config.py` keeps hand-written twins of `VaultMountConfig`/`ProfileConfig` so it stays importable without fastmcp. Rather than write a third twin with twelve fields, `upstream/models.py` was written to be import-free (no `palaia_hub` imports, no fastmcp, and a deliberately empty package `__init__`), and `config.py` imports `UpstreamConfig` from it as `GatewayUpstreamSettings`. Same invariant, one source of truth, no parity test to forget. The reasoning is in both modules' docstrings.
2. **No dashboard UI in this PR.** SPEC-302's deliverables are the registry, store, wiring, health and fences; the screens that use them are SPEC-305 (profile editor: "create/edit assigns … SPEC-302 upstreams via checkboxes") and SPEC-304 (install flows with `secret` config fields). The REST surface is complete and write-only by construction. The SPEC's "stated honestly in the UI" about manual token paste is stated in the two operator-facing surfaces this PR does own: the `config.yaml` template comments and `docs/external-servers.md`. No `v3/web` files changed, so no web checks were run.
3. **Startup deliberately does not probe.** "The mount must not block hub startup" is taken literally: `DynamicGateway.start()` mounts no upstream, and the health monitor's first pass (background, at the end of the app lifespan's startup) is what mounts the reachable ones. Consequence, stated plainly: for a second or two after a start, a connected server's tools are not yet listed. The alternative — mounting unconditionally — would put an 8-second timeout on every `tools/list` of a dead server, which seemed strictly worse.
4. **Conflict refusal is at the namespace level, not the composed tool name.** Upstream tool names are not knowable at config time (they come from a probe), so the config-time refusal covers prefixes: two servers, or a server and a vault's `<name>_memory` family, cannot share one — checked in `GatewayConfig`'s validator and, for a vault created at runtime, explicitly in `add_vault` (`model_copy` does not re-run validators). A pathological prefix-overlap collision (namespace `a` with a tool `b_c` versus namespace `a_b` with a tool `c`) is not detected; it is not silently resolved either, fastmcp's aggregator would surface it, and no test claims otherwise.
5. **`CURATOR_PROFILE_PATH` moved** from `curator/profile.py` to `gateway/config.py` (re-exported from its old home, so every caller is unchanged, and `gateway/api.py`'s hand-copied duplicate is gone). `ProfileConfig` needs the literal to fence itself, and importing the curator package from the schema would cycle.
6. **A merge-conflict marker was already unresolved on the integration branch**, in `docs/events.md` §3.2 — the SPEC-303 marketplace event and the SPEC-301 profile events sat on either side of `<<<<<<< HEAD`/`>>>>>>>`. Since this PR edits that file, both halves were kept and renumbered §3.2/§3.3. Flagging it because it was not mine to find.
7. **Cosmetic:** `render_gateway_section` dumps every field including defaults, so a written-back `upstreams` entry carries explicit `url: null`, `cwd: null` and so on. It round-trips exactly (asserted) and matches how the section already renders vaults/profiles; making it terser would change SPEC-301's existing output.
8. **A rotated secret is applied by an explicit hook, not by rebuilding transports per call.** A credential is baked into a transport at construction time, so `build_secret_change_hook` (wired to `PUT`/`DELETE /api/secrets/{name}`) reconnects the servers that reference that name and rebuilds their profiles. Rebuilding on every probe instead would respawn a `stdio` child once a minute.

## Verification

From `v3/`, on the final commit:

```
$ uv run ruff check server
All checks passed!

$ uv run mypy server/src
Success: no issues found in 164 source files

$ uv run pytest server/tests/upstream -q
68 passed in 64.68s

$ uv run pytest server/tests -q
1658 passed, 15 skipped, 128 warnings in 458.52s (0:07:38)
```

fastmcp stays pinned at 3.4.7; the golden tools snapshots are untouched (an upstream contributes nothing to a zero-config hub, so `golden_tools_snapshot.json` and `golden_stash_tools_snapshot.json` are byte-identical and their drift tests pass unchanged). No `v3/web` changes, so `npm run typecheck` / `vitest` / `npm run build` were not run. Two pre-existing test expectations needed the additive field (`GatewayProfileOut.upstreams`, `GatewaySettings.upstreams`) and were updated with a comment saying why.

## Scope note

Adjacent things deliberately left out: container lifecycle (SPEC-304), registry browsing (SPEC-303), OAuth client flows against third-party authorization servers (explicit non-goal), the profile-editor and marketplace screens (SPEC-305/304), and per-tool visibility toggles within an upstream's family (SPEC-305 deliverable #3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790170865&installation_model_id=428086&pr_number=245&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F245&signature=6d48546ef619cfd7082b47db5daa5e8cda12d9bc0e9f10ca24ca7c82e2eeda39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->