### PR TITLE
docs(v3): Phase-4 SPECs 401–407 + wave plan

### DIFF
--- a/v3/IMPLEMENTATION.md
+++ b/v3/IMPLEMENTATION.md
@@ -165,6 +165,23 @@ foundation and integrates first) → **3b** = 302, 305 (both need 301) →
 | [307](specs/SPEC-307-automations.md) | Automations editor | 201 | Sonnet 5 | medium | — |
 | [308](specs/SPEC-308-phase3-gate.md) | Phase-3 gate evidence | 301–306 | Sonnet 5 | medium | gate evidence |
 
+## 4d. Phase 4 SPEC index (written at the Phase-3 gate, 2026-08-24)
+
+Waves: **4a** = 401, 402, 406 (no mutual deps; 401 is security-critical
+and integrates first) → **4b** = 403 (needs 402) → **4c** = 404, 405 (both
+need 403), then 407 + Phase-4 gate (exit criterion: *two agents on
+different providers hand off work through palaia*).
+
+| SPEC | Title | Depends on | Model | Effort | Review gate |
+|---|---|---|---|---|---|
+| [401](specs/SPEC-401-dashboard-signin.md) | Dashboard sign-in (admin session gate, closes #242) | 203, 204, 205 | **Opus 5** | medium | **Fable 5 security review (max)** |
+| [402](specs/SPEC-402-session-directory.md) | Session directory | 105, 201 | Sonnet 5 | high | Fable 5 review (session secret) |
+| [403](specs/SPEC-403-messenger.md) | Messenger core (envelope fixed in-spec) | 402, 106 | **Opus 5** | medium | Fable 5 review (inbox auth) |
+| [404](specs/SPEC-404-messaging-skills.md) | Messaging skills + push adapters | 403, 207 | Sonnet 5 | high | effectiveness runs |
+| [405](specs/SPEC-405-observability.md) | Team observability (screens + 2 MCP Apps) | 402, 403, 208 | Sonnet 5 | high | owner UX pass |
+| [406](specs/SPEC-406-addon-sdk.md) | Add-on SDK + submission flow | 303, 304 | Sonnet 5 | medium | — |
+| [407](specs/SPEC-407-phase4-gate.md) | Phase-4 gate evidence | 401–405 | Sonnet 5 | medium | gate evidence |
+
 ## 5. Phase 2 work packages (superseded by §4b — kept for provenance)
 
 | Package | Content | Model | Effort |

--- a/v3/specs/SPEC-401-dashboard-signin.md
+++ b/v3/specs/SPEC-401-dashboard-signin.md
@@ -1,0 +1,66 @@
+---
+id: SPEC-401
+title: Dashboard sign-in — the admin session gate
+phase: 4
+depends_on: [SPEC-203, SPEC-204, SPEC-205]
+model: opus-5
+effort: medium
+status: ready
+---
+
+# SPEC-401: Dashboard sign-in
+
+## Goal
+Close issue #242: the admin surface (`/api/*`, the dashboard) gets an owner
+session, which is what the masterplan's mode table requires before a public
+dashboard may exist — and what lifts the temporary "mode 'open' is refused"
+guard.
+
+## Deliverables
+1. **One door, reused** (MASTERPLAN §5.5): the dashboard session IS the
+   SPEC-203/204 login session (`palaia_oauth_session`) — password or IdP,
+   whichever the hub is configured for. No second account system, no second
+   cookie for the same identity.
+2. Enforcement middleware on the admin surface: every `/api/*` route
+   requires a live owner session **when enabled**, except a fixed
+   allowlist that must work logged-out (`/api/health`, `/api/info`, the
+   OAuth/IdP endpoints themselves, and the SSE events stream carries no
+   secrets? — no: events REQUIRE the session; only health/info/sign-in
+   stay open). `/mcp/*` is untouched (its own token/OAuth auth, SPEC-108/
+   203). The dashboard SPA redirects to the sign-in page when a 401 comes
+   back; the sign-in page reuses SPEC-203's (extended, not duplicated).
+3. **CSRF for the REST surface**: state-changing methods (POST/PUT/PATCH/
+   DELETE) under `/api/*` require the double-submit token the login flow
+   already set (SPEC-203's pattern) via an `X-Palaia-CSRF` header; the SPA's
+   API client sends it on every call. GET stays CSRF-free.
+4. Mode policy: enforcement is **mandatory in `open` mode** and **on by
+   default in `cloud`** (the dashboard is VPN-only there, but defense in
+   depth is cheap); in `locked` it is opt-in (`dashboard.require_sign_in`,
+   default false — a LAN hub must keep its zero-config first-run wizard,
+   which is also why enforcement only activates once an owner account or
+   IdP exists; the wizard's first run creates one as its first step in
+   enforcing modes).
+5. Lift the #242 guard: `load_config` and the mode endpoint accept `open`
+   again **iff** sign-in is configured; the refusal message stays for an
+   open-mode config with no owner account/IdP. Restore the open-mode
+   entry-point tests to their pre-guard shape plus the new conditions.
+6. Session UX: sign-out button in the shell; session TTL from
+   `oauth.session_ttl`; the SPA handles expiry mid-use gracefully (one
+   redirect, no lost form state beyond the page).
+
+## Acceptance criteria
+- [ ] with enforcement on: every non-allowlisted `/api/*` route 401s
+      without a session (parametrized walk over the app's real route table,
+      so a new route cannot ship unguarded by accident) and works with one
+- [ ] state-changing call without the CSRF header 403s; the SPA client
+      sends it (vitest on the api client)
+- [ ] `open` mode: accepted with sign-in configured (e2e: public-style
+      bind + login + one admin call), still refused without
+- [ ] `locked` zero-config first run: wizard reachable without any session
+      (regression on SPEC-110's flow)
+- [ ] MCP endpoints unaffected (existing e2e stays green)
+- [ ] jargon-free copy on the sign-in redirects (lint)
+
+## Non-goals
+Multi-user accounts/roles; remember-me beyond the session TTL; rate
+limiting (SPEC-205's middleware already covers auth paths in cloud/open).

--- a/v3/specs/SPEC-402-session-directory.md
+++ b/v3/specs/SPEC-402-session-directory.md
@@ -1,0 +1,64 @@
+---
+id: SPEC-402
+title: Session directory — agents become visible
+phase: 4
+depends_on: [SPEC-105, SPEC-201]
+model: sonnet-5
+effort: high
+status: ready
+---
+
+# SPEC-402: Session directory
+
+## Goal
+MASTERPLAN §5.4's first half: sessions register with real context (scope,
+host, platform, agent kind, model, capabilities), heartbeat with TTL, age
+out visibly — the discovery layer the messenger (SPEC-403) addresses into.
+
+## Deliverables
+1. `palaia_hub.directory`: SQLite-backed session registry under the hub
+   home. A session row (fixed shape): `handle` (server-minted, stable for
+   the registration's lifetime, URL-safe), `scope` (free text, e.g.
+   "refactoring the billing service in repo X"), `host`, `platform`
+   (claude-code | claude-desktop | claude-ai | codex | gemini | other —
+   open enum, stored verbatim), `agent_kind`, `model` (verbatim string the
+   agent self-reports; never trusted for anything but display), `status`
+   (`active` | `idle` | `stale`), `capabilities` (list of free-text tags),
+   `registered_at`, `last_seen_at`, `ttl_seconds`.
+2. Lifecycle: `register` returns the handle + a **session secret** (needed
+   for subsequent heartbeat/update/deregister — another session must not be
+   able to impersonate or evict a peer; stored hashed, SPEC-203's
+   secrets_util pattern). `heartbeat` bumps `last_seen_at`; a session past
+   its TTL turns `stale` (visible, not deleted); past 5×TTL it is pruned.
+   Status `idle` is self-reported; `stale` is always computed server-side.
+3. MCP tool family `directory_*` on gateway profiles (opt-in per profile
+   like stash): `directory_register`, `directory_heartbeat`,
+   `directory_update` (scope/status/capabilities), `directory_list`
+   (filterable by status/platform/capability), `directory_query` (scope
+   substring/role query — "who is working on repo X"), `directory_deregister`.
+   Dual output (structured + text), IDENTITY line distinguishes it from
+   memory/stash, alias absorption per house style.
+4. REST mirror `/api/directory` (list/query only — mutations come from the
+   sessions themselves via MCP) for the dashboard; SPEC-405 builds the
+   screen.
+5. Events (additive): `session.registered`, `session.updated`,
+   `session.idle`, `session.stale`, `session.deregistered` — the masterplan
+   names `session.*` in the §5.6 vocabulary; automations (SPEC-307) can
+   trigger on them.
+6. Scopes: `directory:read`/`directory:write` enforced per-tool
+   (SPEC-108 pattern); golden tools snapshot regenerated via the
+   documented command.
+
+## Acceptance criteria
+- [ ] register → list round-trip through a real `fastmcp.Client`; handle
+      stable across heartbeats
+- [ ] a wrong session secret cannot heartbeat/update/deregister another
+      session (impersonation test)
+- [ ] TTL: expired session shows `stale` (clock-injectable), pruned at 5×TTL
+- [ ] query by scope substring and by capability both filter correctly
+- [ ] events fire on register/stale/deregister (bus test)
+- [ ] read-scoped token cannot register (per-tool scope test)
+
+## Non-goals
+Message delivery (SPEC-403); the dashboard screen (SPEC-405); any
+cross-hub federation.

--- a/v3/specs/SPEC-403-messenger.md
+++ b/v3/specs/SPEC-403-messenger.md
@@ -1,0 +1,71 @@
+---
+id: SPEC-403
+title: Messenger core — structured envelopes, pull delivery
+phase: 4
+depends_on: [SPEC-402, SPEC-106]
+model: opus-5
+effort: medium
+status: ready
+---
+
+# SPEC-403: Messenger core
+
+## Goal
+MASTERPLAN §5.4's second half: typed, token-disciplined messages between
+sessions, brokered by the hub. Pull (MCP tools) is the universal baseline —
+MCP 2026-07-28 removed server-initiated requests, so polling carries the
+async semantics; push adapters are SPEC-404's.
+
+## Deliverables
+1. **Envelope, fixed shape** (implemented verbatim — this is the protocol):
+   `{id (server-minted), type: request | inform | question | handoff |
+   broadcast, from (sender handle), to (recipient handle, or a directory
+   query for broadcast), subject (≤200 chars), urgency: low | normal |
+   high, expects_reply: bool, body (≤4096 UTF-8 bytes — hard cap, loud
+   error naming the fix: "write it to memory and reference it"), refs
+   (list of `memory://` references, validated to resolve in a vault the
+   sender can read), reply_to (envelope id | null), created_at,
+   expires_at}`. The body cap is the token-discipline rule as a mechanism:
+   long content goes into the vault once and is pointed at.
+2. `palaia_hub.messenger`: SQLite store (hub home) — per-recipient inbox
+   with `delivered`/`acked` state, TTL expiry (default 24h, per-message
+   override ≤7d), sender outbox view. Broadcast resolves its directory
+   query at send time to ≤20 recipients (hard cap, loud error) and fans
+   out as individual envelopes.
+3. MCP tool family `messenger_*` (opt-in per profile, like directory):
+   `messenger_send` (validates envelope, resolves recipient handle via the
+   directory, refuses a stale/unknown recipient with a plain-language
+   error), `messenger_check` (new envelopes for MY handle — requires the
+   SPEC-402 session secret, so a session reads only its own inbox; marks
+   delivered), `messenger_ack` (acknowledge/close), `messenger_thread`
+   (an envelope's reply chain). Dual output; the text rendering is compact
+   by design (subject + type + refs, body only on the single-envelope
+   read).
+4. Authorization: sending requires `messenger:send` scope; checking
+   requires the session secret from SPEC-402's registration (a scope
+   alone must not read another session's inbox). The curator profile gets
+   NO messenger tools (same fail-closed map as SPEC-302's fence).
+5. Events (additive): `message.sent`, `message.received` (fires on
+   delivery-check, carrying envelope metadata, never the body),
+   `message.expired`. Automations can notify/webhook on them (SPEC-307's
+   action kinds compose — no new automation work here).
+6. REST read-only mirror `/api/messenger` (threads/flows metadata for
+   SPEC-405's observability screen; bodies only for the owner via the
+   admin surface).
+
+## Acceptance criteria
+- [ ] two real `fastmcp.Client` sessions (registered via SPEC-402) exchange
+      request → reply e2e; thread links via `reply_to`
+- [ ] a 5000-byte body is refused with the write-it-to-memory message; a
+      `refs` entry that resolves nowhere is refused
+- [ ] session A cannot `messenger_check` session B's inbox (secret test)
+- [ ] broadcast over a directory query delivers to every match, caps at 20
+- [ ] expiry: an unchecked envelope past `expires_at` is gone and
+      `message.expired` fired (clock-injectable)
+- [ ] `message.received` carries metadata only — the body never appears on
+      the event bus (contract test)
+- [ ] golden tools snapshot regenerated via the documented command
+
+## Non-goals
+Push delivery, messaging skills, effectiveness runs (SPEC-404); the
+observability UI (SPEC-405); message search; cross-hub delivery.

--- a/v3/specs/SPEC-404-messaging-skills.md
+++ b/v3/specs/SPEC-404-messaging-skills.md
@@ -1,0 +1,58 @@
+---
+id: SPEC-404
+title: Structured-messaging skills + push adapters
+phase: 4
+depends_on: [SPEC-403, SPEC-207]
+model: sonnet-5
+effort: high
+status: ready
+---
+
+# SPEC-404: Messaging skills + push
+
+## Goal
+The habit half of §5.4 ("nothing prompts them") and the delivery half
+beyond polling: skills that make agents register, check and reply as part
+of their normal workflow — measured, not assumed, with SPEC-207's
+effectiveness discipline — plus push where a platform allows it.
+
+## Deliverables
+1. `v3/clients/skills/palaia-messenger/SKILL.md`: register-on-start (scope
+   from the task at hand), check-on-milestone, the reply discipline
+   (`expects_reply` means answer or explicitly decline), the token rule
+   (long content → memory, send the ref), deregister/idle on wrap-up.
+   Wired into the existing plugin manifest so it installs with the
+   SPEC-207 pack; connect-page skill panel lists it (same capability
+   table).
+2. SPEC-207's format lint extended over the new skill (same jargon rules);
+   `## Per-model notes` variant markers where behavior differs.
+3. **Effectiveness harness extension** (env-gated like SPEC-207's): two
+   real `claude` CLI sessions against a real hub — session A gets a task
+   and the skill; does it register, and does it send a `handoff` with a
+   vault ref instead of pasting content? Session B: does it check its
+   inbox unprompted at task start? Same honesty rules: every run printed,
+   the rate is the finding, misses analyzed and prose iterated at least
+   once.
+4. Push adapters, hook-based (SPEC-201/307 machinery, no new delivery
+   system): a `message.received` automation recipe that fires an outbound
+   webhook ("notify my other tooling"), and — if the research dossier's
+   `claude/channel` facts support it in this sandbox — a documented,
+   env-gated proof that a Claude Code session can be poked to check its
+   inbox; if the capability cannot be exercised honestly here, document
+   the integration path and mark it "not verified" rather than shipping
+   dead code.
+5. `docs/messenger.md`: the agent-facing contract (envelope shape, the
+   body cap and why, the check/reply discipline) — written for skill
+   authors and SDK users, jargon-free where user-facing.
+
+## Acceptance criteria
+- [ ] skills pass the format lint; plugin manifest installs both packs
+- [ ] effectiveness runs documented: register + handoff-with-ref and
+      check-on-start rates reported honestly, at least one prose iteration
+- [ ] the webhook recipe delivers on a real `message.received` (e2e over
+      the SPEC-201 outbox)
+- [ ] connect page lists the messenger skill per client capability table
+
+## Non-goals
+New delivery transports; vendor-cloud push (no honest way to test);
+changing the envelope protocol (SPEC-403 owns it).

--- a/v3/specs/SPEC-405-observability.md
+++ b/v3/specs/SPEC-405-observability.md
@@ -1,0 +1,58 @@
+---
+id: SPEC-405
+title: Team observability — directory & message flows, session-monitor app
+phase: 4
+depends_on: [SPEC-402, SPEC-403, SPEC-208]
+model: sonnet-5
+effort: high
+status: ready
+---
+
+# SPEC-405: Team observability
+
+## Goal
+§5.4's trust rule: the human can read along, join in, or shut a
+conversation down. The dashboard shows the live directory and message
+flows; the session-monitor MCP App brings the same view (and the compose
+form) into the chat clients; the stash browser app rounds out the §5.7
+table's Phase-4 rows.
+
+## Deliverables
+1. Dashboard "Agents" screen: the live directory (scope, platform, model,
+   status, idle time — `stale` visibly aged out), plus per-session message
+   flows (threads from `/api/messenger`, metadata first, body on expand —
+   owner-only surface). Live updates via the existing SSE bus
+   (`session.*`, `message.*` events), no polling loop.
+2. Owner controls, plain-language: end a conversation (expire a thread's
+   undelivered envelopes), deregister a stale session, and **send as
+   owner** — a compose form producing a schema-valid envelope (the form IS
+   the schema: type picker, subject, urgency, expects-reply, body with the
+   4KB counter, ref picker from recall search).
+3. Session-monitor MCP App (`/mcp/team` or similar hub-level mount,
+   SPEC-208 shell): live directory + flows read-only, plus the compose
+   form posting through the app bridge under the caller's own token
+   scopes. Plain-text fallback: a compact directory listing. Same
+   security rule as SPEC-304: destructive owner controls (ending
+   conversations, deregistering) stay dashboard-only; the app links out.
+4. Stash browser MCP App (§5.7 Phase-4 row): cache entries with
+   namespace/TTL/size, read-only inspection utility on the SPEC-208 shell.
+   Small by design.
+5. Lume adherence throughout (mono for handles/metadata, Signal rule, no
+   serif — none of this is memory content); jargon-free copy (lint, both
+   screens and both apps' visible text).
+
+## Acceptance criteria
+- [ ] directory screen renders live updates from real `session.*` events
+      (vitest with SSE fixture); stale sessions visually distinct
+- [ ] owner compose posts a valid envelope e2e (REST → SPEC-403 store →
+      recipient's `messenger_check` sees it, sender shown as the owner
+      handle)
+- [ ] end-conversation expires the thread's undelivered envelopes and
+      fires `message.expired`
+- [ ] session-monitor app renders in the SPEC-208 host harness; its
+      destructive controls are links to the dashboard, not tool calls
+- [ ] stash browser app lists real entries via the app bridge
+- [ ] jargon lint green on all new copy
+
+## Non-goals
+Editing messages; message search/archive; analytics.

--- a/v3/specs/SPEC-406-addon-sdk.md
+++ b/v3/specs/SPEC-406-addon-sdk.md
@@ -1,0 +1,60 @@
+---
+id: SPEC-406
+title: Add-on SDK + community submission flow
+phase: 4
+depends_on: [SPEC-303, SPEC-304]
+model: sonnet-5
+effort: medium
+status: ready
+---
+
+# SPEC-406: Add-on SDK
+
+## Goal
+The ecosystem play (§5.3): third parties can build, validate and submit
+add-ons for the curated index — palaia becomes distribution, like HACS is
+for Home Assistant. The SDK is deliberately thin: the manifest IS the
+SPEC-303 entry shape; the SDK's job is scaffolding, validation and an
+honest local test loop.
+
+## Deliverables
+1. `v3/sdk/` (new top-level v3 package, not inside the server): the add-on
+   author's toolkit. `palaia-addon` CLI (small, stdlib+pydantic only):
+   - `init` — scaffold an add-on directory (manifest + README + a minimal
+     working stdio MCP server example in Python, runnable via `uvx`);
+   - `validate` — the manifest against the SPEC-303 entry schema, the
+     config_schema subset (SPEC-304's fixed field kinds), permission
+     declarations, jargon lint over user-facing strings (reuse the
+     SPEC-207 lint's rules — one blocklist, one place: extract it to a
+     shared location both import);
+   - `test` — spin the add-on up locally and drive initialize/tools-list
+     through a real MCP client, printing what a marketplace user would
+     see (name, one-liner, config form fields, permissions).
+2. Submission flow, documented in `v3/docs/addon-submission.md`: a PR
+   against the curated-index source adds the entry; the index maintainer
+   validates (`palaia-addon validate`), reviews permissions, and re-signs
+   with `v3/tools/sign_market_index.py`. What "verified" means (and does
+   not mean) stated plainly. No web submission portal in this phase.
+3. Server-side: nothing new. The SDK consumes published contracts only —
+   a test asserts the SDK's schema copy and `palaia_hub.market.models`
+   cannot drift (parity test, both repos' shapes compared field-by-field).
+4. `v3/sdk/README.md`: the five-minute author path (init → implement →
+   validate → test → submit), jargon-free.
+
+## Acceptance criteria
+- [ ] `init` scaffold passes `validate` and `test` out of the box (the
+      example server answers tools/list through a real client)
+- [ ] `validate` rejects: bad kind, unknown permission, config field type
+      outside the subset, jargon in user-facing strings — each with a
+      plain-language error naming the fix
+- [ ] parity test: SDK schema == server market models (field names, kinds,
+      required-ness)
+- [ ] SDK has no dependency on palaia_hub (importable standalone;
+      `uv run --project v3/sdk` works in isolation)
+- [ ] docs: submission flow complete enough that a stranger needs no other
+      file
+
+## Non-goals
+A hosted submission portal; automatic index publication; ratings; paid
+listings. Container image scanning (curation is a human review in this
+phase).

--- a/v3/specs/SPEC-407-phase4-gate.md
+++ b/v3/specs/SPEC-407-phase4-gate.md
@@ -1,0 +1,49 @@
+---
+id: SPEC-407
+title: Phase-4 gate — "two agents on different providers hand off work"
+phase: 4
+depends_on: [SPEC-401, SPEC-402, SPEC-403, SPEC-404, SPEC-405]
+model: sonnet-5
+effort: medium
+status: ready
+---
+
+# SPEC-407: Phase-4 gate evidence
+
+## Goal
+Prove the roadmap's Phase-4 exit criterion with SPEC-209/308's evidence
+discipline: **two agents on different providers hand off work through
+palaia** — a handoff envelope with a vault reference, sent by one, picked
+up and acted on by the other.
+
+## Deliverables
+1. e2e scenario (extends the SPEC-308 harness): agent A is the real
+   `claude` CLI (OAuth, profile `default`) driven by a task prompt; agent B
+   is a scripted second-provider-shaped MCP client (`fastmcp.Client` with a
+   `plt_` token on a different profile — the sandbox has no codex binary;
+   say so, and pin the wire-level equivalence the same way SPEC-209 did).
+   A registers, writes its findings to memory, sends a `handoff` with the
+   ref; B checks, follows the ref via `recall`/`read`, and completes the
+   task using what A learned. Assert on B's real output containing A's
+   vault-stored fact — the handoff must carry knowledge, not just bytes.
+2. The same scenario's directory half: B found A (or its handoff) via a
+   scope query, not a hardcoded handle.
+3. A skill-driven variant (env-gated, SPEC-404's harness): agent A gets
+   only the task and the skills — no mention of the messenger in the
+   prompt — and the run records whether the handoff happened unprompted
+   (rate reported honestly; this is evidence, not a hard assert).
+4. `v3/docs/client-matrix-results.md` §8: dated "messenger" section —
+   per-client evidence or honest "not verified".
+5. Draft gate paragraph appended to IMPLEMENTATION.md §6 (marked draft —
+   the architect holds the gate); issues filed for quirks, SPEC-209 style.
+
+## Acceptance criteria
+- [ ] the two-agents handoff e2e passes and asserts knowledge transfer
+      (A's fact in B's output), run twice, no flakes
+- [ ] discovery via directory query, not hardcoded handles
+- [ ] skill-driven rate documented from ≥3 real runs
+- [ ] docs updated with dated evidence; full suite green at the end
+
+## Non-goals
+New features; vendor-cloud clients (claude.ai/ChatGPT) — the owner's
+phone test remains the standing manual item.


### PR DESCRIPTION
## Summary

The Phase-3-gate deliverable: seven Phase-4 SPECs and the §4d wave plan, toward the exit criterion **"two agents on different providers hand off work through palaia"**.

- **401 Dashboard sign-in** — the admin session gate (closes #242): one door reused from the OAuth/IdP login, CSRF on the REST surface, per-mode enforcement, and it lifts the temporary open-mode refusal.
- **402 Session directory** — registration/heartbeat/TTL with an impersonation-proof session secret, `directory_*` tool family, `session.*` events.
- **403 Messenger core** — the envelope protocol fixed in-spec (typed, 4KB body cap, vault refs as the token-discipline mechanism), pull delivery, inbox auth via the session secret, broadcast caps.
- **404 Messaging skills + push adapters** — the habit layer, measured with SPEC-207's effectiveness discipline; hook-based push.
- **405 Team observability** — live directory + message flows in the dashboard (read along, join in, shut down), session-monitor and stash-browser MCP Apps.
- **406 Add-on SDK** — thin author toolkit (init/validate/test) + the PR-based submission flow for the signed curated index.
- **407 Phase-4 gate evidence** — real cross-provider handoff with knowledge transfer asserted, discovery via directory query, skill-driven rate reported honestly.

Waves: **4a** = 401, 402, 406 → **4b** = 403 → **4c** = 404, 405, then 407 + gate. Security reviews marked (401 max, 402/403 targeted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790183079&installation_model_id=428086&pr_number=249&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F249&signature=af744c08added520e5e50a6ce23cb9859d88438ba4333860d1bd20d9693d73dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->