### PR TITLE
feat(v3): messaging skills + push adapters (SPEC-404)

### DIFF
--- a/v3/clients/.claude-plugin/marketplace.json
+++ b/v3/clients/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "palaia-memory",
       "source": "./",
-      "description": "Makes an agent use palaia's shared memory without being told: when to recall, how to resume work, and what deserves capturing."
+      "description": "Makes an agent use palaia's shared memory without being told, and work alongside other agent sessions: when to recall, how to resume work, what deserves capturing, and when to register, check in and reply."
     }
   ]
 }

--- a/v3/clients/.claude-plugin/plugin.json
+++ b/v3/clients/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "palaia-memory",
-  "description": "Makes an agent use palaia's shared memory without being told: when to recall, how to resume work, and what deserves capturing.",
+  "description": "Makes an agent use palaia's shared memory without being told, and work alongside other agent sessions: when to recall, how to resume work, what deserves capturing, and when to register, check in and reply.",
   "version": "0.1.0",
   "author": {
     "name": "byte5",
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/byte5ai/palaia/tree/main/v3/clients",
   "repository": "https://github.com/byte5ai/palaia",
   "license": "MIT",
-  "keywords": ["memory", "mcp", "recall", "capture", "palaia"]
+  "keywords": ["memory", "mcp", "recall", "capture", "messaging", "palaia"]
 }

--- a/v3/clients/README.md
+++ b/v3/clients/README.md
@@ -16,10 +16,12 @@ vendor-specific — [Agent Skills](https://agentskills.io) (`SKILL.md`), with
 |---|---|---|
 | [`skills/palaia-memory`](skills/palaia-memory/SKILL.md) | the default | Both halves: recall before deciding, resume with `build_context`, which memory to use, and the capture discipline. |
 | [`skills/palaia-capture`](skills/palaia-capture/SKILL.md) | constrained agents | Saving only — the 4-field contract and drop-and-move-on, nothing about looking things up. |
+| [`skills/palaia-messenger`](skills/palaia-messenger/SKILL.md) | any agent working alongside others | Register on start, check before picking up a task, reply-or-decline, and keeping a message short with a reference instead of pasted content. See [`docs/messenger.md`](../docs/messenger.md) for the full contract. |
 
-Both carry a `## Per-model notes` section, written with the vault format's own
-variant markers (`[anthropic]`, `[openai]`, `[google]`) — the same idea as
-per-model observation variants in a note, applied to skill prose.
+All three carry a `## Per-model notes` section, written with the vault
+format's own variant markers (`[anthropic]`, `[openai]`, `[google]`) — the
+same idea as per-model observation variants in a note, applied to skill
+prose.
 
 ## Installing one
 
@@ -36,7 +38,7 @@ cp v3/clients/skills/palaia-memory/SKILL.md ~/.claude/skills/palaia-memory/
 ## The plugin wrapper
 
 [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json) makes this
-directory a loadable plugin, so both skills install as one unit:
+directory a loadable plugin, so all three skills install as one unit:
 
 ```bash
 claude --plugin-dir v3/clients      # this session only
@@ -63,6 +65,8 @@ calls actually happened. It is excluded from CI (real model calls) and gated:
 cd v3 && PALAIA_EFFECTIVENESS=1 uv run pytest server/tests/effectiveness -s -v
 ```
 
-Read `server/tests/effectiveness/harness.py` before changing a word of a
-skill: it explains the probes, the no-skill baseline they are compared
-against, and why the evidence is collected server-side.
+Read `server/tests/effectiveness/harness.py` before changing a word of the
+memory/capture skills, or `server/tests/effectiveness/messaging_harness.py`
+before changing a word of the messenger skill — each explains its own
+probes, the no-skill baseline they are compared against, and why the
+evidence is collected server-side.

--- a/v3/clients/skills/palaia-messenger/SKILL.md
+++ b/v3/clients/skills/palaia-messenger/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: palaia-messenger
+description: Register this session with the shared directory so other AI sessions and this person's dashboard can see what you are doing, then use it to reach another live session directly instead of relaying everything through the person. Use it at the start of a task, before picking one up, when your work depends on or informs another session's work, and whenever a message asks you for a reply.
+license: MIT
+---
+
+# Working alongside other sessions
+
+This person often has more than one AI session going at once — another
+window, another machine, a different tool entirely — sometimes on the same
+piece of work. The directory is how sessions find each other; the messenger
+is how they talk once found. Both are ordinary parts of doing the work, not
+something to ask permission for.
+
+## Do this without being asked
+
+Three moments, every time:
+
+1. **Starting a task.** Register with the directory, describing what you are
+   about to do in your own words. Anyone else working nearby can now find you.
+2. **Picking up a task, especially one that sounds like a continuation.**
+   Check for anything waiting for you before you start — a handoff, a
+   question, a heads-up. Acting on stale information because you never
+   looked is the failure this exists to prevent.
+3. **A message asks you for a reply.** Answer it, or say plainly that you
+   will not — in the same turn you notice it, not later. A message marked as
+   needing an answer that never gets one leaves the sender waiting on
+   nothing.
+
+None of this is a favour to the person watching. It is the same habit as
+checking a shared document before editing it.
+
+## The tools
+
+| Tool | Use it for |
+|---|---|
+| `directory_register` | Announce this session: what you're doing, at the start of a task. |
+| `directory_heartbeat` | Keep your registration alive during a long task. |
+| `directory_update` | Change what you're doing, or mark yourself idle. |
+| `directory_list` / `directory_query` | Find another live session — by what it's doing, or by a tag it offers. |
+| `directory_deregister` | Leave the directory when a task wraps up. |
+| `messenger_send` | Send one message to a session, or to several at once. |
+| `messenger_check` | Collect whatever has arrived for you. |
+| `messenger_ack` | Close a message once you've dealt with it. |
+| `messenger_thread` | Read a whole back-and-forth, not just the latest message. |
+
+These names are fixed — they do not carry a per-person prefix the way the
+memory tools do. Use the ones your client actually lists.
+
+## Register at the start
+
+Call `directory_register` before anything else in a task that could matter
+to another session — which is most tasks. Describe what you're doing in
+plain words, the way you would tell a colleague: "refactoring the billing
+service", "reviewing PR 214", "debugging the flaky import test". That
+description is what makes you findable — another session looks for
+someone doing something, not for a name.
+
+Keep the handle and secret it gives back. You need both for everything else
+below, and nobody else can act as you without them. If the task runs long,
+call `directory_heartbeat` occasionally so you don't fade out of view; call
+`directory_update` when what you're doing changes enough to describe
+differently, or to mark yourself idle between bursts of activity.
+
+## Check before you start
+
+Before diving into a task — especially one that picks up earlier work, or
+one someone else might reasonably be touching too — call `messenger_check`.
+Do this early and directly, before you spend time trying to work out from
+anything else — files, history, your own guess — whether there is
+something to pick up. Checking is how you find that out; it's not a
+fallback for once other ways of finding out come up empty. It's quick, and
+empty is a fine answer: it just means say so and carry on. Finding
+something changes what "starting" means; not looking does not make that go
+away, and if it turns out nothing local looks like the task you were
+expecting, that is itself a reason to check, not a reason to skip it.
+
+Do this again at natural pauses in a long task, not only once at the very
+start.
+
+## Finding someone to talk to
+
+`directory_list` shows every live session; `directory_query` narrows by a
+plain-word description ("who is touching the billing service") or by a tag a
+session offers. Address one session by the handle it published. To reach
+several at once, `messenger_send` also accepts a query in place of a single
+handle: `*` for everyone live, `capability:<tag>` for everyone offering that
+tag, or any plain-word substring to match against what sessions say they are
+doing. A query that matches nobody, or an unreasonably large group, is
+refused rather than silently guessed at — narrow it and try again.
+
+## Say what kind of message it is
+
+Every message is one of five kinds, and picking the right one is most of
+being clear:
+
+- **request** — asking for work to be done.
+- **question** — asking for an answer.
+- **inform** — telling someone something, no reply needed.
+- **handoff** — passing a piece of work over.
+- **broadcast** — one message, several recipients.
+
+Mark a message as needing a reply only when you actually are waiting on one
+— it is a real flag another session's own habits act on, not a politeness
+setting.
+
+## Keep the message itself short
+
+A message is a pointer between two working sessions, not a place to write
+things down. If what you need to say is more than a couple of sentences —
+the details of a decision, a full explanation, anything somebody would want
+to find again later — write it to memory first, the same way you would
+capture anything else worth keeping, and put a reference to that note in
+the message instead of the content itself. There is a hard length limit on
+the message text for exactly this reason: past a couple of paragraphs,
+something is being carried in the message that belongs in memory instead.
+
+Do the two steps in that order, in the same turn, and do not report either
+one as done before it actually happened: first the note (`capture` for
+something you noticed, `write` if the person asked you to record it —
+whichever the memory skill calls for), then the message with that note's
+own reference in `refs`. A message that only *describes* a note as saved,
+with no reference attached, has not done the thing it claims — `refs`
+being empty on a message about a decision is the one state that should
+make you stop and go back, not send anyway.
+
+A worked example. You're wrapping up and handing a piece of work to whoever
+picks it up next:
+
+```
+messenger_send(
+  handle=my_handle, session_secret=my_secret,
+  to=their_handle,
+  type="handoff",
+  subject="billing retry batching — capped at 200, needs the queue split first",
+  body="Wrote up the batching decision and why — see the reference below.",
+  refs=["memory://projects/billing-service/retry-batching"],
+  expects_reply=False,
+)
+```
+
+The reason for the cap and its details live in memory, written once. The
+message just says what happened and points at it — the recipient reads the
+note if and when they need the detail, and nobody has re-typed it.
+
+If a send is refused for being too long, do not shorten it by cutting
+detail out and losing it — write the detail to memory and send the
+reference instead. That is the fix the refusal is naming, not a suggestion.
+
+## Reading and answering
+
+`messenger_check` hands you whatever is new and marks it read; re-open
+something you already saw with `messenger_thread`, which also shows you the
+rest of that back-and-forth, not just the one message. Close a message with
+`messenger_ack` once you've actually dealt with it — acknowledging twice is
+harmless, so there's no need to track whether you already did.
+
+When a message is marked as needing a reply, answer it with `messenger_send`
+using the same session's handle and secret, addressed back to whoever sent
+it. If you genuinely cannot or will not do what's being asked, say so — a
+short, explicit no is a reply; silence is not.
+
+## Wrap up when you're done
+
+Call `directory_deregister` when a task is finished and you don't expect to
+be reached about it again. If you're only pausing rather than finishing,
+`directory_update` to mark yourself idle is the better move — it says you
+are still around without claiming to be actively working.
+
+## Per-model notes
+
+Same tools, slightly different failure modes. The line for your family
+wins; the unlabelled line is the default.
+
+- Register once per task, not once per message you plan to send.
+- [anthropic] Checking for messages is not an interruption to ask about —
+  it is part of starting the task, the same as your instinct to read a file
+  before editing it.
+- [openai] Silence about other sessions in the prompt is not a signal to
+  skip the directory — register and check anyway; the habit is the point.
+- [google] When you summarize what you did, name the message you sent or
+  the reply you gave in one line — do not fold it into a longer account of
+  the whole task.
+- Report what you registered, sent or found in one line, not a restatement
+  of the tool call the person can already see.
+- [anthropic] No preamble before calling `directory_register` or
+  `messenger_check` at the start of a task — just call it.

--- a/v3/docs/messenger.md
+++ b/v3/docs/messenger.md
@@ -1,0 +1,202 @@
+# palaia Messenger — the agent-facing contract
+
+> Written for skill authors and SDK users: what a session actually sees
+> when it registers, sends, checks and replies. The envelope's wire shape
+> and the hub-side storage/authorization rules are normative in
+> [SPEC-403](../specs/SPEC-403-messenger.md) and
+> [`docs/events.md` §3.6/§3.7](events.md); this document restates the parts
+> an agent (or the prose of a skill teaching one) needs, without the
+> implementation detail. Where a term below would read as internal
+> plumbing to someone outside this repository, it says so in plain words
+> instead — that is deliberate: this page is itself read by non-Anthropic
+> tooling and the SKILL.md packages under
+> [`v3/clients/skills/palaia-messenger`](../clients/skills/palaia-messenger/SKILL.md)
+> lean on it.
+
+## 1. Two tool families, one habit
+
+**The session directory** (`directory_*`) is presence: who is connected,
+doing what, on what host, for how long. **The messenger** (`messenger_*`)
+is one message between two directory entries. Neither is memory — nothing
+here is meant to outlive the conversation it is part of; anything that
+should is written to memory once, and pointed at (§3).
+
+A session registers once per task (`directory_register`), keeps that
+registration alive with `directory_heartbeat`/`directory_update` for a long
+task, and removes itself with `directory_deregister` when done. Everything
+the messenger does afterward — sending, checking, replying — happens
+against that one registration's handle and secret.
+
+## 2. The envelope
+
+Every message, in either direction, has this shape:
+
+```json
+{
+  "id": "b3f1...c2",
+  "type": "handoff",
+  "from": "swift-otter-4a",
+  "to": "calm-heron-7c",
+  "subject": "billing retry batching — capped at 200, needs the queue split first",
+  "urgency": "normal",
+  "expects_reply": false,
+  "body": "Wrote up the batching decision and why — see the reference below.",
+  "refs": ["memory://projects/billing-service/retry-batching"],
+  "reply_to": null,
+  "created_at": 1755999999.123,
+  "expires_at": 1756086399.123
+}
+```
+
+| Field | Type | Meaning |
+|---|---|---|
+| `id` | string | Minted by the hub when the message is sent. Never chosen by the sender. |
+| `type` | `request \| inform \| question \| handoff \| broadcast` | What kind of message this is — see §4. |
+| `from` | string | The sender's own handle, proven by its session secret at send time. |
+| `to` | string | A recipient handle — or, for `type: "broadcast"`, the directory query it was cast with (§5). |
+| `subject` | string, ≤200 characters | One line. Every listing a recipient sees before deciding to open something shows this and nothing else. |
+| `urgency` | `low \| normal \| high` | Self-reported by the sender; a recipient's own habits decide what to do with it. |
+| `expects_reply` | boolean | `true` means the sender is waiting on an answer — see §6. |
+| `body` | string, ≤4096 UTF-8 bytes | The message itself. See §3 for the cap and what to do about it. |
+| `refs` | array of `memory://` references | Pointers into whichever memory the sender can read, checked to actually resolve before the message sends. |
+| `reply_to` | string or null | The id this answers, or null for a fresh message — this is what threads a conversation. |
+| `created_at`, `expires_at` | number | Unix timestamps. A message not checked before `expires_at` is gone (default 24 hours; a sender may ask for up to 7 days). |
+
+## 3. The body cap, and why
+
+The body is capped at 4096 UTF-8 bytes, and a message over that limit is
+refused — not truncated. Truncating would silently drop the half of a
+decision nobody re-reads; refusing, with an error that names the fix,
+keeps the sender in the conversation long enough to actually fix it.
+
+The fix is always the same: **write the long content to memory once, and
+put a reference to it in `refs` instead of pasting it into `body`.** A
+message is a pointer between two working sessions, not a place to write
+things down — the same distinction a note and a comment on it have. A
+`refs` entry that resolves to nothing readable by the sender is refused
+for the same reason a message would be otherwise useless: a recipient
+cannot follow a reference that points nowhere.
+
+This is not a quirk of one implementation — it is the whole reason `refs`
+exists, and it is the one habit worth getting right before anything else
+here: **short message, and a reference for anything long.**
+
+## 4. Message types
+
+| Type | Use it for |
+|---|---|
+| `request` | Asking for work to be done. |
+| `inform` | Telling someone something. No reply implied. |
+| `question` | Asking for an answer. |
+| `handoff` | Passing a piece of work over to another session. |
+| `broadcast` | One message, several recipients at once (§5). A broadcast cannot itself be a reply. |
+
+## 5. Addressing, including broadcast
+
+For every type but `broadcast`, `to` is one recipient's handle, taken from
+the directory (`directory_list`/`directory_query`). An unknown or stale
+handle is refused — a stale session may already be gone, and a message to
+it would sit unread.
+
+For `type: "broadcast"`, `to` is a small query grammar instead of a
+handle, resolved against the directory *at send time*:
+
+| `to` | Reaches |
+|---|---|
+| `*` | Every currently live session. |
+| `capability:<tag>` | Every session that advertised that tag when it registered. |
+| anything else | A case-insensitive substring match against sessions' self-reported scope (what they said they are doing). |
+
+A broadcast fans out to at most 20 recipients, each getting its own message
+id. A query matching nobody, or matching more than the cap, is refused
+outright rather than delivered to part of the audience — a broadcast that
+silently reached half its intended readers is worse than one that visibly
+sent nothing.
+
+## 6. Checking, replying, and threads
+
+Delivery is pull, by design: a session calls `messenger_check` to collect
+whatever has arrived for its own handle, marking each item delivered so it
+is not handed over twice. An empty result is a normal result, not a
+failure — most checks, for most sessions, most of the time, will be empty.
+
+When `expects_reply` is `true`, the receiving session is expected to
+either answer it (`messenger_send` with `reply_to` set to the original
+message's id) or say plainly that it will not — silence is the one wrong
+move, because the sender is specifically waiting. `messenger_thread` reads
+a whole back-and-forth by that same `reply_to` chain, not just the latest
+message, and `messenger_ack` closes a message once a recipient has
+actually dealt with it (acking twice is harmless).
+
+## 7. Authorization: a scope is not an identity
+
+A client needs the `messenger:send` or `messenger:read` scope on its token
+to use the messenger at all — an ordinary per-tool permission, enforced the
+same way every other palaia tool family enforces one. That answers *may
+this client use the messenger*, and nothing more: it does not say which
+session is calling.
+
+*Which session is calling* is answered by the session secret
+`directory_register` returned, passed on every `messenger_*` call
+alongside the caller's handle. A scope alone must never be enough to read
+another session's messages — that is what the secret is for, and it is
+never re-minted: one registration, one secret, reused for every messenger
+call that registration ever makes. Two different sessions can hold tokens
+with identical scopes and still be unable to read each other's messages;
+that is the property this design exists to guarantee.
+
+## 8. Push adapters (beyond polling)
+
+Pull (`messenger_check`) is the universal baseline — nothing about it
+depends on the calling client. Two adapters exist on top of it, so a
+message's arrival can also reach somewhere other than the next poll:
+
+- **Outbound webhook on `message.received`.** No new mechanism: the hub's
+  existing webhook management (`docs/events.md` §4) already matches a hook
+  against any event name on the bus, and the messenger already publishes
+  `message.received` there (metadata only — see `docs/events.md` §3.7).
+  Registering one is exactly registering any other hook:
+
+  ```bash
+  curl -X POST http://<hub>/api/hooks \
+    -H 'Content-Type: application/json' \
+    -d '{"url": "https://my-other-tooling.example/webhook", "events": ["message.received"]}'
+  ```
+
+  The response's `secret` signs every delivery (`X-Palaia-Signature`) —
+  store it once, it is not shown again. From there, delivery is signed,
+  retried and dead-lettered exactly like every other webhook (§4 of
+  `docs/events.md`); nothing about the message pipeline is special-cased.
+  `server/tests/messenger/test_push_recipe.py` runs this recipe against a
+  real local receiver as the SPEC-404 acceptance evidence: two sessions
+  exchange a message, and the webhook fires with a signature that verifies
+  and a payload that carries the same metadata as the bus event — no body,
+  ever.
+
+- **Claude Code's `claude/channel` capability — not verified here.** Claude
+  Code documents an MCP-server capability that can push an event into an
+  already-open session rather than waiting for it to poll (the research
+  dossier names this as a live precedent for exactly this use case). This
+  hub does not implement it, and this repository does not claim to have
+  exercised it: the pinned `fastmcp` 3.4.7 has no support for declaring it,
+  making it would mean hand-rolling a capability outside any documented,
+  version-pinned surface this project relies on elsewhere, and doing that
+  without being able to verify the exact wire behavior against a real
+  Claude Code session would be worse than not shipping it. The integration
+  path, for whoever picks this up once `fastmcp` (or a raw MCP transport
+  layer alongside it) supports declaring the capability: the messenger's
+  own `message.received` event already carries everything a push needs
+  (§3.7 of `docs/events.md`) — the missing piece is purely the transport
+  announcement, not new domain logic.
+
+## 9. See also
+
+- [SPEC-403](../specs/SPEC-403-messenger.md) — the envelope's normative
+  definition and the hub-side store/authorization contract.
+- [`docs/events.md` §3.6/§3.7](events.md) — the `session.*`/`message.*`
+  events this contract's checking and replying produce on the bus, for
+  automations and webhooks.
+- [`v3/clients/skills/palaia-messenger`](../clients/skills/palaia-messenger/SKILL.md)
+  — the habits (register on start, check before starting work, reply or
+  decline, keep it short) written for a model to actually follow, rather
+  than read about.

--- a/v3/server/tests/clients/test_skill_format.py
+++ b/v3/server/tests/clients/test_skill_format.py
@@ -58,6 +58,32 @@ def test_both_spec_207_skill_packages_are_present() -> None:
     assert {"palaia-memory", "palaia-capture"} <= slugs, slugs
 
 
+def test_the_spec_404_messenger_skill_package_is_present() -> None:
+    slugs = {directory.name for directory in discover_skills()}
+    assert "palaia-messenger" in slugs, slugs
+
+
+def test_messenger_skill_teaches_every_spec_404_habit() -> None:
+    """Deliverable #1's five habits, each traceable to a line in the skill:
+    register on start, check before starting work, the reply discipline,
+    the short-message-plus-reference rule, and winding down."""
+    skill, issues = parse_skill(CLIENTS_ROOT / "skills" / "palaia-messenger")
+    assert issues == [], issues
+    assert skill is not None
+    lowered = skill.body.lower()
+    for phrase in (
+        "directory_register",
+        "messenger_check",
+        "messenger_send",
+        "messenger_ack",
+        "expects_reply",
+        "handoff",
+        "memory://",
+        "deregister",
+    ):
+        assert phrase.lower() in lowered, phrase
+
+
 def test_capture_skill_is_the_smaller_one() -> None:
     """``palaia-capture`` exists for constrained agents (SPEC-207 #1).
 
@@ -92,13 +118,18 @@ def test_every_skill_carries_per_model_guidance() -> None:
 
 def test_skills_name_the_four_capture_fields() -> None:
     """The 4-field contract is the one thing a capture cannot be composed
-    without (format spec §7 / SPEC-107's mandatory fields)."""
-    for directory in discover_skills():
-        skill, _ = parse_skill(directory)
+    without (format spec §7 / SPEC-107's mandatory fields).
+
+    Scoped to the two skills that actually teach capture — `palaia-
+    messenger` (SPEC-404) teaches a different discipline entirely and has
+    no reason to name these fields.
+    """
+    for slug in ("palaia-memory", "palaia-capture"):
+        skill, _ = parse_skill(CLIENTS_ROOT / "skills" / slug)
         assert skill is not None
         lowered = skill.body.lower()
         for field in ("what it concerns", "why keep it", "content", "source"):
-            assert field in lowered, (directory.name, field)
+            assert field in lowered, (slug, field)
 
 
 # --- the linter itself -------------------------------------------------

--- a/v3/server/tests/effectiveness/messaging_harness.py
+++ b/v3/server/tests/effectiveness/messaging_harness.py
@@ -1,0 +1,325 @@
+"""SPEC-404 deliverable #3: does the messenger skill actually change what a
+real agent does — unprompted?
+
+Reads on `harness.py`'s own docstring for why this can only be answered by
+running a model (never by reading the skill), why the evidence is collected
+server-side, and why a probe runs several times rather than once. This
+module keeps every one of those constraints and differs only in what is
+being measured and in the hub script it spawns
+(`support/messaging_hub_server.py`, which mounts the session directory and
+messenger tool families — SPEC-402/403 — rather than a lone vault).
+
+Two probes, matching SPEC-404 deliverable #3 verbatim:
+
+- **Session A** (:data:`HANDOFF_PROMPT`): a real end-of-shift task with a
+  decision to hand off. A hit is not just "it called `messenger_send`" —
+  :func:`sent_handoff_with_ref` checks that the send was typed `handoff`
+  *and* carried a `memory://` reference, which is the only way to tell
+  "wrote it to memory once and pointed at it" apart from "pasted the whole
+  decision into the message body", the exact failure the skill's token
+  rule exists to prevent.
+- **Session B** (:data:`CHECK_PROMPT`): a task that never mentions messages
+  at all. A hit is `messenger_check` appearing in the call log with nothing
+  in the prompt that could have suggested it — "checks its inbox
+  unprompted at task start".
+
+A stand-in peer is registered directly against the hub's directory store
+*before* session A's CLI process ever starts (`seed_peer_scope`), so the
+agent has someone real to find — via `directory_list`/`directory_query`,
+the same as it would with a live peer — rather than a name typed into the
+prompt.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from pathlib import Path
+
+from .harness import (
+    CLIENTS_ROOT,
+    GOLDEN_VAULT_ROOT,
+    ProbeError,
+    ProbeResult,
+    ToolCall,
+    claude_cli,
+    default_attempts,
+    stage_plugin,
+)
+
+_MESSAGING_HUB_SCRIPT = Path(__file__).resolve().parent / "support" / "messaging_hub_server.py"
+
+_STARTUP_TIMEOUT = 20.0
+_CLAUDE_TIMEOUT = 420.0
+
+#: The scope the stand-in peer registers with — a substring session A's
+#: prompt names, so a plain `directory_query`/`directory_list` finds it the
+#: way it would find a real live session.
+SEED_PEER_SCOPE = "cleaning up the billing service outage"
+
+#: Should trigger: register, write the decision to memory, then a `handoff`
+#: whose body stays short because the decision travels as a `memory://`
+#: reference instead. Nothing here names a tool or "the messenger" — it is
+#: an ordinary end-of-shift handoff, the shape the skill is meant for.
+HANDOFF_PROMPT = (
+    "It's the end of your shift on the billing-refactor branch. Before you go: "
+    "save this to memory so it is not lost — we capped the API retry batch at "
+    "200 items because a bigger batch trips the downstream rate limiter, and "
+    "raising it needs the request queue split first. Then hand the branch off "
+    "to whichever other session is already working on the billing service, so "
+    "they can pick it up first thing. Reply with one line confirming both are "
+    "done."
+)
+
+#: Should trigger: get oriented for resuming shared work, which under the
+#: skill means checking what arrived while this session was away. Nothing
+#: here says "message", "inbox" or "check" — the task is just "get
+#: oriented". Deliberately says "another session" rather than naming a
+#: literal file or branch to pick up: an early version of this prompt
+#: ("picking up the billing-refactor branch") led the agent to go looking
+#: for a git branch in an intentionally empty project directory instead of
+#: checking for anything left for it — a miss worth fixing in the prompt,
+#: not just in the skill (see the PR notes for the run that caught it).
+CHECK_PROMPT = (
+    "Another session was working on the billing-refactor work with you earlier "
+    "today and may have left you something. Get yourself oriented before doing "
+    "anything else, then tell me in two lines where things stand."
+)
+
+HANDOFF_EXPECTED_TOOLS: tuple[str, ...] = ("messenger_send",)
+CHECK_EXPECTED_TOOLS: tuple[str, ...] = ("messenger_check",)
+
+
+def sent_handoff_with_ref(result: ProbeResult) -> bool:
+    """Session A's actual bar: a `handoff` send carrying a `memory://` ref.
+
+    A `messenger_send` call alone is not the finding — a handoff whose body
+    contains the whole decision, with `refs` left empty, is the exact
+    failure the token rule exists to catch, and would still make
+    ``result.called("messenger_send")`` true.
+    """
+    for call in result.calls_to("messenger_send"):
+        if call.arguments.get("message_type") != "handoff":
+            continue
+        refs = call.arguments.get("refs") or []
+        if isinstance(refs, list) and any(str(ref).strip() for ref in refs):
+            return True
+    return False
+
+
+def registered(result: ProbeResult) -> bool:
+    """Did this session call ``directory_register`` at all — the other half
+    of SPEC-404 deliverable #3's first question."""
+    return result.called("directory_register")
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_health(port: int, timeout: float = _STARTUP_TIMEOUT) -> None:
+    deadline = time.monotonic() + timeout
+    last: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(f"http://127.0.0.1:{port}/api/health", timeout=0.5) as resp:
+                if resp.status == 200:
+                    return
+        except (OSError, urllib.error.URLError) as exc:
+            last = exc
+            time.sleep(0.1)
+    raise ProbeError(f"messaging hub did not become healthy within {timeout}s: {last}")
+
+
+def run_messaging_probe(
+    *,
+    label: str,
+    prompt: str,
+    workdir: Path,
+    skills: tuple[str, ...],
+    mount_vault: bool,
+    seed_peer_scope: str | None = None,
+    model: str | None = None,
+) -> ProbeResult:
+    """Run one messaging probe end to end and return what the agent did.
+
+    ``mount_vault`` decides whether a `default` vault profile exists at
+    all — session A's probe needs one (somewhere to write the note it hands
+    off a reference to); session B's does not, and leaving it out keeps
+    that probe's tool surface to exactly what is being measured.
+    """
+    cli = claude_cli()
+    if cli is None:  # pragma: no cover - guarded by skip_reason()
+        raise ProbeError("claude CLI not on PATH")
+
+    workdir.mkdir(parents=True, exist_ok=True)
+    record_path = workdir / "tool-calls.jsonl"
+    record_path.touch()
+    hub_log = workdir / "hub.log"
+    project_dir = workdir / "project"
+    project_dir.mkdir()
+
+    vault_dir: Path | None = None
+    port = _free_port()
+    server_args = [
+        sys.executable,
+        str(_MESSAGING_HUB_SCRIPT),
+        "--port",
+        str(port),
+        "--record",
+        str(record_path),
+    ]
+    if mount_vault:
+        vault_dir = workdir / "vault"
+        shutil.copytree(GOLDEN_VAULT_ROOT / "work", vault_dir)
+        server_args += ["--vault-dir", str(vault_dir), "--vault-key", "work"]
+        server_args += ["--vault-name", "work"]
+    if seed_peer_scope:
+        server_args += ["--seed-peer-scope", seed_peer_scope]
+
+    with hub_log.open("w") as log_file:
+        hub = subprocess.Popen(  # noqa: S603 - fixed argv, no shell
+            server_args, stdout=log_file, stderr=subprocess.STDOUT
+        )
+        try:
+            _wait_for_health(port)
+
+            servers: dict[str, dict[str, str]] = {
+                "messaging": {"type": "http", "url": f"http://127.0.0.1:{port}/mcp/messaging/"}
+            }
+            allowed_servers = ["mcp__messaging"]
+            if mount_vault:
+                servers["palaia"] = {"type": "http", "url": f"http://127.0.0.1:{port}/mcp/default/"}
+                allowed_servers.append("mcp__palaia")
+            mcp_config = json.dumps({"mcpServers": servers})
+
+            args = [
+                cli,
+                "-p",
+                prompt,
+                "--mcp-config",
+                mcp_config,
+                "--strict-mcp-config",
+                "--allowedTools",
+                " ".join(["Skill", *allowed_servers]),
+                "--output-format",
+                "json",
+                "--no-session-persistence",
+            ]
+            if model:
+                args += ["--model", model]
+            if skills:
+                args += ["--plugin-dir", str(stage_plugin(workdir, skills))]
+
+            try:
+                completed = subprocess.run(  # noqa: S603 - fixed argv, no shell
+                    args,
+                    cwd=project_dir,
+                    capture_output=True,
+                    text=True,
+                    timeout=_CLAUDE_TIMEOUT,
+                )
+            except subprocess.TimeoutExpired as exc:
+                raise ProbeError(f"{label}: claude did not finish in {_CLAUDE_TIMEOUT}s") from exc
+            if completed.returncode != 0:
+                raise ProbeError(
+                    f"{label}: claude exited {completed.returncode}\n{completed.stderr[-2000:]}"
+                )
+            try:
+                payload = json.loads(completed.stdout)
+            except json.JSONDecodeError as exc:
+                raise ProbeError(
+                    f"{label}: claude output was not JSON:\n{completed.stdout[:2000]}"
+                ) from exc
+        finally:
+            hub.terminate()
+            try:
+                hub.wait(timeout=10)
+            except subprocess.TimeoutExpired:  # pragma: no cover - defensive
+                hub.kill()
+                hub.wait(timeout=5)
+
+    recorded = [
+        json.loads(line)
+        for line in record_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    calls = [ToolCall(tool=e["tool"], arguments=e.get("arguments", {})) for e in recorded]
+    models = sorted((payload.get("modelUsage") or {}).keys())
+    (workdir / "result.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    return ProbeResult(
+        label=label,
+        prompt=prompt,
+        skills=skills,
+        calls=calls,
+        reply=str(payload.get("result", "")),
+        model=", ".join(models),
+        cost_usd=float(payload.get("total_cost_usd") or 0.0),
+        duration_ms=int(payload.get("duration_ms") or 0),
+        num_turns=int(payload.get("num_turns") or 0),
+        permission_denials=[
+            str(entry.get("tool_name", entry)) for entry in payload.get("permission_denials") or []
+        ],
+        vault_dir=vault_dir,
+    )
+
+
+def run_messaging_series(
+    *,
+    label: str,
+    prompt: str,
+    workdir: Path,
+    skills: tuple[str, ...],
+    mount_vault: bool,
+    seed_peer_scope: str | None = None,
+    attempts: int | None = None,
+) -> list[ProbeResult]:
+    """Run one messaging probe ``attempts`` times, each with its own hub, its
+    own directory/messenger state and its own fresh session — same
+    isolation reasoning as `harness.run_series`, and for the same reason:
+    attempt *n+1* must not inherit a registration or a delivered envelope
+    from attempt *n*."""
+    count = attempts if attempts is not None else default_attempts()
+    return [
+        run_messaging_probe(
+            label=f"{label} — attempt {index + 1}/{count}",
+            prompt=prompt,
+            workdir=workdir / f"attempt-{index + 1}",
+            skills=skills,
+            mount_vault=mount_vault,
+            seed_peer_scope=seed_peer_scope,
+        )
+        for index in range(count)
+    ]
+
+
+def hit_rate(results: list[ProbeResult], predicate: Callable[[ProbeResult], bool]) -> str:
+    """``k/n`` — how many of ``results`` satisfy ``predicate``, printable
+    straight into a PR the same way `ProbeSeries.hit_rate` is."""
+    hits = sum(1 for result in results if predicate(result))
+    return f"{hits}/{len(results)}"
+
+
+__all__ = [
+    "CHECK_EXPECTED_TOOLS",
+    "CHECK_PROMPT",
+    "CLIENTS_ROOT",
+    "HANDOFF_EXPECTED_TOOLS",
+    "HANDOFF_PROMPT",
+    "SEED_PEER_SCOPE",
+    "hit_rate",
+    "registered",
+    "run_messaging_probe",
+    "run_messaging_series",
+    "sent_handoff_with_ref",
+]

--- a/v3/server/tests/effectiveness/support/messaging_hub_server.py
+++ b/v3/server/tests/effectiveness/support/messaging_hub_server.py
@@ -1,0 +1,261 @@
+"""Hub process for the SPEC-404 messaging effectiveness harness — same shape
+as SPEC-207's ``hub_server.py``, mounting the session directory and
+messenger tool families (SPEC-402/403) instead of (or alongside) the vault.
+
+Two profiles, following the real gateway's own opt-in shape
+(:class:`palaia_hub.gateway.config.ProfileConfig`):
+
+- ``default`` — the vault's memory tools, exactly like the SPEC-207 hub,
+  mounted only when ``--vault-dir`` is given (session A's probe needs a
+  place to write the note it hands off a reference to; session B's probe
+  does not, and omitting it keeps that probe's tool surface to exactly
+  what the messenger skill is being measured against).
+- ``messaging`` — ``directory_*`` + ``messenger_*``, always mounted.
+
+Recording happens by subclassing :class:`DirectoryService`/
+:class:`MessengerService` and overriding exactly the methods the gateway
+tool wrappers call through (:mod:`palaia_hub.gateway.directory_tools`,
+:mod:`palaia_hub.gateway.messenger_tools`) — the same boundary SPEC-207's
+``RecordingService`` records the vault at, and for the same reason: a line
+in the log means a tool body ran with those arguments, independent of how
+any particular client formats its transcript.
+
+``--seed-peer-scope`` registers one stand-in session *before* the agent's
+own session starts, on a service instance the recording subclasses never
+see — so the harness's own setup never shows up as a call the agent made.
+The agent has to find that peer the same way it would find a real one: by
+calling ``directory_list``/``directory_query``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import uvicorn
+
+from palaia_hub.app import create_app
+from palaia_hub.config import HubConfig
+from palaia_hub.directory.service import DirectoryService
+from palaia_hub.directory.store import DirectoryStore
+from palaia_hub.gateway.build import build_gateway
+from palaia_hub.gateway.config import GatewayConfig, ProfileConfig, VaultMountConfig
+from palaia_hub.gateway.wiring import EngineVaultService
+from palaia_hub.index import EmbeddingConfig, VaultIndex
+from palaia_hub.messenger.models import AckResult, CheckResult, SendResult, ThreadResult
+from palaia_hub.messenger.refs import build_vault_ref_validator
+from palaia_hub.messenger.service import MessengerService
+from palaia_hub.messenger.store import MessengerStore
+from palaia_hub.vault import EventBus, VaultEngine, VaultWatcher
+
+logger = logging.getLogger("effectiveness.messaging_hub_server")
+
+
+class _Recorder:
+    """Shared JSONL append, used by both recording subclasses below."""
+
+    def __init__(self, log_path: Path) -> None:
+        self._log_path = log_path
+
+    def record(self, tool: str, **arguments: Any) -> None:
+        line = json.dumps({"tool": tool, "arguments": arguments}, ensure_ascii=False, default=str)
+        with self._log_path.open("a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+
+
+class RecordingDirectoryService(DirectoryService):
+    """:class:`DirectoryService`, recording every call the ``directory_*``
+    tool family actually makes through it.
+
+    Deliberately a subclass, not a hand-rolled duck type: ``build_gateway``
+    and ``create_app`` both type this parameter as ``DirectoryService``, and
+    a subclass is the one way to satisfy that *and* stay a real
+    ``DirectoryService`` for ``.publish`` assignment and for
+    :class:`MessengerService`'s own use of it as the session directory.
+    """
+
+    def __init__(self, store: DirectoryStore, recorder: _Recorder) -> None:
+        super().__init__(store)
+        self._recorder = recorder
+
+    async def register(self, **kwargs: Any) -> Any:  # noqa: ANN401 - passthrough
+        self._recorder.record("directory_register", **kwargs)
+        return await super().register(**kwargs)
+
+    async def heartbeat(self, handle: str, session_secret: str) -> Any:
+        self._recorder.record("directory_heartbeat", handle=handle)
+        return await super().heartbeat(handle, session_secret)
+
+    async def update(self, handle: str, session_secret: str, **kwargs: Any) -> Any:
+        self._recorder.record("directory_update", handle=handle, **kwargs)
+        return await super().update(handle, session_secret, **kwargs)
+
+    async def deregister(self, handle: str, session_secret: str) -> Any:
+        self._recorder.record("directory_deregister", handle=handle)
+        return await super().deregister(handle, session_secret)
+
+    async def list(self, **kwargs: Any) -> Any:
+        self._recorder.record("directory_list", **kwargs)
+        return await super().list(**kwargs)
+
+    async def query(self, **kwargs: Any) -> Any:
+        self._recorder.record("directory_query", **kwargs)
+        return await super().query(**kwargs)
+
+
+class RecordingMessengerService(MessengerService):
+    """:class:`MessengerService`, recording every call the ``messenger_*``
+    tool family actually makes through it. Same reasoning as
+    :class:`RecordingDirectoryService` above for why this is a subclass.
+    """
+
+    def __init__(self, *args: Any, recorder: _Recorder, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._recorder = recorder
+
+    async def send(self, **kwargs: Any) -> SendResult:
+        shown = {k: v for k, v in kwargs.items() if k != "session_secret"}
+        self._recorder.record("messenger_send", **shown)
+        return await super().send(**kwargs)
+
+    async def check(self, handle: str, session_secret: str) -> CheckResult:
+        self._recorder.record("messenger_check", handle=handle)
+        return await super().check(handle, session_secret)
+
+    async def ack(self, handle: str, session_secret: str, envelope_id: str) -> AckResult:
+        self._recorder.record("messenger_ack", handle=handle, envelope_id=envelope_id)
+        return await super().ack(handle, session_secret, envelope_id)
+
+    async def thread(self, handle: str, session_secret: str, envelope_id: str) -> ThreadResult:
+        self._recorder.record("messenger_thread", handle=handle, envelope_id=envelope_id)
+        return await super().thread(handle, session_secret, envelope_id)
+
+
+async def _run(
+    *,
+    host: str,
+    port: int,
+    record_path: Path,
+    vault_dir: Path | None,
+    vault_key: str,
+    vault_name: str,
+    purpose: str,
+    seed_peer_scope: str | None,
+) -> None:
+    recorder = _Recorder(record_path)
+
+    directory_store = DirectoryStore(":memory:")
+    # A plain, unwrapped facade over the same store — used ONLY for the
+    # harness's own setup below, so seeding never shows up in the log as a
+    # call the agent made.
+    setup_directory = DirectoryService(directory_store)
+    directory_service = RecordingDirectoryService(directory_store, recorder)
+
+    if seed_peer_scope:
+        await setup_directory.register(
+            scope=seed_peer_scope,
+            host="peer-host",
+            platform="other-tool",
+            agent_kind="coding assistant",
+        )
+
+    indexes: dict[str, VaultIndex] = {}
+    vault_services: dict[str, Any] = {}
+    profiles = [
+        ProfileConfig(path="messaging", vaults=[], directory=True, messenger=True),
+    ]
+    watcher: VaultWatcher | None = None
+    engine: VaultEngine | None = None
+    index: VaultIndex | None = None
+    if vault_dir is not None:
+        engine = VaultEngine(vault_dir, vault_name, bus=EventBus())
+        await engine.open(purpose=purpose, create=True)
+        index = VaultIndex(engine, embedding=EmbeddingConfig(enabled=False))
+        await index.open()
+        watcher = VaultWatcher(engine)
+        await watcher.start()
+        indexes[vault_key] = index
+        vault_services[vault_key] = EngineVaultService(engine, index)
+        profiles.append(
+            ProfileConfig(path="default", vaults=[vault_key])
+        )
+
+    messenger_store = MessengerStore(":memory:")
+    messenger_service = RecordingMessengerService(
+        messenger_store,
+        directory_service,
+        ref_validator=build_vault_ref_validator(indexes),
+        recorder=recorder,
+    )
+
+    gateway_config = GatewayConfig(
+        vaults=[VaultMountConfig(key=vault_key, name=vault_name, purpose=purpose)]
+        if vault_dir is not None
+        else [],
+        profiles=profiles,
+    )
+    gateway = build_gateway(
+        gateway_config,
+        vault_services,
+        directory_service=directory_service,
+        messenger_service=messenger_service,
+    )
+    app = create_app(HubConfig(log_level="info"), gateway=gateway)
+
+    server = uvicorn.Server(uvicorn.Config(app, host=host, port=port, log_level="warning"))
+    try:
+        await server.serve()
+    finally:
+        if watcher is not None:
+            await watcher.stop()
+        if index is not None:
+            await index.close()
+        if engine is not None:
+            await engine.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--record", required=True, help="JSONL file every tool call is appended to")
+    parser.add_argument(
+        "--vault-dir", default=None, help="mount a 'default' vault profile from this directory"
+    )
+    parser.add_argument("--vault-key", default="work")
+    parser.add_argument("--vault-name", default="work")
+    parser.add_argument(
+        "--purpose",
+        default=(
+            "Work knowledge: projects, decisions and how this team does things. "
+            "Read it before deciding; add to it when something is worth keeping."
+        ),
+    )
+    parser.add_argument(
+        "--seed-peer-scope",
+        default=None,
+        help="pre-register one stand-in session with this scope, before the agent connects",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(
+        _run(
+            host=args.host,
+            port=args.port,
+            record_path=Path(args.record),
+            vault_dir=Path(args.vault_dir) if args.vault_dir else None,
+            vault_key=args.vault_key,
+            vault_name=args.vault_name,
+            purpose=args.purpose,
+            seed_peer_scope=args.seed_peer_scope,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/v3/server/tests/effectiveness/test_messenger_effectiveness.py
+++ b/v3/server/tests/effectiveness/test_messenger_effectiveness.py
@@ -1,0 +1,154 @@
+"""SPEC-404 deliverable #3: does the messenger skill change what a real
+agent does, unprompted?
+
+Same opt-in gate as SPEC-207's suite (`test_skill_effectiveness.py`) and for
+the same reason — real model calls, real money, a CLI not every runner
+has::
+
+    PALAIA_EFFECTIVENESS=1 uv run pytest server/tests/effectiveness -s -v
+
+Read `messaging_harness.py` first: it explains the two probes, why session
+A's peer is seeded outside the recorded path, and why a `messenger_send`
+call alone is not the finding for the handoff probe. As in SPEC-207: the
+assertion is the floor (the behaviour is reachable with the skill at all),
+the printed hit rate is the finding, and the no-skill baselines assert
+nothing about tool use — only that the run completed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from .harness import ProbeResult, default_attempts, skip_reason
+from .messaging_harness import (
+    CHECK_PROMPT,
+    HANDOFF_PROMPT,
+    SEED_PEER_SCOPE,
+    hit_rate,
+    registered,
+    run_messaging_probe,
+    run_messaging_series,
+    sent_handoff_with_ref,
+)
+
+_SKIP = skip_reason()
+pytestmark = pytest.mark.skipif(_SKIP is not None, reason=_SKIP or "")
+
+
+def _report(label: str, results: list[ProbeResult]) -> None:
+    print(f"\n## {label}")
+    for result in results:
+        print(result.summary())
+
+
+# --- session A: register + handoff with a reference --------------------
+
+
+def test_session_a_registers_and_hands_off_with_a_reference(tmp_path: Path) -> None:
+    """The task never mentions the messenger. A full hit is registering
+    *and* sending a `handoff` whose `refs` carries the decision instead of
+    its body — the token rule, exercised rather than merely stated."""
+    results = run_messaging_series(
+        label="register + handoff-with-ref — palaia-messenger",
+        prompt=HANDOFF_PROMPT,
+        workdir=tmp_path / "runs",
+        skills=("palaia-memory", "palaia-messenger"),
+        mount_vault=True,
+        seed_peer_scope=SEED_PEER_SCOPE,
+    )
+    _report("register + handoff-with-ref", results)
+    print(f"- registered: {hit_rate(results, registered)}")
+    print(f"- handoff carried a memory:// ref (not a pasted copy): "
+          f"{hit_rate(results, sent_handoff_with_ref)}")
+
+    assert any(registered(r) for r in results), (
+        f"never registered in {len(results)} attempt(s). "
+        f"Tools seen: {[r.tools_used for r in results]}"
+    )
+    assert any(sent_handoff_with_ref(r) for r in results), (
+        f"never sent a handoff with a memory:// ref in {len(results)} attempt(s). "
+        f"messenger_send calls: "
+        f"{[r.calls_to('messenger_send') for r in results]}"
+    )
+
+
+# --- session B: check-on-start -------------------------------------------
+
+
+def test_session_b_checks_its_inbox_unprompted(tmp_path: Path) -> None:
+    """The task says nothing about messages. A hit is `messenger_check`
+    appearing anyway, at the start of an ordinary "get oriented" task."""
+    results = run_messaging_series(
+        label="check-on-start — palaia-messenger",
+        prompt=CHECK_PROMPT,
+        workdir=tmp_path / "runs",
+        skills=("palaia-messenger",),
+        mount_vault=False,
+    )
+    _report("check-on-start", results)
+    print(f"- checked its inbox: {hit_rate(results, lambda r: r.called('messenger_check'))}")
+
+    assert any(r.called("messenger_check") for r in results), (
+        f"never checked its inbox in {len(results)} attempt(s). "
+        f"Tools seen: {[r.tools_used for r in results]}"
+    )
+
+
+# --- baselines ------------------------------------------------------------
+
+
+def test_baseline_handoff_without_the_skill_is_recorded(tmp_path: Path) -> None:
+    """Control: the identical handoff task, hub connected, no skill loaded.
+    Asserted only to have completed — whether it registers or hands off
+    anyway is reported, not demanded either way."""
+    results = run_messaging_series(
+        label="register + handoff-with-ref — BASELINE (no skill)",
+        prompt=HANDOFF_PROMPT,
+        workdir=tmp_path / "runs",
+        skills=(),
+        mount_vault=True,
+        seed_peer_scope=SEED_PEER_SCOPE,
+    )
+    _report("register + handoff-with-ref — BASELINE", results)
+    assert len(results) == default_attempts()
+    for result in results:
+        assert result.reply.strip(), "a baseline run produced no reply at all"
+
+
+def test_baseline_check_without_the_skill_is_recorded(tmp_path: Path) -> None:
+    """Control for the check-on-start probe."""
+    results = run_messaging_series(
+        label="check-on-start — BASELINE (no skill)",
+        prompt=CHECK_PROMPT,
+        workdir=tmp_path / "runs",
+        skills=(),
+        mount_vault=False,
+    )
+    _report("check-on-start — BASELINE", results)
+    assert len(results) == default_attempts()
+    for result in results:
+        assert result.reply.strip(), "a baseline run produced no reply at all"
+
+
+# --- the harness itself ---------------------------------------------------
+
+
+def test_a_messaging_run_records_the_calls_it_makes(tmp_path: Path) -> None:
+    """The recorder has to be trustworthy before any result above means
+    anything, so one probe drives it with the tools named outright."""
+    result = run_messaging_probe(
+        label="messaging harness self-check",
+        prompt=(
+            "Call the directory_register tool with scope 'self-check', then call "
+            "messenger_check with the handle and session_secret you just got back, "
+            "then reply with the word DONE and nothing else."
+        ),
+        workdir=tmp_path / "run",
+        skills=(),
+        mount_vault=False,
+    )
+    print(result.summary())
+    assert result.called("directory_register"), result.tools_used
+    assert result.called("messenger_check"), result.tools_used

--- a/v3/server/tests/messenger/test_push_recipe.py
+++ b/v3/server/tests/messenger/test_push_recipe.py
@@ -1,0 +1,127 @@
+"""SPEC-404 deliverable #4: the `message.received` push recipe.
+
+"No new delivery system" is the deliverable's own constraint, and this test
+is the evidence for it: the messenger already publishes `message.received`
+onto the hub's one event bus (SPEC-403 deliverable #5), and SPEC-201's
+outbound-webhook mechanism already matches a hook against any event name —
+so "notify my other tooling when a message arrives" needs nothing new,
+just a hook registered on that one event name. `docs/messenger.md` documents
+the exact `POST /api/hooks` call this test drives directly against the real
+dispatcher/outbox pair, the same real-local-receiver pattern
+`hooks/test_delivery.py` uses for its own acceptance criteria.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from webhook_receiver import LocalReceiver
+
+from palaia_hub.directory.service import DirectoryService
+from palaia_hub.events.bus import EventBus, publish_event
+from palaia_hub.hooks.delivery import HookDispatcher
+from palaia_hub.hooks.outbox import HookOutbox
+from palaia_hub.hooks.signing import verify
+from palaia_hub.hooks.store import HookStore
+from palaia_hub.messenger.service import MessengerService
+
+pytestmark = pytest.mark.anyio
+
+SECRET_BODY = "the-body-that-must-not-travel-over-the-webhook-either"
+
+
+async def test_a_message_received_webhook_delivers_with_a_valid_signature(
+    tmp_path: Path,
+    service: MessengerService,
+    directory: DirectoryService,
+    local_receiver: LocalReceiver,
+) -> None:
+    """The recipe end to end: register the hook the way `docs/messenger.md`
+    tells an operator to, then have two real sessions exchange a message
+    and let the real hook pipeline carry the notification — no messenger-
+    specific code anywhere in :mod:`palaia_hub.hooks`."""
+    hook_store = HookStore(tmp_path)
+    outbox = HookOutbox(tmp_path / "outbox.sqlite3")
+    dispatcher = HookDispatcher(hook_store, outbox)
+    created = hook_store.create(local_receiver.url, ["message.received"])
+
+    # The hub's real bus, wired exactly as `create_app` wires it (see
+    # `test_automations_compose.py` for the sibling case with automations
+    # instead of a webhook).
+    bus = EventBus()
+    bus.on(dispatcher.on_event)
+    service.publish = lambda name, data: publish_event(
+        bus, name, origin="messenger", data=data
+    )
+
+    a = await directory.register(scope="build pipeline")
+    b = await directory.register(scope="notify my other tooling")
+    await service.send(
+        sender=a.session.handle,
+        session_secret=a.session_secret,
+        message_type="inform",
+        to=b.session.handle,
+        subject="build finished",
+        body=SECRET_BODY,
+    )
+    await service.check(b.session.handle, b.session_secret)
+
+    delivered = await dispatcher.deliver_due()
+    await dispatcher.aclose()
+
+    assert delivered == 1
+    assert len(local_receiver.requests) == 1
+    request = local_receiver.requests[0]
+    signature = request.headers["X-Palaia-Signature"]
+    assert verify(created.secret, request.body, signature)
+
+    body = json.loads(request.body)
+    assert body["event"] == "message.received"
+    assert body["data"]["subject"] == "build finished"
+    assert body["data"]["type"] == "inform"
+    # The same "never the body" contract as the bus itself, still true one
+    # hop further down the SPEC-201 outbox — a webhook payload built from
+    # anything but `EnvelopeMetadata` would be a second place that rule has
+    # to be remembered.
+    assert "body" not in body["data"]
+    assert SECRET_BODY not in request.body.decode("utf-8")
+
+
+async def test_a_hook_scoped_to_a_different_event_never_fires(
+    tmp_path: Path,
+    service: MessengerService,
+    directory: DirectoryService,
+    local_receiver: LocalReceiver,
+) -> None:
+    """The other half of "no new delivery system": ordinary event-filter
+    behaviour applies to `message.*` exactly as it does to anything else on
+    the bus — a hook not asking for this event does not receive it."""
+    hook_store = HookStore(tmp_path)
+    outbox = HookOutbox(tmp_path / "outbox.sqlite3")
+    dispatcher = HookDispatcher(hook_store, outbox)
+    hook_store.create(local_receiver.url, ["memory.entry.created"])
+
+    bus = EventBus()
+    bus.on(dispatcher.on_event)
+    service.publish = lambda name, data: publish_event(
+        bus, name, origin="messenger", data=data
+    )
+
+    a = await directory.register(scope="a")
+    b = await directory.register(scope="b")
+    await service.send(
+        sender=a.session.handle,
+        session_secret=a.session_secret,
+        message_type="inform",
+        to=b.session.handle,
+        subject="not for this hook",
+    )
+    await service.check(b.session.handle, b.session_secret)
+
+    delivered = await dispatcher.deliver_due()
+    await dispatcher.aclose()
+
+    assert delivered == 0
+    assert local_receiver.requests == []

--- a/v3/web/src/components/SkillPanel.test.tsx
+++ b/v3/web/src/components/SkillPanel.test.tsx
@@ -13,13 +13,14 @@ function mount(clientId: string, clientName = "Test Client") {
 }
 
 describe("SkillPanel", () => {
-  it("offers both skills with install steps to a client that loads them", () => {
+  it("offers every skill with install steps to a client that loads them", () => {
     mount("claude-code-cli", "Claude Code CLI");
 
     expect(screen.getByText(/teaching it to use the memory/i)).toBeInTheDocument();
     expect(screen.getByText("palaia-memory")).toBeInTheDocument();
     expect(screen.getByText("palaia-capture")).toBeInTheDocument();
-    expect(screen.getAllByRole("link", { name: /download skill\.md/i })).toHaveLength(2);
+    expect(screen.getByText("palaia-messenger")).toBeInTheDocument();
+    expect(screen.getAllByRole("link", { name: /download skill\.md/i })).toHaveLength(3);
     expect(screen.getByText(/--plugin-dir/)).toBeInTheDocument();
   });
 
@@ -44,6 +45,6 @@ describe("SkillPanel", () => {
 
     expect(screen.getByText(/if your tool reads skill\.md folders/i)).toBeInTheDocument();
     // Unverified is not unsupported: the files are still offered.
-    expect(screen.getAllByRole("link", { name: /download skill\.md/i })).toHaveLength(2);
+    expect(screen.getAllByRole("link", { name: /download skill\.md/i })).toHaveLength(3);
   });
 });

--- a/v3/web/src/lib/skills.test.ts
+++ b/v3/web/src/lib/skills.test.ts
@@ -10,8 +10,12 @@ import {
 } from "./skills";
 
 describe("skill catalog", () => {
-  it("carries both SPEC-207 packages, read from the shipped files", () => {
-    expect(SKILLS.map((s) => s.slug)).toEqual(["palaia-memory", "palaia-capture"]);
+  it("carries every shipped package, read from the shipped files", () => {
+    expect(SKILLS.map((s) => s.slug)).toEqual([
+      "palaia-memory",
+      "palaia-capture",
+      "palaia-messenger",
+    ]);
   });
 
   it("shows the skill's own words — the page cannot drift from the file", () => {

--- a/v3/web/src/lib/skills.ts
+++ b/v3/web/src/lib/skills.ts
@@ -7,7 +7,7 @@
  * clients that can actually load one, which is what `SkillSupport` on each
  * catalog entry decides.
  *
- * The text is not restated here: both packages are imported straight from
+ * The text is not restated here: every package is imported straight from
  * `v3/clients/skills/**` with `?raw`, and the name and one-line summary shown
  * in the UI are read out of that file's own frontmatter. There is exactly one
  * copy of every word a user sees, and it is the file the agent loads — so the
@@ -16,6 +16,7 @@
  */
 import captureSource from "../../../clients/skills/palaia-capture/SKILL.md?raw";
 import memorySource from "../../../clients/skills/palaia-memory/SKILL.md?raw";
+import messengerSource from "../../../clients/skills/palaia-messenger/SKILL.md?raw";
 
 export interface SkillInstall {
   /** One line: how this client takes a skill. */
@@ -71,6 +72,10 @@ export const SKILLS: SkillPackage[] = [
     captureSource,
     "For a smaller or tightly budgeted agent: saving only, nothing about looking things up.",
   ),
+  pkg(
+    messengerSource,
+    "For an agent working alongside other AI sessions on the same work: register, check in before starting, and reply or decline.",
+  ),
 ];
 
 export function skillBySlug(slug: string): SkillPackage | undefined {
@@ -92,7 +97,7 @@ const CLAUDE_SKILLS_FOLDER: SkillInstall = {
   steps: [
     "Create ~/.claude/skills/<name>/ and save SKILL.md into it — one folder per skill.",
     "Start a new session; the skill is offered from then on, and loads itself when a task needs it.",
-    "Trying it out first: clone this repo and pass v3/clients as a plugin, which loads both skills for that session only.",
+    "Trying it out first: clone this repo and pass v3/clients as a plugin, which loads every skill in it for that session only.",
   ],
   command: "claude --plugin-dir /path/to/palaia/v3/clients",
 };


### PR DESCRIPTION
## Summary

Implements [SPEC-404](v3/specs/SPEC-404-messaging-skills.md): the messenger skill, its effectiveness harness, the `message.received` push recipe, and the agent-facing contract doc.

1. **`v3/clients/skills/palaia-messenger/SKILL.md`** — register-on-start (scope from the task at hand), check-before-starting-work, the reply discipline (`expects_reply` → answer or explicitly decline), the token rule (long content → memory, then a `memory://` reference — never pasted), and deregister/idle on wrap-up. Installs with the existing SPEC-207 plugin (`v3/clients/.claude-plugin/`, same manifest, no new package) and is offered on the connect page's skill panel per client (`v3/web/src/lib/skills.ts`).
2. **Format lint**: the existing SPEC-207 lint (`server/tests/clients/skill_lint.py`) already runs generically over every skill package, so the new skill is covered as-is — no jargon, valid frontmatter, `## Per-model notes` with ≥2 `[anthropic]/[openai]/[google]` markers. Added `test_the_spec_404_messenger_skill_package_is_present` and `test_messenger_skill_teaches_every_spec_404_habit`, and re-scoped `test_skills_name_the_four_capture_fields` to the two capture-teaching skills only (the messenger skill has no reason to name those four fields).
3. **Effectiveness harness extension** (`server/tests/effectiveness/support/messaging_hub_server.py` + `messaging_harness.py` + `test_messenger_effectiveness.py`): a real hub mounting the session directory + messenger (and, for session A, a vault), two real `claude` CLI sessions, server-side call recording via `DirectoryService`/`MessengerService` subclasses that record exactly the calls the `directory_*`/`messenger_*` tool families make. **Every run below is real, not simulated.**
4. **Push adapters**: `docs/messenger.md` §8 documents the `message.received` → outbound-webhook recipe (no new mechanism — the existing SPEC-201 hook store already matches any event name), proven end to end in `server/tests/messenger/test_push_recipe.py` against a real local receiver (signature verifies, payload is metadata-only). Claude Code's `claude/channel` push capability is documented as the integration path but marked **not verified** — see Deviations below.
5. **`docs/messenger.md`** — the envelope shape, the body cap and why, addressing/broadcast grammar, the check/reply discipline, authorization (scope vs. session secret), and the push adapters, written for skill authors and SDK users.

## Effectiveness runs (honest, with one prose iteration each)

Real `claude` CLI (2.1.245) against a real hub, `PALAIA_EFFECTIVENESS=1 uv run pytest server/tests/effectiveness -s -v`. Every run printed below; nothing retried into a pass.

**Session A — register + handoff with a `memory://` reference** (never pasted content):
- First pass (original skill text): registered 2/2, handoff carried a ref 1/2. The miss: the model claimed "saved to memory" in its reply with no `capture`/`write` call and no `refs` on the send.
- **Iteration**: added an explicit order-of-operations rule to the skill ("write the note first, in the same turn, then the message with that note's own reference — a message that only *describes* a note as saved, with no reference, has not done the thing it claims").
- Second pass (revised skill): registered **3/3**, handoff carried a ref **2/3**.
- Baseline (no skill, 3 attempts): registered 1/3, handoff carried a ref 0/3.

**Session B — checks for messages unprompted at task start**:
- First pass (original prompt + skill): checked **1/3**. The miss: the prompt said "picking up the billing-refactor *branch*", and against the harness's intentionally empty project directory the model went looking for a literal git branch instead of checking for anything left for it.
- **Iteration** (two changes, both reported): (a) skill — "checking is how you find that out, not a fallback for once other ways come up empty"; (b) harness prompt — reworded to "another session… may have left you something" instead of naming a literal branch/file.
- Second pass (revised prompt + skill): checked **3/3**.
- Baseline (no skill, 3 attempts): checked 0/3.

Not fully fixed by this SPEC: in one handoff run, the model narrated "saved to memory" without any memory tool call at all — a `palaia-memory` (SPEC-207) skill/model-honesty gap the messenger skill's own wording can nudge (and did, some) but can't fully own. Worth a follow-up.

## Deviations (least-deviation, stated per the workflow's own rule)

- **Claude Code's `claude/channel` push capability is not exercised.** The research dossier names it as a live precedent; the pinned `fastmcp` 3.4.7 has no support for declaring it, and hand-rolling an undocumented, unpinned protocol extension without a way to verify its wire behavior against a real Claude Code session would be worse than shipping nothing. Documented as an integration path in `docs/messenger.md` §8, explicitly marked not verified, per the SPEC's own instruction to do exactly that rather than ship dead code.
- The `AutomationEditor.tsx` recipe UI (SPEC-307) was **not** touched: its action kinds are `memory_write`/`stash_set`/`notification`, not `webhook` — the webhook mechanism is SPEC-201's `/api/hooks`, which already matches any event name including `message.received` with zero new code. The "recipe" is the documented `/api/hooks` call in `docs/messenger.md` §8, proven e2e in `test_push_recipe.py`.

## Acceptance criteria

- [x] skills pass the format lint; plugin manifest installs both packs (`uv run python server/tests/clients/skill_lint.py` → `skill format OK (3 package(s))`)
- [x] effectiveness runs documented: register + handoff-with-ref and check-on-start rates reported honestly above, one prose iteration each
- [x] the webhook recipe delivers on a real `message.received` (e2e over the SPEC-201 outbox) — `server/tests/messenger/test_push_recipe.py`
- [x] connect page lists the messenger skill per client capability table — `v3/web/src/lib/skills.ts` (`SKILLS` now carries all three packages; `SkillPanel` renders whatever `SKILLS` holds)

## Verification

From `v3/`:
```
uv sync
uv run ruff check server        # All checks passed!
uv run mypy server/src          # Success: no issues found in 183 source files
uv run pytest server/tests -q   # 1949 passed, 21 skipped (effectiveness, env-gated), 0 failed
```
Web (touched `v3/web/src/lib/skills.ts` and two tests):
```
cd v3/web
npm run typecheck   # clean
npx vitest run      # 18 files, 84 passed
npm run lint        # 0 errors (4 pre-existing warnings, unrelated files)
npm run build       # succeeds
```
Effectiveness (env-gated, real model calls, excluded from CI by construction — see numbers above):
```
PALAIA_EFFECTIVENESS=1 uv run pytest server/tests/effectiveness -s -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp


---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790258432&installation_model_id=428086&pr_number=255&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F255&signature=336471a97c3d3603cf6e8b12dad1de32ccca580544e894692ce3494297bc14f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->