### PR TITLE
fix(v3): OAuth scope ceiling includes mounted built-in families

### DIFF
--- a/v3/server/src/palaia_hub/cli.py
+++ b/v3/server/src/palaia_hub/cli.py
@@ -225,20 +225,30 @@ async def _serve_async(config: HubConfig) -> None:
 
 def _profile_scopes(profiles: Sequence[ProfileConfig]) -> dict[str, list[str]]:
     """``{profile: grantable scopes}``, one entry per profile, scoped to
-    exactly the vaults *that* profile mounts (SPEC-301) — every vault a
-    profile serves contributes a read and a write scope, the same
-    vocabulary SPEC-108 tokens use (:func:`palaia_hub.auth.scopes.
-    vault_scope`), so a client's scopes mean the same thing whichever
-    credential carried them.
+    exactly what *that* profile mounts (SPEC-301) — every vault it serves
+    contributes a read and a write scope, and each mounted built-in family
+    (stash SPEC-202, directory SPEC-402, messenger SPEC-403) contributes its
+    own pair. The same vocabulary SPEC-108 tokens use, so a client's scopes
+    mean the same thing whichever credential carried them; before this
+    listed the built-ins, an OAuth client could never be granted them at
+    all, only a ``plt_`` token could (found during SPEC-403).
     """
-    return {
-        profile.path: [
+
+    def scopes_for(profile: ProfileConfig) -> list[str]:
+        scopes = [
             scope
             for key in profile.vaults
             for scope in (f"vault:{key}:read", f"vault:{key}:write")
         ]
-        for profile in profiles
-    }
+        if profile.stash:
+            scopes += ["stash:read", "stash:write"]
+        if profile.directory:
+            scopes += ["directory:read", "directory:write"]
+        if profile.messenger:
+            scopes += ["messenger:read", "messenger:send"]
+        return scopes
+
+    return {profile.path: scopes_for(profile) for profile in profiles}
 
 
 def _gateway_profiles_for_oauth(config: HubConfig) -> list[ProfileConfig]:

--- a/v3/server/tests/oauth/test_gateway_config_spec301.py
+++ b/v3/server/tests/oauth/test_gateway_config_spec301.py
@@ -140,3 +140,36 @@ async def test_old_oauth_profiles_config_still_works_with_no_gateway_section(
     oauth_server = _maybe_oauth_server(config)
     assert oauth_server is not None
     assert set(oauth_server.resources.profiles) == {"legacy"}
+
+
+def test_profile_scopes_include_mounted_builtin_families() -> None:
+    """An OAuth client can be granted the stash/directory/messenger scopes
+    of the profiles that actually mount those families (SPEC-403 follow-up:
+    before this, only plt_ tokens could carry them)."""
+    from palaia_hub.cli import _profile_scopes
+    from palaia_hub.gateway.config import ProfileConfig
+
+    scopes = _profile_scopes(
+        [
+            ProfileConfig(
+                path="team",
+                vaults=["work"],
+                stash=True,
+                directory=True,
+                messenger=True,
+            ),
+            ProfileConfig(path="plain", vaults=["work"]),
+        ]
+    )
+
+    assert scopes["team"] == [
+        "vault:work:read",
+        "vault:work:write",
+        "stash:read",
+        "stash:write",
+        "directory:read",
+        "directory:write",
+        "messenger:read",
+        "messenger:send",
+    ]
+    assert scopes["plain"] == ["vault:work:read", "vault:work:write"]


### PR DESCRIPTION
## Summary

SPEC-403's PR flagged this pre-existing gap: `cli._profile_scopes` only put `vault:<key>:read|write` into the OAuth server's grantable set, so an OAuth client could never be granted `stash:*`, `directory:*` or `messenger:*` — only `plt_` tokens could carry them. A profile's ceiling now also contributes each built-in family it actually mounts (stash, directory, messenger), keeping the ceiling exactly as narrow as the profile's real surface. Blocking for SPEC-407's gate e2e (the OAuth `claude` CLI needs `messenger:send`).

## Verification

```
uv run ruff check server    All checks passed!
uv run mypy server/src      Success (183 files)
uv run pytest server/tests  1945 passed + 1 unrelated timing flake (#253: vault watcher
                            test failed once under full-suite load; passes 3/3 standalone,
                            diff touches only cli.py)
```

New test: `test_profile_scopes_include_mounted_builtin_families`.

## Scope

`v3/server/src/palaia_hub/cli.py` + one test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790256021&installation_model_id=428086&pr_number=254&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F254&signature=d15fc84fe97f4322a2d0886534542cb143fbbfda2f3508579e1b298be1ae5efc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->