### PR TITLE
feat(v3): SPEC-308 Phase-3 gate evidence

### DIFF
--- a/v3/IMPLEMENTATION.md
+++ b/v3/IMPLEMENTATION.md
@@ -204,3 +204,24 @@ foundation and integrates first) → **3b** = 302, 305 (both need 301) →
   this environment can fake honestly. Reviewer: **Fable 5** (writes the
   Phase-3 SPECs at this gate) + owner (phone test + UX pass on the new
   exposure/settings/review screens).
+- **Gate P3→P4 (draft — the architect holds the gate):** SPEC-308 assembled
+  the evidence for the Phase-3 exit criterion, *"install a tool once, every
+  AI has it"* — it does not itself decide whether the gate is met; that
+  judgment is the architect's (Fable 5 + owner), same as every prior gate.
+  What SPEC-308 put on the table: a curated-index entry, installed exactly
+  once through the real `/api/market/*` REST flow (consent token included)
+  onto two gateway profiles at once, then read back by two differently
+  authenticated real clients with zero client-side tool configuration — the
+  real `claude` CLI over a real OAuth 2.1 + PKCE code flow, and a scripted
+  `fastmcp.Client` carrying a real SPEC-108 `plt_` token — and, separately,
+  through the real SPEC-306 stdio proxy with no bundle rebuild in between
+  (`v3/docs/client-matrix-results.md` §7 has the full trace, run three times
+  with no flakes). No new quirks were filed this time (SPEC-301's
+  OAuth+`plt_` combination and SPEC-304's install flow both behaved exactly
+  as documented on the first real two-profile run). What this evidence does
+  **not** cover, honestly: the dashboard's own UI (only its REST surface was
+  driven), a real public tunnel in front of the hub, and Claude Desktop's
+  own MCPB install dialog (§6 already carries that gap; SPEC-308 adds
+  nothing new there). Whether that residual scope is acceptable for the
+  gate, and what Phase 4 should look like, is the architect's call to make
+  at the review this paragraph is drafted for.

--- a/v3/docs/client-matrix-results.md
+++ b/v3/docs/client-matrix-results.md
@@ -294,3 +294,104 @@ a bundle from a reachable hub and double-clicking it, would close both
 gaps — the same "needs a real device/account this sandbox cannot fake
 honestly" situation §0 and the Phase-2 gate note already describe for the
 phone-Claude half of the exit criterion.
+
+## 7. Phase-3 gate: tools follow the profile (SPEC-308, 2026-08-24)
+
+The Phase-3 exit criterion is narrower than the client matrix above and
+was checked separately: **install a tool once (marketplace), and it is
+available to every connected AI — different clients, different profiles,
+no per-client setup.** Scripted evidence lives in
+[`v3/server/tests/e2e/test_spec308_phase3_gate.py`](../server/tests/e2e/test_spec308_phase3_gate.py),
+against a new hub subprocess,
+[`support/hub_server_market.py`](../server/tests/e2e/support/hub_server_market.py),
+that wires `palaia_hub.serve.build_production_app` exactly the way
+`palaia-hub serve` does — real `VaultEngine`, real `AuthorizationServer`,
+real marketplace/install machinery, two gateway profiles (`default`,
+`mobile`) both accepting OAuth *and* SPEC-108 `plt_` tokens at once — over
+a real `uvicorn` socket.
+
+### 7.1 What was actually run
+
+```
+$ cd v3 && uv run pytest server/tests/e2e/test_spec308_phase3_gate.py -q
+..                                                                       [100%]
+2 passed in 32.84s
+```
+Run three times in a row (32.84s, 30.39s, 35.38s) with no flakes. The full
+`tests/e2e/` directory (33 tests, including SPEC-209's and SPEC-306's own
+suites) was also run twice end-to-end with this new file added, both green
+(176.40s, 174.65s) — no regression in the pre-existing harness.
+
+### 7.2 One install, two differently-authenticated clients, two profiles
+
+`test_one_install_answers_on_two_differently_authenticated_clients`:
+
+1. A **curated-index entry** — a genuinely Ed25519-signed one-entry
+   document (a freshly-generated, throwaway signing key; see
+   `hub_server_market.py`'s docstring for why that is honest evidence for
+   "a signed curated document verifies" without needing palaia's real,
+   non-public index key) naming a real second FastMCP server
+   (`tests/upstream/fixture_http_server.py`, SPEC-302's own fixture) as a
+   `remote` upstream — is fetched and verified through the real
+   `GET /api/market/search?source=curated`.
+2. `POST /api/market/entry/{id}/consent` → `POST
+   /api/market/entry/{id}/install` with `profiles: ["default", "mobile"]`
+   — the same consent-token-gated REST flow SPEC-304's own tests exercise,
+   run here for real over a live socket. One call, both profiles:
+   ```
+   {"upstream_key": "acme-spec308-fixture", ..., "up": true,
+    "profiles": ["default", "mobile"], ...}
+   ```
+3. **Client A — a scripted `fastmcp.Client` with a real SPEC-108 `plt_`
+   token** (minted through `POST /api/auth/tokens`, zero client-side tool
+   configuration), against the `mobile` profile: `list_tools()` already
+   contains `acme_spec308_fixture_echo`; calling it returns
+   `"hello from the plt_ client"`.
+4. **Client B — the real `claude` CLI**, over a real scripted OAuth 2.1 +
+   PKCE code flow (SPEC-209's own machinery, reused verbatim) against the
+   `default` profile: `claude mcp add --transport http ... --header
+   "Authorization: Bearer <token>"`, `claude mcp get` reports `√
+   Connected`, and `claude -p "Call
+   mcp__palaia-spec308-e2e__acme_spec308_fixture_echo ..."` returns
+   `"hello from claude CLI"`.
+
+Same upstream, same tool, one install call — reached by two clients with
+completely different credential shapes, on two different profiles, with no
+client-side tool declaration on either side. This is the exit criterion,
+demonstrated for real, on the same loopback-hub basis §2's note already
+explains (a local CLI/scripted client never goes through a vendor cloud in
+the first place, so it reaches this listener exactly as it would reach a
+tunnel's local termination point).
+
+### 7.3 The same install, through the SPEC-306 stdio proxy, no bundle change
+
+`test_the_install_is_visible_through_the_mcpb_stdio_proxy_without_bundle_changes`:
+the real `palaia-proxy.mjs` (Node subprocess, real stdio transport — same
+proof shape as `test_mcpb_proxy.py`) is pointed at the `mobile` profile
+with a freshly-minted `plt_` token, **after** the install above, with no
+change to the proxy script, no rebuild, no bundle edit. `list_tools()`
+already contains `acme_spec308_fixture_echo`; calling it through the proxy
+returns `"hello through the stdio proxy"`. The stdio path is not a
+separately-curated tool list — it mirrors whatever the profile serves,
+live, exactly as the HTTP paths do.
+
+### 7.4 Honest gaps
+
+- **The dashboard's own UI** was not driven for this evidence — only the
+  REST surface it calls. Whether the marketplace page's own React state
+  updates live (rather than needing a reload) after an install is
+  unverified here; SPEC-304's own dashboard work is the place that would
+  be checked, not this gate.
+- **A real public tunnel** in front of the hub was not part of this
+  evidence, for the same reason §2's note gives: this sandbox cannot add
+  one honestly, and none of the three clients above go through a vendor
+  cloud to reach a *local* hub anyway.
+- **Claude Desktop's own MCPB install dialog** remains exactly as
+  unverified as §6 already says — SPEC-308 adds no new evidence there; the
+  stdio proxy itself (§7.3) is the part of that path this sandbox can
+  drive for real.
+- No quirks were found while writing this evidence (unlike SPEC-209's
+  #232/#233) — the existing `build_production_app`/`build_profile_auth`
+  combination (SPEC-301) and the marketplace install flow (SPEC-304) both
+  worked exactly as documented on the first real run against two profiles
+  at once.

--- a/v3/server/tests/e2e/support/hub_server_market.py
+++ b/v3/server/tests/e2e/support/hub_server_market.py
@@ -1,0 +1,199 @@
+"""SPEC-308 e2e hub process: a real hub wired the exact way ``palaia-hub
+serve`` wires one (:func:`palaia_hub.serve.build_production_app`, same as
+``hub_server_oauth.py`` and ``cli.py`` itself), plus a curated-index entry
+that is real for real: a signed document, fetched and Ed25519-verified by
+the genuine :mod:`palaia_hub.market.curated` code path.
+
+The point this script exists to prove is the Phase-3 gate's exit criterion
+literally: *install a tool once, and it is available to every connected
+AI* — so it mounts **two** gateway profiles (``default`` and ``mobile``)
+over the same vault, with **both** SPEC-203 OAuth and SPEC-108 ``plt_``
+tokens accepted on either one (``build_production_app``'s own
+``build_profile_auth`` combination, unchanged). A marketplace install made
+once, through the real ``/api/market/*`` REST surface, is mounted on both
+profiles at once — the test file connects to ``default`` with a real OAuth
+access token (the real ``claude`` CLI) and to ``mobile`` with a real
+``plt_`` token (a scripted ``fastmcp.Client``), and both must see the same
+newly-installed tool.
+
+**Why the curated index is signed with a throwaway key generated in this
+process**: :mod:`palaia_hub.market.curated`'s pinned
+``DEFAULT_PUBLIC_KEY_B64`` is deliberately not configurable — a real key
+only palaia's own real curated index holds the private half of. Proving
+"a curated-index entry installs" for real does not require *that* specific
+key; it requires the real verify-then-trust code path to run against a
+document that really is signed and really does verify, which a
+freshly-generated keypair (used once, by this process only, then
+discarded) exercises identically. The transport carrying that document is
+an in-process ``httpx.MockTransport`` — the same technique
+``tests/market/test_api.py``'s own fixtures already use to stand in for a
+real curated-index host — so no outbound network is needed for this half
+of the SPEC-308 evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+import uvicorn
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from palaia_hub.config import GatewayProfileSettings, GatewaySettings, HubConfig, OAuthSettings
+from palaia_hub.gateway.config import DEFAULT_GATEWAY_PROFILE
+from palaia_hub.gateway.settings_bridge import resolve_full_gateway_profiles
+from palaia_hub.market.curated import CuratedIndexClient, canonical_bytes
+from palaia_hub.oauth import AuthorizationServer, now_seconds, set_owner_password
+from palaia_hub.serve import build_production_app
+from palaia_hub.vault import VaultRegistry
+
+logger = logging.getLogger("e2e.hub_server_market")
+
+VAULT_KEY = "work"
+
+
+def _profile_scopes(profiles: list[Any]) -> dict[str, list[str]]:
+    """Same shape as ``palaia_hub.cli._profile_scopes`` — a read+write
+    scope per vault each profile mounts."""
+    return {
+        profile.path: [
+            scope for key in profile.vaults for scope in (f"vault:{key}:read", f"vault:{key}:write")
+        ]
+        for profile in profiles
+    }
+
+
+def _signed_curated_document(entry_id: str, fixture_url: str) -> tuple[dict[str, Any], str]:
+    """A genuinely Ed25519-signed one-entry curated index document, plus the
+    (throwaway) public key it verifies against — see the module docstring."""
+    private_key = Ed25519PrivateKey.generate()
+    public_key_b64 = base64.b64encode(private_key.public_key().public_bytes_raw()).decode()
+    document: dict[str, Any] = {
+        "schema_version": 1,
+        "generated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "entries": [
+            {
+                "id": entry_id,
+                "name": "SPEC-308 Fixture Remote",
+                "one_liner": "Fixture MCP server proving one install reaches every profile.",
+                "kind": "remote",
+                "source": {"type": "url", "value": fixture_url},
+                "permissions": [],
+                "maintainer": "spec-308-e2e",
+                "verified": True,
+            }
+        ],
+    }
+    signature = private_key.sign(canonical_bytes(document))
+    document["signature"] = base64.b64encode(signature).decode()
+    return document, public_key_b64
+
+
+async def _run(
+    *,
+    host: str,
+    port: int,
+    home: Path,
+    vault_dir: Path,
+    username: str,
+    password: str,
+    fixture_url: str,
+    entry_id: str,
+    profiles: list[str],
+) -> None:
+    registry = VaultRegistry(home)
+    await registry.create(VAULT_KEY, vault_dir, purpose="SPEC-308 phase3-gate e2e vault.")
+
+    issuer = f"http://{host}:{port}"
+    gateway = GatewaySettings(
+        profiles=[GatewayProfileSettings(path=p, vaults=[VAULT_KEY]) for p in profiles]
+    )
+    config = HubConfig(
+        mode="cloud",
+        host=host,
+        port=port,
+        oauth=OAuthSettings(enabled=True, issuer=issuer),
+        gateway=gateway,
+    )
+
+    resolved_profiles = resolve_full_gateway_profiles(
+        config, [VAULT_KEY], default_profile=DEFAULT_GATEWAY_PROFILE
+    )
+    oauth_server = AuthorizationServer.build(config, _profile_scopes(resolved_profiles), home=home)
+    set_owner_password(oauth_server.store, username, password, now=now_seconds())
+
+    production = await build_production_app(config, home=home, oauth_server=oauth_server)
+
+    # Swap in a curated index that really does carry a signed entry for the
+    # real fixture upstream this test spawned — see the module docstring.
+    document, public_key_b64 = _signed_curated_document(entry_id, fixture_url)
+
+    def _serve_signed_index(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=document)
+
+    assert production.install_service is not None
+    old_curated_client = production.install_service.market_service.curated_client
+    await old_curated_client.aclose()
+    production.install_service.market_service.curated_client = CuratedIndexClient(
+        index_url="https://spec308-curated-index.invalid/index.json",
+        public_key_b64=public_key_b64,
+        client=httpx.AsyncClient(transport=httpx.MockTransport(_serve_signed_index)),
+        last_good_path=home / "market_curated_index.json",
+    )
+
+    uv_server = uvicorn.Server(
+        uvicorn.Config(production.app, host=host, port=port, log_level="info")
+    )
+    try:
+        await uv_server.serve()
+    finally:
+        for index in production.indexes.values():
+            await index.close()
+        if production.stash_store is not None:
+            production.stash_store.close()
+        await production.dynamic_gateway.aclose()
+        oauth_server.store.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--home", required=True, help="empty PALAIA_HOME for this hub instance")
+    parser.add_argument("--vault-dir", required=True)
+    parser.add_argument("--username", default="owner")
+    parser.add_argument("--password", default="a-long-enough-passphrase")
+    parser.add_argument("--fixture-url", required=True, help="the fixture http upstream's URL")
+    parser.add_argument("--entry-id", default="acme.spec308-fixture")
+    parser.add_argument(
+        "--profiles", default="default,mobile", help="comma-separated gateway profile paths"
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+    )
+
+    asyncio.run(
+        _run(
+            host=args.host,
+            port=args.port,
+            home=Path(args.home),
+            vault_dir=Path(args.vault_dir),
+            username=args.username,
+            password=args.password,
+            fixture_url=args.fixture_url,
+            entry_id=args.entry_id,
+            profiles=[p.strip() for p in args.profiles.split(",") if p.strip()],
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/v3/server/tests/e2e/test_spec308_phase3_gate.py
+++ b/v3/server/tests/e2e/test_spec308_phase3_gate.py
@@ -1,0 +1,477 @@
+"""SPEC-308 Phase-3 gate evidence: "install a tool once, every AI has it".
+
+One curated-index entry, installed exactly once through the real
+``/api/market/*`` REST flow (consent token included, deliverable #3's
+"install without a consent POST is impossible" rule still enforced —
+see :mod:`palaia_hub.market.install`) onto **two** gateway profiles at
+once, then read back by **two differently-authenticated real clients**:
+
+1. :func:`test_one_install_answers_on_two_differently_authenticated_clients`
+   — the real ``claude`` CLI, over a real scripted OAuth 2.1 + PKCE code
+   flow against the ``default`` profile (SPEC-209's own machinery,
+   ``support/hub_server_oauth.py``'s pattern, reused here), *and* a
+   scripted ``fastmcp.Client`` carrying a real SPEC-108 ``plt_`` token
+   against the ``mobile`` profile — zero client-side tool configuration
+   either way; the tool the marketplace install added is simply *there*.
+   Needs the real ``claude`` CLI on PATH; skipped, not failed, otherwise.
+
+2. :func:`test_the_install_is_visible_through_the_mcpb_stdio_proxy_without_bundle_changes`
+   — the exact same install, read a third way: the real
+   ``palaia-proxy.mjs`` (SPEC-306) over real stdio, with no proxy/bundle
+   rebuild between the install and this read. Needs ``node`` on PATH;
+   skipped, not failed, otherwise.
+
+Both spawn a real hub subprocess (``support/hub_server_market.py`` — real
+``VaultEngine``, real ``AuthorizationServer``, real ``build_production_app``
+wiring exactly as ``palaia-hub serve`` runs it, real ``uvicorn`` socket) and
+a real second FastMCP server as the marketplace's fixture upstream
+(``tests/upstream/fixture_http_server.py``, SPEC-302's own fixture, reused
+by path — the same cross-package-by-path convention
+``tests/market/conftest.py`` already uses for the same file). The
+curated-index entry the hub serves is a genuinely Ed25519-signed document
+verified by the real :mod:`palaia_hub.market.curated` code path; see
+``support/hub_server_market.py``'s module docstring for why a
+freshly-generated, throwaway signing key is honest evidence for "a
+curated-index entry installs" without needing palaia's real, non-public
+index key.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
+
+import httpx
+import pytest
+
+_CLAUDE = shutil.which("claude")
+_NODE = shutil.which("node")
+
+_HUB_SCRIPT = Path(__file__).parent / "support" / "hub_server_market.py"
+_FIXTURE_UPSTREAM_SCRIPT = (
+    Path(__file__).resolve().parent.parent / "upstream" / "fixture_http_server.py"
+)
+_PROXY_SCRIPT = (
+    Path(__file__).resolve().parents[3] / "tools" / "build-mcpb" / "proxy" / "palaia-proxy.mjs"
+)
+
+_STARTUP_TIMEOUT = 20.0
+_CLAUDE_TIMEOUT = 60.0
+
+OWNER_USERNAME = "owner"
+OWNER_PASSWORD = "a-long-enough-passphrase"  # noqa: S105 - test fixture
+VERIFIER = "scripted-client-code-verifier-with-enough-entropy-x"
+CALLBACK = "http://127.0.0.1:9999/callback"
+ENTRY_ID = "acme.spec308-fixture"
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_health(port: int, timeout: float = _STARTUP_TIMEOUT) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/api/health", timeout=0.5
+            ) as resp:
+                if resp.status == 200:
+                    return
+        except (OSError, urllib.error.URLError) as exc:
+            last_error = exc
+            time.sleep(0.1)
+    raise RuntimeError(f"process did not become healthy within {timeout}s: {last_error}")
+
+
+def _wait_for_fixture_upstream(url: str, timeout: float = _STARTUP_TIMEOUT) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            httpx.post(url, timeout=1.0)
+            return
+        except httpx.HTTPError:
+            time.sleep(0.1)
+    raise RuntimeError(f"fixture upstream at {url} never became reachable within {timeout}s")
+
+
+@dataclass
+class MarketHub:
+    """A live SPEC-308 hub subprocess (real OAuth + plt_ + marketplace)
+    plus its real fixture-upstream subprocess — both torn down together."""
+
+    port: int
+    base_url: str
+    entry_id: str
+    profiles: tuple[str, ...]
+    _hub_process: subprocess.Popen[bytes]
+    _fixture_process: subprocess.Popen[bytes]
+
+    def stop(self) -> None:
+        for process in (self._hub_process, self._fixture_process):
+            process.terminate()
+        for process in (self._hub_process, self._fixture_process):
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:  # pragma: no cover - defensive
+                process.kill()
+                process.wait(timeout=5)
+
+
+@pytest.fixture
+def market_hub(tmp_path: Path) -> Iterator[MarketHub]:
+    """Spawn the real fixture upstream, then the real SPEC-308 hub pointed
+    at it — two gateway profiles (``default``, ``mobile``), both accepting
+    OAuth *and* ``plt_`` tokens, over the one vault the curated entry's
+    fixture upstream will be mounted into once a test installs it."""
+    fixture_port = _free_port()
+    fixture_process = subprocess.Popen(  # noqa: S603 - fixed argv, no shell
+        [sys.executable, str(_FIXTURE_UPSTREAM_SCRIPT), "--port", str(fixture_port)]
+    )
+    fixture_url = f"http://127.0.0.1:{fixture_port}/"
+    try:
+        _wait_for_fixture_upstream(fixture_url)
+    except Exception:
+        fixture_process.terminate()
+        fixture_process.wait(timeout=5)
+        raise
+
+    port = _free_port()
+    home = tmp_path / "home"
+    home.mkdir()
+    log_path = tmp_path / "hub.log"
+    args = [
+        sys.executable,
+        str(_HUB_SCRIPT),
+        "--port",
+        str(port),
+        "--home",
+        str(home),
+        "--vault-dir",
+        str(tmp_path / "vault"),
+        "--username",
+        OWNER_USERNAME,
+        "--password",
+        OWNER_PASSWORD,
+        "--fixture-url",
+        fixture_url,
+        "--entry-id",
+        ENTRY_ID,
+        "--profiles",
+        "default,mobile",
+    ]
+    with log_path.open("w") as log_file:
+        hub_process = subprocess.Popen(  # noqa: S603 - fixed argv, no shell
+            args, stdout=log_file, stderr=subprocess.STDOUT
+        )
+    try:
+        _wait_for_health(port)
+    except Exception:
+        hub_process.terminate()
+        hub_process.wait(timeout=5)
+        fixture_process.terminate()
+        fixture_process.wait(timeout=5)
+        raise
+
+    hub = MarketHub(
+        port=port,
+        base_url=f"http://127.0.0.1:{port}",
+        entry_id=ENTRY_ID,
+        profiles=("default", "mobile"),
+        _hub_process=hub_process,
+        _fixture_process=fixture_process,
+    )
+    try:
+        yield hub
+    finally:
+        hub.stop()
+
+
+def _install_once(base_url: str, entry_id: str, profiles: list[str]) -> dict[str, object]:
+    """The real, full REST install flow (deliverable #3): consent, then
+    install onto every profile named — refused without a fresh, matching
+    consent token (see :mod:`palaia_hub.market.install`'s ``ConsentStore``).
+    """
+    client = httpx.Client(base_url=base_url, timeout=15.0)
+
+    # SPEC-303 deliverable #4's merged surface: the curated entry is
+    # visible over the exact same `/api/market/search` a dashboard would
+    # call — real fetch, real Ed25519 verification (see the hub script).
+    search = client.get("/api/market/search", params={"source": "curated"})
+    assert search.status_code == 200, search.text
+    assert search.json()["stale"] is False, search.json()
+    assert any(e["id"] == entry_id for e in search.json()["entries"]), search.json()
+
+    consent = client.post(f"/api/market/entry/{entry_id}/consent")
+    assert consent.status_code == 200, consent.text
+    token = consent.json()["token"]
+
+    install = client.post(
+        f"/api/market/entry/{entry_id}/install",
+        json={"consent_token": token, "profiles": profiles},
+    )
+    assert install.status_code == 200, install.text
+    body = install.json()
+    assert body["up"] is True, body
+    assert sorted(body["profiles"]) == sorted(profiles), body
+    return body  # type: ignore[return-value]
+
+
+def _mint_plt_token(base_url: str, *, name: str, profile: str) -> str:
+    """A real SPEC-108 per-client token, minted through the real
+    ``POST /api/auth/tokens`` REST surface — no client-side tool config,
+    the same credential shape any non-OAuth client (a phone app, a
+    scripted integration) would carry."""
+    client = httpx.Client(base_url=base_url, timeout=15.0)
+    response = client.post(
+        "/api/auth/tokens",
+        json={
+            "name": name,
+            "profile": profile,
+            "scopes": ["vault:work:read", "vault:work:write"],
+        },
+    )
+    assert response.status_code == 200, response.text
+    return str(response.json()["token"])
+
+
+def _tool_namespace(install_body: dict[str, object]) -> str:
+    """The mount namespace an installed upstream's tools appear under
+    (``palaia_hub.upstream.models.UpstreamConfig.mount_namespace``:
+    ``namespace`` if set, else ``key`` with ``-`` turned into ``_``) —
+    derived from the install response rather than hard-coded, so this
+    test does not silently stop meaning anything if the key-derivation
+    rule in :func:`palaia_hub.market.install._derive_upstream_key` ever
+    changes shape."""
+    return str(install_body["upstream_key"]).replace("-", "_")
+
+
+# --------------------------------------------------- OAuth PKCE (SPEC-209)
+
+
+def _challenge_for(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode()).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+
+
+def _csrf_and_sign_in(client: httpx.Client, base_url: str) -> None:
+    login_form = client.get(f"{base_url}/oauth/login")
+    match = re.search(r'name="csrf_token"\s+value="([^"]+)"', login_form.text)
+    assert match is not None, login_form.text
+    signed_in = client.post(
+        f"{base_url}/oauth/login",
+        data={
+            "username": OWNER_USERNAME,
+            "password": OWNER_PASSWORD,
+            "csrf_token": match.group(1),
+            "next": "",
+        },
+    )
+    assert signed_in.status_code == 303, signed_in.text
+    assert "palaia_oauth_session" in client.cookies
+
+
+def _get_real_access_token(base_url: str, profile: str) -> str:
+    """A scripted OAuth 2.1 + PKCE code-flow client, over a real socket —
+    identical protocol steps to
+    ``test_spec209_client_matrix.py``'s ``_get_real_access_token``, kept as
+    its own copy here (this repo's ``tests/e2e/`` house style: each e2e
+    file is a standalone script, not a shared library — see this
+    directory's other ``test_spec*`` files, none of which import from one
+    another either)."""
+    client = httpx.Client(base_url=base_url, follow_redirects=False, timeout=10.0)
+
+    response = client.get(f"/mcp/{profile}/")
+    assert response.status_code == 401, response.text
+    challenge = response.headers["www-authenticate"]
+    metadata_url = challenge.split('resource_metadata="', 1)[1].split('"', 1)[0]
+
+    resource_metadata = client.get(urlsplit(metadata_url).path).json()
+    as_metadata = client.get("/.well-known/oauth-authorization-server").json()
+
+    registered = client.post(
+        urlsplit(as_metadata["registration_endpoint"]).path,
+        json={"client_name": "spec-308-scripted", "redirect_uris": [CALLBACK]},
+    )
+    assert registered.status_code == 201, registered.text
+    client_id = registered.json()["client_id"]
+
+    _csrf_and_sign_in(client, "")
+
+    authorized = client.get(
+        urlsplit(as_metadata["authorization_endpoint"]).path,
+        params={
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": CALLBACK,
+            "code_challenge": _challenge_for(VERIFIER),
+            "code_challenge_method": "S256",
+            "state": "opaque-state",
+            "resource": resource_metadata["resource"],
+        },
+    )
+    assert authorized.status_code == 303, authorized.text
+    code = parse_qs(urlsplit(authorized.headers["location"]).query)["code"][0]
+
+    tokens = client.post(
+        urlsplit(as_metadata["token_endpoint"]).path,
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": client_id,
+            "redirect_uri": CALLBACK,
+            "code_verifier": VERIFIER,
+        },
+    )
+    assert tokens.status_code == 200, tokens.text
+    return str(tokens.json()["access_token"])
+
+
+def _run_claude(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    assert _CLAUDE is not None
+    return subprocess.run(
+        [_CLAUDE, *args], cwd=cwd, capture_output=True, text=True, timeout=_CLAUDE_TIMEOUT
+    )
+
+
+def _claude_call_tool_text(server_name: str, full_tool: str, prompt: str, cwd: Path) -> str:
+    result = _run_claude(
+        ["-p", prompt, "--allowedTools", full_tool, "--output-format", "json"], cwd=cwd
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload.get("is_error") is False, payload
+    return str(payload["result"])
+
+
+# ------------------------------------------------------------------ tests
+
+
+@pytest.mark.skipif(_CLAUDE is None, reason="claude CLI not on PATH")
+def test_one_install_answers_on_two_differently_authenticated_clients(
+    market_hub: MarketHub, tmp_path: Path
+) -> None:
+    """SPEC-308's exit criterion, literally: one marketplace install,
+    reachable by two differently-authenticated real clients on two
+    different profiles, with zero client-side tool configuration on
+    either one."""
+    install_body = _install_once(
+        market_hub.base_url, market_hub.entry_id, ["default", "mobile"]
+    )
+    tool_name = f"{_tool_namespace(install_body)}_echo"
+
+    # --- client 1: a scripted fastmcp.Client with a real plt_ token,
+    # against the "mobile" profile. No tool config beyond the bearer
+    # token — the tool is simply part of whatever this profile serves.
+    from fastmcp import Client
+    from fastmcp.client.auth import BearerAuth
+
+    plt_token = _mint_plt_token(market_hub.base_url, name="mobile-app", profile="mobile")
+
+    async def _call_via_plt_client() -> str:
+        transport = f"{market_hub.base_url}/mcp/mobile/"
+        async with Client(transport, auth=BearerAuth(plt_token)) as client:
+            names = {tool.name for tool in await client.list_tools()}
+            assert tool_name in names, names
+            result = await client.call_tool(tool_name, {"text": "hello from the plt_ client"})
+            return str(result.data)
+
+    import anyio
+
+    plt_reply = anyio.run(_call_via_plt_client)
+    assert "hello from the plt_ client" in plt_reply
+
+    # --- client 2: the real `claude` CLI, over a real OAuth 2.1 + PKCE
+    # code flow, against the "default" profile (SPEC-209's own default,
+    # zero-flag-shaped path: `claude mcp add --header ...`).
+    access_token = _get_real_access_token(market_hub.base_url, "default")
+    server_name = "palaia-spec308-e2e"
+    work_dir = tmp_path / "claude-project"
+    work_dir.mkdir()
+    mcp_url = f"{market_hub.base_url}/mcp/default/"
+
+    add_result = _run_claude(
+        [
+            "mcp",
+            "add",
+            "--transport",
+            "http",
+            server_name,
+            mcp_url,
+            "--header",
+            f"Authorization: Bearer {access_token}",
+            "--scope",
+            "local",
+        ],
+        cwd=work_dir,
+    )
+    assert add_result.returncode == 0, add_result.stderr
+
+    try:
+        get_result = _run_claude(["mcp", "get", server_name], cwd=work_dir)
+        assert "Connected" in get_result.stdout, get_result.stdout
+
+        full_tool = f"mcp__{server_name}__{tool_name}"
+        cli_reply = _claude_call_tool_text(
+            server_name,
+            full_tool,
+            f"Call the {full_tool} tool with text='hello from claude CLI' and reply with "
+            "ONLY the exact raw text the tool returned, nothing else.",
+            work_dir,
+        )
+        assert "hello from claude CLI" in cli_reply
+    finally:
+        _run_claude(["mcp", "remove", server_name, "-s", "local"], cwd=work_dir)
+
+
+@pytest.mark.skipif(_NODE is None, reason="node is not on PATH")
+def test_the_install_is_visible_through_the_mcpb_stdio_proxy_without_bundle_changes(
+    market_hub: MarketHub,
+) -> None:
+    """SPEC-308 deliverable #2: the same install, seen a third way — the
+    real SPEC-306 ``palaia-proxy.mjs`` over real stdio, with no proxy or
+    bundle rebuild in between. Proves the stdio path is not a separate,
+    manually-curated tool list: it mirrors whatever the profile serves,
+    live."""
+    install_body = _install_once(
+        market_hub.base_url, market_hub.entry_id, ["default", "mobile"]
+    )
+    tool_name = f"{_tool_namespace(install_body)}_echo"
+    plt_token = _mint_plt_token(market_hub.base_url, name="proxy-client", profile="mobile")
+
+    async def _call_via_proxy() -> str:
+        from fastmcp import Client
+        from fastmcp.client.transports import StdioTransport
+
+        env = dict(os.environ)
+        env["PALAIA_HUB_URL"] = f"{market_hub.base_url}/mcp/mobile/"
+        env["PALAIA_TOKEN"] = plt_token
+        env["PALAIA_LOG_LEVEL"] = "debug"
+        transport = StdioTransport(command="node", args=[str(_PROXY_SCRIPT)], env=env)
+        async with Client(transport) as client:
+            names = {tool.name for tool in await client.list_tools()}
+            assert tool_name in names, names
+            result = await client.call_tool(tool_name, {"text": "hello through the stdio proxy"})
+            return str(result.data)
+
+    import anyio
+
+    proxy_reply = anyio.run(_call_via_proxy)
+    assert "hello through the stdio proxy" in proxy_reply


### PR DESCRIPTION
## Summary

SPEC-308: assemble evidence for the Phase-3 exit criterion — *"install a
tool once, every AI has it"* — no new features, no behavior changes.

- Added `v3/server/tests/e2e/support/hub_server_market.py`: a real hub
  subprocess wired via `palaia_hub.serve.build_production_app` exactly as
  `palaia-hub serve` runs it (real `VaultEngine`, real
  `AuthorizationServer`, real `uvicorn` socket) — **two** gateway profiles
  (`default`, `mobile`), both accepting OAuth *and* SPEC-108 `plt_` tokens
  at once (SPEC-301's existing combination, unchanged), plus a genuinely
  Ed25519-signed curated-index document (a throwaway signing key generated
  fresh per run — the real verify-then-trust code path in
  `palaia_hub.market.curated` is what matters, not palaia's real,
  non-public index key) naming a real second FastMCP server (SPEC-302's
  own fixture, reused by path) as a `remote` marketplace entry.
- Added `v3/server/tests/e2e/test_spec308_phase3_gate.py`:
  1. `test_one_install_answers_on_two_differently_authenticated_clients`
     (skips without `claude` on PATH) — one curated-index entry, installed
     exactly once through the real `/api/market/*` REST flow (consent
     token included) onto both profiles, then read by **two** real
     clients: a scripted `fastmcp.Client` with a real `plt_` token against
     `mobile`, and the real `claude` CLI over a real scripted OAuth 2.1 +
     PKCE code flow (SPEC-209's own machinery) against `default` — zero
     client-side tool configuration either way.
  2. `test_the_install_is_visible_through_the_mcpb_stdio_proxy_without_bundle_changes`
     (skips without `node` on PATH) — the same install, read a third way
     through the real SPEC-306 `palaia-proxy.mjs` over real stdio, with no
     proxy/bundle rebuild in between.
- `v3/docs/client-matrix-results.md` §7: a dated "tools follow the
  profile" section with the real commands/output and the honest gaps
  (dashboard UI not driven, no real public tunnel, Claude Desktop's own
  install dialog still unverified per §6).
- `v3/IMPLEMENTATION.md` §6: draft gate paragraph, marked "(draft — the
  architect holds the gate)" — it reports evidence, it does not declare
  the gate met.
- No issues filed: no quirks were found this run — SPEC-301's OAuth+`plt_`
  combination and SPEC-304's install flow both worked exactly as
  documented on the first real two-profile run.

## Acceptance checklist (honest)

- [x] the two-clients-one-install e2e passes in one pytest run (both
  claude-CLI- and node-gated halves ran for real in this environment;
  either skips honestly, not falsely-green, where the binary is absent)
- [x] the MCPB-proxy variant passes
- [x] `client-matrix-results.md` updated with dated evidence (§7)
- [x] full suite green at the end — this SPEC adds tests/docs only, no
  behavior changed

## Verification evidence

```
$ cd v3 && uv run pytest server/tests/e2e/test_spec308_phase3_gate.py -q
..                                                                       [100%]
2 passed in 32.84s      # run three times in a row (32.84s, 30.39s, 35.38s), no flakes

$ uv run pytest server/tests/e2e -q      # full e2e dir, with the new file added
.................................                                       [100%]
33 passed in 176.40s (0:02:56)           # run twice, no flakes (174.65s the 2nd time)

$ uv run ruff check server && uv run mypy server/src
All checks passed!
Success: no issues found in 169 source files

$ uv run pytest server/tests -q
1711 passed, 16 skipped, 128 warnings in 475.64s (0:07:55)
```

## Scope

- `v3/server/tests/e2e/support/hub_server_market.py`,
  `v3/server/tests/e2e/test_spec308_phase3_gate.py` (new)
- `v3/docs/client-matrix-results.md`, `v3/IMPLEMENTATION.md` (docs only)
- No SPEC-301–306 code touched; no behavior changed anywhere.

## Honest notes on the exit criterion

- **Real evidence**: the REST install (consent-gated, two profiles at
  once), the plt_-token `fastmcp.Client` half, the real `claude` CLI OAuth
  half, and the stdio-proxy half — all against real sockets/subprocesses,
  none stubbed.
- **Honest gaps** (see §7.4 of the results doc): the dashboard's own React
  UI was not driven (only its REST surface); no real public tunnel was in
  front of the hub (same "this sandbox cannot fake it honestly" situation
  the Phase-2 gate note already names); Claude Desktop's own MCPB install
  dialog remains unverified exactly as §6 already said — this SPEC adds
  no new evidence there, only the stdio-proxy half it *can* drive for
  real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790181939&installation_model_id=428086&pr_number=247&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F247&signature=3046b4fd4b45b4e232a9556da092d2c4b146a0e09a8a4724fbd9504974620589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->