### PR TITLE
feat(v3): marketplace install flows + MCP App (SPEC-304)

### DIFF
--- a/v3/docs/events.md
+++ b/v3/docs/events.md
@@ -129,6 +129,21 @@ included in `data` at all.
 | `gateway.upstream.updated` | `gateway` | `upstream`, `display_name`, `enabled`, `profiles` | `PATCH /api/gateway/upstreams/{key}` changes one (including switching it off). |
 | `gateway.upstream.disconnected` | `gateway` | `upstream` | `DELETE /api/gateway/upstreams/{key}` removes one; every profile that mounted it is rebuilt without it. |
 
+### 3.5 Marketplace install/lifecycle events (SPEC-304, additive)
+
+Emitted by `palaia_hub.market.install.InstallService` — every one of these
+is on top of an ordinary `gateway.upstream.*` event above (an install
+connects an upstream the same way `POST /api/gateway/upstreams` does), so a
+webhook filtering on the marketplace names below sees the add-on's own
+lifecycle without also having to parse the generic upstream events.
+
+| Event | Origin | `data` fields | Fires when |
+|---|---|---|---|
+| `addon.installed` | `market` | `entry_id`, `upstream_key`, `kind`, `name` | `POST /api/market/entry/{id}/install` succeeds. |
+| `addon.updated` | `market` | `entry_id`, `upstream_key`, `installed_ref` | `POST /api/market/installed/{key}/update` succeeds (containers only — see the SPEC's non-goals: no auto-update). |
+| `addon.uninstalled` | `market` | `entry_id`, `upstream_key` | `DELETE /api/market/installed/{key}` removes an installed add-on. |
+| `addon.update_available` | `market` | `entry_id`, `upstream_key`, `installed_ref`, `available_ref` | The curated index refreshes (`market.index.updated`) and an installed container's recorded image no longer matches the entry's current one — the dashboard badge this SPEC's deliverable #4 asks for. |
+
 `health` also travels the same bus and wire format (SSE only; it is not a
 webhook-filterable v1 name — see §6) — it is the dashboard's periodic
 liveness snapshot, carried over unchanged from before this SPEC.

--- a/v3/server/src/palaia_hub/app.py
+++ b/v3/server/src/palaia_hub/app.py
@@ -43,12 +43,19 @@ from .events import (
 from .gateway import DynamicGateway, GatewayASGI, VaultService
 from .gateway.api import build_gateway_profiles_router
 from .gateway.apps.hub_status_app import HubStatusDeps, build_hub_status_server
+from .gateway.apps.market_app import MarketAppDeps, build_market_server
 from .gateway.stash_tools import build_stash_gateway
 from .gateway.wiring import EngineVaultService
 from .hooks import OUTBOX_RELATIVE_PATH, HookDispatcher, HookOutbox, HookStore, build_hooks_router
 from .index import VaultIndex
 from .logging import setup_logging
-from .market import MarketService, build_market_router
+from .market import (
+    InstallService,
+    MarketService,
+    build_market_install_router,
+    build_market_router,
+    wire_market_index_updates,
+)
 from .mcpb import build_mcpb_router
 from .modes import AuthRateLimitMiddleware, ModeAuditLog, build_modes_router
 from .notifications import NotificationStore, build_notifications_router
@@ -87,6 +94,7 @@ def create_app(
     oauth_server: AuthorizationServer | None = None,
     stash_service: StashService | None = None,
     market_service: MarketService | None = None,
+    install_service: InstallService | None = None,
     hook_store: HookStore | None = None,
     hook_outbox: HookOutbox | None = None,
     curator: CuratorScheduler | None = None,
@@ -192,7 +200,21 @@ def create_app(
             mounts ``/api/market/*`` and wires its
             ``market.index.updated`` event onto ``event_bus``. Omitted
             (the default), the hub runs with no marketplace surface at
-            all, same as before this parameter existed.
+            all, same as before this parameter existed. Also mounts the
+            marketplace MCP App at ``/mcp/market`` (SPEC-304 deliverable
+            #5) — independent of ``install_service``: browsing needs only
+            this.
+        install_service: marketplace install/lifecycle flows (SPEC-304
+            deliverables #1/#3/#4 —
+            :class:`~palaia_hub.market.install.InstallService`). Given
+            together with ``market_service`` and ``event_bus``, mounts the
+            consent/install/installed-add-on REST surface under
+            ``/api/market/*`` (alongside ``market_service``'s own read-only
+            routes) and subscribes its update check onto
+            ``market.index.updated``. Omitted (the default), the hub
+            serves marketplace *browsing* (when ``market_service`` is
+            given) but no install flow at all — the dashboard's install
+            button then has nothing to call.
         hook_store: outbound-webhook configuration (SPEC-201). Given, mounts
             the ``/api/hooks`` REST surface and starts the delivery worker
             that turns every published event into a signed webhook POST for
@@ -299,6 +321,22 @@ def create_app(
         hub_status_server = build_hub_status_server(hub_status_deps)
         hub_status_asgi_app = hub_status_server.http_app(path="/")
 
+    # SPEC-304 deliverable #5: the marketplace MCP App, mounted at
+    # `/mcp/market` — hub-level, same standalone-FastMCP-instance shape as
+    # hub_status above. Gated on `market_service` alone (not
+    # `install_service`): browsing needs no install machinery at all.
+    market_asgi_app = None
+    if market_service is not None:
+        market_app_deps = MarketAppDeps(
+            market_service=market_service,
+            dashboard_url=(
+                config.exposure.public_url.rstrip("/")
+                if config.exposure.public_url
+                else None
+            ),
+        )
+        market_asgi_app = build_market_server(market_app_deps).http_app(path="/")
+
     # One lifespan runs BOTH concerns: the events background tasks (SPEC-109)
     # and, when a gateway is mounted, its session-manager lifespan (SPEC-105 —
     # skipping it hangs the mounted profiles on their first request). The
@@ -403,6 +441,8 @@ def create_app(
                     await stack.enter_async_context(stash_gateway.lifespan(app_))
                 if hub_status_asgi_app is not None:
                     await stack.enter_async_context(hub_status_asgi_app.lifespan(app_))
+                if market_asgi_app is not None:
+                    await stack.enter_async_context(market_asgi_app.lifespan(app_))
                 yield
         finally:
             await stop_background_tasks(tasks)
@@ -448,6 +488,8 @@ def create_app(
         app.mount("/mcp/stash", stash_gateway.app)
     if hub_status_asgi_app is not None:
         app.mount("/mcp/hub", hub_status_asgi_app)
+    if market_asgi_app is not None:
+        app.mount("/mcp/market", market_asgi_app)
     if dynamic_gateway is not None:
         # One mount, forever: DynamicGateway owns everything below "/mcp"
         # and rebuilds its own internal routing as profiles come and go
@@ -602,6 +644,12 @@ def create_app(
         app.include_router(build_stash_router(stash_service))
     if market_service is not None:
         app.include_router(build_market_router(market_service))
+    if install_service is not None:
+        app.include_router(build_market_install_router(install_service))
+        # SPEC-304 deliverable #4: recompute every installed container's
+        # update status whenever the curated index refreshes, and publish
+        # `addon.update_available` for whichever just turned stale.
+        wire_market_index_updates(event_bus, install_service)
     if hook_store is not None:
         assert outbox is not None  # built above, together with hook_store's dispatcher
         app.include_router(build_hooks_router(hook_store, outbox))

--- a/v3/server/src/palaia_hub/gateway/apps/__init__.py
+++ b/v3/server/src/palaia_hub/gateway/apps/__init__.py
@@ -9,6 +9,10 @@
   (:mod:`palaia_hub.gateway.memory_tools`).
 - :mod:`palaia_hub.gateway.apps.review_app` — the review-queue app page
   attached to the memory tool family's ``review_queue`` tool.
+- :mod:`palaia_hub.gateway.apps.market_app` — SPEC-304's marketplace app:
+  a hub-level ``browse_marketplace`` tool + its card-grid page. Its
+  "Install" control always deep-links to the dashboard; it never installs
+  anything itself.
 
 ``vendor/`` holds the two third-party assets these pages embed inline (the
 MCP Apps view SDK bundle and two self-hosted font files) — see

--- a/v3/server/src/palaia_hub/gateway/apps/market_app.py
+++ b/v3/server/src/palaia_hub/gateway/apps/market_app.py
@@ -1,0 +1,260 @@
+"""Marketplace MCP App (SPEC-304 deliverable #5, MASTERPLAN §5.7 table).
+
+Browse/search as a card grid inside the client, with an inline detail
+view (permissions, maintainer, verified state) — the same
+:class:`~palaia_hub.market.models.MarketEntry` shape the dashboard's own
+marketplace screen reads, so nothing here special-cases a source either.
+
+**"Install itself always deep-links to the dashboard consent screen — the
+app never performs the install"** (the SPEC's own words, restating
+MASTERPLAN §5.7's "security-sensitive administration stays
+dashboard-only"). This page contains no install tool call at all: its
+"Install" control is a plain ``<a target="_blank">`` to this hub's
+dashboard, built server-side from ``config.exposure.public_url`` (the same
+field the exposure wizard already fills in — SPEC-205) — never a guess at
+an origin the sandboxed app iframe cannot reliably know. A hub with no
+public URL recorded yet (the common case for a brand-new locked-mode hub)
+shows plain instructions instead of a dead link, same "never a dead end"
+posture :mod:`palaia_hub.gateway.apps.hub_status_app` and the dashboard's
+own Clients screen already hold to.
+"""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+from fastmcp.apps import AppConfig
+from fastmcp.tools.base import ToolResult
+from mcp.types import ToolAnnotations
+from pydantic import BaseModel, ConfigDict, Field
+
+from ...market.models import MarketEntry
+from ...market.service import MarketService
+from .shell import render_app_page
+
+RESOURCE_URI = "ui://palaia/marketplace.html"
+
+_TITLE = "palaia · Marketplace"
+
+#: How many results the plain-text fallback (a host without the MCP Apps
+#: extension) lists — deliverable #5's "plain-text fallback lists top
+#: results".
+_TEXT_FALLBACK_LIMIT = 10
+
+
+class MarketBrowseEntry(BaseModel):
+    """One card — the fields the grid *and* its inline detail view need."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    name: str
+    one_liner: str
+    kind: str
+    verified: bool
+    provenance: str
+    maintainer: str
+    permissions: list[str] = Field(default_factory=list)
+
+
+class MarketBrowseResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    query: str
+    entries: list[MarketBrowseEntry] = Field(default_factory=list)
+    stale: bool = False
+    #: This hub's dashboard, if known (``config.exposure.public_url`` —
+    #: SPEC-205) — the base every "Install" deep link is built from. ``None``
+    #: means the page shows plain instructions instead of a link (see the
+    #: module docstring).
+    dashboard_url: str | None = None
+
+
+def _to_browse_entry(entry: MarketEntry) -> MarketBrowseEntry:
+    return MarketBrowseEntry(
+        id=entry.id,
+        name=entry.name,
+        one_liner=entry.one_liner,
+        kind=entry.kind,
+        verified=entry.verified,
+        provenance=entry.provenance,
+        maintainer=entry.maintainer,
+        permissions=list(entry.permissions),
+    )
+
+
+class MarketAppDeps:
+    """State ``browse_marketplace`` reads — a plain bag, mirroring
+    :class:`~palaia_hub.gateway.apps.hub_status_app.HubStatusDeps`."""
+
+    def __init__(self, *, market_service: MarketService, dashboard_url: str | None) -> None:
+        self.market_service = market_service
+        self.dashboard_url = dashboard_url
+
+
+async def collect_market_browse(deps: MarketAppDeps, query: str = "") -> MarketBrowseResult:
+    result = await deps.market_service.search(query)
+    return MarketBrowseResult(
+        query=query,
+        entries=[_to_browse_entry(e) for e in result.entries],
+        stale=result.stale,
+        dashboard_url=deps.dashboard_url,
+    )
+
+
+def _text_summary(result: MarketBrowseResult) -> str:
+    if not result.entries:
+        return "No marketplace entries matched." if result.query else "The marketplace is empty."
+    lines = [
+        f"{'Search' if result.query else 'Browse'} results"
+        f"{f' for {result.query!r}' if result.query else ''} "
+        f"({len(result.entries)} found, showing up to {_TEXT_FALLBACK_LIMIT}):"
+    ]
+    for entry in result.entries[:_TEXT_FALLBACK_LIMIT]:
+        mark = "verified" if entry.verified else "unverified"
+        lines.append(f"- {entry.name} ({entry.kind}, {mark}) — {entry.one_liner}")
+    if result.dashboard_url:
+        lines.append(f"Install any of these from the dashboard: {result.dashboard_url}/marketplace")
+    else:
+        lines.append("Install from this hub's dashboard, under Marketplace.")
+    return "\n".join(lines)
+
+
+_BODY_HTML = '<div id="root" class="stack"><div class="empty">Loading…</div></div>'
+
+_SCRIPT_JS = r"""
+(function () {
+  var app = new window.McpAppLib.App({ name: "palaia-marketplace", version: "1.0.0" }, {});
+  var transport = new window.McpAppLib.PostMessageTransport(window.parent, window.parent);
+  var root = document.getElementById("root");
+  var state = { entries: [], dashboardUrl: null, openId: null };
+
+  function escapeHtml(s) {
+    return String(s == null ? "" : s).replace(/[&<>"']/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+    });
+  }
+
+  function installHref(id) {
+    if (!state.dashboardUrl) return null;
+    var base = state.dashboardUrl.replace(/\/+$/, "");
+    return base + "/marketplace?install=" + encodeURIComponent(id);
+  }
+
+  function render() {
+    if (!state.entries.length) {
+      root.innerHTML = '<div class="empty">No marketplace entries yet.</div>';
+      return;
+    }
+    var html = '<div class="stack stack--2">';
+    for (var i = 0; i < state.entries.length; i++) {
+      var e = state.entries[i];
+      var open = state.openId === e.id;
+      html += '<div class="card">'
+        + '<div class="card__head" data-idx="' + i + '" style="cursor:pointer">'
+        + '<div><span class="card__title">' + escapeHtml(e.name) + '</span>'
+        + '<div class="t-xs t-muted">' + escapeHtml(e.one_liner) + '</div></div>'
+        + '<span class="badge ' + (e.verified ? 'badge--ok' : 'badge--warn') + '">'
+        + '<span class="dot"></span>' + (e.verified ? 'verified' : 'unverified') + '</span>'
+        + '</div>';
+      if (open) {
+        var href = installHref(e.id);
+        var subline = escapeHtml(e.kind) + ' · ' + escapeHtml(e.maintainer);
+        html += '<div class="card__body stack stack--2">'
+          + '<div class="t-xs t-subtle">' + subline + '</div>';
+        if (e.permissions && e.permissions.length) {
+          var perms = escapeHtml(e.permissions.join(", "));
+          html += '<div class="t-xs t-muted">Permissions: ' + perms + '</div>';
+        }
+        if (href) {
+          html += '<a class="btn btn--primary" href="' + href + '" target="_blank" rel="noopener">'
+            + 'Install and connect' + '</a>';
+        } else {
+          html += '<p class="t-xs t-muted">Open this hub&rsquo;s dashboard, then Marketplace, '
+            + 'to install.</p>';
+        }
+        html += '</div>';
+      }
+      html += '</div>';
+    }
+    html += '</div>';
+    root.innerHTML = html;
+    var heads = root.querySelectorAll("[data-idx]");
+    for (var j = 0; j < heads.length; j++) {
+      heads[j].addEventListener("click", (function (idx) {
+        return function () {
+          var id = state.entries[idx].id;
+          state.openId = state.openId === id ? null : id;
+          render();
+        };
+      })(Number(heads[j].getAttribute("data-idx"))));
+    }
+  }
+
+  function loadFromResult(sc) {
+    sc = sc || {};
+    state.entries = Array.isArray(sc.entries) ? sc.entries : [];
+    state.dashboardUrl = sc.dashboard_url || null;
+    render();
+  }
+
+  app.addEventListener("toolresult", function (params) {
+    loadFromResult(params.structuredContent);
+  });
+
+  app.connect(transport);
+})();
+"""
+
+
+def render_marketplace_html() -> str:
+    return render_app_page(title=_TITLE, body_html=_BODY_HTML, script_js=_SCRIPT_JS)
+
+
+def build_market_server(deps: MarketAppDeps) -> FastMCP:
+    """The standalone hub-level ``browse_marketplace`` tool server, mounted
+    at ``/mcp/market`` by :func:`palaia_hub.app.create_app` — mirrors
+    :func:`~palaia_hub.gateway.apps.hub_status_app.build_hub_status_server`'s
+    shape for this SPEC's one hub-level app."""
+    server = FastMCP(
+        name="palaia-marketplace",
+        instructions=(
+            "IDENTITY: this is the palaia marketplace — browse and search add-ons "
+            "(remote tools, containerized servers, skills). Call browse_marketplace "
+            "with a search phrase, or with no arguments to see what's available. "
+            "Installing is done from this hub's own dashboard, never from here."
+        ),
+    )
+
+    @server.tool(
+        name="browse_marketplace",
+        description=(
+            "Browse or search palaia's marketplace of add-ons. Returns a card grid "
+            "in clients that render it, or a plain list otherwise. Installing an "
+            "entry always opens this hub's dashboard — this tool never installs "
+            "anything itself."
+        ),
+        annotations=ToolAnnotations(
+            readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+        ),
+        app=AppConfig(resource_uri=RESOURCE_URI),
+    )
+    async def browse_marketplace(query: str = "") -> ToolResult:
+        result = await collect_market_browse(deps, query)
+        return ToolResult(content=_text_summary(result), structured_content=result)
+
+    @server.resource(RESOURCE_URI, name="marketplace_app")
+    def _market_resource() -> str:
+        return render_marketplace_html()
+
+    return server
+
+
+__all__ = [
+    "RESOURCE_URI",
+    "MarketAppDeps",
+    "MarketBrowseEntry",
+    "MarketBrowseResult",
+    "build_market_server",
+    "collect_market_browse",
+    "render_marketplace_html",
+]

--- a/v3/server/src/palaia_hub/gateway/settings_bridge.py
+++ b/v3/server/src/palaia_hub/gateway/settings_bridge.py
@@ -23,13 +23,14 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 import yaml
 
-from ..config import GatewaySettings, HubConfig
+from ..config import GatewayProfileSettings, GatewaySettings, HubConfig
 from ..modes.patch import replace_config_section
 from ..upstream.models import UpstreamConfig
-from .config import ProfileConfig, VaultMountConfig
+from .config import CURATOR_PROFILE_PATH, ProfileConfig, VaultMountConfig
 
 
 class GatewaySettingsError(ValueError):
@@ -195,6 +196,43 @@ def persist_gateway_settings(path: Path, settings: GatewaySettings) -> None:
     replace_config_section(path, "gateway", render_gateway_section(settings))
 
 
+def snapshot_gateway_settings(dynamic_gateway: Any, config: HubConfig) -> GatewaySettings:
+    """The gateway's current live shape, in ``config.yaml``'s own
+    :class:`GatewaySettings` schema — the "live-then-persisted" snapshot
+    every REST surface that mutates the gateway writes back after applying
+    a change (SPEC-301's own profile CRUD builds this inline; SPEC-304's
+    marketplace install flow reuses this shared version instead of a third
+    hand-copy — see that module for why). ``dynamic_gateway`` is typed
+    ``Any`` here rather than
+    :class:`~palaia_hub.gateway.dynamic.DynamicGateway` to avoid a circular
+    import (``dynamic.py`` itself imports this module); only ``.config`` is
+    ever read off it.
+
+    The curator's own profile is excluded (synthesized from ``curator:``,
+    never itself persisted); every per-vault identity override already in
+    ``config.gateway.vaults`` is carried through untouched, since this
+    function never sees a vault edit.
+    """
+    existing_vaults = config.gateway.vaults if config.gateway is not None else []
+    profiles = [p for p in dynamic_gateway.config.profiles if p.path != CURATOR_PROFILE_PATH]
+    return GatewaySettings(
+        vaults=existing_vaults,
+        profiles=[
+            GatewayProfileSettings(
+                path=p.path,
+                label=p.label,
+                vaults=list(p.vaults),
+                stash=p.stash,
+                hidden_tools=list(p.hidden_tools),
+                semantic_routing=p.semantic_routing,
+                upstreams=list(p.upstreams),
+            )
+            for p in profiles
+        ],
+        upstreams=list(dynamic_gateway.config.upstreams),
+    )
+
+
 __all__ = [
     "GatewaySettingsError",
     "apply_vault_overrides",
@@ -203,4 +241,5 @@ __all__ = [
     "resolve_full_gateway_profiles",
     "resolve_profiles",
     "resolve_upstreams",
+    "snapshot_gateway_settings",
 ]

--- a/v3/server/src/palaia_hub/market/__init__.py
+++ b/v3/server/src/palaia_hub/market/__init__.py
@@ -15,24 +15,43 @@ from .curated import (
     CuratedIndexResult,
     IndexVerificationError,
 )
+from .install import (
+    CONSENT_TTL_SECONDS,
+    ConsentStore,
+    InstalledAddonOut,
+    InstallService,
+    MarketInstallError,
+    build_market_install_router,
+    wire_market_index_updates,
+)
+from .installed_store import InstalledAddonRecord, InstalledAddonStore
 from .manual import ManualEntryError, ManualEntryStore
 from .models import EntryKind, ManualEntryCreate, MarketEntry, Provenance, SourceLocator
 from .service import MarketSearchResult, MarketService
 
 __all__ = [
+    "CONSENT_TTL_SECONDS",
     "DEFAULT_INDEX_URL",
     "DEFAULT_PUBLIC_KEY_B64",
+    "ConsentStore",
     "CuratedIndexClient",
     "CuratedIndexResult",
     "EntryKind",
     "IndexVerificationError",
+    "InstallService",
+    "InstalledAddonOut",
+    "InstalledAddonRecord",
+    "InstalledAddonStore",
     "ManualEntryCreate",
     "ManualEntryError",
     "ManualEntryStore",
     "MarketEntry",
+    "MarketInstallError",
     "MarketSearchResult",
     "MarketService",
     "Provenance",
     "SourceLocator",
+    "build_market_install_router",
     "build_market_router",
+    "wire_market_index_updates",
 ]

--- a/v3/server/src/palaia_hub/market/docker_runtime.py
+++ b/v3/server/src/palaia_hub/market/docker_runtime.py
@@ -1,0 +1,200 @@
+"""Docker lifecycle for containerized marketplace add-ons (SPEC-304 #1).
+
+palaia never talks to a docker daemon over a client library — the SPEC's
+own words are "docker via subprocess against the local socket... no new
+daemon dependency", meaning exactly the ``docker`` CLI, already on the
+operator's machine if they use containers at all. Every container this
+module ever starts is a plain ``docker run --rm -i <image>``, spawned as
+the child process of an ordinary ``stdio`` upstream
+(:class:`~palaia_hub.upstream.models.UpstreamConfig` ``kind="stdio"``) —
+not a second thing palaia supervises. Docker's own ``--rm`` reaps the
+container the moment that child process exits.
+
+**Restart-on-crash is inherited, not reimplemented.** fastmcp's
+``StdioTransport.connect()`` already detects a dead child session and
+respawns it on the next use (verified against the installed fastmcp
+3.4.7 / ``mcp`` SDK: ``connect()`` calls ``self.disconnect()`` first
+whenever ``_is_session_dead()``), and
+:class:`~palaia_hub.upstream.monitor.UpstreamHealthMonitor` already calls
+``list_tools()`` on every configured upstream once a minute. A crashed
+container add-on is therefore respawned by the very next health probe —
+no extra supervision loop lives here.
+
+**No secret ever reaches an argument list.** ``docker run -e NAME`` with
+no ``=value`` forwards *docker's own process environment* variable
+``NAME`` into the container — never the value on argv, which a process
+listing (``ps``) would otherwise show in plain text. The actual value is
+injected into the environment the CLI itself runs in, by
+:class:`~palaia_hub.upstream.service.UpstreamService` at spawn time via
+``UpstreamConfig.env_secrets`` (the same mechanism, and the same
+docstring rule, an ordinary stdio upstream's own secrets already use — see
+that model). :func:`build_stdio_run_args` only ever receives *names*.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+from dataclasses import dataclass
+
+DEFAULT_PULL_TIMEOUT_SECONDS = 300.0
+DEFAULT_PROBE_TIMEOUT_SECONDS = 5.0
+DEFAULT_REMOVE_TIMEOUT_SECONDS = 30.0
+
+
+class DockerError(RuntimeError):
+    """A docker subprocess call failed to do what it was asked.
+
+    The message is the tail of the CLI's own stderr — never an argument
+    list (see the module docstring's mount/env rule), so it is always safe
+    to return verbatim in a REST error.
+    """
+
+
+def docker_binary() -> str | None:
+    """Absolute path to the ``docker`` CLI, or ``None`` if it is not on ``PATH``."""
+    return shutil.which("docker")
+
+
+async def docker_available(*, timeout: float = DEFAULT_PROBE_TIMEOUT_SECONDS) -> bool:
+    """Whether a usable docker CLI *and* a reachable daemon exist here.
+
+    Every container-lifecycle test that needs a real daemon calls this
+    first and skips honestly when it is ``False`` (SPEC-304 acceptance
+    criterion: "env-gated on docker availability; skipped honestly
+    otherwise") — never a silent no-op standing in for the real thing.
+    """
+    binary = docker_binary()
+    if binary is None:
+        return False
+    try:
+        process = await asyncio.create_subprocess_exec(
+            binary,
+            "info",
+            "--format",
+            "{{.ServerVersion}}",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except OSError:
+        return False
+    try:
+        await asyncio.wait_for(process.communicate(), timeout=timeout)
+    except TimeoutError:
+        process.kill()
+        await process.wait()
+        return False
+    return process.returncode == 0
+
+
+@dataclass(frozen=True, slots=True)
+class ContainerRunArgs:
+    """The resolved ``docker run`` invocation for one add-on install."""
+
+    command: str
+    args: list[str]
+
+
+def build_stdio_run_args(
+    image: str,
+    *,
+    container_name: str,
+    mounts: dict[str, str],
+    plain_env: dict[str, str],
+    secret_env_vars: list[str],
+) -> ContainerRunArgs:
+    """The argv for ``docker run --rm -i`` backing one container add-on.
+
+    ``mounts`` is ``{config field: host path}`` — each bind-mounted
+    read-write at the *same* absolute path inside the container (palaia's
+    declared-mount convention: a ``config_schema`` string property with
+    ``"format": "path"`` is a mount; every other non-secret property is a
+    plain environment variable, its name upper-cased). ``secret_env_vars``
+    names environment variables whose value never appears here at all —
+    see the module docstring.
+    """
+    args = ["run", "--rm", "-i", "--name", container_name]
+    for host_path in mounts.values():
+        args += ["-v", f"{host_path}:{host_path}"]
+    for key, value in sorted(plain_env.items()):
+        args += ["-e", f"{key}={value}"]
+    for key in sorted(secret_env_vars):
+        args += ["-e", key]
+    args.append(image)
+    return ContainerRunArgs(command="docker", args=args)
+
+
+async def pull_image(image: str, *, timeout: float = DEFAULT_PULL_TIMEOUT_SECONDS) -> None:
+    """``docker pull <image>``.
+
+    Raises:
+        DockerError: docker is missing, the pull failed, or it did not
+            finish within ``timeout`` — the message names the reason, the
+            tail of stderr for a failed pull.
+    """
+    binary = docker_binary()
+    if binary is None:
+        raise DockerError("docker is not installed (or not on PATH) on this host.")
+    try:
+        process = await asyncio.create_subprocess_exec(
+            binary,
+            "pull",
+            image,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except OSError as exc:
+        raise DockerError(f"could not run docker: {exc}") from exc
+    try:
+        _stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=timeout)
+    except TimeoutError:
+        process.kill()
+        await process.wait()
+        raise DockerError(f"pulling {image!r} did not finish within {timeout:.0f}s.") from None
+    if process.returncode != 0:
+        tail = stderr.decode("utf-8", "replace").strip().splitlines()[-5:]
+        raise DockerError(f"docker pull {image!r} failed: {' | '.join(tail) or 'no output'}")
+
+
+async def remove_container(
+    container_name: str, *, timeout: float = DEFAULT_REMOVE_TIMEOUT_SECONDS
+) -> None:
+    """Best-effort ``docker rm -f`` — never raises.
+
+    A container that already exited under ``--rm`` is not there to
+    remove, and that is success, not failure: uninstall must never fail
+    just because the container was already gone.
+    """
+    binary = docker_binary()
+    if binary is None:
+        return
+    try:
+        process = await asyncio.create_subprocess_exec(
+            binary,
+            "rm",
+            "-f",
+            container_name,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            await asyncio.wait_for(process.communicate(), timeout=timeout)
+        except TimeoutError:
+            process.kill()
+            await process.wait()
+    except OSError:
+        pass
+
+
+__all__ = [
+    "DEFAULT_PROBE_TIMEOUT_SECONDS",
+    "DEFAULT_PULL_TIMEOUT_SECONDS",
+    "DEFAULT_REMOVE_TIMEOUT_SECONDS",
+    "ContainerRunArgs",
+    "DockerError",
+    "build_stdio_run_args",
+    "docker_available",
+    "docker_binary",
+    "pull_image",
+    "remove_container",
+]

--- a/v3/server/src/palaia_hub/market/install.py
+++ b/v3/server/src/palaia_hub/market/install.py
@@ -1,0 +1,808 @@
+"""Install flows for marketplace entries (SPEC-304 deliverables #1/#3/#4).
+
+Every install lands in *existing* machinery rather than reinventing it: a
+successful plan is exactly one :class:`~palaia_hub.upstream.models.
+UpstreamConfig`, handed to the same
+:meth:`~palaia_hub.gateway.dynamic.DynamicGateway.register_upstream` /
+:meth:`~palaia_hub.upstream.service.UpstreamService.register` /
+``config.yaml`` write-back sequence SPEC-302's own
+``POST /api/gateway/upstreams`` uses (see
+:mod:`palaia_hub.gateway.settings_bridge`'s ``snapshot_gateway_settings``,
+shared by both). This module's only real job is *resolving* that config
+from a marketplace entry's ``kind``/``source``/``config_schema`` — plus the
+consent gate deliverable #3 requires, and the small amount of bookkeeping
+(:mod:`palaia_hub.market.installed_store`) the update surface needs.
+
+**The four install shapes** (deliverable #1):
+
+- ``remote`` with ``source.type == "url"`` — a straight ``http`` upstream.
+- ``remote`` with ``source.type == "registry_ref"`` — the official
+  registry's ``server.json`` for that id is fetched (never cached from the
+  merged entry, which never carries ``remotes``/``packages`` — see
+  :mod:`palaia_hub.market.service`); a ``remotes[]`` entry there resolves to
+  ``http`` the same as above, otherwise its first ``packages[]`` entry (an
+  npm/pypi/nuget package — the "stdio command entries" the SPEC names) is
+  resolved to a ``stdio`` upstream running ``npx``/``uvx``/``dnx``. Any
+  other package kind is refused with a plain-language reason rather than a
+  guess.
+- ``container`` — the declared image is pulled, then run as ``docker run
+  --rm -i`` and connected as a ``stdio`` upstream (see
+  :mod:`palaia_hub.market.docker_runtime` for why this is also how
+  restart-on-crash and "no leftover container" both fall out for free).
+- ``skill`` / ``mcpb`` / ``plugin`` — refused here, by design: "the
+  marketplace lists them, it does not reinvent their delivery" (the SPEC's
+  own words). The dashboard hides the install button for these kinds and
+  offers the connect page instead.
+
+**Config fields → env / mounts / secrets.** A ``config_schema`` property is
+one of three things, from its own JSON Schema keywords (deliverable #2's
+fixed subset): ``"type": "secret"`` writes the submitted value into the
+secret store, named ``market.<entry id>.<field>``, and is never handed
+back — decrypted only at connect/spawn time, exactly like every other
+upstream secret (:mod:`palaia_hub.upstream.secrets`'s never-return-values
+rule, unchanged, reused). A string property with ``"format": "path"`` is a
+declared filesystem mount (container installs only) — bind-mounted
+read-write at the same absolute path inside the container. Everything else
+becomes a plain environment variable / header, named by the field's own
+key, upper-cased.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets as secrets_module
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from ..config import HubConfig, config_file_path
+from ..events import EventBus
+from ..events.schema import Envelope
+from ..gateway.build import GatewayConfigError
+from ..gateway.config import CURATOR_PROFILE_PATH
+from ..gateway.dynamic import DynamicGateway
+from ..gateway.settings_bridge import persist_gateway_settings, snapshot_gateway_settings
+from ..registry.client import RegistryOfflineError
+from ..upstream.models import UpstreamAuthConfig, UpstreamConfig, UpstreamConflictError
+from ..upstream.secrets import SecretStore, SecretStoreError
+from ..upstream.service import UpstreamNotConfiguredError, UpstreamService
+from . import docker_runtime
+from .installed_store import InstalledAddonRecord, InstalledAddonStore
+from .models import EntryKind, MarketEntry
+from .service import MarketService
+
+logger = logging.getLogger("palaia_hub.market.install")
+
+#: How long a consent token lives before it must be re-issued (deliverable
+#: #3): long enough to fill in a config form, short enough that a leaked
+#: token (e.g. in a shared screen recording) is not useful for long.
+CONSENT_TTL_SECONDS = 600.0
+
+_KIND_LABELS: dict[str, str] = {
+    "skill": "a skill",
+    "mcpb": "a downloadable bundle",
+    "plugin": "a plugin",
+}
+
+
+class MarketInstallError(RuntimeError):
+    """An install/update/consent request cannot be honored.
+
+    The message is plain language, safe to return to the dashboard
+    verbatim — it never interpolates a secret value (every place a secret
+    could appear instead names the secret by field/name only, the same
+    rule :mod:`palaia_hub.upstream.secrets` already holds to).
+    """
+
+
+# --------------------------------------------------------------- consent
+
+
+@dataclass
+class _ConsentEntry:
+    entry_id: str
+    expires_at: float
+    used: bool = False
+
+
+class ConsentStore:
+    """Short-lived, single-use consent tokens (deliverable #3).
+
+    The dashboard's consent screen itself is just ``GET
+    /api/market/entry/{id}`` (already carries kind/source/verified/
+    permissions) rendered with a confirm button; this store is what makes
+    skipping that screen structurally impossible rather than a UI
+    convention — ``install`` refuses without a token this store issued
+    for the *same* entry, unused, unexpired.
+    """
+
+    def __init__(self, *, ttl_seconds: float = CONSENT_TTL_SECONDS) -> None:
+        self._ttl = ttl_seconds
+        self._tokens: dict[str, _ConsentEntry] = {}
+
+    def issue(self, entry_id: str) -> tuple[str, float]:
+        token = secrets_module.token_urlsafe(24)
+        expires_at = time.time() + self._ttl
+        self._tokens[token] = _ConsentEntry(entry_id=entry_id, expires_at=expires_at)
+        return token, expires_at
+
+    def consume(self, token: str, entry_id: str) -> None:
+        """Raise :class:`MarketInstallError` unless ``token`` was issued for
+        ``entry_id``, is unused and unexpired — then mark it used."""
+        entry = self._tokens.pop(token, None)
+        if (
+            entry is None
+            or entry.used
+            or entry.expires_at < time.time()
+            or entry.entry_id != entry_id
+        ):
+            raise MarketInstallError(
+                "This install link is missing, already used, expired, or was "
+                "issued for a different entry. Fix: open the entry again and "
+                "confirm the consent screen before installing."
+            )
+
+
+# ----------------------------------------------------------- config split
+
+
+def _secret_name(entry_id: str, field_name: str) -> str:
+    slug = entry_id.replace(".", "_").replace("/", "_")
+    return f"market.{slug}.{field_name}"
+
+
+def _split_config(
+    config_schema: dict[str, Any] | None, config: dict[str, Any]
+) -> tuple[dict[str, str], dict[str, str], dict[str, str]]:
+    """Split submitted ``config`` values into ``(plain, secret, mounts)`` —
+    each ``{field name: string value}`` — per the module docstring's
+    "config fields → env / mounts / secrets" rule. A field absent from
+    ``config_schema`` (or with no schema at all) is treated as plain."""
+    properties = (config_schema or {}).get("properties", {})
+    if not isinstance(properties, dict):
+        properties = {}
+    plain: dict[str, str] = {}
+    secret: dict[str, str] = {}
+    mounts: dict[str, str] = {}
+    for key, value in config.items():
+        prop = properties.get(key, {})
+        raw = "" if value is None else str(value)
+        if isinstance(prop, dict) and prop.get("type") == "secret":
+            secret[key] = raw
+        elif isinstance(prop, dict) and prop.get("format") == "path":
+            mounts[key] = raw
+        else:
+            plain[key] = raw
+    return plain, secret, mounts
+
+
+# -------------------------------------------------------------- planning
+
+
+@dataclass(frozen=True, slots=True)
+class InstallPlan:
+    """What :func:`_build_plan` resolved: the upstream to connect, plus the
+    bookkeeping :class:`~palaia_hub.market.installed_store.
+    InstalledAddonRecord` needs that an :class:`UpstreamConfig` alone
+    cannot carry."""
+
+    upstream: UpstreamConfig
+    image: str | None = None
+    container_name: str | None = None
+
+
+def _resolve_stdio_command(package: dict[str, Any]) -> tuple[str, list[str]]:
+    """The command line for one official-registry package entry.
+
+    Only npm (``npx``), pypi (``uvx``) and nuget (``dnx``) packages are
+    resolved — every other ``registry_type``/``runtime_hint`` combination
+    is refused with a plain reason (deliverable #1's "stdio command
+    entries") rather than guessed at.
+    """
+    registry_type = str(package.get("registry_type", "")).lower()
+    identifier = str(package.get("identifier", ""))
+    version = package.get("version")
+    ref = f"{identifier}@{version}" if version else identifier
+    runtime_hint = str(package.get("runtime_hint", "")).lower()
+    if not runtime_hint:
+        runtime_hint = {"npm": "npx", "pypi": "uvx", "nuget": "dnx"}.get(registry_type, "")
+    if runtime_hint not in ("npx", "uvx", "dnx") or not identifier:
+        label = registry_type or "this"
+        raise MarketInstallError(
+            f"palaia does not know how to run a {label!r} package yet — only npm "
+            "(npx), pypi (uvx) and nuget (dnx) packages install automatically."
+        )
+    base_args = ["-y", ref] if runtime_hint == "npx" else [ref]
+    extra_args = [
+        str(arg.get("value"))
+        for arg in (package.get("package_arguments") or [])
+        if isinstance(arg, dict) and arg.get("value")
+    ]
+    return runtime_hint, [*base_args, *extra_args]
+
+
+async def _resolve_registry_ref_plan(
+    entry: MarketEntry,
+    config: dict[str, Any],
+    *,
+    key: str,
+    display_name: str,
+    market_service: MarketService,
+    secret_store: SecretStore,
+) -> InstallPlan:
+    registry_id = entry.source.value
+    try:
+        server = await market_service.registry_client.detail(registry_id)
+    except RegistryOfflineError as exc:
+        raise MarketInstallError(
+            f"could not reach the registry to resolve {registry_id!r}: {exc}"
+        ) from exc
+    if server is None:
+        raise MarketInstallError(f"the registry no longer lists {registry_id!r}.")
+    raw = server.raw.get("server", server.raw)
+    remotes = raw.get("remotes") or []
+    if remotes:
+        url = str(remotes[0].get("url", ""))
+        if not url:
+            raise MarketInstallError(f"{entry.name!r}'s registry listing has no usable address.")
+        return _build_http_plan(
+            entry, config, key=key, display_name=display_name, url=url, secret_store=secret_store
+        )
+
+    packages = raw.get("packages") or []
+    if not packages:
+        raise MarketInstallError(
+            f"{entry.name!r} declares neither a remote address nor a runnable "
+            "package — palaia does not know how to install it yet."
+        )
+    command, args = _resolve_stdio_command(packages[0])
+    plain, secret_values, _mounts = _split_config(entry.config_schema, config)
+    env = {k.upper(): v for k, v in plain.items()}
+    env_secrets: dict[str, str] = {}
+    for field_name, value in secret_values.items():
+        name = _secret_name(entry.id, field_name)
+        secret_store.put(name, value)
+        env_secrets[field_name.upper()] = name
+    upstream = UpstreamConfig(
+        key=key,
+        kind="stdio",
+        display_name=display_name,
+        command=command,
+        args=args,
+        env=env,
+        env_secrets=env_secrets,
+    )
+    return InstallPlan(upstream=upstream)
+
+
+def _build_http_plan(
+    entry: MarketEntry,
+    config: dict[str, Any],
+    *,
+    key: str,
+    display_name: str,
+    url: str,
+    secret_store: SecretStore,
+) -> InstallPlan:
+    plain, secret_values, _mounts = _split_config(entry.config_schema, config)
+    headers = {k.upper(): v for k, v in plain.items()}
+    auth: UpstreamAuthConfig | None = None
+    if secret_values:
+        # The first declared secret field is the bearer/API-key token — the
+        # overwhelmingly common case for a `remote` entry's `config_schema`
+        # (one credential). Any *additional* secret field still gets stored
+        # (never lost), just not wired into `auth` — a `remote` upstream has
+        # exactly one auth slot (`UpstreamAuthConfig`); a second credential
+        # is a shape this SPEC's fixed config_schema subset does not
+        # anticipate, and silently dropping it would be worse than storing
+        # it unused.
+        first_field = next(iter(secret_values))
+        for field_name, value in secret_values.items():
+            secret_store.put(_secret_name(entry.id, field_name), value)
+        auth = UpstreamAuthConfig(secret_name=_secret_name(entry.id, first_field))
+    upstream = UpstreamConfig(
+        key=key,
+        kind="http",
+        display_name=display_name,
+        url=url,
+        headers=headers,
+        auth=auth,
+    )
+    return InstallPlan(upstream=upstream)
+
+
+async def _resolve_container_plan(
+    entry: MarketEntry,
+    config: dict[str, Any],
+    *,
+    key: str,
+    display_name: str,
+    secret_store: SecretStore,
+) -> InstallPlan:
+    image = entry.source.value
+    if not image:
+        raise MarketInstallError(f"{entry.name!r} has no image declared to install.")
+    await docker_runtime.pull_image(image)
+    plain, secret_values, mounts = _split_config(entry.config_schema, config)
+    env = {k.upper(): v for k, v in plain.items()}
+    env_secrets: dict[str, str] = {}
+    for field_name, value in secret_values.items():
+        name = _secret_name(entry.id, field_name)
+        secret_store.put(name, value)
+        env_secrets[field_name.upper()] = name
+    container_name = _container_name(key)
+    run_args = docker_runtime.build_stdio_run_args(
+        image,
+        container_name=container_name,
+        mounts=mounts,
+        plain_env=env,
+        secret_env_vars=list(env_secrets.keys()),
+    )
+    upstream = UpstreamConfig(
+        key=key,
+        kind="stdio",
+        display_name=display_name,
+        command=run_args.command,
+        args=run_args.args,
+        env={},
+        env_secrets=env_secrets,
+    )
+    return InstallPlan(upstream=upstream, image=image, container_name=container_name)
+
+
+def _container_name(key: str) -> str:
+    return f"palaia-addon-{key}"
+
+
+async def _build_plan(
+    entry: MarketEntry,
+    config: dict[str, Any],
+    *,
+    key: str,
+    display_name: str,
+    market_service: MarketService,
+    secret_store: SecretStore,
+) -> InstallPlan:
+    if entry.kind == "remote":
+        if entry.source.type == "url":
+            return _build_http_plan(
+                entry, config, key=key, display_name=display_name, url=entry.source.value,
+                secret_store=secret_store,
+            )
+        if entry.source.type == "registry_ref":
+            return await _resolve_registry_ref_plan(
+                entry, config, key=key, display_name=display_name,
+                market_service=market_service, secret_store=secret_store,
+            )
+        raise MarketInstallError(
+            f"a 'remote' entry cannot install from a {entry.source.type!r} source."
+        )
+    if entry.kind == "container":
+        return await _resolve_container_plan(
+            entry, config, key=key, display_name=display_name, secret_store=secret_store,
+        )
+    label = _KIND_LABELS.get(entry.kind, entry.kind)
+    raise MarketInstallError(
+        f"{entry.name!r} is {label} — install it from the connect page instead; "
+        "the marketplace only lists it here."
+    )
+
+
+def _derive_upstream_key(entry_id: str) -> str:
+    lowered = entry_id.lower()
+    cleaned = "".join(ch if ch.isalnum() or ch in "-_" else "-" for ch in lowered)
+    cleaned = cleaned.strip("-_") or "addon"
+    if not (cleaned[0].isalnum()):
+        cleaned = f"a{cleaned}"
+    return cleaned[:64]
+
+
+# ------------------------------------------------------------------- REST
+
+
+class ConsentTokenOut(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    token: str
+    expires_at: float
+
+
+class InstallRequest(BaseModel):
+    """``POST /api/market/entry/{id}/install`` — the consent token proves
+    the consent screen (deliverable #3) was actually shown; without a valid
+    one this endpoint always refuses (see :class:`ConsentStore`)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    consent_token: str
+    config: dict[str, Any] = Field(default_factory=dict)
+    profiles: list[str] = Field(default_factory=list)
+    display_name: str | None = None
+
+
+class InstalledAddonOut(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    upstream_key: str
+    entry_id: str
+    name: str
+    kind: EntryKind
+    provenance: str
+    installed_ref: str
+    current_ref: str | None
+    update_available: bool
+    up: bool
+    status: str
+    profiles: list[str]
+    installed_at: float
+
+
+class InstallService:
+    """Ties entry resolution to the existing upstream/gateway machinery.
+
+    Args:
+        market_service: where an entry (and, for a ``registry_ref``, the
+            official registry's raw ``server.json``) comes from.
+        dynamic_gateway: the live gateway an install connects to and a
+            profile is mounted on — the exact same instance SPEC-302's
+            ``/api/gateway/upstreams`` router uses.
+        upstream_service: the registry/health side of the same servers.
+        secret_store: where a ``config_schema`` ``secret`` field's value
+            goes. ``None`` refuses any entry whose config declares one.
+        home: where ``config.yaml`` lives, for the write-back.
+        config: the running :class:`~palaia_hub.config.HubConfig` (read
+            only, for its ``gateway.vaults`` identity overrides — see
+            :func:`~palaia_hub.gateway.settings_bridge.
+            snapshot_gateway_settings`).
+        installed_store: persisted install records backing the update
+            surface and ``GET /api/market/installed``.
+        publish: optional ``(event, data)`` sink for ``addon.*`` events.
+    """
+
+    def __init__(
+        self,
+        *,
+        market_service: MarketService,
+        dynamic_gateway: DynamicGateway,
+        upstream_service: UpstreamService,
+        secret_store: SecretStore,
+        home: Path,
+        config: HubConfig,
+        installed_store: InstalledAddonStore | None = None,
+        publish: Callable[[str, dict[str, Any]], None] | None = None,
+    ) -> None:
+        self.market_service = market_service
+        self.dynamic_gateway = dynamic_gateway
+        self.upstream_service = upstream_service
+        self.secret_store = secret_store
+        self.config_path = config_file_path(home)
+        self.config = config
+        self.installed_store = installed_store or InstalledAddonStore(
+            home / "market_installed.json"
+        )
+        self.consent = ConsentStore()
+        self._publish = publish or (lambda event, data: None)
+
+    # ---------------------------------------------------------- consent
+
+    async def issue_consent(self, entry_id: str) -> ConsentTokenOut:
+        entry = await self.market_service.get_entry(entry_id)
+        if entry is None:
+            raise HTTPException(status_code=404, detail=f"no marketplace entry {entry_id!r}")
+        token, expires_at = self.consent.issue(entry_id)
+        return ConsentTokenOut(token=token, expires_at=expires_at)
+
+    # ---------------------------------------------------------- install
+
+    async def install(self, entry_id: str, request: InstallRequest) -> InstalledAddonOut:
+        entry = await self.market_service.get_entry(entry_id)
+        if entry is None:
+            raise HTTPException(status_code=404, detail=f"no marketplace entry {entry_id!r}")
+        try:
+            self.consent.consume(request.consent_token, entry_id)
+        except MarketInstallError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        key = _derive_upstream_key(entry_id)
+        if key in self.upstream_service.configs:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{entry.name!r} is already installed. Uninstall it first, or update it.",
+            )
+        display_name = request.display_name or entry.name
+
+        try:
+            plan = await _build_plan(
+                entry, request.config, key=key, display_name=display_name,
+                market_service=self.market_service, secret_store=self.secret_store,
+            )
+        except (MarketInstallError, docker_runtime.DockerError, SecretStoreError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        try:
+            await self.dynamic_gateway.register_upstream(plan.upstream)
+        except (UpstreamConflictError, ValidationError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        await self.upstream_service.register(plan.upstream)
+        try:
+            await self._mount_on(key, request.profiles)
+        except GatewayConfigError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        await self.dynamic_gateway.refresh_upstreams([key])
+        self._persist()
+
+        record = InstalledAddonRecord(
+            upstream_key=key,
+            entry_id=entry_id,
+            name=entry.name,
+            kind=entry.kind,
+            provenance=entry.provenance,
+            installed_ref=entry.source.value,
+            image=plan.image,
+            container_name=plan.container_name,
+            installed_at=time.time(),
+        )
+        self.installed_store.put(record)
+        self._publish(
+            "addon.installed",
+            {"entry_id": entry_id, "upstream_key": key, "kind": entry.kind, "name": entry.name},
+        )
+        return await self._out(record)
+
+    async def _mount_on(self, key: str, profile_paths: list[str]) -> None:
+        for path in profile_paths:
+            if path == CURATOR_PROFILE_PATH:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "the curator profile never mounts an external server: it "
+                        "runs a model over your own notes, and an outside tool in "
+                        "that session could exfiltrate them."
+                    ),
+                )
+            current = next(
+                (p for p in self.dynamic_gateway.config.profiles if p.path == path), None
+            )
+            if current is None:
+                raise HTTPException(status_code=404, detail=f"no profile at path {path!r}")
+            if key in current.upstreams:
+                continue
+            await self.dynamic_gateway.upsert_profile(
+                path,
+                list(current.vaults),
+                label=current.label,
+                stash=current.stash,
+                upstreams=[*current.upstreams, key],
+            )
+
+    def _persist(self) -> None:
+        persist_gateway_settings(
+            self.config_path, snapshot_gateway_settings(self.dynamic_gateway, self.config)
+        )
+
+    # -------------------------------------------------------- installed
+
+    async def _out(self, record: InstalledAddonRecord) -> InstalledAddonOut:
+        try:
+            status = self.upstream_service.status(record.upstream_key)
+            up, detail = status.up, status.detail
+        except UpstreamNotConfiguredError:
+            # The generic `/api/gateway/upstreams` surface can disconnect a
+            # server this store still remembers installing (it is a
+            # separate write path — see the module docstring). Reported
+            # honestly rather than a 500: this entry needs reinstalling or
+            # removing from the list, not a crash.
+            up, detail = False, "No longer connected — reinstall it, or remove it below."
+        current_ref: str | None = None
+        entry = await self.market_service.get_entry(record.entry_id)
+        if entry is not None:
+            current_ref = entry.source.value
+        profiles = sorted(
+            p.path
+            for p in self.dynamic_gateway.config.profiles
+            if record.upstream_key in p.upstreams
+        )
+        return InstalledAddonOut(
+            upstream_key=record.upstream_key,
+            entry_id=record.entry_id,
+            name=record.name,
+            kind=record.kind,  # type: ignore[arg-type]
+            provenance=record.provenance,
+            installed_ref=record.installed_ref,
+            current_ref=current_ref,
+            update_available=(
+                current_ref is not None
+                and current_ref != record.installed_ref
+                and record.kind == "container"
+            ),
+            up=up,
+            status=detail,
+            profiles=profiles,
+            installed_at=record.installed_at,
+        )
+
+    async def list_installed(self) -> list[InstalledAddonOut]:
+        return [await self._out(record) for record in self.installed_store.list()]
+
+    async def update(self, upstream_key: str) -> InstalledAddonOut:
+        record = self.installed_store.get(upstream_key)
+        if record is None:
+            raise HTTPException(
+                status_code=404, detail=f"no add-on installed under {upstream_key!r}"
+            )
+        if record.kind != "container":
+            raise HTTPException(
+                status_code=400,
+                detail="only a container add-on can be updated one-click — reconnect a "
+                "remote/stdio server through its own edit form instead.",
+            )
+        entry = await self.market_service.get_entry(record.entry_id)
+        if entry is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"the marketplace no longer lists {record.entry_id!r} — cannot update.",
+            )
+        new_image = entry.source.value
+        try:
+            await docker_runtime.pull_image(new_image)
+        except docker_runtime.DockerError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        try:
+            current = self.upstream_service.config(upstream_key)
+        except UpstreamNotConfiguredError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        run_args = docker_runtime.build_stdio_run_args(
+            new_image,
+            container_name=record.container_name or _container_name(upstream_key),
+            mounts={},
+            plain_env=current.env,
+            secret_env_vars=list(current.env_secrets.keys()),
+        )
+        # `model_copy` skips validators (same caveat SPEC-302's own
+        # `PATCH /api/gateway/upstreams/{key}` documents) — re-construct so
+        # a now-invalid combination is refused rather than mounted.
+        updated = UpstreamConfig.model_validate(
+            current.model_copy(
+                update={"command": run_args.command, "args": run_args.args}
+            ).model_dump()
+        )
+        await self.dynamic_gateway.register_upstream(updated)
+        await self.upstream_service.register(updated)
+        await self.dynamic_gateway.refresh_upstreams([upstream_key])
+        self._persist()
+
+        new_record = InstalledAddonRecord(
+            upstream_key=record.upstream_key,
+            entry_id=record.entry_id,
+            name=record.name,
+            kind=record.kind,
+            provenance=record.provenance,
+            installed_ref=new_image,
+            image=new_image,
+            container_name=record.container_name,
+            installed_at=record.installed_at,
+        )
+        self.installed_store.put(new_record)
+        self._publish(
+            "addon.updated",
+            {"entry_id": record.entry_id, "upstream_key": upstream_key, "installed_ref": new_image},
+        )
+        return await self._out(new_record)
+
+    async def uninstall(self, upstream_key: str) -> None:
+        record = self.installed_store.get(upstream_key)
+        if record is None:
+            raise HTTPException(
+                status_code=404, detail=f"no add-on installed under {upstream_key!r}"
+            )
+        try:
+            await self.dynamic_gateway.remove_upstream(upstream_key)
+        except KeyError:
+            pass
+        await self.upstream_service.unregister(upstream_key)
+        if record.container_name is not None:
+            # Best-effort: `docker run --rm` already reaps a cleanly-exited
+            # container the moment its stdio child process closes (which
+            # `unregister` above just triggered) — this only cleans up the
+            # rare case where it did not exit cleanly, so uninstall never
+            # leaves one behind (SPEC-304 acceptance criterion).
+            await docker_runtime.remove_container(record.container_name)
+        self._persist()
+        self.installed_store.delete(upstream_key)
+        self._publish(
+            "addon.uninstalled", {"entry_id": record.entry_id, "upstream_key": upstream_key}
+        )
+
+    async def check_updates(self) -> list[InstalledAddonOut]:
+        """Recompute every installed container's update status and publish
+        ``addon.update_available`` for one whose availability just turned
+        on — called after the curated index refreshes (deliverable #4)."""
+        changed: list[InstalledAddonOut] = []
+        for record in self.installed_store.list():
+            out = await self._out(record)
+            if out.update_available:
+                changed.append(out)
+                self._publish(
+                    "addon.update_available",
+                    {
+                        "entry_id": out.entry_id,
+                        "upstream_key": out.upstream_key,
+                        "installed_ref": out.installed_ref,
+                        "available_ref": out.current_ref,
+                    },
+                )
+        return changed
+
+
+def build_market_install_router(service: InstallService) -> APIRouter:
+    router = APIRouter(prefix="/api/market", tags=["market"])
+
+    @router.post("/entry/{entry_id}/consent", response_model=ConsentTokenOut)
+    async def issue_consent(entry_id: str) -> ConsentTokenOut:
+        return await service.issue_consent(entry_id)
+
+    @router.post("/entry/{entry_id}/install", response_model=InstalledAddonOut)
+    async def install_entry(entry_id: str, body: InstallRequest) -> InstalledAddonOut:
+        return await service.install(entry_id, body)
+
+    @router.get("/installed", response_model=list[InstalledAddonOut])
+    async def list_installed() -> list[InstalledAddonOut]:
+        return await service.list_installed()
+
+    @router.post("/installed/{upstream_key}/update", response_model=InstalledAddonOut)
+    async def update_installed(upstream_key: str) -> InstalledAddonOut:
+        return await service.update(upstream_key)
+
+    @router.post("/installed/check_updates", response_model=list[InstalledAddonOut])
+    async def check_updates() -> list[InstalledAddonOut]:
+        return await service.check_updates()
+
+    @router.delete("/installed/{upstream_key}", status_code=204)
+    async def uninstall_installed(upstream_key: str) -> None:
+        await service.uninstall(upstream_key)
+
+    return router
+
+
+def wire_market_index_updates(event_bus: EventBus, service: InstallService) -> Callable[[], None]:
+    """Subscribe ``service.check_updates()`` onto ``market.index.updated``
+    (deliverable #4: "addon.update_available event, curated index version
+    vs installed"). ``EventBus.on`` callbacks are synchronous, so the
+    actual (async) check is scheduled as a background task — a failure in
+    it is logged, never raised into the publisher (same posture every
+    other bus subscriber in this codebase takes)."""
+
+    def _on_event(envelope: Envelope) -> None:
+        if envelope.event != "market.index.updated":
+            return
+
+        async def _run() -> None:
+            try:
+                await service.check_updates()
+            except Exception:  # noqa: BLE001 - a failed check must not break the bus
+                logger.exception("checking for marketplace add-on updates failed")
+
+        asyncio.create_task(_run())
+
+    return event_bus.on(_on_event)
+
+
+__all__ = [
+    "CONSENT_TTL_SECONDS",
+    "ConsentStore",
+    "ConsentTokenOut",
+    "InstallPlan",
+    "InstallRequest",
+    "InstallService",
+    "InstalledAddonOut",
+    "MarketInstallError",
+    "build_market_install_router",
+    "wire_market_index_updates",
+]

--- a/v3/server/src/palaia_hub/market/installed_store.py
+++ b/v3/server/src/palaia_hub/market/installed_store.py
@@ -1,0 +1,131 @@
+"""Bookkeeping for what the marketplace has installed (SPEC-304 #1/#4).
+
+One JSON file, one record per installed add-on — deliberately not a
+second source of truth for *whether* an add-on is mounted (that is
+:class:`~palaia_hub.upstream.service.UpstreamService`'s job, keyed the
+same way); this store only remembers what an
+:class:`~palaia_hub.upstream.models.UpstreamConfig` alone cannot: which
+marketplace entry it came from, what its ``source`` looked like at
+install time (to detect "the curated index now lists a newer image" —
+deliverable #4's update surface), and — for a container — the deterministic
+name its ``docker run`` was given, so uninstall can remove it by name even
+if the upstream registry entry is already gone.
+
+Same atomic-write pattern as
+:meth:`palaia_hub.market.curated.CuratedIndexClient._write_last_good`:
+write to a sibling temp file, then ``rename`` over the real path, so a
+crash mid-write never leaves a half-written file behind.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..config import palaia_home
+
+INSTALLED_RELATIVE_PATH = "market_installed.json"
+
+
+@dataclass(frozen=True, slots=True)
+class InstalledAddonRecord:
+    """One installed marketplace entry."""
+
+    upstream_key: str
+    entry_id: str
+    name: str
+    kind: str
+    provenance: str
+    #: The entry's ``source.value`` at install time (an image ref, a
+    #: registry id, or a url) — compared against the *current* entry on
+    #: every ``GET /api/market/installed`` to decide ``update_available``.
+    installed_ref: str
+    #: The image reference actually pulled, for a container install —
+    #: ``None`` for every other kind.
+    image: str | None
+    #: The deterministic ``docker run --name`` this container was given —
+    #: ``None`` for every other kind. Used by uninstall/update to remove a
+    #: container even after its upstream registry entry is already gone.
+    container_name: str | None
+    installed_at: float
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "upstream_key": self.upstream_key,
+            "entry_id": self.entry_id,
+            "name": self.name,
+            "kind": self.kind,
+            "provenance": self.provenance,
+            "installed_ref": self.installed_ref,
+            "image": self.image,
+            "container_name": self.container_name,
+            "installed_at": self.installed_at,
+        }
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> InstalledAddonRecord:
+        return cls(
+            upstream_key=data["upstream_key"],
+            entry_id=data["entry_id"],
+            name=data["name"],
+            kind=data["kind"],
+            provenance=data["provenance"],
+            installed_ref=data["installed_ref"],
+            image=data.get("image"),
+            container_name=data.get("container_name"),
+            installed_at=data["installed_at"],
+        )
+
+
+class InstalledAddonStore:
+    """CRUD for :class:`InstalledAddonRecord`, keyed by ``upstream_key``."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or (palaia_home() / INSTALLED_RELATIVE_PATH)
+        self._lock = threading.Lock()
+
+    def _read_all(self) -> dict[str, dict[str, Any]]:
+        try:
+            raw: Any = json.loads(self.path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            return {}
+        return raw if isinstance(raw, dict) else {}
+
+    def _write_all(self, records: dict[str, dict[str, Any]]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(records), encoding="utf-8")
+        tmp.replace(self.path)
+
+    def put(self, record: InstalledAddonRecord) -> None:
+        with self._lock:
+            records = self._read_all()
+            records[record.upstream_key] = record.to_json()
+            self._write_all(records)
+
+    def get(self, upstream_key: str) -> InstalledAddonRecord | None:
+        with self._lock:
+            raw = self._read_all().get(upstream_key)
+        return InstalledAddonRecord.from_json(raw) if raw is not None else None
+
+    def list(self) -> list[InstalledAddonRecord]:
+        with self._lock:
+            records = self._read_all()
+        return [
+            InstalledAddonRecord.from_json(records[key]) for key in sorted(records)
+        ]
+
+    def delete(self, upstream_key: str) -> bool:
+        with self._lock:
+            records = self._read_all()
+            if upstream_key not in records:
+                return False
+            del records[upstream_key]
+            self._write_all(records)
+        return True
+
+
+__all__ = ["INSTALLED_RELATIVE_PATH", "InstalledAddonRecord", "InstalledAddonStore"]

--- a/v3/server/src/palaia_hub/serve.py
+++ b/v3/server/src/palaia_hub/serve.py
@@ -52,7 +52,7 @@ from .gateway.settings_bridge import (
 from .gateway.wiring import EngineVaultService
 from .hooks import HookStore
 from .index import VaultIndex
-from .market import CuratedIndexClient, ManualEntryStore, MarketService
+from .market import CuratedIndexClient, InstallService, ManualEntryStore, MarketService
 from .notifications import NotificationStore
 from .notifications.store import NOTIFICATIONS_RELATIVE_PATH
 from .oauth import AuthorizationServer
@@ -93,6 +93,10 @@ class ProductionApp:
     #: The encrypted credential store backing those servers. Closed here,
     #: same as ``stash_store``.
     secret_store: SecretStore | None = None
+    #: Marketplace install/lifecycle flows (SPEC-304). Holds no resources
+    #: of its own to close — everything it touches (``upstream_service``,
+    #: ``secret_store``, ``dynamic_gateway``) is already listed above.
+    install_service: InstallService | None = None
 
 
 def _index_event_hook(event_bus: EventBus, vault_key: str) -> HubEventHook:
@@ -293,6 +297,23 @@ async def build_production_app(
         upstream_service, on_change=dynamic_gateway.refresh_upstreams
     )
 
+    # SPEC-304: marketplace install/lifecycle flows, on top of the same
+    # dynamic_gateway/upstream_service/secret_store the SPEC-302 upstream
+    # surface above already built — see palaia_hub.market.install for why
+    # this is a thin layer over that machinery rather than a parallel one.
+    def _publish_addon_event(event: str, data: dict[str, Any]) -> None:
+        publish_from_hook(event_bus, event, data, origin="market")
+
+    install_service = InstallService(
+        market_service=market_service,
+        dynamic_gateway=dynamic_gateway,
+        upstream_service=upstream_service,
+        secret_store=secret_store,
+        home=stash_home,
+        config=config,
+        publish=_publish_addon_event,
+    )
+
     app = create_app(
         config,
         dynamic_gateway=dynamic_gateway,
@@ -305,6 +326,7 @@ async def build_production_app(
         stash_service=stash_service,
         hook_store=hook_store,
         market_service=market_service,
+        install_service=install_service,
         curator=curator.scheduler if curator else None,
         automation_store=automation_store,
         automation_outbox=automation_outbox,
@@ -326,6 +348,7 @@ async def build_production_app(
         stash_store=stash_store,
         upstream_service=upstream_service,
         secret_store=secret_store,
+        install_service=install_service,
     )
 
 

--- a/v3/server/src/palaia_hub/upstream/api.py
+++ b/v3/server/src/palaia_hub/upstream/api.py
@@ -33,12 +33,12 @@ from pathlib import Path
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
-from ..config import GatewayProfileSettings, GatewaySettings, HubConfig, config_file_path
+from ..config import HubConfig, config_file_path
 from ..events import EventBus, publish_event
 from ..gateway.build import GatewayConfigError
 from ..gateway.config import CURATOR_PROFILE_PATH
 from ..gateway.dynamic import DynamicGateway
-from ..gateway.settings_bridge import persist_gateway_settings
+from ..gateway.settings_bridge import persist_gateway_settings, snapshot_gateway_settings
 from .models import UpstreamConfig, UpstreamConflictError
 from .secrets import SecretStore, SecretStoreError, validate_secret_name
 from .service import UpstreamNotConfiguredError, UpstreamService
@@ -282,26 +282,11 @@ def build_upstreams_router(
         the per-vault identity overrides already in the file are carried
         through untouched.
         """
-        existing_vaults = config.gateway.vaults if config.gateway is not None else []
-        profiles = [
-            p for p in dynamic_gateway.config.profiles if p.path != CURATOR_PROFILE_PATH
-        ]
+        # The shared live-then-persisted snapshot (settings_bridge): a
+        # hand-built copy here once dropped hidden_tools/semantic_routing
+        # from every profile on any upstream edit or secret rotation.
         persist_gateway_settings(
-            config_path,
-            GatewaySettings(
-                vaults=existing_vaults,
-                profiles=[
-                    GatewayProfileSettings(
-                        path=p.path,
-                        label=p.label,
-                        vaults=list(p.vaults),
-                        stash=p.stash,
-                        upstreams=list(p.upstreams),
-                    )
-                    for p in profiles
-                ],
-                upstreams=list(dynamic_gateway.config.upstreams),
-            ),
+            config_path, snapshot_gateway_settings(dynamic_gateway, config)
         )
 
     def _publish(event: str, data: dict[str, object]) -> None:

--- a/v3/server/tests/gateway/test_apps_market.py
+++ b/v3/server/tests/gateway/test_apps_market.py
@@ -1,0 +1,132 @@
+"""Marketplace MCP App acceptance tests (SPEC-304 deliverable #5).
+
+Same in-memory :class:`fastmcp.Client` pattern as
+``test_apps_hub_status.py`` (see that file's own docstring for why no test
+here drives a real HTTP streamable session) — plus the one thing unique to
+this app: proving "install itself always deep-links to the dashboard...
+the app never performs the install" by inspecting the page's own script
+rather than a browser.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+from fastmcp import Client
+
+from palaia_hub.app import create_app
+from palaia_hub.config import HubConfig
+from palaia_hub.gateway.apps.market_app import (
+    _SCRIPT_JS,
+    MarketAppDeps,
+    build_market_server,
+    collect_market_browse,
+    render_marketplace_html,
+)
+from palaia_hub.market.curated import CuratedIndexClient
+from palaia_hub.market.manual import ManualEntryStore
+from palaia_hub.market.service import MarketService
+from palaia_hub.registry.client import RegistryClient
+
+
+def _empty_registry_handler(request: httpx.Request) -> httpx.Response:
+    return httpx.Response(200, json={"servers": []})
+
+
+def _offline_curated_handler(request: httpx.Request) -> httpx.Response:
+    raise httpx.ConnectError("offline in this test")
+
+
+def _market_service(tmp_path: Path) -> MarketService:
+    registry_client = RegistryClient(
+        client=httpx.AsyncClient(transport=httpx.MockTransport(_empty_registry_handler)),
+        cache_dir=tmp_path / "registry_cache",
+    )
+    curated_client = CuratedIndexClient(
+        client=httpx.AsyncClient(transport=httpx.MockTransport(_offline_curated_handler)),
+        last_good_path=tmp_path / "last_good.json",
+    )
+    manual_store = ManualEntryStore(tmp_path / "manual.sqlite3")
+    return MarketService(
+        registry_client=registry_client, curated_client=curated_client, manual_store=manual_store
+    )
+
+
+@pytest.mark.anyio
+async def test_collect_market_browse_reads_the_starter_index(tmp_path: Path) -> None:
+    deps = MarketAppDeps(market_service=_market_service(tmp_path), dashboard_url=None)
+
+    result = await collect_market_browse(deps)
+
+    assert {e.id for e in result.entries} >= {"palaia.fetch", "palaia.filesystem"}
+    assert result.dashboard_url is None
+
+
+@pytest.mark.anyio
+async def test_market_tool_is_reachable_and_carries_the_ui_resource(tmp_path: Path) -> None:
+    deps = MarketAppDeps(
+        market_service=_market_service(tmp_path), dashboard_url="https://hub.example.com"
+    )
+    server = build_market_server(deps)
+
+    async with Client(server) as client:
+        tools = await client.list_tools()
+        (browse_tool,) = [t for t in tools if t.name == "browse_marketplace"]
+        assert browse_tool.meta is not None
+        assert browse_tool.meta["ui"]["resourceUri"] == "ui://palaia/marketplace.html"
+
+        result = await client.call_tool("browse_marketplace", {})
+        resources = await client.list_resources()
+
+    assert {str(r.uri) for r in resources} == {"ui://palaia/marketplace.html"}
+    payload = result.structured_content
+    assert payload["dashboard_url"] == "https://hub.example.com"
+    # Plain-text fallback (SPEC-304 deliverable #5: "plain-text fallback
+    # lists top results") — a usable summary with no app host at all.
+    assert "Browse results" in result.content[0].text
+
+
+@pytest.mark.anyio
+async def test_a_search_query_narrows_the_plain_text_summary(tmp_path: Path) -> None:
+    deps = MarketAppDeps(market_service=_market_service(tmp_path), dashboard_url=None)
+    server = build_market_server(deps)
+
+    async with Client(server) as client:
+        result = await client.call_tool("browse_marketplace", {"query": "filesystem"})
+
+    assert result.structured_content["query"] == "filesystem"
+    assert [e["id"] for e in result.structured_content["entries"]] == ["palaia.filesystem"]
+
+
+def test_the_page_never_calls_a_server_tool_to_install() -> None:
+    """SPEC-304 deliverable #5: "install itself always deep-links to the
+    dashboard consent screen — the app never performs the install".
+    Asserted against the page's own script, since no browser drives it
+    here (see the module docstring)."""
+    # The vendored bridge SDK (embedded in every app's page) defines
+    # `callServerTool` as a method every app *could* use — checking the
+    # whole rendered page would always find that definition. What matters
+    # is that *this app's own* script (`_SCRIPT_JS`, this page's only
+    # page-specific logic) never invokes it at all.
+    assert "callServerTool" not in _SCRIPT_JS
+    # The deep link is a plain anchor, opened in a new tab/window — never a
+    # fetch/XHR (which the app's strict CSP would refuse anyway).
+    assert 'target="_blank"' in _SCRIPT_JS
+    assert "installHref" in _SCRIPT_JS
+    assert render_marketplace_html()  # still renders as one full page
+
+
+def test_market_mount_present_only_with_a_market_service(tmp_path: Path) -> None:
+    without_service = create_app(HubConfig())
+    with TestClient(without_service) as rest:
+        assert rest.get("/mcp/market").status_code == 404
+
+    with_service = create_app(HubConfig(), market_service=_market_service(tmp_path))
+    with TestClient(with_service) as rest:
+        # 406, not 404 — same "the mount exists" proof
+        # test_apps_hub_status.py's own mount test uses (see that file's
+        # docstring for why no full JSON-RPC round trip is attempted here).
+        assert rest.get("/mcp/market").status_code == 406

--- a/v3/server/tests/market/conftest.py
+++ b/v3/server/tests/market/conftest.py
@@ -2,17 +2,84 @@ from __future__ import annotations
 
 import base64
 import json
-from collections.abc import Callable
+import subprocess
+import sys
+import time
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
 
+import httpx
 import pytest
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 from palaia_hub.market.curated import canonical_bytes
 
+#: The same fixture MCP server ``tests/upstream`` uses — referenced by
+#: path rather than by importing that package's own ``conftest.py``
+#: fixture (this repo's test layout treats each ``tests/<area>/`` as its
+#: own top-level package with no shared parent to import across; see this
+#: file's ``http_upstream`` fixture below).
+_UPSTREAM_HTTP_SERVER = (
+    Path(__file__).resolve().parent.parent / "upstream" / "fixture_http_server.py"
+)
+
 
 @pytest.fixture
 def anyio_backend() -> str:
     return "asyncio"
+
+
+def _free_port() -> int:
+    import socket
+
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@dataclass
+class HttpUpstream:
+    """A running fixture MCP server (SPEC-302's, reused here) in its own
+    process — SPEC-304's install flow connects to it exactly like a real
+    ``remote`` marketplace entry's declared address."""
+
+    url: str
+    process: subprocess.Popen[bytes]
+
+    def stop(self) -> None:
+        self.process.terminate()
+        try:
+            self.process.wait(timeout=10)
+        except subprocess.TimeoutExpired:  # pragma: no cover - stubborn child
+            self.process.kill()
+            self.process.wait(timeout=10)
+
+
+@pytest.fixture
+def http_upstream() -> Iterator[HttpUpstream]:
+    """An unauthenticated fixture MCP server, in its own process."""
+    port = _free_port()
+    process = subprocess.Popen(
+        [sys.executable, str(_UPSTREAM_HTTP_SERVER), "--port", str(port)]
+    )
+    url = f"http://127.0.0.1:{port}/"
+    deadline = time.time() + 30
+    try:
+        while time.time() < deadline:
+            if process.poll() is not None:  # pragma: no cover - fixture start failure
+                raise RuntimeError("the fixture upstream exited before becoming reachable")
+            try:
+                httpx.post(url, timeout=1.0)
+                break
+            except httpx.HTTPError:
+                time.sleep(0.1)
+        else:  # pragma: no cover - fixture start failure
+            process.terminate()
+            raise RuntimeError("the fixture upstream never became reachable")
+        yield HttpUpstream(url=url, process=process)
+    finally:
+        HttpUpstream(url=url, process=process).stop()
 
 
 @pytest.fixture

--- a/v3/server/tests/market/test_docker_runtime.py
+++ b/v3/server/tests/market/test_docker_runtime.py
@@ -1,0 +1,122 @@
+"""Unit tests for :mod:`palaia_hub.market.docker_runtime` — the pure argv
+builder always runs; the subprocess-touching functions are exercised with
+a faked ``asyncio.create_subprocess_exec`` so this file needs no real
+docker at all (the real daemon is exercised by
+``test_install_container.py``, itself skipped honestly without one).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import pytest
+
+from palaia_hub.market import docker_runtime
+
+
+def test_build_stdio_run_args_shape() -> None:
+    run_args = docker_runtime.build_stdio_run_args(
+        "ghcr.io/palaia/addon-fetch:1.0.0",
+        container_name="palaia-addon-fetch",
+        mounts={"mount_path": "/data/notes"},
+        plain_env={"USER_AGENT": "palaia/1.0"},
+        secret_env_vars=["API_KEY"],
+    )
+
+    assert run_args.command == "docker"
+    assert run_args.args[:4] == ["run", "--rm", "-i", "--name"]
+    assert "palaia-addon-fetch" in run_args.args
+    assert "-v" in run_args.args
+    mount_idx = run_args.args.index("-v")
+    assert run_args.args[mount_idx + 1] == "/data/notes:/data/notes"
+    assert "-e" in run_args.args
+    assert "USER_AGENT=palaia/1.0" in run_args.args
+    # The secret's *name* appears bare — never a value, and the value
+    # itself never appears anywhere in the argv (SPEC-304's own rule).
+    assert "API_KEY" in run_args.args
+    assert not any("API_KEY=" in arg for arg in run_args.args)
+    assert run_args.args[-1] == "ghcr.io/palaia/addon-fetch:1.0.0"
+
+
+def test_build_stdio_run_args_with_no_mounts_or_env() -> None:
+    run_args = docker_runtime.build_stdio_run_args(
+        "ghcr.io/acme/tool:1.0.0",
+        container_name="palaia-addon-tool",
+        mounts={},
+        plain_env={},
+        secret_env_vars=[],
+    )
+
+    assert run_args.args == [
+        "run", "--rm", "-i", "--name", "palaia-addon-tool", "ghcr.io/acme/tool:1.0.0",
+    ]
+
+
+@pytest.mark.anyio
+async def test_docker_available_is_false_when_the_binary_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(docker_runtime, "docker_binary", lambda: None)
+
+    assert await docker_runtime.docker_available() is False
+
+
+@dataclass
+class _FakeProcess:
+    returncode: int
+    stdout_bytes: bytes = b""
+    stderr_bytes: bytes = b""
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        return self.stdout_bytes, self.stderr_bytes
+
+    def kill(self) -> None:
+        pass
+
+    async def wait(self) -> int:
+        return self.returncode
+
+
+@pytest.mark.anyio
+async def test_docker_available_true_when_daemon_answers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(docker_runtime, "docker_binary", lambda: "/usr/bin/docker")
+
+    async def fake_exec(*args: object, **kwargs: object) -> _FakeProcess:
+        return _FakeProcess(returncode=0)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    assert await docker_runtime.docker_available() is True
+
+
+@pytest.mark.anyio
+async def test_pull_image_raises_with_stderr_tail_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(docker_runtime, "docker_binary", lambda: "/usr/bin/docker")
+
+    async def fake_exec(*args: object, **kwargs: object) -> _FakeProcess:
+        return _FakeProcess(returncode=1, stderr_bytes=b"Error: no such image\nunauthorized\n")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    with pytest.raises(docker_runtime.DockerError, match="unauthorized"):
+        await docker_runtime.pull_image("ghcr.io/does-not/exist:1.0.0")
+
+
+@pytest.mark.anyio
+async def test_pull_image_raises_when_docker_is_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(docker_runtime, "docker_binary", lambda: None)
+
+    with pytest.raises(docker_runtime.DockerError, match="not installed"):
+        await docker_runtime.pull_image("ghcr.io/acme/tool:1.0.0")
+
+
+@pytest.mark.anyio
+async def test_remove_container_never_raises_when_docker_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(docker_runtime, "docker_binary", lambda: None)
+
+    await docker_runtime.remove_container("palaia-addon-anything")  # must not raise

--- a/v3/server/tests/market/test_install.py
+++ b/v3/server/tests/market/test_install.py
@@ -1,0 +1,452 @@
+"""SPEC-304 deliverables #1/#3/#4 over REST, through the real production
+app — mirrors ``tests/upstream/test_api.py``'s own pattern (the exact
+wiring ``palaia-hub serve`` runs), since an install lands in that same
+upstream/gateway machinery.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from fastmcp import Client
+
+from palaia_hub.config import load_config
+from palaia_hub.market.docker_runtime import DockerError
+from palaia_hub.registry.client import RegistryOfflineError
+from palaia_hub.registry.models import RegistryServer
+from palaia_hub.serve import ProductionApp, build_production_app
+from palaia_hub.vault import VaultRegistry
+
+from .conftest import HttpUpstream
+
+pytestmark = pytest.mark.anyio
+
+BASE_URL = "https://testserver"
+SECRET = "sk-never-echo-this-back-9931"
+
+
+async def _hub(tmp_path: Path) -> ProductionApp:
+    registry = VaultRegistry(tmp_path)
+    await registry.create("work", tmp_path / "vaults" / "work", purpose="Work vault.")
+    config = load_config(home=tmp_path)
+    return await build_production_app(config, home=tmp_path)
+
+
+@asynccontextmanager
+async def _running(production: ProductionApp) -> AsyncIterator[httpx.AsyncClient]:
+    try:
+        async with production.app.router.lifespan_context(production.app):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=production.app), base_url=BASE_URL
+            ) as http:
+                yield http
+    finally:
+        await production.dynamic_gateway.aclose()
+        if production.stash_store is not None:
+            production.stash_store.close()
+        for index in production.indexes.values():
+            await index.close()
+
+
+def _manual_remote_entry(
+    entry_id: str, url: str, *, config_schema: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "id": entry_id,
+        "name": "Fixture Remote",
+        "one_liner": "A fixture MCP server for tests.",
+        "kind": "remote",
+        "source": {"type": "url", "value": url},
+        "maintainer": "tests",
+    }
+    if config_schema is not None:
+        body["config_schema"] = config_schema
+    return body
+
+
+async def _create_manual_remote(
+    http: httpx.AsyncClient, entry_id: str, url: str, *, config_schema: dict[str, Any] | None = None
+) -> httpx.Response:
+    return await http.post(
+        "/api/market/manual", json=_manual_remote_entry(entry_id, url, config_schema=config_schema)
+    )
+
+
+async def _consent(http: httpx.AsyncClient, entry_id: str) -> str:
+    response = await http.post(f"/api/market/entry/{entry_id}/consent")
+    assert response.status_code == 200, response.text
+    return str(response.json()["token"])
+
+
+# --------------------------------------------------------- remote install
+
+
+async def test_one_click_install_of_a_remote_entry_is_callable_without_a_restart(
+    tmp_path: Path, http_upstream: HttpUpstream
+) -> None:
+    """SPEC-304 acceptance criterion: "from a curated-index entry,
+    one-click install of a remote fixture upstream -> its tool callable
+    through a profile without restart"."""
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        entry_id = "acme.fixture-remote"
+        create = await _create_manual_remote(http, entry_id, http_upstream.url)
+        assert create.status_code == 201
+
+        token = await _consent(http, entry_id)
+        install = await http.post(
+            f"/api/market/entry/{entry_id}/install",
+            json={"consent_token": token, "profiles": ["default"]},
+        )
+        assert install.status_code == 200, install.text
+        body = install.json()
+        assert body["entry_id"] == entry_id
+        assert body["profiles"] == ["default"]
+        assert body["up"] is True
+
+        # No restart: the same running profile server answers immediately.
+        async with Client(production.dynamic_gateway.profile_servers["default"]) as client:
+            names = {tool.name for tool in await client.list_tools()}
+            assert any(name.endswith("_echo") for name in names)
+
+
+async def test_install_without_a_consent_post_is_impossible(
+    tmp_path: Path, http_upstream: HttpUpstream
+) -> None:
+    """SPEC-304 acceptance criterion: install without a consent POST is
+    impossible."""
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        entry_id = "acme.no-consent"
+        await _create_manual_remote(http, entry_id, http_upstream.url)
+
+        no_token = await http.post(
+            f"/api/market/entry/{entry_id}/install",
+            json={"consent_token": "made-up-token", "profiles": []},
+        )
+        assert no_token.status_code == 400
+        assert "consent" in no_token.json()["detail"].lower()
+
+        assert (await http.get("/api/market/installed")).json() == []
+
+
+async def test_a_consent_token_is_single_use(tmp_path: Path, http_upstream: HttpUpstream) -> None:
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        entry_id = "acme.reuse-token"
+        await _create_manual_remote(http, entry_id, http_upstream.url)
+        token = await _consent(http, entry_id)
+
+        first = await http.post(
+            f"/api/market/entry/{entry_id}/install", json={"consent_token": token, "profiles": []}
+        )
+        assert first.status_code == 200
+
+        second_entry_id = "acme.reuse-token-2"
+        await http.post(
+            "/api/market/manual", json=_manual_remote_entry(second_entry_id, http_upstream.url)
+        )
+        reused = await http.post(
+            f"/api/market/entry/{second_entry_id}/install",
+            json={"consent_token": token, "profiles": []},
+        )
+        assert reused.status_code == 400
+
+
+async def test_a_consent_token_does_not_transfer_to_another_entry(
+    tmp_path: Path, http_upstream: HttpUpstream
+) -> None:
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        entry_a = "acme.entry-a"
+        entry_b = "acme.entry-b"
+        await _create_manual_remote(http, entry_a, http_upstream.url)
+        await _create_manual_remote(http, entry_b, http_upstream.url)
+        token = await _consent(http, entry_a)
+
+        wrong_entry = await http.post(
+            f"/api/market/entry/{entry_b}/install", json={"consent_token": token, "profiles": []}
+        )
+        assert wrong_entry.status_code == 400
+
+
+async def test_installing_twice_is_refused(tmp_path: Path, http_upstream: HttpUpstream) -> None:
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        entry_id = "acme.twice"
+        await _create_manual_remote(http, entry_id, http_upstream.url)
+        token = await _consent(http, entry_id)
+        first = await http.post(
+            f"/api/market/entry/{entry_id}/install", json={"consent_token": token, "profiles": []}
+        )
+        assert first.status_code == 200
+
+        token2 = await _consent(http, entry_id)
+        second = await http.post(
+            f"/api/market/entry/{entry_id}/install", json={"consent_token": token2, "profiles": []}
+        )
+        assert second.status_code == 400
+        assert "already installed" in second.json()["detail"]
+
+
+async def test_skill_entries_are_refused_with_a_connect_page_hint(tmp_path: Path) -> None:
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        entry_id = "acme.a-skill"
+        await http.post(
+            "/api/market/manual",
+            json={
+                "id": entry_id,
+                "name": "A Skill",
+                "one_liner": "A skill, not installable here.",
+                "kind": "skill",
+                "source": {"type": "url", "value": "https://example.com/SKILL.md"},
+                "maintainer": "tests",
+            },
+        )
+        token = await _consent(http, entry_id)
+        response = await http.post(
+            f"/api/market/entry/{entry_id}/install", json={"consent_token": token, "profiles": []}
+        )
+        assert response.status_code == 400
+        assert "connect page" in response.json()["detail"]
+
+
+async def test_uninstall_disconnects_and_persists(
+    tmp_path: Path, http_upstream: HttpUpstream
+) -> None:
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        entry_id = "acme.uninstall-me"
+        await _create_manual_remote(http, entry_id, http_upstream.url)
+        token = await _consent(http, entry_id)
+        install = await http.post(
+            f"/api/market/entry/{entry_id}/install",
+            json={"consent_token": token, "profiles": ["default"]},
+        )
+        upstream_key = install.json()["upstream_key"]
+
+        deleted = await http.delete(f"/api/market/installed/{upstream_key}")
+        assert deleted.status_code == 204
+        assert (await http.get("/api/market/installed")).json() == []
+
+        listing = await http.get("/api/gateway/upstreams")
+        assert listing.json() == []
+
+    reloaded = load_config(home=tmp_path, create_if_missing=False)
+    assert reloaded.gateway is not None
+    assert reloaded.gateway.upstreams == []
+
+
+# --------------------------------------------------------- secret round-trip
+
+
+async def test_a_secret_config_field_round_trips_and_never_comes_back(
+    tmp_path: Path, http_upstream: HttpUpstream
+) -> None:
+    """SPEC-304 acceptance criterion: a ``secret`` config field round-trips
+    into the secret store and is never present in any subsequent GET
+    (contract test)."""
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        entry_id = "acme.needs-secret"
+        schema = {
+            "type": "object",
+            "properties": {"api_key": {"type": "secret", "title": "API key"}},
+        }
+        await _create_manual_remote(http, entry_id, http_upstream.url, config_schema=schema)
+        token = await _consent(http, entry_id)
+        install = await http.post(
+            f"/api/market/entry/{entry_id}/install",
+            json={"consent_token": token, "config": {"api_key": SECRET}, "profiles": []},
+        )
+        assert install.status_code == 200, install.text
+        assert SECRET not in install.text
+
+        for path in (
+            "/api/market/installed",
+            "/api/gateway/upstreams",
+            "/api/secrets",
+        ):
+            response = await http.get(path)
+            assert SECRET not in response.text, f"leaked at {path}"
+
+        secret_names = [s["name"] for s in (await http.get("/api/secrets")).json()]
+        assert any(name.endswith(".api_key") for name in secret_names)
+
+    assert SECRET not in (tmp_path / "config.yaml").read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------- registry_ref -> stdio
+
+
+class _FakeRegistryDetail:
+    """Stands in for :class:`RegistryClient` for exactly one ``detail``
+    lookup — deliverable #1's "stdio command entries" resolution needs a
+    registry ``server.json`` shaped payload, which the merged
+    :class:`~palaia_hub.market.models.MarketEntry` a manual/curated entry
+    carries never has (see :mod:`palaia_hub.market.install`'s docstring)."""
+
+    def __init__(self, server: RegistryServer | None) -> None:
+        self._server = server
+
+    async def detail(self, server_id: str) -> RegistryServer | None:
+        return self._server
+
+
+async def test_registry_ref_resolves_a_stdio_command_from_an_npm_package(
+    tmp_path: Path,
+) -> None:
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        entry_id = "acme.npm-tool"
+        await http.post(
+            "/api/market/manual",
+            json={
+                "id": entry_id,
+                "name": "NPM Tool",
+                "one_liner": "An npm-packaged MCP server.",
+                "kind": "remote",
+                "source": {"type": "registry_ref", "value": "io.example/npm-tool"},
+                "maintainer": "tests",
+            },
+        )
+        assert production.install_service is not None
+        production.install_service.market_service.registry_client = _FakeRegistryDetail(  # type: ignore[assignment]
+            RegistryServer(
+                id="io.example/npm-tool",
+                name="npm-tool",
+                description="An npm tool.",
+                version="1.2.0",
+                raw={
+                    "server": {
+                        "packages": [
+                            {
+                                "registry_type": "npm",
+                                "identifier": "@acme/npm-tool",
+                                "version": "1.2.0",
+                                "package_arguments": [{"value": "--quiet"}],
+                            }
+                        ]
+                    }
+                },
+            )
+        )
+
+        token = await _consent(http, entry_id)
+        install = await http.post(
+            f"/api/market/entry/{entry_id}/install", json={"consent_token": token, "profiles": []}
+        )
+        assert install.status_code == 200, install.text
+
+    upstream = production.dynamic_gateway.config.upstreams[0]
+    assert upstream.kind == "stdio"
+    assert upstream.command == "npx"
+    assert upstream.args == ["-y", "@acme/npm-tool@1.2.0", "--quiet"]
+
+
+async def test_an_unsupported_package_kind_is_refused_plainly(tmp_path: Path) -> None:
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        entry_id = "acme.mystery-package"
+        await http.post(
+            "/api/market/manual",
+            json={
+                "id": entry_id,
+                "name": "Mystery",
+                "one_liner": "A package palaia cannot run.",
+                "kind": "remote",
+                "source": {"type": "registry_ref", "value": "io.example/mystery"},
+                "maintainer": "tests",
+            },
+        )
+        assert production.install_service is not None
+        production.install_service.market_service.registry_client = _FakeRegistryDetail(  # type: ignore[assignment]
+            RegistryServer(
+                id="io.example/mystery",
+                name="mystery",
+                description="",
+                version=None,
+                raw={"server": {"packages": [{"registry_type": "cargo", "identifier": "mystery"}]}},
+            )
+        )
+
+        token = await _consent(http, entry_id)
+        response = await http.post(
+            f"/api/market/entry/{entry_id}/install", json={"consent_token": token, "profiles": []}
+        )
+        assert response.status_code == 400
+        assert "does not know how to run" in response.json()["detail"]
+
+
+async def test_registry_offline_during_resolution_is_a_plain_400(tmp_path: Path) -> None:
+    class _OfflineRegistry:
+        async def detail(self, server_id: str) -> RegistryServer | None:
+            raise RegistryOfflineError("no network in this test")
+
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        entry_id = "acme.offline-registry"
+        await http.post(
+            "/api/market/manual",
+            json={
+                "id": entry_id,
+                "name": "Offline",
+                "one_liner": "x",
+                "kind": "remote",
+                "source": {"type": "registry_ref", "value": "io.example/offline"},
+                "maintainer": "tests",
+            },
+        )
+        assert production.install_service is not None
+        production.install_service.market_service.registry_client = _OfflineRegistry()  # type: ignore[assignment]
+
+        token = await _consent(http, entry_id)
+        response = await http.post(
+            f"/api/market/entry/{entry_id}/install", json={"consent_token": token, "profiles": []}
+        )
+        assert response.status_code == 400
+        assert "registry" in response.json()["detail"].lower()
+
+
+# ---------------------------------------------------------- container path
+
+
+async def test_container_install_surfaces_a_pull_failure_plainly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The install path for ``container`` entries (docker daemon interaction
+    itself is exercised, docker-gated, in ``test_install_container.py``) —
+    here only the "pull fails" branch, which needs no real daemon."""
+    from palaia_hub.market import install as install_module
+
+    async def _fail_pull(image: str, *, timeout: float = 300.0) -> None:
+        raise DockerError(f"docker pull {image!r} failed: no such image")
+
+    monkeypatch.setattr(install_module.docker_runtime, "pull_image", _fail_pull)
+
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        entry_id = "acme.container-tool"
+        await http.post(
+            "/api/market/manual",
+            json={
+                "id": entry_id,
+                "name": "Container Tool",
+                "one_liner": "x",
+                "kind": "container",
+                "source": {"type": "image", "value": "ghcr.io/acme/does-not-exist:1.0.0"},
+                "maintainer": "tests",
+            },
+        )
+        token = await _consent(http, entry_id)
+        response = await http.post(
+            f"/api/market/entry/{entry_id}/install", json={"consent_token": token, "profiles": []}
+        )
+        assert response.status_code == 400
+        assert "no such image" in response.json()["detail"]

--- a/v3/server/tests/market/test_install_container.py
+++ b/v3/server/tests/market/test_install_container.py
@@ -1,0 +1,162 @@
+"""Container add-on lifecycle, against a real docker daemon (SPEC-304
+acceptance criterion: "install -> running -> health visible -> update ->
+uninstall leaves no container behind (env-gated on docker availability,
+skipped honestly otherwise)").
+
+Building the fixture image needs both a reachable docker daemon *and*
+network access (a base image pull, then a ``pip install`` of ``fastmcp``
+inside it) — either being unavailable is reported as an honest skip, never
+a failure: this module tests palaia's own lifecycle code, not whether the
+sandbox running it happens to have a daemon or network reachable right
+now.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from palaia_hub.config import load_config
+from palaia_hub.market.docker_runtime import docker_available
+from palaia_hub.serve import ProductionApp, build_production_app
+from palaia_hub.vault import VaultRegistry
+
+from .test_install import _consent, _running
+
+pytestmark = pytest.mark.anyio
+
+IMAGE_TAG = "palaia-test-fixture-addon:latest"
+
+
+def _docker_ready() -> bool:
+    return asyncio.run(docker_available())
+
+
+async def _hub(tmp_path: Path) -> ProductionApp:
+    registry = VaultRegistry(tmp_path)
+    await registry.create("work", tmp_path / "vaults" / "work", purpose="Work vault.")
+    config = load_config(home=tmp_path)
+    return await build_production_app(config, home=tmp_path)
+
+
+@pytest.fixture(scope="module")
+def fixture_image(tmp_path_factory: pytest.TempPathFactory) -> str:
+    """Build a tiny local image wrapping the same fixture MCP server the
+    ``stdio``-upstream tests already use — skips honestly (never fails)
+    when the daemon or the network needed to build it is unavailable."""
+    if not _docker_ready():
+        pytest.skip("no reachable docker daemon in this environment")
+
+    build_dir = tmp_path_factory.mktemp("addon-image-build")
+    script_src = (
+        Path(__file__).resolve().parent.parent / "upstream" / "fixture_stdio_server.py"
+    ).read_text(encoding="utf-8")
+    (build_dir / "server.py").write_text(script_src, encoding="utf-8")
+    (build_dir / "Dockerfile").write_text(
+        textwrap.dedent(
+            """\
+            FROM python:3.12-slim
+            RUN pip install --no-cache-dir fastmcp==3.4.7
+            COPY server.py /server.py
+            ENV FIXTURE_TOKEN=container-fixture-token
+            CMD ["python", "/server.py"]
+            """
+        ),
+        encoding="utf-8",
+    )
+    try:
+        subprocess.run(
+            ["docker", "build", "-t", IMAGE_TAG, str(build_dir)],
+            check=True,
+            capture_output=True,
+            timeout=300,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        pytest.skip(f"could not build the fixture image (no network?): {exc}")
+    yield IMAGE_TAG
+    subprocess.run(["docker", "rmi", "-f", IMAGE_TAG], capture_output=True)
+
+
+async def test_container_install_run_update_uninstall_lifecycle(
+    tmp_path: Path, fixture_image: str
+) -> None:
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        entry_id = "acme.fixture-container"
+        await http.post(
+            "/api/market/manual",
+            json={
+                "id": entry_id,
+                "name": "Fixture Container",
+                "one_liner": "A fixture MCP server, containerized.",
+                "kind": "container",
+                "source": {"type": "image", "value": fixture_image},
+                "maintainer": "tests",
+            },
+        )
+        token = await _consent(http, entry_id)
+        install = await http.post(
+            f"/api/market/entry/{entry_id}/install",
+            json={"consent_token": token, "profiles": ["default"]},
+        )
+        assert install.status_code == 200, install.text
+        installed = install.json()
+        upstream_key = installed["upstream_key"]
+        assert installed["kind"] == "container"
+
+        # Health visible.
+        probed = await http.post(f"/api/gateway/upstreams/{upstream_key}/probe")
+        assert probed.json()["up"] is True
+        assert "whoami" in probed.json()["tools"] or "add" in probed.json()["tools"]
+
+        # Update — same tag, but exercises the one-click update path end to
+        # end (re-pull, rebuild the connection).
+        updated = await http.post(f"/api/market/installed/{upstream_key}/update")
+        assert updated.status_code == 200, updated.text
+
+        # Uninstall leaves no container behind.
+        container_name = f"palaia-addon-{upstream_key}"
+        uninstalled = await http.delete(f"/api/market/installed/{upstream_key}")
+        assert uninstalled.status_code == 204
+
+    remaining = subprocess.run(
+        ["docker", "ps", "-a", "--filter", f"name=^{container_name}$", "--format", "{{.Names}}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert remaining.stdout.strip() == ""
+
+
+async def test_updating_a_non_container_add_on_is_refused(tmp_path: Path) -> None:
+    production = await _hub(tmp_path)
+    async with _running(production) as http:
+        entry_id = "acme.fixture-remote-for-update"
+        # A `remote` entry, never actually connected — this test only
+        # proves the "only a container can be updated" rule, which needs
+        # no docker at all.
+        await http.post(
+            "/api/market/manual",
+            json={
+                "id": entry_id,
+                "name": "Remote",
+                "one_liner": "x",
+                "kind": "remote",
+                "source": {"type": "url", "value": "https://example.invalid/mcp"},
+                "maintainer": "tests",
+            },
+        )
+        token = await _consent(http, entry_id)
+        install = await http.post(
+            f"/api/market/entry/{entry_id}/install",
+            json={"consent_token": token, "profiles": []},
+        )
+        upstream_key = install.json()["upstream_key"]
+
+        response = await http.post(f"/api/market/installed/{upstream_key}/update")
+        assert response.status_code == 400
+        assert "container" in response.json()["detail"]

--- a/v3/server/tests/market/test_installed_store.py
+++ b/v3/server/tests/market/test_installed_store.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from palaia_hub.market.installed_store import InstalledAddonRecord, InstalledAddonStore
+
+
+def _record(upstream_key: str = "palaia-fetch") -> InstalledAddonRecord:
+    return InstalledAddonRecord(
+        upstream_key=upstream_key,
+        entry_id="palaia.fetch",
+        name="Fetch",
+        kind="container",
+        provenance="curated",
+        installed_ref="ghcr.io/palaia/addon-fetch:1.0.0",
+        image="ghcr.io/palaia/addon-fetch:1.0.0",
+        container_name="palaia-addon-fetch",
+        installed_at=1234.5,
+    )
+
+
+def test_put_then_get_round_trips(tmp_path: Path) -> None:
+    store = InstalledAddonStore(tmp_path / "installed.json")
+    store.put(_record())
+
+    got = store.get("palaia-fetch")
+    assert got == _record()
+
+
+def test_get_missing_returns_none(tmp_path: Path) -> None:
+    store = InstalledAddonStore(tmp_path / "installed.json")
+    assert store.get("nothing-here") is None
+
+
+def test_list_is_sorted_by_key(tmp_path: Path) -> None:
+    store = InstalledAddonStore(tmp_path / "installed.json")
+    store.put(_record("zeta"))
+    store.put(_record("alpha"))
+
+    assert [r.upstream_key for r in store.list()] == ["alpha", "zeta"]
+
+
+def test_delete_removes_the_record(tmp_path: Path) -> None:
+    store = InstalledAddonStore(tmp_path / "installed.json")
+    store.put(_record())
+
+    assert store.delete("palaia-fetch") is True
+    assert store.get("palaia-fetch") is None
+    assert store.delete("palaia-fetch") is False
+
+
+def test_a_fresh_store_with_no_file_yet_lists_empty(tmp_path: Path) -> None:
+    store = InstalledAddonStore(tmp_path / "does-not-exist-yet.json")
+    assert store.list() == []
+
+
+def test_write_is_atomic_no_half_written_file_survives_a_second_write(tmp_path: Path) -> None:
+    path = tmp_path / "installed.json"
+    store = InstalledAddonStore(path)
+    store.put(_record("one"))
+    store.put(_record("two"))
+
+    # No leftover .tmp sibling after two successful writes.
+    assert not path.with_suffix(".tmp").exists()
+    assert {r.upstream_key for r in store.list()} == {"one", "two"}

--- a/v3/web/src/components/ConfigSchemaForm.test.tsx
+++ b/v3/web/src/components/ConfigSchemaForm.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { MarketConfigSchema } from "../lib/api/client";
+import { ConfigSchemaForm, missingRequiredFields } from "./ConfigSchemaForm";
+
+const SCHEMA: MarketConfigSchema = {
+  type: "object",
+  properties: {
+    api_key: { type: "secret", title: "Access token" },
+    region: { type: "string", title: "Region", enum: ["us", "eu"] },
+    port: { type: "number", title: "Port" },
+    verbose: { type: "boolean", title: "Verbose logging" },
+    mount_path: { type: "string", title: "Folder to expose", format: "path" },
+  },
+  required: ["api_key"],
+};
+
+describe("ConfigSchemaForm (SPEC-304 deliverable #2)", () => {
+  it("renders nothing to configure when the schema has no properties", () => {
+    render(<ConfigSchemaForm schema={null} values={{}} onChange={vi.fn()} />);
+
+    expect(screen.getByText(/ready to connect/i)).toBeInTheDocument();
+  });
+
+  it("renders every field kind and reports value changes", () => {
+    const onChange = vi.fn();
+    render(<ConfigSchemaForm schema={SCHEMA} values={{}} onChange={onChange} />);
+
+    fireEvent.change(screen.getByLabelText(/access token/i), {
+      target: { value: "sk-secret" },
+    });
+    expect(onChange).toHaveBeenCalledWith({ api_key: "sk-secret" });
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "eu" } });
+    expect(onChange).toHaveBeenCalledWith({ region: "eu" });
+
+    fireEvent.change(screen.getByLabelText(/^port/i), { target: { value: "8080" } });
+    expect(onChange).toHaveBeenCalledWith({ port: 8080 });
+
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onChange).toHaveBeenCalledWith({ verbose: true });
+
+    // The password field never shows a previous value — a config form is
+    // always opened blank (the hub never echoes a stored secret back).
+    expect(screen.getByLabelText(/access token/i)).toHaveAttribute("type", "password");
+  });
+
+  it("marks a required field's label and flags it as missing until filled", () => {
+    render(<ConfigSchemaForm schema={SCHEMA} values={{}} onChange={vi.fn()} />);
+
+    expect(screen.getByText(/access token \(required\)/i)).toBeInTheDocument();
+    expect(missingRequiredFields(SCHEMA, {})).toEqual(["api_key"]);
+    expect(missingRequiredFields(SCHEMA, { api_key: "x" })).toEqual([]);
+  });
+
+  it("hints that a path field is a shared folder", () => {
+    render(<ConfigSchemaForm schema={SCHEMA} values={{}} onChange={vi.fn()} />);
+
+    expect(screen.getByText(/shared with the add-on/i)).toBeInTheDocument();
+  });
+});

--- a/v3/web/src/components/ConfigSchemaForm.tsx
+++ b/v3/web/src/components/ConfigSchemaForm.tsx
@@ -1,0 +1,139 @@
+/**
+ * SPEC-304 deliverable #2: one shared form renderer for every add-on's
+ * `config_schema` — string / number / boolean / enum / secret, the fixed
+ * subset the hub's install endpoint understands. Labels come straight
+ * from the schema's own `title`s (jargon-free by the marketplace
+ * curator's own convention, not by anything this component enforces);
+ * a `secret` field never carries its previous value back in — see
+ * `Marketplace.tsx`'s install flow for why (the hub never echoes one
+ * back either).
+ */
+import type { MarketConfigSchema } from "../lib/api/client";
+import { LabeledInput, SwitchRow } from "./Field";
+
+export type ConfigFormValue = string | number | boolean;
+export type ConfigFormValues = Record<string, ConfigFormValue>;
+
+/** Field names the schema marks required but the current values leave
+ * blank — used to disable the install action until every one is filled. */
+export function missingRequiredFields(
+  schema: MarketConfigSchema | null | undefined,
+  values: ConfigFormValues,
+): string[] {
+  const required = schema?.required ?? [];
+  return required.filter((key) => {
+    const value = values[key];
+    return value === undefined || value === "";
+  });
+}
+
+export function ConfigSchemaForm({
+  schema,
+  values,
+  onChange,
+}: {
+  schema: MarketConfigSchema | null | undefined;
+  values: ConfigFormValues;
+  onChange: (values: ConfigFormValues) => void;
+}) {
+  const properties = schema?.properties ?? {};
+  const required = new Set(schema?.required ?? []);
+  const keys = Object.keys(properties);
+
+  if (keys.length === 0) {
+    return <p className="t-xs t-muted">This add-on needs no setup — it is ready to connect.</p>;
+  }
+
+  function setValue(key: string, value: ConfigFormValue) {
+    onChange({ ...values, [key]: value });
+  }
+
+  return (
+    <div className="stack stack--3">
+      {keys.map((key) => {
+        const prop = properties[key] ?? {};
+        const label = prop.title || key;
+        const suffix = required.has(key) ? " (required)" : "";
+        const value = values[key];
+
+        if (prop.type === "boolean") {
+          return (
+            <SwitchRow
+              key={key}
+              label={label}
+              checked={Boolean(value)}
+              onChange={(checked) => setValue(key, checked)}
+            />
+          );
+        }
+
+        if (prop.enum && prop.enum.length > 0) {
+          return (
+            <div className="field" key={key}>
+              <span className="field__label">
+                {label}
+                {suffix}
+              </span>
+              <select
+                className="input"
+                value={typeof value === "string" ? value : ""}
+                onChange={(event) => setValue(key, event.target.value)}
+              >
+                <option value="" disabled>
+                  Choose one…
+                </option>
+                {prop.enum.map((choice) => (
+                  <option key={choice} value={choice}>
+                    {choice}
+                  </option>
+                ))}
+              </select>
+            </div>
+          );
+        }
+
+        if (prop.type === "secret") {
+          return (
+            <LabeledInput
+              key={key}
+              label={`${label}${suffix}`}
+              type="password"
+              autoComplete="off"
+              hint="Stored safely on this hub and never shown again once you save it."
+              value={typeof value === "string" ? value : ""}
+              onChange={(event) => setValue(key, event.target.value)}
+            />
+          );
+        }
+
+        if (prop.type === "number") {
+          return (
+            <LabeledInput
+              key={key}
+              label={`${label}${suffix}`}
+              type="number"
+              value={value === undefined ? "" : String(value)}
+              onChange={(event) =>
+                setValue(key, event.target.value === "" ? "" : Number(event.target.value))
+              }
+            />
+          );
+        }
+
+        return (
+          <LabeledInput
+            key={key}
+            label={`${label}${suffix}`}
+            hint={
+              prop.format === "path"
+                ? "A folder on this computer — shared with the add-on."
+                : undefined
+            }
+            value={typeof value === "string" ? value : ""}
+            onChange={(event) => setValue(key, event.target.value)}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/v3/web/src/components/index.ts
+++ b/v3/web/src/components/index.ts
@@ -1,6 +1,7 @@
 export * from "./Badge";
 export * from "./Button";
 export * from "./Card";
+export * from "./ConfigSchemaForm";
 export * from "./ConnectPanel";
 export * from "./EmptyState";
 export * from "./Field";

--- a/v3/web/src/lib/api/client.ts
+++ b/v3/web/src/lib/api/client.ts
@@ -165,7 +165,28 @@ export interface GatewayProfile {
   hidden_tools: string[];
   semantic_routing: boolean;
   tool_count: number;
+  /** External servers (SPEC-302) this profile mounts, by key. */
+  upstreams: string[];
   managed: boolean;
+}
+
+/** SPEC-302's external-server registry, as the profile editor reads it to
+ * offer upstream-server checkboxes (SPEC-304 follow-up) — mirrors
+ * `palaia_hub.upstream.api.UpstreamOut`. */
+export interface GatewayUpstream {
+  key: string;
+  kind: "http" | "stdio";
+  display_name: string;
+  namespace: string;
+  enabled: boolean;
+  target: string;
+  profiles: string[];
+  up: boolean;
+  status: string;
+  checked_at: number | null;
+  tools: string[];
+  secret_names: string[];
+  tool_renames: Record<string, string>;
 }
 
 /** `palaia_hub.gateway.api.GatewayToolOut`. */
@@ -293,6 +314,76 @@ export interface NotificationRecord {
   source: string;
   created_at: string;
   read: boolean;
+}
+
+/** SPEC-303/304's marketplace — opt-in on the hub (present only when a
+ * `market_service` is given to `create_app`), hand-written for the same
+ * reason the other opt-in surfaces above are. Mirrors
+ * `palaia_hub.market.models.MarketEntry`. */
+export type MarketEntryKind = "remote" | "container" | "mcpb" | "skill" | "plugin";
+export type MarketProvenance = "registry" | "curated" | "manual";
+export type MarketSourceType = "registry_ref" | "image" | "url";
+
+export interface MarketSourceLocator {
+  type: MarketSourceType;
+  value: string;
+}
+
+/** A `config_schema` property (SPEC-304 deliverable #2's fixed subset).
+ * `type: "secret"` is palaia's own extension, not a JSON Schema primitive
+ * — the one signal the form renderer needs to route a value to the
+ * secret store instead of a plain field. `format: "path"` on a string
+ * marks a declared container mount. */
+export interface MarketConfigProperty {
+  type?: "string" | "number" | "boolean" | "secret";
+  title?: string;
+  enum?: string[];
+  format?: string;
+}
+
+export interface MarketConfigSchema {
+  type?: "object";
+  properties?: Record<string, MarketConfigProperty>;
+  required?: string[];
+}
+
+export interface MarketEntry {
+  id: string;
+  name: string;
+  one_liner: string;
+  kind: MarketEntryKind;
+  source: MarketSourceLocator;
+  config_schema: MarketConfigSchema | null;
+  permissions: string[];
+  maintainer: string;
+  verified: boolean;
+  provenance: MarketProvenance;
+}
+
+export interface MarketSearchResult {
+  entries: MarketEntry[];
+  stale: boolean;
+  notes: Record<string, string>;
+}
+
+export interface ConsentToken {
+  token: string;
+  expires_at: number;
+}
+
+export interface InstalledAddon {
+  upstream_key: string;
+  entry_id: string;
+  name: string;
+  kind: MarketEntryKind;
+  provenance: MarketProvenance;
+  installed_ref: string;
+  current_ref: string | null;
+  update_available: boolean;
+  up: boolean;
+  status: string;
+  profiles: string[];
+  installed_at: number;
 }
 
 /** Base URL for API calls. Empty string = same-origin (the hub serves the
@@ -442,6 +533,7 @@ export const api = {
     stash?: boolean;
     hidden_tools?: string[];
     semantic_routing?: boolean;
+    upstreams?: string[];
   }) => postJson<GatewayProfile>("/api/gateway/profiles", body),
   updateGatewayProfile: (
     profilePath: string,
@@ -451,6 +543,7 @@ export const api = {
       stash?: boolean;
       hidden_tools?: string[];
       semantic_routing?: boolean;
+      upstreams?: string[];
     },
   ) => patchJson<GatewayProfile>(`/api/gateway/profiles/${profilePath}`, body),
   deleteGatewayProfile: (profilePath: string) =>
@@ -465,6 +558,9 @@ export const api = {
     vaultKey: string,
     body: { name?: string; purpose?: string; tool_renames?: Record<string, string> },
   ) => patchJson<GatewayVaultIdentity>(`/api/gateway/vaults/${vaultKey}`, body),
+  // SPEC-302's registry, read here so the profile editor (SPEC-304 follow-up)
+  // can offer an upstream-server checkbox next to the vault checkboxes.
+  listGatewayUpstreams: () => getJson<GatewayUpstream[]>("/api/gateway/upstreams"),
 
   // ---- SPEC-108's token surface, consumed here for "connected clients" ----
   listTokens: () => getJson<TokenInfo[]>("/api/auth/tokens"),
@@ -560,4 +656,43 @@ export const api = {
     postJson<SelfTestResult>("/api/exposure/selftest", {
       public_url: publicUrl,
     }),
+
+  // ---- SPEC-303/304: the marketplace ----
+  searchMarket: (q = "", source?: MarketProvenance) =>
+    getJson<MarketSearchResult>(`/api/market/search${queryString({ q, source })}`),
+  getMarketEntry: (entryId: string) => getJson<MarketEntry>(`/api/market/entry/${entryId}`),
+  createManualMarketEntry: (body: {
+    id: string;
+    name: string;
+    one_liner: string;
+    kind: MarketEntryKind;
+    source: MarketSourceLocator;
+    config_schema?: MarketConfigSchema | null;
+    permissions?: string[];
+    maintainer: string;
+  }) => postJson<MarketEntry>("/api/market/manual", body),
+  /** The consent screen's own POST (SPEC-304 deliverable #3) — the token
+   * it returns is what `installMarketEntry` below must be given; there is
+   * no install path that skips this call. */
+  issueMarketConsent: (entryId: string) =>
+    postJson<ConsentToken>(`/api/market/entry/${entryId}/consent`, {}),
+  installMarketEntry: (
+    entryId: string,
+    body: {
+      consent_token: string;
+      config?: Record<string, string | number | boolean>;
+      profiles?: string[];
+      display_name?: string | null;
+    },
+  ) => postJson<InstalledAddon>(`/api/market/entry/${entryId}/install`, body),
+  listInstalledAddons: () => getJson<InstalledAddon[]>("/api/market/installed"),
+  updateInstalledAddon: (upstreamKey: string) =>
+    postJson<InstalledAddon>(`/api/market/installed/${upstreamKey}/update`, {}),
+  uninstallAddon: (upstreamKey: string) =>
+    fetch(`${API_BASE}/api/market/installed/${upstreamKey}`, { method: "DELETE" }).then(
+      (response) => {
+        if (!response.ok)
+          throw new ApiError("/api/market/installed", response.status, undefined);
+      },
+    ),
 };

--- a/v3/web/src/routes/Marketplace.test.tsx
+++ b/v3/web/src/routes/Marketplace.test.tsx
@@ -1,0 +1,299 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ToastProvider } from "../components/Toast";
+import type { GatewayProfile, InstalledAddon, MarketEntry } from "../lib/api/client";
+import { api } from "../lib/api/client";
+import { Marketplace } from "./Marketplace";
+
+const FETCH_ENTRY: MarketEntry = {
+  id: "palaia.fetch",
+  name: "Fetch",
+  one_liner: "Fetch and convert web pages to markdown.",
+  kind: "container",
+  source: { type: "image", value: "ghcr.io/palaia/addon-fetch:1.0.0" },
+  config_schema: {
+    type: "object",
+    properties: { user_agent: { type: "string", title: "User agent string" } },
+  },
+  permissions: ["network"],
+  maintainer: "palaia",
+  verified: true,
+  provenance: "curated",
+};
+
+const SKILL_ENTRY: MarketEntry = {
+  id: "palaia.viewer",
+  name: "Memory Graph Viewer",
+  one_liner: "A read-only viewer for the knowledge graph.",
+  kind: "skill",
+  source: { type: "url", value: "https://addons.palaia.dev/viewer/SKILL.md" },
+  config_schema: null,
+  permissions: ["memory-scope:read"],
+  maintainer: "palaia",
+  verified: true,
+  provenance: "curated",
+};
+
+const MANUAL_SECRET_ENTRY: MarketEntry = {
+  id: "acme.tracker",
+  name: "Issue Tracker",
+  one_liner: "Connects to a project tracker.",
+  kind: "remote",
+  source: { type: "url", value: "https://tracker.example.com/mcp" },
+  config_schema: {
+    type: "object",
+    properties: { token: { type: "secret", title: "Access token" } },
+    required: ["token"],
+  },
+  permissions: [],
+  maintainer: "someone",
+  verified: false,
+  provenance: "manual",
+};
+
+const DEFAULT_PROFILE: GatewayProfile = {
+  path: "default",
+  label: null,
+  vaults: ["work"],
+  stash: false,
+  hidden_tools: [],
+  semantic_routing: false,
+  tool_count: 15,
+  upstreams: [],
+  managed: false,
+};
+
+const INSTALLED_FETCH: InstalledAddon = {
+  upstream_key: "palaia-fetch",
+  entry_id: "palaia.fetch",
+  name: "Fetch",
+  kind: "container",
+  provenance: "curated",
+  installed_ref: "ghcr.io/palaia/addon-fetch:1.0.0",
+  current_ref: "ghcr.io/palaia/addon-fetch:1.1.0",
+  update_available: true,
+  up: true,
+  status: "Connected — 1 tool.",
+  profiles: ["default"],
+  installed_at: 1_700_000_000,
+};
+
+function mount(initialPath = "/marketplace") {
+  return render(
+    <ToastProvider>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Marketplace />
+      </MemoryRouter>
+    </ToastProvider>,
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Marketplace screen (SPEC-304)", () => {
+  it("lists search results as cards", async () => {
+    vi.spyOn(api, "searchMarket").mockResolvedValue({ entries: [FETCH_ENTRY], stale: false, notes: {} });
+    vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([DEFAULT_PROFILE]);
+    vi.spyOn(api, "listInstalledAddons").mockResolvedValue([]);
+
+    mount();
+
+    expect(await screen.findByText("Fetch")).toBeInTheDocument();
+    expect(screen.getByText(/fetch and convert web pages/i)).toBeInTheDocument();
+  });
+
+  it("shows an empty state when nothing matches", async () => {
+    vi.spyOn(api, "searchMarket").mockResolvedValue({ entries: [], stale: false, notes: {} });
+    vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([]);
+    vi.spyOn(api, "listInstalledAddons").mockResolvedValue([]);
+
+    mount();
+
+    expect(await screen.findByText(/nothing matched/i)).toBeInTheDocument();
+  });
+
+  it("shows permissions and a stronger warning for an unverified entry, gated behind consent", async () => {
+    vi.spyOn(api, "searchMarket").mockResolvedValue({
+      entries: [MANUAL_SECRET_ENTRY],
+      stale: false,
+      notes: {},
+    });
+    vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([DEFAULT_PROFILE]);
+    vi.spyOn(api, "listInstalledAddons").mockResolvedValue([]);
+
+    mount();
+    fireEvent.click(await screen.findByRole("button", { name: /details/i }));
+
+    expect(await screen.findByText(/you added this one yourself/i)).toBeInTheDocument();
+    // The install button exists but does nothing until a secret is filled
+    // in and consent is actually issued — proven by the next test.
+    expect(screen.getByRole("button", { name: /install and connect/i })).toBeInTheDocument();
+  });
+
+  it("issues consent before installing, then installs with the collected config", async () => {
+    vi.spyOn(api, "searchMarket").mockResolvedValue({
+      entries: [MANUAL_SECRET_ENTRY],
+      stale: false,
+      notes: {},
+    });
+    vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([DEFAULT_PROFILE]);
+    vi.spyOn(api, "listInstalledAddons").mockResolvedValue([]);
+    const consentSpy = vi
+      .spyOn(api, "issueMarketConsent")
+      .mockResolvedValue({ token: "tok_abc123", expires_at: 9999999999 });
+    const installSpy = vi.spyOn(api, "installMarketEntry").mockResolvedValue({
+      upstream_key: "acme-tracker",
+      entry_id: "acme.tracker",
+      name: "Issue Tracker",
+      kind: "remote",
+      provenance: "manual",
+      installed_ref: "https://tracker.example.com/mcp",
+      current_ref: "https://tracker.example.com/mcp",
+      update_available: false,
+      up: true,
+      status: "Connected.",
+      profiles: [],
+      installed_at: 1,
+    });
+
+    mount();
+    fireEvent.click(await screen.findByRole("button", { name: /details/i }));
+    fireEvent.change(await screen.findByLabelText(/access token/i), {
+      target: { value: "sk-secret" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /install and connect/i }));
+
+    await waitFor(() => expect(consentSpy).toHaveBeenCalledWith("acme.tracker"));
+    await waitFor(() =>
+      expect(installSpy).toHaveBeenCalledWith(
+        "acme.tracker",
+        expect.objectContaining({
+          consent_token: "tok_abc123",
+          config: { token: "sk-secret" },
+        }),
+      ),
+    );
+  });
+
+  it("hands off a skill entry to the Clients page instead of installing it", async () => {
+    vi.spyOn(api, "searchMarket").mockResolvedValue({ entries: [SKILL_ENTRY], stale: false, notes: {} });
+    vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([]);
+    vi.spyOn(api, "listInstalledAddons").mockResolvedValue([]);
+    const installSpy = vi.spyOn(api, "installMarketEntry");
+
+    mount();
+    fireEvent.click(await screen.findByRole("button", { name: /details/i }));
+
+    expect(await screen.findByRole("link", { name: /go to clients/i })).toHaveAttribute(
+      "href",
+      "/clients",
+    );
+    expect(screen.queryByRole("button", { name: /install and connect/i })).not.toBeInTheDocument();
+    expect(installSpy).not.toHaveBeenCalled();
+  });
+
+  it("opens the deep-linked entry's consent panel from ?install=", async () => {
+    vi.spyOn(api, "searchMarket").mockResolvedValue({ entries: [], stale: false, notes: {} });
+    vi.spyOn(api, "getMarketEntry").mockResolvedValue(FETCH_ENTRY);
+    vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([DEFAULT_PROFILE]);
+    vi.spyOn(api, "listInstalledAddons").mockResolvedValue([]);
+
+    mount("/marketplace?install=palaia.fetch");
+
+    expect(await screen.findByText("Fetch")).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: /install and connect/i })).toBeInTheDocument();
+  });
+
+  it("lists an installed add-on with an update badge and lets it be updated", async () => {
+    vi.spyOn(api, "searchMarket").mockResolvedValue({ entries: [], stale: false, notes: {} });
+    vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([]);
+    vi.spyOn(api, "listInstalledAddons").mockResolvedValue([INSTALLED_FETCH]);
+    const updateSpy = vi.spyOn(api, "updateInstalledAddon").mockResolvedValue({
+      ...INSTALLED_FETCH,
+      update_available: false,
+    });
+
+    mount();
+
+    fireEvent.click(await screen.findByRole("button", { name: /^update$/i }));
+
+    await waitFor(() => expect(updateSpy).toHaveBeenCalledWith("palaia-fetch"));
+  });
+
+  it("removes an installed add-on after confirming", async () => {
+    vi.spyOn(api, "searchMarket").mockResolvedValue({ entries: [], stale: false, notes: {} });
+    vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([]);
+    vi.spyOn(api, "listInstalledAddons").mockResolvedValue([INSTALLED_FETCH]);
+    const uninstallSpy = vi.spyOn(api, "uninstallAddon").mockResolvedValue(undefined);
+
+    mount();
+
+    fireEvent.click(await screen.findByRole("button", { name: /^remove$/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /yes, remove it/i }));
+
+    await waitFor(() => expect(uninstallSpy).toHaveBeenCalledWith("palaia-fetch"));
+  });
+});
+
+/**
+ * SPEC-304 acceptance criterion: "jargon lint on all new UI copy
+ * (SPEC-205's DOM-scan pattern)" — same scoping as every other screen's
+ * own lint: headings, buttons, badges, options, and field labels never
+ * carry this codebase's internal names for the thing a person just reads
+ * as "a connected tool"/"an add-on".
+ */
+describe("Marketplace screen copy — no jargon in the surface (system.md §3 rule 0)", () => {
+  const BANNED = [
+    /\bjson\b/i,
+    /\basgi\b/i,
+    /\brest\b/i,
+    /\burl\b/i,
+    /\bapi\b/i,
+    /\bhttp\b/i,
+    /\bnamespace\b/i,
+    /\bfastmcp\b/i,
+    /\bmcp\b/i,
+    /\bupstream\b/i,
+    /\bstdio\b/i,
+    /\bregistry_ref\b/i,
+    /\bprovenance\b/i,
+  ];
+
+  it("no heading, button, badge, option, or field label uses an implementation word", async () => {
+    vi.spyOn(api, "searchMarket").mockResolvedValue({
+      entries: [FETCH_ENTRY, MANUAL_SECRET_ENTRY],
+      stale: false,
+      notes: {},
+    });
+    vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([DEFAULT_PROFILE]);
+    vi.spyOn(api, "listInstalledAddons").mockResolvedValue([INSTALLED_FETCH]);
+
+    mount();
+    await screen.findAllByRole("button", { name: /details/i });
+    for (const button of screen.getAllByRole("button", { name: /details/i })) {
+      fireEvent.click(button);
+    }
+    await screen.findByRole("button", { name: /install and connect/i });
+
+    const controls = [
+      ...screen.queryAllByRole("heading"),
+      ...screen.queryAllByRole("button"),
+      ...screen.queryAllByRole("option"),
+      ...Array.from(
+        document.querySelectorAll(".badge, .card__title, .card__subject, .field__label"),
+      ),
+    ];
+
+    expect(controls.length).toBeGreaterThan(5);
+    for (const element of controls) {
+      const text = element.textContent ?? "";
+      for (const pattern of BANNED) {
+        expect(text).not.toMatch(pattern);
+      }
+    }
+  });
+});

--- a/v3/web/src/routes/Marketplace.tsx
+++ b/v3/web/src/routes/Marketplace.tsx
@@ -1,0 +1,416 @@
+/**
+ * SPEC-304: the marketplace screen — browse (SPEC-303's merged model:
+ * the official registry, palaia's curated index, and manual entries, all
+ * in one shape), install with one click, see health and updates.
+ *
+ * Every install goes through the same two steps regardless of kind: this
+ * screen's own consent panel (deliverable #3 — kind, source, verified
+ * state, permissions, always shown before a `POST .../install` can
+ * succeed at all: the hub itself refuses one without a fresh consent
+ * token) and, for `remote`/`container` entries, a form generated from the
+ * entry's `config_schema` (deliverable #2). A `skill`/`mcpb`/`plugin`
+ * entry hands off to the Clients page instead — this screen only lists
+ * it (MASTERPLAN §5.3, and this SPEC's own words: "the marketplace lists
+ * them, it does not reinvent their delivery").
+ */
+import { useEffect, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+
+import {
+  Badge,
+  Button,
+  Card,
+  CardBody,
+  CardHead,
+  ConfigSchemaForm,
+  EmptyState,
+  missingRequiredFields,
+  Segmented,
+  useToast,
+  type ConfigFormValues,
+} from "../components";
+import type {
+  GatewayProfile,
+  InstalledAddon,
+  MarketEntry,
+  MarketEntryKind,
+  MarketProvenance,
+} from "../lib/api/client";
+import { api, ApiError } from "../lib/api/client";
+import { InfoIcon, MarketplaceIcon, WarningIcon } from "../shell/icons";
+
+const HANDED_OFF_KINDS: MarketEntryKind[] = ["skill", "mcpb", "plugin"];
+
+const KIND_LABEL: Record<MarketEntryKind, string> = {
+  remote: "Remote server",
+  container: "Runs in a container",
+  mcpb: "Downloadable bundle",
+  skill: "Skill",
+  plugin: "Plugin",
+};
+
+const SOURCE_FILTERS: { value: MarketProvenance | "all"; label: string }[] = [
+  { value: "all", label: "Everything" },
+  { value: "curated", label: "Curated" },
+  { value: "registry", label: "Community registry" },
+  { value: "manual", label: "Added by hand" },
+];
+
+function describeError(err: unknown): string {
+  if (err instanceof ApiError) {
+    const body = err.body as { detail?: string } | undefined;
+    if (body?.detail) return body.detail;
+    return `The hub answered ${err.status}.`;
+  }
+  return "Could not reach the hub.";
+}
+
+function declaredMounts(entry: MarketEntry): string[] {
+  const properties = entry.config_schema?.properties ?? {};
+  return Object.entries(properties)
+    .filter(([, prop]) => prop.format === "path")
+    .map(([key, prop]) => prop.title || key);
+}
+
+function InstallPanel({
+  entry,
+  profiles,
+  onInstalled,
+}: {
+  entry: MarketEntry;
+  profiles: GatewayProfile[];
+  onInstalled: () => void;
+}) {
+  const toast = useToast();
+  const [config, setConfig] = useState<ConfigFormValues>({});
+  const [selectedProfiles, setSelectedProfiles] = useState<Set<string>>(
+    new Set(profiles.some((p) => p.path === "default") ? ["default"] : []),
+  );
+  const [installing, setInstalling] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const mounts = declaredMounts(entry);
+  const missing = missingRequiredFields(entry.config_schema, config);
+
+  function toggleProfile(path: string, on: boolean) {
+    setSelectedProfiles((prev) => {
+      const next = new Set(prev);
+      if (on) next.add(path);
+      else next.delete(path);
+      return next;
+    });
+  }
+
+  async function install() {
+    setInstalling(true);
+    setError(null);
+    try {
+      const { token } = await api.issueMarketConsent(entry.id);
+      await api.installMarketEntry(entry.id, {
+        consent_token: token,
+        config,
+        profiles: [...selectedProfiles],
+      });
+      toast.show(`${entry.name} installed.`);
+      onInstalled();
+    } catch (err) {
+      setError(describeError(err));
+    } finally {
+      setInstalling(false);
+    }
+  }
+
+  return (
+    <div className="stack stack--3">
+      {!entry.verified ? (
+        <div className="banner banner--warn">
+          <WarningIcon className="icon icon--sm" />
+          <div>
+            <p className="banner__title">Not checked by palaia</p>
+            <p className="t-sm t-muted">
+              {entry.provenance === "manual"
+                ? "You added this one yourself — palaia has not reviewed it."
+                : "This came from the open community registry, which anyone can publish to."}
+            </p>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="stack stack--2">
+        <span className="field__label">What it needs</span>
+        {entry.permissions.length === 0 ? (
+          <p className="t-xs t-muted">Nothing beyond running.</p>
+        ) : (
+          <p className="t-xs t-muted">{entry.permissions.join(", ")}</p>
+        )}
+        {entry.kind === "container" ? (
+          <p className="t-xs t-muted">Image: {entry.source.value}</p>
+        ) : null}
+        {mounts.length > 0 ? (
+          <p className="t-xs t-muted">Folders it will read and write: {mounts.join(", ")}</p>
+        ) : null}
+      </div>
+
+      <ConfigSchemaForm schema={entry.config_schema} values={config} onChange={setConfig} />
+
+      {profiles.length > 0 ? (
+        <div className="stack stack--2">
+          <span className="field__label">Which clients should see it</span>
+          {profiles.map((profile) => (
+            <label key={profile.path} className="row" style={{ gap: 8 }}>
+              <input
+                type="checkbox"
+                checked={selectedProfiles.has(profile.path)}
+                onChange={(event) => toggleProfile(profile.path, event.target.checked)}
+              />
+              <span className="t-sm">{profile.label ?? profile.path}</span>
+            </label>
+          ))}
+        </div>
+      ) : null}
+
+      {error ? <p className="field__error">{error}</p> : null}
+
+      <div className="row">
+        <Button
+          variant="primary"
+          onClick={install}
+          disabled={installing || missing.length > 0}
+        >
+          {installing ? "Installing…" : "Install and connect"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function EntryCard({
+  entry,
+  open,
+  onToggle,
+  profiles,
+  onInstalled,
+}: {
+  entry: MarketEntry;
+  open: boolean;
+  onToggle: () => void;
+  profiles: GatewayProfile[];
+  onInstalled: () => void;
+}) {
+  const handedOff = HANDED_OFF_KINDS.includes(entry.kind);
+
+  return (
+    <Card>
+      <CardHead title={entry.name} meta={KIND_LABEL[entry.kind]}>
+        <Button variant="ghost" size="sm" onClick={onToggle} aria-expanded={open}>
+          {open ? "Close" : "Details"}
+        </Button>
+      </CardHead>
+      <CardBody className="stack stack--2">
+        <div className="row row--wrap" style={{ gap: 6 }}>
+          <Badge variant={entry.verified ? "ok" : "warn"}>
+            {entry.verified ? "Checked by palaia" : "Not checked"}
+          </Badge>
+          <span className="t-xs t-subtle">by {entry.maintainer}</span>
+        </div>
+        <p className="t-sm t-muted">{entry.one_liner}</p>
+
+        {open ? (
+          handedOff ? (
+            <div className="stack stack--2">
+              <p className="t-sm t-muted">
+                Set this one up from the Clients page — it is delivered straight to the
+                client you connect, not through this hub.
+              </p>
+              <Link className="btn btn--primary" to="/clients">
+                Go to Clients
+              </Link>
+            </div>
+          ) : (
+            <InstallPanel entry={entry} profiles={profiles} onInstalled={onInstalled} />
+          )
+        ) : null}
+      </CardBody>
+    </Card>
+  );
+}
+
+function InstalledRow({ addon, onChanged }: { addon: InstalledAddon; onChanged: () => void }) {
+  const toast = useToast();
+  const [busy, setBusy] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+
+  async function update() {
+    setBusy(true);
+    try {
+      await api.updateInstalledAddon(addon.upstream_key);
+      toast.show(`${addon.name} updated.`);
+      onChanged();
+    } catch (err) {
+      toast.show(describeError(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function uninstall() {
+    setBusy(true);
+    try {
+      await api.uninstallAddon(addon.upstream_key);
+      toast.show(`${addon.name} removed.`);
+      onChanged();
+    } catch (err) {
+      toast.show(describeError(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="listrow">
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div className="listrow__title">{addon.name}</div>
+        <div className="listrow__meta">{addon.status}</div>
+      </div>
+      <div className="row" style={{ gap: 6 }}>
+        <Badge variant={addon.up ? "ok" : "risk"}>{addon.up ? "running" : "not running"}</Badge>
+        {addon.update_available ? (
+          <Button size="sm" onClick={update} disabled={busy}>
+            {busy ? "Updating…" : "Update"}
+          </Button>
+        ) : null}
+        {confirming ? (
+          <>
+            <Button size="sm" variant="ghost" onClick={() => setConfirming(false)} disabled={busy}>
+              Never mind
+            </Button>
+            <Button size="sm" variant="risk" onClick={uninstall} disabled={busy}>
+              Yes, remove it
+            </Button>
+          </>
+        ) : (
+          <Button size="sm" variant="risk" onClick={() => setConfirming(true)} disabled={busy}>
+            Remove
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function Marketplace() {
+  const [searchParams] = useSearchParams();
+  // The marketplace MCP App's "Install and connect" always deep-links here
+  // instead of installing anything itself (MASTERPLAN §5.7) — read once, as
+  // the initial value of the one piece of state that already tracks which
+  // card is open, rather than a separate effect fighting over it.
+  const [openId, setOpenId] = useState<string | null>(() => searchParams.get("install"));
+  const [query, setQuery] = useState("");
+  const [source, setSource] = useState<MarketProvenance | "all">("all");
+  const [entries, setEntries] = useState<MarketEntry[] | null>(null);
+  const [stale, setStale] = useState(false);
+  const [profiles, setProfiles] = useState<GatewayProfile[]>([]);
+  const [installed, setInstalled] = useState<InstalledAddon[] | null>(null);
+
+  function refreshInstalled() {
+    api
+      .listInstalledAddons()
+      .then(setInstalled)
+      .catch(() => setInstalled([]));
+  }
+
+  useEffect(() => {
+    api
+      .searchMarket(query, source === "all" ? undefined : source)
+      .then((result) => {
+        setEntries(result.entries);
+        setStale(result.stale);
+      })
+      .catch(() => {
+        setEntries([]);
+      });
+  }, [query, source]);
+
+  useEffect(() => {
+    api.listGatewayProfiles().then(setProfiles).catch(() => setProfiles([]));
+    refreshInstalled();
+  }, []);
+
+  // The deep-linked entry might not be in the current search results at
+  // all (a curated entry reached from outside any query) — fetch it once
+  // and fold it in, so its consent panel (already open, above) has
+  // something real to show.
+  useEffect(() => {
+    if (!openId || entries === null || entries.some((e) => e.id === openId)) return;
+    api
+      .getMarketEntry(openId)
+      .then((entry) => setEntries((prev) => [entry, ...(prev ?? [])]))
+      .catch(() => {
+        // The linked entry no longer exists — the panel below already
+        // says plainly that nothing matched, no extra handling needed.
+      });
+  }, [openId, entries]);
+
+  return (
+    <section className="stack stack--4">
+      <div className="row row--wrap" style={{ justifyContent: "space-between" }}>
+        <p className="t-sm t-muted" style={{ maxWidth: 560 }}>
+          Add-ons for every client at once: browse, install with one click, and see what needs
+          updating — all from here.
+        </p>
+      </div>
+
+      <div className="row row--wrap" style={{ gap: 12 }}>
+        <input
+          className="input"
+          style={{ maxWidth: 280 }}
+          placeholder="Search add-ons…"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+        />
+        <Segmented options={SOURCE_FILTERS} value={source} onChange={setSource} />
+      </div>
+
+      {stale ? (
+        <div className="banner banner--warn">
+          <InfoIcon className="icon icon--sm" />
+          <p className="t-sm t-muted">
+            Showing the last copy palaia saved — it could not reach every source just now.
+          </p>
+        </div>
+      ) : null}
+
+      {entries && entries.length === 0 ? (
+        <EmptyState mark={<MarketplaceIcon className="icon--lg" />} title="Nothing matched.">
+          Try a different search, or check back once the curated list grows.
+        </EmptyState>
+      ) : (
+        <div className="stack stack--3">
+          {(entries ?? []).map((entry) => (
+            <EntryCard
+              key={entry.id}
+              entry={entry}
+              open={openId === entry.id}
+              onToggle={() => setOpenId((current) => (current === entry.id ? null : entry.id))}
+              profiles={profiles}
+              onInstalled={() => {
+                setOpenId(null);
+                refreshInstalled();
+              }}
+            />
+          ))}
+        </div>
+      )}
+
+      {installed && installed.length > 0 ? (
+        <div className="stack stack--2">
+          <span className="field__label">Installed</span>
+          <Card>
+            {installed.map((addon) => (
+              <InstalledRow key={addon.upstream_key} addon={addon} onChanged={refreshInstalled} />
+            ))}
+          </Card>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/v3/web/src/routes/ToolProfiles.test.tsx
+++ b/v3/web/src/routes/ToolProfiles.test.tsx
@@ -2,7 +2,13 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ToastProvider } from "../components/Toast";
-import type { GatewayProfile, GatewayTool, GatewayVaultIdentity, VaultSummary } from "../lib/api/client";
+import type {
+  GatewayProfile,
+  GatewayTool,
+  GatewayUpstream,
+  GatewayVaultIdentity,
+  VaultSummary,
+} from "../lib/api/client";
 import { api, ApiError } from "../lib/api/client";
 import { ToolProfiles } from "./ToolProfiles";
 
@@ -24,6 +30,7 @@ const DEFAULT_PROFILE: GatewayProfile = {
   hidden_tools: [],
   semantic_routing: false,
   tool_count: 15,
+  upstreams: [],
   managed: false,
 };
 
@@ -35,7 +42,24 @@ const CURATOR_PROFILE: GatewayProfile = {
   hidden_tools: [],
   semantic_routing: false,
   tool_count: 15,
+  upstreams: [],
   managed: true,
+};
+
+const FETCH_UPSTREAM: GatewayUpstream = {
+  key: "fetch",
+  kind: "stdio",
+  display_name: "Fetch",
+  namespace: "fetch",
+  enabled: true,
+  target: "docker run --rm -i ghcr.io/palaia/addon-fetch:1.0.0",
+  profiles: [],
+  up: true,
+  status: "Connected — 1 tool.",
+  checked_at: 1_700_000_000,
+  tools: ["fetch"],
+  secret_names: [],
+  tool_renames: {},
 };
 
 const WORK_TOOLS: GatewayTool[] = [
@@ -69,6 +93,7 @@ describe("ToolProfiles screen (SPEC-305)", () => {
     vi.spyOn(api, "listGatewayProfiles").mockRejectedValue(NOT_MOUNTED);
     vi.spyOn(api, "listGatewayVaults").mockResolvedValue([]);
     vi.spyOn(api, "listVaults").mockResolvedValue([]);
+    vi.spyOn(api, "listGatewayUpstreams").mockResolvedValue([]);
 
     mount();
 
@@ -81,6 +106,7 @@ describe("ToolProfiles screen (SPEC-305)", () => {
     vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([DEFAULT_PROFILE]);
     vi.spyOn(api, "listGatewayVaults").mockResolvedValue([WORK_VAULT_IDENTITY]);
     vi.spyOn(api, "listVaults").mockResolvedValue([WORK_VAULT]);
+    vi.spyOn(api, "listGatewayUpstreams").mockResolvedValue([]);
 
     mount();
 
@@ -92,6 +118,7 @@ describe("ToolProfiles screen (SPEC-305)", () => {
     vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([CURATOR_PROFILE]);
     vi.spyOn(api, "listGatewayVaults").mockResolvedValue([WORK_VAULT_IDENTITY]);
     vi.spyOn(api, "listVaults").mockResolvedValue([WORK_VAULT]);
+    vi.spyOn(api, "listGatewayUpstreams").mockResolvedValue([]);
 
     mount();
 
@@ -103,6 +130,7 @@ describe("ToolProfiles screen (SPEC-305)", () => {
     const listSpy = vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([]);
     vi.spyOn(api, "listGatewayVaults").mockResolvedValue([WORK_VAULT_IDENTITY]);
     vi.spyOn(api, "listVaults").mockResolvedValue([WORK_VAULT]);
+    vi.spyOn(api, "listGatewayUpstreams").mockResolvedValue([]);
     const createSpy = vi.spyOn(api, "createGatewayProfile").mockResolvedValue({
       ...DEFAULT_PROFILE,
       path: "codex",
@@ -122,8 +150,35 @@ describe("ToolProfiles screen (SPEC-305)", () => {
 
     await waitFor(() =>
       expect(createSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ path: "codex", vaults: ["work"] }),
+        expect.objectContaining({ path: "codex", vaults: ["work"], upstreams: [] }),
       ),
+    );
+  });
+
+  it("assigns a connected tool to a new profile through its checkbox", async () => {
+    const listSpy = vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([]);
+    vi.spyOn(api, "listGatewayVaults").mockResolvedValue([WORK_VAULT_IDENTITY]);
+    vi.spyOn(api, "listVaults").mockResolvedValue([WORK_VAULT]);
+    vi.spyOn(api, "listGatewayUpstreams").mockResolvedValue([FETCH_UPSTREAM]);
+    const createSpy = vi.spyOn(api, "createGatewayProfile").mockResolvedValue({
+      ...DEFAULT_PROFILE,
+      path: "codex",
+      upstreams: ["fetch"],
+    });
+
+    mount();
+    await screen.findByText(/no tool profiles yet/i);
+
+    fireEvent.click(screen.getByRole("button", { name: /new tool profile/i }));
+    fireEvent.change(screen.getByLabelText(/address segment/i), {
+      target: { value: "codex" },
+    });
+    fireEvent.click(await screen.findByLabelText(/^fetch/i));
+    listSpy.mockResolvedValue([{ ...DEFAULT_PROFILE, path: "codex", upstreams: ["fetch"] }]);
+    fireEvent.click(screen.getByRole("button", { name: /^create$/i }));
+
+    await waitFor(() =>
+      expect(createSpy).toHaveBeenCalledWith(expect.objectContaining({ upstreams: ["fetch"] })),
     );
   });
 
@@ -131,6 +186,7 @@ describe("ToolProfiles screen (SPEC-305)", () => {
     vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([DEFAULT_PROFILE]);
     vi.spyOn(api, "listGatewayVaults").mockResolvedValue([WORK_VAULT_IDENTITY]);
     vi.spyOn(api, "listVaults").mockResolvedValue([WORK_VAULT]);
+    vi.spyOn(api, "listGatewayUpstreams").mockResolvedValue([FETCH_UPSTREAM]);
     vi.spyOn(api, "listGatewayProfileTools").mockResolvedValue(WORK_TOOLS);
     const updateSpy = vi.spyOn(api, "updateGatewayProfile").mockResolvedValue({
       ...DEFAULT_PROFILE,
@@ -152,10 +208,35 @@ describe("ToolProfiles screen (SPEC-305)", () => {
     );
   });
 
+  it("assigns an already-connected tool to an existing profile through its checkbox", async () => {
+    vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([DEFAULT_PROFILE]);
+    vi.spyOn(api, "listGatewayVaults").mockResolvedValue([WORK_VAULT_IDENTITY]);
+    vi.spyOn(api, "listVaults").mockResolvedValue([WORK_VAULT]);
+    vi.spyOn(api, "listGatewayUpstreams").mockResolvedValue([FETCH_UPSTREAM]);
+    vi.spyOn(api, "listGatewayProfileTools").mockResolvedValue(WORK_TOOLS);
+    const updateSpy = vi.spyOn(api, "updateGatewayProfile").mockResolvedValue({
+      ...DEFAULT_PROFILE,
+      upstreams: ["fetch"],
+    });
+
+    mount();
+    fireEvent.click(await screen.findByRole("button", { name: /^edit$/i }));
+    fireEvent.click(await screen.findByLabelText(/^fetch/i));
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() =>
+      expect(updateSpy).toHaveBeenCalledWith(
+        "default",
+        expect.objectContaining({ upstreams: ["fetch"] }),
+      ),
+    );
+  });
+
   it("cannot delete the default profile", async () => {
     vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([DEFAULT_PROFILE]);
     vi.spyOn(api, "listGatewayVaults").mockResolvedValue([WORK_VAULT_IDENTITY]);
     vi.spyOn(api, "listVaults").mockResolvedValue([WORK_VAULT]);
+    vi.spyOn(api, "listGatewayUpstreams").mockResolvedValue([]);
 
     mount();
 
@@ -166,6 +247,7 @@ describe("ToolProfiles screen (SPEC-305)", () => {
   it("renames a vault's tool and reports a sanitized value", async () => {
     vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([DEFAULT_PROFILE]);
     vi.spyOn(api, "listVaults").mockResolvedValue([WORK_VAULT]);
+    vi.spyOn(api, "listGatewayUpstreams").mockResolvedValue([]);
     const listVaultsSpy = vi
       .spyOn(api, "listGatewayVaults")
       .mockResolvedValue([WORK_VAULT_IDENTITY]);
@@ -213,6 +295,7 @@ describe("ToolProfiles screen copy — no jargon in the surface (system.md §3 r
     vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([DEFAULT_PROFILE]);
     vi.spyOn(api, "listGatewayVaults").mockResolvedValue([WORK_VAULT_IDENTITY]);
     vi.spyOn(api, "listVaults").mockResolvedValue([WORK_VAULT]);
+    vi.spyOn(api, "listGatewayUpstreams").mockResolvedValue([FETCH_UPSTREAM]);
     vi.spyOn(api, "listGatewayProfileTools").mockResolvedValue(WORK_TOOLS);
 
     mount();

--- a/v3/web/src/routes/ToolProfiles.tsx
+++ b/v3/web/src/routes/ToolProfiles.tsx
@@ -22,6 +22,7 @@ import {
 import type {
   GatewayProfile,
   GatewayTool,
+  GatewayUpstream,
   GatewayVaultIdentity,
   VaultSummary,
 } from "../lib/api/client";
@@ -101,20 +102,60 @@ function ToolVisibilityList({
   );
 }
 
+/** SPEC-304 follow-up: the checkbox section next to the vault list — an
+ * installed marketplace add-on (or any server connected under Tools &
+ * skills) becomes usable by a profile here, the same way a vault does.
+ * "Connected tools" rather than "upstream servers": the latter is this
+ * codebase's own internal name for the thing, not a word a person reading
+ * this screen needs. */
+function ConnectedToolsList({
+  upstreams,
+  selected,
+  onToggle,
+}: {
+  upstreams: GatewayUpstream[];
+  selected: Set<string>;
+  onToggle: (key: string, on: boolean) => void;
+}) {
+  if (upstreams.length === 0) {
+    return <span className="t-xs t-muted">No external tools connected yet.</span>;
+  }
+  return (
+    <div className="stack stack--2">
+      {upstreams.map((upstream) => (
+        <label key={upstream.key} className="row" style={{ gap: 8 }}>
+          <input
+            type="checkbox"
+            checked={selected.has(upstream.key)}
+            onChange={(event) => onToggle(upstream.key, event.target.checked)}
+          />
+          <span className="t-sm">{upstream.display_name}</span>
+          <span className="t-xs t-subtle">{upstream.up ? "connected" : "not responding"}</span>
+        </label>
+      ))}
+    </div>
+  );
+}
+
 function ProfileEditForm({
   profile,
   vaults,
+  upstreams,
   onSaved,
   onCancel,
 }: {
   profile: GatewayProfile;
   vaults: VaultSummary[];
+  upstreams: GatewayUpstream[];
   onSaved: () => void;
   onCancel: () => void;
 }) {
   const toast = useToast();
   const [label, setLabel] = useState(profile.label ?? "");
   const [selectedVaults, setSelectedVaults] = useState<Set<string>>(new Set(profile.vaults));
+  const [selectedUpstreams, setSelectedUpstreams] = useState<Set<string>>(
+    new Set(profile.upstreams),
+  );
   const [stash, setStash] = useState(profile.stash);
   const [semanticRouting, setSemanticRouting] = useState(profile.semantic_routing);
   const [tools, setTools] = useState<GatewayTool[] | null>(null);
@@ -146,6 +187,15 @@ function ProfileEditForm({
     });
   }
 
+  function toggleUpstream(key: string, on: boolean) {
+    setSelectedUpstreams((prev) => {
+      const next = new Set(prev);
+      if (on) next.add(key);
+      else next.delete(key);
+      return next;
+    });
+  }
+
   function toggleTool(name: string, visible: boolean) {
     setHidden((prev) => {
       const next = new Set(prev);
@@ -165,6 +215,7 @@ function ProfileEditForm({
         stash,
         hidden_tools: [...hidden],
         semantic_routing: semanticRouting,
+        upstreams: [...selectedUpstreams],
       });
       toast.show(`${profile.path} saved.`);
       onSaved();
@@ -203,6 +254,15 @@ function ProfileEditForm({
             <span className="t-xs t-muted">No vaults exist yet.</span>
           ) : null}
         </div>
+      </div>
+
+      <div className="stack stack--2">
+        <span className="field__label">Connected tools this profile can use</span>
+        <ConnectedToolsList
+          upstreams={upstreams}
+          selected={selectedUpstreams}
+          onToggle={toggleUpstream}
+        />
       </div>
 
       <SwitchRow
@@ -306,10 +366,12 @@ function DeleteProfileControl({
 function ProfileCard({
   profile,
   vaults,
+  upstreams,
   onChanged,
 }: {
   profile: GatewayProfile;
   vaults: VaultSummary[];
+  upstreams: GatewayUpstream[];
   onChanged: () => void;
 }) {
   const toast = useToast();
@@ -360,6 +422,7 @@ function ProfileCard({
           <ProfileEditForm
             profile={profile}
             vaults={vaults}
+            upstreams={upstreams}
             onSaved={() => {
               setEditing(false);
               onChanged();
@@ -388,10 +451,12 @@ function ProfileCard({
 
 function CreateProfileCard({
   vaults,
+  upstreams,
   existingPaths,
   onCreated,
 }: {
   vaults: VaultSummary[];
+  upstreams: GatewayUpstream[];
   existingPaths: Set<string>;
   onCreated: () => void;
 }) {
@@ -400,6 +465,7 @@ function CreateProfileCard({
   const [path, setPath] = useState("");
   const [label, setLabel] = useState("");
   const [selectedVaults, setSelectedVaults] = useState<Set<string>>(new Set());
+  const [selectedUpstreams, setSelectedUpstreams] = useState<Set<string>>(new Set());
   const [stash, setStash] = useState(false);
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -424,6 +490,15 @@ function CreateProfileCard({
     });
   }
 
+  function toggleUpstream(key: string, on: boolean) {
+    setSelectedUpstreams((prev) => {
+      const next = new Set(prev);
+      if (on) next.add(key);
+      else next.delete(key);
+      return next;
+    });
+  }
+
   async function create() {
     if (!cleanPath || pathTaken) return;
     setCreating(true);
@@ -434,12 +509,14 @@ function CreateProfileCard({
         label: label.trim() || null,
         vaults: [...selectedVaults],
         stash,
+        upstreams: [...selectedUpstreams],
       });
       toast.show(`${cleanPath} created.`);
       setOpen(false);
       setPath("");
       setLabel("");
       setSelectedVaults(new Set());
+      setSelectedUpstreams(new Set());
       setStash(false);
       onCreated();
     } catch (err) {
@@ -479,6 +556,14 @@ function CreateProfileCard({
               <span className="t-sm">{vault.key}</span>
             </label>
           ))}
+        </div>
+        <div className="stack stack--2">
+          <span className="field__label">Connected tools</span>
+          <ConnectedToolsList
+            upstreams={upstreams}
+            selected={selectedUpstreams}
+            onToggle={toggleUpstream}
+          />
         </div>
         <SwitchRow
           label="Also carry the built-in stash tools"
@@ -596,6 +681,7 @@ export function ToolProfiles() {
   const [profiles, setProfiles] = useState<GatewayProfile[] | null>(null);
   const [vaultIdentities, setVaultIdentities] = useState<GatewayVaultIdentity[]>([]);
   const [vaultSummaries, setVaultSummaries] = useState<VaultSummary[]>([]);
+  const [upstreams, setUpstreams] = useState<GatewayUpstream[]>([]);
   const [available, setAvailable] = useState(true);
 
   function refresh() {
@@ -610,6 +696,7 @@ export function ToolProfiles() {
       });
     api.listGatewayVaults().then(setVaultIdentities).catch(() => setVaultIdentities([]));
     api.listVaults().then(setVaultSummaries).catch(() => setVaultSummaries([]));
+    api.listGatewayUpstreams().then(setUpstreams).catch(() => setUpstreams([]));
   }
 
   useEffect(refresh, []);
@@ -638,6 +725,7 @@ export function ToolProfiles() {
         </p>
         <CreateProfileCard
           vaults={vaultSummaries}
+          upstreams={upstreams}
           existingPaths={new Set((profiles ?? []).map((p) => p.path))}
           onCreated={refresh}
         />
@@ -655,6 +743,7 @@ export function ToolProfiles() {
               key={profile.path}
               profile={profile}
               vaults={vaultSummaries}
+              upstreams={upstreams}
               onChanged={refresh}
             />
           ))}

--- a/v3/web/src/routes/index.tsx
+++ b/v3/web/src/routes/index.tsx
@@ -8,14 +8,15 @@ import { ComingSoon } from "./ComingSoon";
 import { Explorer } from "./Explorer";
 import { Exposure } from "./Exposure";
 import { Home } from "./Home";
+import { Marketplace } from "./Marketplace";
 import { Onboarding } from "./onboarding/Onboarding";
 import { Settings } from "./Settings";
 import { ToolProfiles } from "./ToolProfiles";
 
-// Paths SPEC-110/SPEC-201/SPEC-204/SPEC-205/SPEC-305 build a real screen
-// for — everything else in NAV_GROUPS still falls through to ComingSoon
-// below, so no nav destination is ever a dead link (SPEC-109's rule,
-// carried forward).
+// Paths SPEC-110/SPEC-201/SPEC-204/SPEC-205/SPEC-305/SPEC-304 build a real
+// screen for — everything else in NAV_GROUPS still falls through to
+// ComingSoon below, so no nav destination is ever a dead link (SPEC-109's
+// rule, carried forward).
 const BUILT_PATHS = new Set([
   "/",
   "/explorer",
@@ -24,6 +25,7 @@ const BUILT_PATHS = new Set([
   "/exposure",
   "/settings",
   "/tools",
+  "/marketplace",
 ]);
 
 const placeholderRoutes = NAV_GROUPS.flatMap((group) => group.items)
@@ -49,6 +51,7 @@ export const router = createBrowserRouter([
       { path: "exposure", element: <Exposure /> },
       { path: "settings", element: <Settings /> },
       { path: "tools", element: <ToolProfiles /> },
+      { path: "marketplace", element: <Marketplace /> },
       ...placeholderRoutes,
     ],
   },

--- a/v3/web/src/shell/icons.tsx
+++ b/v3/web/src/shell/icons.tsx
@@ -192,3 +192,14 @@ export function WarningIcon(props: SVGProps<SVGSVGElement>) {
     </Icon>
   );
 }
+
+/** SPEC-304: the marketplace nav item — a storefront glyph. */
+export function MarketplaceIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <Icon {...props}>
+      <path d="M4 9.5 5.5 4h13L20 9.5" />
+      <path d="M4 9.5h16V19a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1z" />
+      <path d="M9 9.5a3 3 0 0 0 6 0" />
+    </Icon>
+  );
+}

--- a/v3/web/src/shell/navConfig.tsx
+++ b/v3/web/src/shell/navConfig.tsx
@@ -8,6 +8,7 @@ import {
   HomeIcon,
   InboxIcon,
   LinkIcon,
+  MarketplaceIcon,
   ReviewIcon,
   SettingsIcon,
   ToolsIcon,
@@ -50,6 +51,7 @@ export const NAV_GROUPS: NavGroupConfig[] = [
     items: [
       { path: "/clients", label: "Clients", icon: ClientsIcon },
       { path: "/tools", label: "Tools & skills", icon: ToolsIcon },
+      { path: "/marketplace", label: "Marketplace", icon: MarketplaceIcon },
     ],
   },
   {


### PR DESCRIPTION
## Summary

Implements SPEC-304 (Marketplace v1) on top of SPEC-302's upstream/secret-store machinery and SPEC-303's merged read model:

- **Install flows per entry kind** (`palaia_hub.market.install`): `remote` (direct `url`, or a `registry_ref` resolved against the official registry's `server.json` — a `remotes[]` entry becomes `http`, a `packages[]` entry becomes a `stdio` upstream running `npx`/`uvx`/`dnx`); `container` (pull the declared image, run it as `docker run --rm -i` and connect it as an ordinary `stdio` upstream — see `palaia_hub.market.docker_runtime` for why this gets restart-on-crash and "no leftover container" for free from fastmcp's own dead-session reconnect + docker's `--rm`); `skill`/`mcpb`/`plugin` refused with a plain-language hand-off to the connect page.
- **Config UI generated from `config_schema`** (`ConfigSchemaForm.tsx`): string/number/boolean/enum/secret, `format: "path"` marks a declared container mount.
- **Consent screen + fixed consent-token gate** (`ConsentStore` in `install.py`): `POST /api/market/entry/{id}/consent` issues a short-lived, single-use, entry-bound token; `install` refuses without a valid one — structurally, not just a UI convention.
- **Update surface**: `addon.update_available` event (fires when the curated index refreshes and an installed container's image no longer matches), one-click `POST /api/market/installed/{key}/update`, `GET /api/market/installed` for the dashboard badge/list.
- **Marketplace MCP App** (`gateway/apps/market_app.py`, mounted at `/mcp/market`): browse/search card grid + inline detail; its "Install and connect" is a plain `<a target="_blank">` deep link to the dashboard (`config.exposure.public_url` + `/marketplace?install=<id>`) — it never calls a server tool to install.
- **Marketplace dashboard screen** (`Marketplace.tsx`, nav: Connections → Marketplace): browse/search/filter, the consent+config+profile-picker panel, installed list with update/uninstall.
- **Follow-up requested in the task**: added the upstream-servers checkbox section to the profile editor (`ToolProfiles.tsx`) next to the vault checkboxes, wired to the same `upstreams` field the REST already supported.

## Acceptance checklist

- [x] e2e: one-click install of a `remote` fixture upstream → its tool callable through a profile without restart (`test_install.py::test_one_click_install_of_a_remote_entry_is_callable_without_a_restart`) — installed from a **manual**-provenance entry rather than literally a curated-index one; see Deviations.
- [x] container lifecycle against a fixture image: install → running → health visible → update → uninstall leaves no container behind, env-gated on docker availability, skipped honestly otherwise (`test_install_container.py`) — see Deviations for why this could not be exercised for real in this sandbox.
- [x] a `secret` config field round-trips into the secret store and is never present in any subsequent GET (`test_install.py::test_a_secret_config_field_round_trips_and_never_comes_back`).
- [x] consent screen renders permissions + verified state; install without a consent POST is impossible (`test_install.py`'s consent tests: missing/reused/cross-entry tokens all refused with 400; `Marketplace.test.tsx`'s consent-gated install test).
- [x] marketplace app renders in a host harness (SPEC-208 pattern), install action deep-links instead of installing (`test_apps_market.py`).
- [x] jargon lint on all new UI copy (`Marketplace.test.tsx`'s own lint describe block; `ToolProfiles.test.tsx`'s existing lint now also scans the new upstream-checkbox section).

## Verification (from `v3/`)

- `uv run ruff check server` → all checks passed
- `uv run mypy server/src` → Success: no issues found in 169 source files
- `uv run pytest server/tests -q` → **1709 passed, 16 skipped** (the container-lifecycle test is one of the 16; skipped honestly — this sandbox's docker CLI exists but its daemon is unreachable)
- `npm run typecheck` (web) → clean
- `npx vitest run` (web) → **73 passed** (16 files)
- `npm run lint` (web) → 0 errors (4 pre-existing `react-refresh` warnings, same class already present on `ConnectPanel.tsx`/`Toast.tsx`/`theme.tsx` before this PR)
- `npm run build` (web) → succeeds

## Deviations / notes for the reviewer

1. **"From a curated-index entry"** — the e2e install test uses a `manual`-provenance fixture rather than a literal curated-index one. `InstallService.install()` dispatches purely on `entry.kind`/`entry.source`, which SPEC-303's own contract test already proves is identical across all three provenances (`MarketEntry` is one shape regardless of source) — so this is functionally the same path, just without needing a second signed-index fixture. Flagging rather than hiding it.
2. **Container lifecycle test is unverified in this sandbox.** Docker's CLI is present but its daemon is unreachable here (`Cannot connect to the Docker daemon`), so `test_install_container.py` skips honestly — exactly the behavior the acceptance criterion asks for. The test builds a real tiny image (the existing `fixture_stdio_server.py` + `fastmcp`) and drives install → probe → update → uninstall → `docker ps -a` against it; it needs a real reachable daemon (and network, to build the image) to actually run.
3. **Pre-existing bug found, not fixed (out of scope):** `palaia_hub.upstream.api`'s own `_persist()` closure drops a profile's `hidden_tools`/`semantic_routing` on every upstream connect/update/disconnect (compare it to `gateway/api.py`'s own `_persist`, which includes both). I did not touch that file — my own equivalent, `gateway.settings_bridge.snapshot_gateway_settings` (a new, purely additive helper reused only by `market/install.py`), includes both fields correctly. Worth a follow-up fix to `upstream/api.py` outside this PR.
4. **Scope trim:** no dashboard UI was added for *creating* a manual marketplace entry — SPEC-303 already ships that REST endpoint (`POST /api/market/manual`); SPEC-304's job is browsing/installing across all three sources (delivered), not a second write surface for manual entries.
5. `registry_ref` → `stdio` resolution reads `packages[].registry_type/identifier/version/runtime_hint/package_arguments` per the official registry's `server.json` schema (cited in `v3/research/mcp-landscape-2026.md` §4); only npm/pypi/nuget resolve automatically — anything else is refused with a plain reason rather than guessed at. Not exercised against a live registry call (network-gated, same honesty posture SPEC-303's own registry tests already use); covered by a mocked-registry unit test instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790179386&installation_model_id=428086&pr_number=246&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F246&signature=8064006b43be9ed48caf75be44f2005d424906df1ea8eee69bb156da00a1dbe9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->