### PR TITLE
v3: SPEC-405 team observability (Agents screen + 2 MCP Apps)

### DIFF
--- a/v3/docs/events.md
+++ b/v3/docs/events.md
@@ -156,7 +156,7 @@ session secret — only the public fields also returned by
 | `session.updated` | `directory` | same shape | `directory_update` changes `scope`/`capabilities` (or sets `status` to `active`). |
 | `session.idle` | `directory` | same shape | `directory_update` sets `status` to `idle` — fired instead of `session.updated` for that call. |
 | `session.stale` | `directory` | `handle` | A session's *computed* status (never self-reported) first crosses into `stale` — checked lazily on the next directory call after its TTL elapses, and fired exactly once per staleness spell (a heartbeat resets the mark, so going stale twice fires this twice). |
-| `session.deregistered` | `directory` | `handle` | `directory_deregister` removes a session (a repeat call on an already-gone handle does not re-fire this). |
+| `session.deregistered` | `directory` | `handle` | `directory_deregister` removes a session, or (SPEC-405) the owner does the same with no secret via `POST /api/directory/{handle}/deregister` — the same event either way; a repeat call on an already-gone handle does not re-fire this. |
 
 ### 3.7 Messenger events (SPEC-403, additive)
 
@@ -175,9 +175,9 @@ it.
 
 | Event | Origin | `data` fields | Fires when |
 |---|---|---|---|
-| `message.sent` | `messenger` | the envelope metadata above | `messenger_send` mints an envelope — once per envelope, so a broadcast fires this once per resolved recipient. |
+| `message.sent` | `messenger` | the envelope metadata above | `messenger_send` mints an envelope — once per envelope, so a broadcast fires this once per resolved recipient. (SPEC-405) The owner's `POST /api/messenger/send` mints one the same way, with `from: "owner"`. |
 | `message.received` | `messenger` | same shape (`state: delivered`) | `messenger_check` hands an envelope to its recipient. Fires exactly once per envelope, not on every poll: a checked envelope is `delivered` and is never handed over again. |
-| `message.expired` | `messenger` | same shape | The TTL sweep deletes an envelope past its `expires_at` (default 24h, per-message override up to 7 days). The row and its body are gone; this event is all that is left of it. |
+| `message.expired` | `messenger` | same shape | The TTL sweep deletes an envelope past its `expires_at` (default 24h, per-message override up to 7 days), or (SPEC-405) the owner ends a conversation via `POST /api/messenger/threads/{id}/end`, which expires only that thread's still-`pending` copies. Either way: the row and its body are gone; this event is all that is left of it. |
 
 Bodies reach exactly two places: the recipient, through `messenger_check`'s
 own result, and the operator, through `GET /api/messenger/envelopes/{id}`
@@ -188,6 +188,32 @@ behind the admin-session gate (`palaia_hub.admin_session`). The other
 `health` also travels the same bus and wire format (SSE only; it is not a
 webhook-filterable v1 name — see §6) — it is the dashboard's periodic
 liveness snapshot, carried over unchanged from before this SPEC.
+
+### 3.8 Team observability: owner controls and the two MCP Apps (SPEC-405)
+
+No new event names — §3.6/§3.7's tables above already say where the two
+owner-only writes land. What SPEC-405 actually adds:
+
+* **Two owner-only REST writes**, both behind
+  `palaia_hub.admin_session`'s sign-in-and-CSRF gate: `POST
+  /api/directory/{handle}/deregister` (no session secret — the owner's
+  signed-in session is the stronger proof) and `POST /api/messenger/send`
+  (compose and send as the owner; `POST /api/messenger/threads/{id}/end`
+  ends a conversation). None of the three is exposed as an MCP tool —
+  MASTERPLAN §5.7's rule that destructive administration stays
+  dashboard-only.
+* **The dashboard's Agents screen**, reading the directory and message
+  flows live off this same SSE bus (`session.*`/`message.*` — no polling
+  loop) and driving the three writes above.
+* **Two MCP Apps** on the SPEC-208 shell: the session-monitor app
+  (`/mcp/team`, mounted when both `directory_service` and
+  `messenger_service` are wired) — read-only directory + flows, plus a
+  compose form that calls the *same* `messenger_send` tool a session would
+  call directly (never the owner routes above); and the stash browser app
+  (a `stash_browse` tool added to the existing `/mcp/stash` mount) —
+  namespace/key/size/expiry, never a stored value. Both deep-link to this
+  dashboard for anything destructive, same pattern as the marketplace
+  app's "Install" link (SPEC-304).
 
 ## 4. Outbound webhooks
 

--- a/v3/server/src/palaia_hub/app.py
+++ b/v3/server/src/palaia_hub/app.py
@@ -52,6 +52,7 @@ from .gateway import DynamicGateway, GatewayASGI, VaultService
 from .gateway.api import build_gateway_profiles_router
 from .gateway.apps.hub_status_app import HubStatusDeps, build_hub_status_server
 from .gateway.apps.market_app import MarketAppDeps, build_market_server
+from .gateway.apps.team_app import TeamAppDeps, build_team_server
 from .gateway.directory_tools import build_directory_gateway
 from .gateway.messenger_tools import build_messenger_gateway
 from .gateway.stash_tools import build_stash_gateway
@@ -218,11 +219,15 @@ def create_app(
             all, same as before this parameter existed.
         messenger_service: the hub's messenger (SPEC-403). Given, mounts
             the ``messenger_*`` tool family at ``/mcp/messenger`` and the
-            read-only ``/api/messenger`` REST mirror, and wires its
-            ``message.*`` events onto this app's bus. Omitted (the default),
-            the hub runs with no messenger surface at all — every
-            ``messenger: true`` profile flag then mounts nothing, exactly
-            like ``stash``/``directory`` ahead of their services.
+            ``/api/messenger`` REST mirror (read-only plus the two SPEC-405
+            owner controls — sending as the owner, ending a conversation),
+            and wires its ``message.*`` events onto this app's bus. Omitted
+            (the default), the hub runs with no messenger surface at all —
+            every ``messenger: true`` profile flag then mounts nothing,
+            exactly like ``stash``/``directory`` ahead of their services.
+            Given together with ``directory_service``, also mounts the
+            session-monitor MCP App (SPEC-405 deliverable #3) at
+            ``/mcp/team``.
         market_service: the marketplace read model (SPEC-303 — official
             registry + curated index + manual entries, merged). Given,
             mounts ``/api/market/*`` and wires its
@@ -381,6 +386,25 @@ def create_app(
         )
         market_asgi_app = build_market_server(market_app_deps).http_app(path="/")
 
+    # SPEC-405 deliverable #3: the session-monitor MCP App, mounted at
+    # `/mcp/team` — hub-level, same standalone-FastMCP-instance shape as
+    # hub_status/market above. Gated on *both* directory_service and
+    # messenger_service: there is nothing to monitor with only one of the
+    # two (a directory with no messenger has no flows to show; a messenger
+    # with no directory has no peers to address).
+    team_asgi_app = None
+    if directory_service is not None and messenger_service is not None:
+        team_app_deps = TeamAppDeps(
+            directory_service=directory_service,
+            messenger_service=messenger_service,
+            dashboard_url=(
+                config.exposure.public_url.rstrip("/")
+                if config.exposure.public_url
+                else None
+            ),
+        )
+        team_asgi_app = build_team_server(team_app_deps).http_app(path="/")
+
     # One lifespan runs BOTH concerns: the events background tasks (SPEC-109)
     # and, when a gateway is mounted, its session-manager lifespan (SPEC-105 —
     # skipping it hangs the mounted profiles on their first request). The
@@ -491,6 +515,8 @@ def create_app(
                     await stack.enter_async_context(hub_status_asgi_app.lifespan(app_))
                 if market_asgi_app is not None:
                     await stack.enter_async_context(market_asgi_app.lifespan(app_))
+                if team_asgi_app is not None:
+                    await stack.enter_async_context(team_asgi_app.lifespan(app_))
                 yield
         finally:
             await stop_background_tasks(tasks)
@@ -557,6 +583,8 @@ def create_app(
         app.mount("/mcp/hub", hub_status_asgi_app)
     if market_asgi_app is not None:
         app.mount("/mcp/market", market_asgi_app)
+    if team_asgi_app is not None:
+        app.mount("/mcp/team", team_asgi_app)
     if dynamic_gateway is not None:
         # One mount, forever: DynamicGateway owns everything below "/mcp"
         # and rebuilds its own internal routing as profiles come and go

--- a/v3/server/src/palaia_hub/auth/scopes.py
+++ b/v3/server/src/palaia_hub/auth/scopes.py
@@ -75,7 +75,9 @@ def required_scope_for_action(vault_key: str, action: str) -> str:
 # scopes are plain ``stash:read``/``stash:write`` rather than
 # ``vault:<key>:<permission>``. Same fail-closed rule as above: only actions
 # on :data:`STASH_READ_ACTIONS` get the weaker scope.
-STASH_READ_ACTIONS: frozenset[str] = frozenset({"stash_get", "stash_list", "stash_status"})
+STASH_READ_ACTIONS: frozenset[str] = frozenset(
+    {"stash_get", "stash_list", "stash_status", "stash_browse"}
+)
 STASH_WRITE_ACTIONS: frozenset[str] = frozenset({"stash_set", "stash_del"})
 
 

--- a/v3/server/src/palaia_hub/directory/service.py
+++ b/v3/server/src/palaia_hub/directory/service.py
@@ -156,6 +156,20 @@ class DirectoryService:
         self._emit_stale(newly_stale)
         return DeregisterResult(handle=handle, deregistered=deregistered)
 
+    async def admin_deregister(self, handle: str) -> DeregisterResult:
+        """Owner control: deregister a session with no secret (SPEC-405
+        deliverable #2). See :meth:`~palaia_hub.directory.store.
+        DirectoryStore.admin_deregister` for why this is safe: it has
+        exactly one caller, already behind the owner's own sign-in gate.
+        """
+        deregistered, newly_stale = await asyncio.to_thread(
+            self._store.admin_deregister, handle
+        )
+        if deregistered:
+            self._emit("session.deregistered", {"handle": handle})
+        self._emit_stale(newly_stale)
+        return DeregisterResult(handle=handle, deregistered=deregistered)
+
     async def list(
         self,
         *,

--- a/v3/server/src/palaia_hub/directory/store.py
+++ b/v3/server/src/palaia_hub/directory/store.py
@@ -389,6 +389,31 @@ class DirectoryStore:
             self._conn.commit()
         return True, [h for h in newly_stale if h != handle]
 
+    def admin_deregister(
+        self, handle: str, *, now: float | None = None
+    ) -> tuple[bool, list[str]]:
+        """Owner control: remove a session's row with no secret required
+        (SPEC-405 deliverable #2 — "deregister a stale session").
+
+        Has exactly one caller in production,
+        :mod:`palaia_hub.directory_api`'s ``POST /api/directory/{handle}/
+        deregister``, which sits behind the owner's signed-in session and
+        CSRF token (:mod:`palaia_hub.admin_session`) — a *stronger* proof of
+        "the owner really did this" than the session secret :meth:`deregister`
+        demands of an ordinary caller, not a weaker substitute for it. Same
+        idempotent-success shape as :meth:`deregister`: an already-gone
+        handle answers ``False``, never :class:`SessionNotFoundError`.
+        """
+        current = self._now(now)
+        with self._lock:
+            newly_stale = self._sweep_locked(current)
+            row = self._get_row_locked(handle)
+            if row is None:
+                return False, newly_stale
+            self._conn.execute("DELETE FROM session_registry WHERE handle = ?", (handle,))
+            self._conn.commit()
+        return True, [h for h in newly_stale if h != handle]
+
     # `list` is defined last among this class's methods, deliberately: a
     # method literally named `list` shadows the builtin `list[...]` inside
     # every *subsequent* return-type annotation in this class body (mypy

--- a/v3/server/src/palaia_hub/directory_api.py
+++ b/v3/server/src/palaia_hub/directory_api.py
@@ -1,17 +1,33 @@
 """``/api/directory`` REST mirror of the session directory (SPEC-402
 deliverable #4), for the dashboard (SPEC-405 builds the screen) and any
-other non-MCP caller. **List/query only** — mutations (register, heartbeat,
-update, deregister) come from the sessions themselves, over MCP, holding
-their own session secret; nothing here can act on a session's behalf, which
-is exactly the point of the secret (see
+other non-MCP caller.
+
+**List/query are read-only for everyone.** Every ordinary mutation
+(register, heartbeat, update, deregister) still comes from the sessions
+themselves, over MCP, holding their own session secret — nothing here can
+act *as* a session, which is exactly the point of the secret (see
 :mod:`palaia_hub.directory.store`'s module docstring).
+
+**One owner control lives here, deliberately.** ``POST /{handle}/
+deregister`` is SPEC-405 deliverable #2's "deregister a stale session" —
+the one directory mutation the *owner* may make without holding that
+session's secret, because this route is not "act as a session", it is "act
+as the owner, on a session". ``/api/*`` already sits behind
+:mod:`palaia_hub.admin_session`'s sign-in-and-CSRF gate wherever the hub's
+mode requires one, which is what makes that safe: MASTERPLAN §5.4 trust
+rule #7, "the human can read along, join in, or shut a conversation down"
+— this is the directory's half of "shut down" (the messenger's half,
+ending a conversation, is the equivalent route in
+:mod:`palaia_hub.messenger_api`). Every *other* route here stays read-only,
+on purpose — this is the one, named exception, not a precedent for adding
+more without the same trust-rule citation.
 """
 
 from __future__ import annotations
 
 from fastapi import APIRouter
 
-from .directory.models import ListResult, QueryResult, SessionStatus
+from .directory.models import DeregisterResult, ListResult, QueryResult, SessionStatus
 from .directory.service import DirectoryService
 
 
@@ -31,6 +47,14 @@ def build_directory_router(service: DirectoryService) -> APIRouter:
         scope_contains: str | None = None, capability: str | None = None
     ) -> QueryResult:
         return await service.query(scope_contains=scope_contains, capability=capability)
+
+    @router.post("/{handle}/deregister", response_model=DeregisterResult)
+    async def deregister_session(handle: str) -> DeregisterResult:
+        """Owner control (SPEC-405 deliverable #2): remove ``handle`` from
+        the directory without its session secret. Idempotent — an
+        already-gone handle answers ``deregistered=false``, not a 404, the
+        same shape the MCP tool's own ``directory_deregister`` uses."""
+        return await service.admin_deregister(handle)
 
     return router
 

--- a/v3/server/src/palaia_hub/gateway/apps/stash_browser_app.py
+++ b/v3/server/src/palaia_hub/gateway/apps/stash_browser_app.py
@@ -1,0 +1,230 @@
+"""Stash browser MCP App (SPEC-405 deliverable #4, MASTERPLAN §5.7's
+Phase-4 "Stash browser" row: "cache entries with TTL/size ... inspection
+utility").
+
+Attached to a new ``stash_browse`` tool in
+:mod:`palaia_hub.gateway.stash_tools` via ``meta.ui.resourceUri`` — the same
+"attach an app to an existing family's own tool" shape SPEC-208 already used
+for ``review_queue``/``search``/``recall`` (:mod:`palaia_hub.gateway.
+memory_tools`), applied here to the stash family instead of the memory one.
+The stash is a hub-level singleton (one per hub, not one per vault), so —
+like :mod:`~palaia_hub.gateway.apps.hub_status_app` and
+:mod:`~palaia_hub.gateway.apps.market_app` — its tool and its ``ui://``
+resource are registered on the *same* ``FastMCP`` instance rather than
+needing the shared-registration indirection the per-vault memory family
+uses.
+
+**Small by design, on purpose (the SPEC's own words).** ``stash_browse``
+never returns a stored *value* — only ``namespace``/``key``/``size_bytes``/
+expiry/staleness. A cache entry can hold anything (a job's working state, a
+rate-limit counter, a draft) and this is an inspection utility, not a
+viewer: seeing what is cached, how big it is and when it expires answers
+"is the stash doing something sane" without dumping arbitrary cached data
+into a chat transcript. Reading one entry's actual value still works, the
+same way it always has, via ``stash_get`` — this app just never calls it.
+
+**Two levels, one tool, same shape as** :mod:`~palaia_hub.gateway.
+apps.hub_status_app`'s "call the same tool again to refresh": an empty
+``namespace`` argument renders the namespace overview (counts, total size,
+budget); passing one of those namespaces back in renders that namespace's
+entries. No second tool, no drill-down tool name to thread through
+``structured_content`` — the one tool answers both questions depending on
+what it is asked.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ...stash.models import StashEntry
+from ...stash.service import StashService
+from .shell import render_app_page
+
+RESOURCE_URI = "ui://palaia/stash_browser.html"
+
+_TITLE = "palaia · Stash browser"
+
+
+class StashBrowseEntry(BaseModel):
+    """One cache entry, minus its value (see the module docstring)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    namespace: str
+    key: str
+    size_bytes: int
+    created_at: float
+    updated_at: float
+    expires_at: float | None
+    stale: bool
+
+
+class StashBrowseResult(BaseModel):
+    """``stash_browse``'s result: the namespace overview, or one
+    namespace's entries — see the module docstring for which."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    #: The namespace this result drills into, or ``""`` for the overview.
+    namespace: str = ""
+    #: Every namespace's entry count (from ``stash_status``) — always
+    #: present, so the overview and a drill-down both know what else there
+    #: is to look at.
+    namespaces: dict[str, int] = Field(default_factory=dict)
+    total_entries: int = 0
+    total_bytes: int = 0
+    budget_bytes: int = 0
+    #: This namespace's entries, minus their values. Empty at the overview
+    #: level (``namespace == ""``).
+    entries: list[StashBrowseEntry] = Field(default_factory=list)
+
+
+def _to_browse_entry(namespace: str, entry: StashEntry) -> StashBrowseEntry:
+    return StashBrowseEntry(
+        namespace=namespace,
+        key=entry.key,
+        size_bytes=entry.size_bytes,
+        created_at=entry.created_at,
+        updated_at=entry.updated_at,
+        expires_at=entry.expires_at,
+        stale=entry.stale,
+    )
+
+
+async def collect_stash_browse(service: StashService, namespace: str = "") -> StashBrowseResult:
+    status = await service.status()
+    namespace = namespace.strip()
+    entries: list[StashBrowseEntry] = []
+    if namespace:
+        listing = await service.list(namespace)
+        entries = [_to_browse_entry(namespace, entry) for entry in listing.entries]
+    return StashBrowseResult(
+        namespace=namespace,
+        namespaces=dict(status.namespaces),
+        total_entries=status.total_entries,
+        total_bytes=status.total_bytes,
+        budget_bytes=status.budget_bytes,
+        entries=entries,
+    )
+
+
+def stash_browse_summary(result: StashBrowseResult) -> str:
+    if not result.namespace:
+        if not result.namespaces:
+            return "The stash is empty."
+        parts = ", ".join(f"{ns} ({count})" for ns, count in result.namespaces.items())
+        return (
+            f"{result.total_entries} entries, {result.total_bytes}/{result.budget_bytes} "
+            f"bytes used, across {len(result.namespaces)} namespace(s): {parts}"
+        )
+    if not result.entries:
+        return f"namespace {result.namespace!r} has no entries."
+    lines = [f"{len(result.entries)} entr{'y' if len(result.entries) == 1 else 'ies'} "
+             f"in {result.namespace!r}:"]
+    for entry in result.entries:
+        stale_note = " (stale)" if entry.stale else ""
+        expiry = "no expiry" if entry.expires_at is None else f"expires {entry.expires_at:.0f}"
+        lines.append(f"- {entry.key}: {entry.size_bytes} bytes, {expiry}{stale_note}")
+    return "\n".join(lines)
+
+
+_BODY_HTML = '<div id="root" class="stack"><div class="empty">Loading…</div></div>'
+
+_SCRIPT_JS = r"""
+(function () {
+  var app = new window.McpAppLib.App({ name: "palaia-stash-browser", version: "1.0.0" }, {});
+  var transport = new window.McpAppLib.PostMessageTransport(window.parent, window.parent);
+  var root = document.getElementById("root");
+  var state = { namespace: "", namespaces: {}, entries: [] };
+
+  function escapeHtml(s) {
+    return String(s == null ? "" : s).replace(/[&<>"']/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+    });
+  }
+
+  function browse(namespace) {
+    app.callServerTool({ name: "stash_browse", arguments: { namespace: namespace } })
+      .then(function (result) {
+        if (!result.isError) loadFromResult(result.structuredContent);
+      });
+  }
+
+  function render() {
+    var html = "";
+    if (state.namespace) {
+      html += '<div class="row" style="margin-bottom:8px">'
+        + '<button class="btn" id="back">&larr; All namespaces</button></div>';
+      html += '<div class="card"><div class="card__head"><span class="card__title">'
+        + escapeHtml(state.namespace) + "</span></div><div>";
+      if (!state.entries.length) {
+        html += '<div class="empty">No entries in this namespace.</div>';
+      }
+      for (var i = 0; i < state.entries.length; i++) {
+        var e = state.entries[i];
+        var expiry = e.expires_at == null
+          ? "no expiry"
+          : "expires " + new Date(e.expires_at * 1000).toLocaleString();
+        html += '<div class="listrow"><div style="flex:1;min-width:0">'
+          + '<div class="listrow__title t-mono">' + escapeHtml(e.key) + "</div>"
+          + '<div class="listrow__meta">' + expiry + (e.stale ? " · stale" : "") + "</div>"
+          + '</div><div class="t-mono t-muted">' + e.size_bytes + " bytes</div></div>";
+      }
+      html += "</div></div>";
+    } else {
+      var names = Object.keys(state.namespaces);
+      html += '<div class="card"><div class="card__head">'
+        + '<span class="card__title">Namespaces</span></div><div>';
+      if (!names.length) {
+        html += '<div class="empty">The stash is empty.</div>';
+      }
+      for (var j = 0; j < names.length; j++) {
+        var name = names[j];
+        html += '<div class="listrow" data-ns="' + escapeHtml(name) + '" style="cursor:pointer">'
+          + '<div style="flex:1;min-width:0"><div class="listrow__title">'
+          + escapeHtml(name) + "</div></div>"
+          + '<div class="t-mono t-muted">' + state.namespaces[name] + " entr"
+          + (state.namespaces[name] === 1 ? "y" : "ies") + "</div></div>";
+      }
+      html += "</div></div>";
+    }
+    root.innerHTML = html;
+    var back = document.getElementById("back");
+    if (back) back.addEventListener("click", function () { browse(""); });
+    var rows = root.querySelectorAll("[data-ns]");
+    for (var k = 0; k < rows.length; k++) {
+      rows[k].addEventListener("click", (function (row) {
+        return function () { browse(row.getAttribute("data-ns")); };
+      })(rows[k]));
+    }
+  }
+
+  function loadFromResult(sc) {
+    sc = sc || {};
+    state.namespace = sc.namespace || "";
+    state.namespaces = sc.namespaces || {};
+    state.entries = Array.isArray(sc.entries) ? sc.entries : [];
+    render();
+  }
+
+  app.addEventListener("toolresult", function (params) {
+    loadFromResult(params.structuredContent);
+  });
+
+  app.connect(transport);
+})();
+"""
+
+
+def render_stash_browser_html() -> str:
+    return render_app_page(title=_TITLE, body_html=_BODY_HTML, script_js=_SCRIPT_JS)
+
+
+__all__ = [
+    "RESOURCE_URI",
+    "StashBrowseEntry",
+    "StashBrowseResult",
+    "collect_stash_browse",
+    "render_stash_browser_html",
+    "stash_browse_summary",
+]

--- a/v3/server/src/palaia_hub/gateway/apps/team_app.py
+++ b/v3/server/src/palaia_hub/gateway/apps/team_app.py
@@ -1,0 +1,382 @@
+"""Session-monitor MCP App (SPEC-405 deliverable #3, MASTERPLAN §5.7's
+Phase-4 "Session monitor / messenger" row: "live agent directory + message
+flows; structured-message compose form").
+
+Its own standalone ``FastMCP`` instance, mounted at ``/mcp/team`` — same
+"one hub-level server, not per-vault" shape as
+:mod:`~palaia_hub.gateway.apps.hub_status_app` and
+:mod:`~palaia_hub.gateway.apps.market_app`, gated on *both* the SPEC-402
+directory service and the SPEC-403 messenger service being wired (there is
+nothing to monitor without either).
+
+**Why this server carries its own copy of ``messenger_send``.** The
+compose form's "Send" action calls back through the MCP Apps bridge
+(``app.callServerTool``), which only ever reaches a tool on the *same*
+server that served the calling page's ``ui://`` resource — it cannot reach
+across to :mod:`palaia_hub.gateway.messenger_tools`'s own ``/mcp/messenger``
+mount. So this module registers the identical tool via
+:func:`~palaia_hub.gateway.messenger_tools.register_messenger_send_tool` on
+*this* server too — one implementation of "send a message", running on two
+mounts, not two implementations that could drift. The compose form still
+needs the caller's own handle and session secret, exactly as calling
+``messenger_send`` on ``/mcp/messenger`` directly would (MASTERPLAN §5.7:
+"under the same per-client token and scopes — no second auth surface"; the
+SPEC-402 session secret is a second credential by design, reused, never
+bypassed, for either mount).
+
+**Read-only for everyone else: no bodies, no destructive controls.** The
+directory + flows read (``session_monitor``) never shows a message body
+(the flows feed here is metadata only, same as the dashboard's own
+``/api/messenger`` mirror) — an MCP App is not the owner's admin surface,
+so it gets the same withheld-body treatment every non-owner reader does.
+Ending a conversation and deregistering a session are the SPEC-304 rule
+this SPEC inherits: dashboard-only. This page never calls a tool for
+either — it deep-links to the dashboard's Agents screen instead, the exact
+"Install itself always deep-links..." pattern
+:mod:`~palaia_hub.gateway.apps.market_app` already established for its own
+destructive-elsewhere action.
+"""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+from fastmcp.apps import AppConfig
+from fastmcp.tools.base import ToolResult
+from mcp.types import ToolAnnotations
+from pydantic import BaseModel, ConfigDict, Field
+
+from ...auth.enforcement import missing_directory_scope_error, missing_messenger_scope_error
+from ...directory.models import SessionRecord
+from ...directory.service import DirectoryService
+from ...messenger.models import EnvelopeMetadata
+from ...messenger.service import MessengerService
+from ..messenger_tools import register_messenger_send_tool
+from .shell import render_app_page
+
+RESOURCE_URI = "ui://palaia/team.html"
+
+_TITLE = "palaia · Agents"
+
+#: How many recent flows `session_monitor` renders — a monitor panel, not
+#: a full message archive (same reasoning as
+#: `~palaia_hub.gateway.apps.market_app`'s text-fallback limit, applied to
+#: the structured payload here rather than only the text one).
+_FLOW_LIMIT = 30
+
+
+class TeamMonitorResult(BaseModel):
+    """``session_monitor``'s result: the live directory, recent message
+    flows (metadata only — no bodies, see the module docstring), which
+    tool the compose form calls, and this hub's dashboard for the
+    destructive controls this app never performs itself."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    sessions: list[SessionRecord] = Field(default_factory=list)
+    flows: list[EnvelopeMetadata] = Field(default_factory=list)
+    #: Always ``"messenger_send"`` — named explicitly (rather than assumed)
+    #: so the page's own script never hard-codes a tool name it did not
+    #: get from a result, the same discipline
+    #: `~palaia_hub.gateway.apps.recall_app`'s `pick_tool` field documents.
+    send_tool: str = "messenger_send"
+    #: This hub's dashboard, if known (`config.exposure.public_url`) — the
+    #: base the "manage from the dashboard" deep link is built from. `None`
+    #: means the page shows plain instructions instead (see
+    #: `~palaia_hub.gateway.apps.market_app`'s identical fallback).
+    dashboard_url: str | None = None
+
+
+class TeamAppDeps:
+    """State ``session_monitor`` reads — a plain bag, mirroring
+    :class:`~palaia_hub.gateway.apps.hub_status_app.HubStatusDeps`."""
+
+    def __init__(
+        self,
+        *,
+        directory_service: DirectoryService,
+        messenger_service: MessengerService,
+        dashboard_url: str | None,
+    ) -> None:
+        self.directory_service = directory_service
+        self.messenger_service = messenger_service
+        self.dashboard_url = dashboard_url
+
+
+async def collect_team_monitor(deps: TeamAppDeps) -> TeamMonitorResult:
+    directory_result = await deps.directory_service.list()
+    flows_result = await deps.messenger_service.flows(limit=_FLOW_LIMIT)
+    return TeamMonitorResult(
+        sessions=directory_result.sessions,
+        flows=flows_result.flows,
+        dashboard_url=deps.dashboard_url,
+    )
+
+
+def _text_summary(result: TeamMonitorResult) -> str:
+    """The plain-text fallback (SPEC-405 deliverable #3): a compact
+    directory listing, for a host with no MCP Apps extension."""
+    if not result.sessions:
+        return "No agents are registered with this hub right now."
+    lines = [f"{len(result.sessions)} agent(s) registered:"]
+    for session in result.sessions:
+        platform = session.platform or "unknown platform"
+        scope = session.scope or "no scope reported"
+        lines.append(f"- {session.handle} ({platform}, {session.status}) — {scope}")
+    if result.flows:
+        lines.append(f"{len(result.flows)} recent message(s) — see the dashboard to read them.")
+    return "\n".join(lines)
+
+
+_BODY_HTML = '<div id="root" class="stack"><div class="empty">Loading…</div></div>'
+
+_SCRIPT_JS = r"""
+(function () {
+  var app = new window.McpAppLib.App({ name: "palaia-team", version: "1.0.0" }, {});
+  var transport = new window.McpAppLib.PostMessageTransport(window.parent, window.parent);
+  var root = document.getElementById("root");
+  var state = { sessions: [], flows: [], sendTool: "messenger_send", dashboardUrl: null };
+  var composeOpen = false;
+  var sending = false;
+  var sendError = "";
+
+  function escapeHtml(s) {
+    return String(s == null ? "" : s).replace(/[&<>"']/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+    });
+  }
+
+  function manageHref() {
+    if (!state.dashboardUrl) return null;
+    return state.dashboardUrl.replace(/\/+$/, "") + "/agents";
+  }
+
+  function statusBadgeClass(status) {
+    if (status === "stale") return "badge--risk";
+    if (status === "idle") return "badge--warn";
+    return "badge--ok";
+  }
+
+  function renderDirectory() {
+    if (!state.sessions.length) {
+      return '<div class="empty">No agents are registered with this hub right now.</div>';
+    }
+    var html = "";
+    for (var i = 0; i < state.sessions.length; i++) {
+      var s = state.sessions[i];
+      html += '<div class="listrow"><div style="flex:1;min-width:0">'
+        + '<div class="listrow__title t-mono">' + escapeHtml(s.handle) + "</div>"
+        + '<div class="listrow__meta">' + escapeHtml(s.scope || "no scope reported") + "</div>"
+        + '<div class="listrow__meta">' + escapeHtml(s.platform || "unknown platform")
+        + (s.model ? " · " + escapeHtml(s.model) : "") + "</div></div>"
+        + '<span class="badge ' + statusBadgeClass(s.status) + '"><span class="dot"></span>'
+        + escapeHtml(s.status) + "</span></div>";
+    }
+    return html;
+  }
+
+  function renderFlows() {
+    if (!state.flows.length) {
+      return '<div class="empty">No messages yet.</div>';
+    }
+    var html = "";
+    for (var i = 0; i < state.flows.length; i++) {
+      var f = state.flows[i];
+      html += '<div class="listrow"><div style="flex:1;min-width:0">'
+        + '<div class="listrow__title">' + escapeHtml(f.subject) + "</div>"
+        + '<div class="listrow__meta">' + escapeHtml(f.from) + " &rarr; "
+        + escapeHtml(f.recipient) + " · " + escapeHtml(f.type) + "/" + escapeHtml(f.urgency)
+        + "</div></div><span class=\"badge\">" + escapeHtml(f.state) + "</span></div>";
+    }
+    return html;
+  }
+
+  function renderCompose() {
+    if (!composeOpen) {
+      return '<button class="btn btn--primary" id="open-compose">Send a message</button>';
+    }
+    var html = '<div class="card"><div class="card__body stack stack--2">'
+      + '<div class="t-xs t-muted">Sends over your own connection, with your own handle and '
+      + 'secret — the same as calling messenger_send yourself.</div>'
+      + '<input class="input" id="f-handle" placeholder="Your agent handle" />'
+      + '<input class="input" id="f-secret" type="password" '
+      + 'placeholder="Your session secret" />'
+      + '<input class="input" id="f-to" '
+      + 'placeholder="To (handle, or * / capability:tag for everyone)" />'
+      + '<select class="input" id="f-type">'
+      + '<option value="inform">Inform</option><option value="request">Request</option>'
+      + '<option value="question">Question</option><option value="handoff">Handoff</option>'
+      + '<option value="broadcast">Broadcast</option></select>'
+      + '<input class="input" id="f-subject" placeholder="Subject" maxlength="200" />'
+      + '<textarea class="input" id="f-body" placeholder="Message" rows="3" '
+      + 'maxlength="4096"></textarea>'
+      + '<select class="input" id="f-urgency">'
+      + '<option value="normal">Normal</option><option value="low">Low</option>'
+      + '<option value="high">High</option></select>'
+      + '<label class="row" style="gap:6px"><input type="checkbox" id="f-reply" />'
+      + '<span class="t-sm">Needs a reply</span></label>'
+      + (sendError ? '<p class="field__error">' + escapeHtml(sendError) + "</p>" : "")
+      + '<div class="row"><button class="btn btn--primary" id="do-send" '
+      + (sending ? "disabled" : "") + ">" + (sending ? "Sending…" : "Send") + "</button>"
+      + '<button class="btn" id="cancel-compose">Cancel</button></div>'
+      + "</div></div>";
+    return html;
+  }
+
+  function render() {
+    var href = manageHref();
+    var html = '<div class="row--between">'
+      + '<span class="t-xs t-muted">Ending a conversation or removing an agent '
+      + 'happens from the dashboard.</span>';
+    if (href) {
+      html += '<a class="btn" href="' + href + '" target="_blank" rel="noopener">'
+        + "Open dashboard</a>";
+    }
+    html += "</div>";
+    html += '<div class="card"><div class="card__head">'
+      + '<span class="card__title">Agents</span></div><div>'
+      + renderDirectory() + "</div></div>";
+    html += '<div class="card"><div class="card__head">'
+      + '<span class="card__title">Recent messages</span></div><div>'
+      + renderFlows() + "</div></div>";
+    html += renderCompose();
+    root.innerHTML = html;
+
+    var openBtn = document.getElementById("open-compose");
+    if (openBtn) openBtn.addEventListener("click", function () { composeOpen = true; render(); });
+    var cancelBtn = document.getElementById("cancel-compose");
+    if (cancelBtn) cancelBtn.addEventListener("click", function () {
+      composeOpen = false; sendError = ""; render();
+    });
+    var sendBtn = document.getElementById("do-send");
+    if (sendBtn) sendBtn.addEventListener("click", send);
+  }
+
+  function fieldValue(id) {
+    var el = document.getElementById(id);
+    return el ? el.value : "";
+  }
+
+  function send() {
+    if (sending) return;
+    sendError = "";
+    var args = {
+      handle: fieldValue("f-handle"),
+      session_secret: fieldValue("f-secret"),
+      to: fieldValue("f-to"),
+      message_type: fieldValue("f-type"),
+      subject: fieldValue("f-subject"),
+      body: fieldValue("f-body"),
+      urgency: fieldValue("f-urgency"),
+      expects_reply: !!document.getElementById("f-reply").checked,
+    };
+    if (!args.handle || !args.session_secret || !args.to || !args.subject) {
+      sendError = "Fill in your handle, secret, a recipient and a subject.";
+      render();
+      return;
+    }
+    sending = true;
+    render();
+    app.callServerTool({ name: state.sendTool, arguments: args }).then(function (result) {
+      sending = false;
+      if (result.isError) {
+        sendError = (result.content && result.content[0] && result.content[0].text)
+          || "Could not send.";
+        render();
+        return;
+      }
+      composeOpen = false;
+      app.callServerTool({ name: "session_monitor", arguments: {} }).then(function (refreshed) {
+        if (!refreshed.isError) loadFromResult(refreshed.structuredContent);
+      });
+    });
+  }
+
+  function loadFromResult(sc) {
+    sc = sc || {};
+    state.sessions = Array.isArray(sc.sessions) ? sc.sessions : [];
+    state.flows = Array.isArray(sc.flows) ? sc.flows : [];
+    state.sendTool = sc.send_tool || "messenger_send";
+    state.dashboardUrl = sc.dashboard_url || null;
+    render();
+  }
+
+  app.addEventListener("toolresult", function (params) {
+    loadFromResult(params.structuredContent);
+  });
+
+  app.connect(transport);
+})();
+"""
+
+
+def render_team_html() -> str:
+    return render_app_page(title=_TITLE, body_html=_BODY_HTML, script_js=_SCRIPT_JS)
+
+
+def build_team_server(deps: TeamAppDeps) -> FastMCP:
+    """The standalone hub-level ``session_monitor`` (+ ``messenger_send``)
+    server, mounted at ``/mcp/team`` by :func:`palaia_hub.app.create_app` —
+    mirrors :func:`~palaia_hub.gateway.apps.hub_status_app.
+    build_hub_status_server`'s shape."""
+    server = FastMCP(
+        name="palaia-team",
+        instructions=(
+            "IDENTITY: this is the team monitor — the live directory of "
+            "connected agent sessions and recent message flows for this "
+            "palaia hub. Call session_monitor to see who is around and "
+            "what has been said (message bodies are not shown here — read "
+            "them the same way you always do, with messenger_check/"
+            "messenger_thread on your own connection). messenger_send here "
+            "is the exact same tool as on the messenger's own connection: "
+            "it needs your own handle and session_secret from "
+            "directory_register, same as always."
+        ),
+    )
+
+    @server.tool(
+        name="session_monitor",
+        description=(
+            "The live agent directory and recent message flows (metadata "
+            "only — no message bodies). Renders as a panel in clients that "
+            "support it, or a compact plain-text listing otherwise."
+        ),
+        annotations=ToolAnnotations(
+            readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+        ),
+        app=AppConfig(resource_uri=RESOURCE_URI),
+    )
+    async def session_monitor() -> ToolResult:
+        # Reuse the directory's/messenger's own established read actions
+        # ("directory_list", "messenger_check") to ask for exactly the
+        # `directory:read`/`messenger:read` scopes those already carry,
+        # rather than adding "session_monitor" to either family's own
+        # read-action allow-list — those lists are that family's *own* tool
+        # names (asserted exhaustively in
+        # ``server/tests/auth/test_directory_scopes.py``/
+        # ``test_messenger_scopes.py``), and this tool lives in neither
+        # family's server.
+        missing = missing_directory_scope_error("directory_list") or missing_messenger_scope_error(
+            "messenger_check"
+        )
+        if missing is not None:
+            return ToolResult(content=missing, is_error=True)
+        result = await collect_team_monitor(deps)
+        return ToolResult(content=_text_summary(result), structured_content=result)
+
+    register_messenger_send_tool(server, deps.messenger_service)
+
+    @server.resource(RESOURCE_URI, name="team_app")
+    def _team_resource() -> str:
+        return render_team_html()
+
+    return server
+
+
+__all__ = [
+    "RESOURCE_URI",
+    "TeamAppDeps",
+    "TeamMonitorResult",
+    "build_team_server",
+    "collect_team_monitor",
+    "render_team_html",
+]

--- a/v3/server/src/palaia_hub/gateway/messenger_tools.py
+++ b/v3/server/src/palaia_hub/gateway/messenger_tools.py
@@ -137,9 +137,20 @@ def render_envelopes(envelopes: list[Envelope], *, empty: str) -> str:
     return "\n".join(lines)
 
 
-def build_messenger_server(service: MessengerService) -> FastMCP:
-    """Build the messenger tool family, backed by ``service``."""
-    server = FastMCP(name="palaia-messenger", instructions=MESSENGER_IDENTITY)
+def register_messenger_send_tool(server: FastMCP, service: MessengerService) -> None:
+    """Register ``messenger_send`` on ``server``, backed by ``service``.
+
+    Factored out of :func:`build_messenger_server` so a *second*,
+    independent ``FastMCP`` instance — the session-monitor MCP App's own
+    server (:mod:`palaia_hub.gateway.apps.team_app`, SPEC-405) — can carry a
+    working compose action. That app's page calls back through the MCP Apps
+    bridge (``app.callServerTool``), which only ever reaches a tool on the
+    *same* server that served the calling page's ``ui://`` resource — it
+    cannot reach across to this module's own ``/mcp/messenger`` mount. Both
+    registrations call this exact function, so "compose from the team app"
+    and "call messenger_send on ``/mcp/messenger`` directly" are the same
+    tool running twice, not two implementations of one rule.
+    """
 
     def desc(detail: str) -> str:
         return f"{MESSENGER_IDENTITY}\n\n{detail}"
@@ -270,6 +281,16 @@ def build_messenger_server(service: MessengerService) -> FastMCP:
             )
         return ToolResult(content=text, structured_content=result)
 
+
+def build_messenger_server(service: MessengerService) -> FastMCP:
+    """Build the messenger tool family, backed by ``service``."""
+    server = FastMCP(name="palaia-messenger", instructions=MESSENGER_IDENTITY)
+
+    def desc(detail: str) -> str:
+        return f"{MESSENGER_IDENTITY}\n\n{detail}"
+
+    register_messenger_send_tool(server, service)
+
     @server.tool(
         name="messenger_check",
         description=desc(
@@ -379,5 +400,6 @@ __all__ = [
     "MessengerGatewayASGI",
     "build_messenger_gateway",
     "build_messenger_server",
+    "register_messenger_send_tool",
     "render_envelopes",
 ]

--- a/v3/server/src/palaia_hub/gateway/stash_tools.py
+++ b/v3/server/src/palaia_hub/gateway/stash_tools.py
@@ -29,6 +29,7 @@ from dataclasses import dataclass
 from typing import Annotated, Any
 
 from fastmcp import FastMCP
+from fastmcp.apps import AppConfig
 from fastmcp.tools.base import ToolResult
 from mcp.types import ToolAnnotations
 from pydantic import AliasChoices, Field
@@ -37,6 +38,14 @@ from starlette.types import ASGIApp
 from ..auth.enforcement import missing_stash_scope_error
 from ..stash.models import StashError
 from ..stash.service import StashService
+from .apps.stash_browser_app import (
+    RESOURCE_URI as STASH_BROWSER_URI,
+)
+from .apps.stash_browser_app import (
+    collect_stash_browse,
+    render_stash_browser_html,
+    stash_browse_summary,
+)
 
 STASH_TOOL_ACTIONS: tuple[str, ...] = (
     "stash_set",
@@ -44,6 +53,7 @@ STASH_TOOL_ACTIONS: tuple[str, ...] = (
     "stash_del",
     "stash_list",
     "stash_status",
+    "stash_browse",
 )
 
 STASH_IDENTITY = (
@@ -206,6 +216,42 @@ def build_stash_server(service: StashService) -> FastMCP:
             f"{result.total_bytes}/{result.budget_bytes} bytes used"
         )
         return ToolResult(content=text, structured_content=result)
+
+    @server.tool(
+        name="stash_browse",
+        description=desc(
+            "Browse the stash as an inspection panel: namespace, key, size, "
+            "and expiry — never the stored value itself (this is for seeing "
+            "what is cached and how big it is, not for reading it; use "
+            "stash_get for that). Call with no namespace for the overview "
+            "of every namespace and its entry count; pass one of those "
+            "namespaces back in to see its entries."
+        ),
+        annotations=ToolAnnotations(
+            readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+        ),
+        app=AppConfig(resource_uri=STASH_BROWSER_URI),
+    )
+    async def stash_browse(
+        namespace: Annotated[
+            str,
+            Field(
+                validation_alias=AliasChoices("namespace", "ns", "scope"),
+                description=(
+                    "Drill into this namespace's entries, or leave unset for "
+                    "the namespace overview."
+                ),
+            ),
+        ] = "",
+    ) -> ToolResult:
+        if (err := _scope_error("stash_browse")) is not None:
+            return err
+        result = await collect_stash_browse(service, namespace)
+        return ToolResult(content=stash_browse_summary(result), structured_content=result)
+
+    @server.resource(STASH_BROWSER_URI, name="stash_browser_app")
+    def _stash_browser_resource() -> str:
+        return render_stash_browser_html()
 
     return server
 

--- a/v3/server/src/palaia_hub/messenger/models.py
+++ b/v3/server/src/palaia_hub/messenger/models.py
@@ -89,6 +89,19 @@ CAPABILITY_QUERY_PREFIX = "capability:"
 #: ``to`` value meaning "every live session in the directory".
 EVERYONE_QUERY = "*"
 
+#: The ``from`` every owner-sent envelope carries (SPEC-405 deliverable #2:
+#: "send as owner"). Never a SPEC-402 directory handle — the owner has no
+#: session to register, and never needs one: the dashboard's own
+#: ``/api/messenger/send`` route is already behind the owner's signed-in
+#: session and CSRF token (:mod:`palaia_hub.admin_session`), which is what
+#: :meth:`~palaia_hub.messenger.service.MessengerService.send_as_owner`
+#: trusts instead of a session secret. A real directory handle can never
+#: collide with this value (handles are random
+#: :data:`~palaia_hub.directory.store.HANDLE_CHARS`-character tokens, never
+#: a plain word), so a recipient can tell "the owner" apart from any agent
+#: session on sight.
+OWNER_HANDLE = "owner"
+
 
 class Envelope(BaseModel):
     """One message between two sessions — the fixed protocol shape.
@@ -277,6 +290,26 @@ class ThreadMetadataResult(BaseModel):
 
     root_id: str
     flows: list[EnvelopeMetadata]
+
+
+class EndConversationResult(BaseModel):
+    """Owner control: "end a conversation" (SPEC-405 deliverable #2,
+    MASTERPLAN §5.4 trust rule #7 — "shut a conversation down").
+
+    ``expired`` is only the envelopes this call itself expired — the
+    thread's still-``pending`` (undelivered) copies. Delivered/acked copies
+    are left alone: the SPEC's own words are "expires the thread's
+    undelivered envelopes", not "deletes the conversation's history", and a
+    recipient who already has a copy locally is not un-sent to by this
+    call. Deliberately not exposed as an MCP tool: the SPEC-304 rule this
+    SPEC inherits keeps destructive owner controls dashboard-only, and this
+    is one — see :mod:`palaia_hub.messenger_api`.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    root_id: str
+    expired: list[EnvelopeMetadata]
 
 
 class EnvelopeDetailResult(BaseModel):
@@ -493,11 +526,13 @@ __all__ = [
     "MAX_SUBJECT_CHARS",
     "MAX_TTL_SECONDS",
     "MEMORY_SCHEME",
+    "OWNER_HANDLE",
     "AckResult",
     "BodyTooLargeError",
     "BroadcastError",
     "CheckResult",
     "DeliveryState",
+    "EndConversationResult",
     "Envelope",
     "EnvelopeDetailResult",
     "EnvelopeMetadata",

--- a/v3/server/src/palaia_hub/messenger/service.py
+++ b/v3/server/src/palaia_hub/messenger/service.py
@@ -54,10 +54,12 @@ from ..directory.models import (
 )
 from .models import (
     MAX_BROADCAST_RECIPIENTS,
+    OWNER_HANDLE,
     AckResult,
     BroadcastError,
     CheckResult,
     DeliveryState,
+    EndConversationResult,
     Envelope,
     EnvelopeDetailResult,
     EnvelopeMetadata,
@@ -200,9 +202,100 @@ class MessengerService:
         delivered broadcast is not a state this store can reach.
         """
         await self._authenticate(sender, session_secret)
+        return await self._send(
+            sender=sender,
+            message_type=message_type,
+            to=to,
+            subject=subject,
+            body=body,
+            urgency=urgency,
+            expects_reply=expects_reply,
+            refs=refs,
+            reply_to=reply_to,
+            ttl_seconds=ttl_seconds,
+            readable_vaults=readable_vaults,
+            fence_reply=True,
+        )
+
+    async def send_as_owner(
+        self,
+        *,
+        message_type: MessageType,
+        to: str,
+        subject: str,
+        body: str = "",
+        urgency: Urgency = "normal",
+        expects_reply: bool = False,
+        refs: list[str] | None = None,
+        reply_to: str | None = None,
+        ttl_seconds: float | None = None,
+        readable_vaults: frozenset[str] | None = None,
+    ) -> SendResult:
+        """Owner control: send as the hub's owner (SPEC-405 deliverable #2,
+        MASTERPLAN §5.4 trust rule #7 — "the human can ... join in").
+
+        No SPEC-402 session secret is checked here — there is no session to
+        prove one for. This is safe only because it has exactly one caller,
+        :mod:`palaia_hub.messenger_api`'s ``POST /api/messenger/send``,
+        which sits behind the owner's signed-in session and CSRF token
+        (:mod:`palaia_hub.admin_session`): a *stronger* proof of "this really
+        is the owner" than a session secret is of "this really is session
+        X", not a weaker substitute for it. The sender is always
+        :data:`~palaia_hub.messenger.models.OWNER_HANDLE`, and a reply is not
+        fenced to a thread the owner already took part in — reading along
+        and then answering is exactly trust rule #7's "join in", so the
+        fence :meth:`send` applies to an ordinary session does not apply
+        here.
+        """
+        return await self._send(
+            sender=OWNER_HANDLE,
+            message_type=message_type,
+            to=to,
+            subject=subject,
+            body=body,
+            urgency=urgency,
+            expects_reply=expects_reply,
+            refs=refs,
+            reply_to=reply_to,
+            ttl_seconds=ttl_seconds,
+            readable_vaults=readable_vaults,
+            fence_reply=False,
+        )
+
+    async def _send(
+        self,
+        *,
+        sender: str,
+        message_type: MessageType,
+        to: str,
+        subject: str,
+        body: str,
+        urgency: Urgency,
+        expects_reply: bool,
+        refs: list[str] | None,
+        reply_to: str | None,
+        ttl_seconds: float | None,
+        readable_vaults: frozenset[str] | None,
+        fence_reply: bool,
+    ) -> SendResult:
+        """The validate-address-store pipeline shared by :meth:`send` (an
+        authenticated session, fenced to threads it took part in) and
+        :meth:`send_as_owner` (already-authenticated by the dashboard's own
+        gate, never fenced) — one implementation of "what a send actually
+        does", not two copies that could drift.
+        """
         clean_refs = check_refs(refs)
         self._check_refs_resolve(clean_refs, readable_vaults)
-        parent = await self._resolve_reply_to(sender, reply_to)
+        parent = await self._reply_target(reply_to)
+        if fence_reply and parent is not None and sender not in (
+            parent.envelope.from_,
+            parent.recipient,
+        ):
+            raise NotYourEnvelopeError(
+                f"envelope {reply_to!r} is not yours to reply to — you are neither "
+                "its sender nor its recipient. Fix: reply only to envelopes "
+                "messenger_check handed you."
+            )
         if parent is not None and message_type == "broadcast":
             raise InvalidEnvelopeError(
                 "a broadcast cannot be a reply. Fix: reply to the one envelope you "
@@ -263,12 +356,12 @@ class MessengerService:
                 "nowhere, which is the whole reason refs exists."
             )
 
-    async def _resolve_reply_to(self, sender: str, reply_to: str | None) -> InboxItem | None:
-        """The envelope being answered — and the fence around it.
-
-        A reply may only be written against an envelope the sender actually
-        took part in. Without this, ``reply_to`` would be a way to inject a
-        message into a stranger's thread by guessing an id.
+    async def _reply_target(self, reply_to: str | None) -> InboxItem | None:
+        """The envelope ``reply_to`` names, or ``None`` — no participant
+        fence here (that is :meth:`_send`'s job, via ``fence_reply``): an
+        ordinary session's reply may only answer a thread it took part in,
+        but the owner's :meth:`send_as_owner` may reply to anything (trust
+        rule #7's "join in"), and this helper is what both share.
         """
         if reply_to is None:
             return None
@@ -278,12 +371,6 @@ class MessengerService:
             raise EnvelopeNotFoundError(
                 f"reply_to names no envelope ({reply_to!r}). Fix: reply to an id "
                 "messenger_check gave you — an envelope past its expires_at is gone."
-            )
-        if sender not in (item.envelope.from_, item.recipient):
-            raise NotYourEnvelopeError(
-                f"envelope {reply_to!r} is not yours to reply to — you are neither "
-                "its sender nor its recipient. Fix: reply only to envelopes "
-                "messenger_check handed you."
             )
         return item
 
@@ -462,6 +549,23 @@ class MessengerService:
                 f"no envelope {envelope_id!r} (never sent, or expired away)."
             )
         return EnvelopeDetailResult(item=item)
+
+    async def end_conversation(self, envelope_id: str) -> EndConversationResult:
+        """Owner control: expire a thread's undelivered envelopes (SPEC-405
+        deliverable #2, MASTERPLAN §5.4 trust rule #7 — "shut a conversation
+        down"). See :meth:`~palaia_hub.messenger.store.MessengerStore.
+        expire_thread` for exactly what "undelivered" excludes. Fires
+        ``message.expired`` for every envelope this call itself expired, and
+        for whatever the routine TTL sweep found on the way in — both are
+        the same event, because both mean the same thing to whoever would
+        have received them: this envelope will not be delivered.
+        """
+        root_id, thread_expired, swept = await asyncio.to_thread(
+            self._store.expire_thread, envelope_id
+        )
+        self._emit_expired(swept)
+        self._emit_expired(thread_expired)
+        return EndConversationResult(root_id=root_id, expired=thread_expired)
 
     async def sweep(self) -> list[EnvelopeMetadata]:
         """Run the TTL sweep alone and fire ``message.expired`` for each.

--- a/v3/server/src/palaia_hub/messenger/store.py
+++ b/v3/server/src/palaia_hub/messenger/store.py
@@ -337,10 +337,13 @@ class MessengerStore:
             item = _row_to_item(row) if row is not None else None
         return item, expired
 
-    def thread(
-        self, envelope_id: str, *, now: float | None = None
-    ) -> tuple[list[InboxItem], list[EnvelopeMetadata]]:
-        """One envelope's whole reply chain, oldest first.
+    def _collect_thread_rows_locked(self, envelope_id: str) -> list[sqlite3.Row]:
+        """Every row in ``envelope_id``'s whole thread (its root's full
+        subtree), oldest first. Must be called already holding ``self._lock``,
+        after a sweep. Shared by :meth:`thread` (read) and
+        :meth:`expire_thread` (SPEC-405's "end a conversation") so both walk
+        the *identical* tree — the second was added as this method's own
+        second caller, not as a hand-copied variant of the walk below.
 
         Walks ``reply_to`` up to the root (bounded by
         :data:`MAX_THREAD_DEPTH`, so a cycle cannot hang the hub), then
@@ -349,48 +352,83 @@ class MessengerStore:
         what still exists, honestly, rather than an error about a message
         nobody can read any more.
         """
+        row = self._row_locked(envelope_id)
+        if row is None:
+            raise EnvelopeNotFoundError(
+                f"no envelope {envelope_id!r}. Fix: check the id — an envelope "
+                "past its expires_at is deleted, threads included."
+            )
+        root = row
+        seen_up = {root["id"]}
+        for _ in range(MAX_THREAD_DEPTH):
+            parent_id = root["reply_to"]
+            if parent_id is None or parent_id in seen_up:
+                break
+            parent = self._row_locked(parent_id)
+            if parent is None:
+                break
+            root = parent
+            seen_up.add(root["id"])
+        collected: dict[str, sqlite3.Row] = {root["id"]: root}
+        frontier = [root["id"]]
+        while frontier:
+            placeholders = ",".join("?" for _ in frontier)
+            children = self._conn.execute(
+                "SELECT rowid AS seq, * FROM messenger_envelopes "
+                f"WHERE reply_to IN ({placeholders})",
+                tuple(frontier),
+            ).fetchall()
+            frontier = []
+            for child in children:
+                if child["id"] in collected:
+                    continue
+                collected[child["id"]] = child
+                frontier.append(child["id"])
+        return sorted(collected.values(), key=lambda r: (r["created_at"], r["seq"]))
+
+    def thread(
+        self, envelope_id: str, *, now: float | None = None
+    ) -> tuple[list[InboxItem], list[EnvelopeMetadata]]:
+        """One envelope's whole reply chain, oldest first.
+
+        See :meth:`_collect_thread_rows_locked` for how the chain is found.
+        """
         current = self._now(now)
         with self._lock:
             expired = self._sweep_locked(current)
-            row = self._row_locked(envelope_id)
-            if row is None:
-                raise EnvelopeNotFoundError(
-                    f"no envelope {envelope_id!r}. Fix: check the id — an envelope "
-                    "past its expires_at is deleted, threads included."
-                )
-            root = row
-            seen_up = {root["id"]}
-            for _ in range(MAX_THREAD_DEPTH):
-                parent_id = root["reply_to"]
-                if parent_id is None or parent_id in seen_up:
-                    break
-                parent = self._row_locked(parent_id)
-                if parent is None:
-                    break
-                root = parent
-                seen_up.add(root["id"])
-            collected: dict[str, sqlite3.Row] = {root["id"]: root}
-            frontier = [root["id"]]
-            while frontier:
-                placeholders = ",".join("?" for _ in frontier)
-                children = self._conn.execute(
-                    "SELECT rowid AS seq, * FROM messenger_envelopes "
-                    f"WHERE reply_to IN ({placeholders})",
-                    tuple(frontier),
-                ).fetchall()
-                frontier = []
-                for child in children:
-                    if child["id"] in collected:
-                        continue
-                    collected[child["id"]] = child
-                    frontier.append(child["id"])
-            items = [
-                _row_to_item(row)
-                for row in sorted(
-                    collected.values(), key=lambda r: (r["created_at"], r["seq"])
-                )
-            ]
+            rows = self._collect_thread_rows_locked(envelope_id)
+            items = [_row_to_item(row) for row in rows]
         return items, expired
+
+    def expire_thread(
+        self, envelope_id: str, *, now: float | None = None
+    ) -> tuple[str, list[EnvelopeMetadata], list[EnvelopeMetadata]]:
+        """Owner control: end a conversation (SPEC-405 deliverable #2) by
+        expiring every still-``pending`` (undelivered) copy in
+        ``envelope_id``'s whole thread. Returns ``(root_id, thread_expired,
+        swept_expired)`` — ``thread_expired`` is what this call itself
+        deleted; ``swept_expired`` is whatever the routine TTL sweep found
+        stale on the way in, same as every other method here.
+
+        Delivered/acked copies are left standing: this ends the parts of
+        the conversation that have not reached anyone yet, not the record
+        of what already has (see :class:`~palaia_hub.messenger.models.
+        EndConversationResult`'s docstring for why).
+        """
+        current = self._now(now)
+        with self._lock:
+            swept = self._sweep_locked(current)
+            rows = self._collect_thread_rows_locked(envelope_id)
+            root_id = rows[0]["id"]
+            pending = [row for row in rows if row["state"] == "pending"]
+            thread_expired = [EnvelopeMetadata.of(_row_to_item(row)) for row in pending]
+            if pending:
+                self._conn.executemany(
+                    "DELETE FROM messenger_envelopes WHERE id = ?",
+                    [(row["id"],) for row in pending],
+                )
+                self._conn.commit()
+        return root_id, thread_expired, swept
 
     def outbox(
         self, sender: str, *, now: float | None = None

--- a/v3/server/src/palaia_hub/messenger_api.py
+++ b/v3/server/src/palaia_hub/messenger_api.py
@@ -1,41 +1,86 @@
-"""``/api/messenger`` read-only mirror of the messenger (SPEC-403
-deliverable #6), for SPEC-405's team-observability screen and any other
-non-MCP reader.
+"""``/api/messenger`` REST mirror of the messenger (SPEC-403 deliverable
+#6), for SPEC-405's team-observability screen and any other non-MCP reader.
 
-**Read-only, on purpose.** Sending, checking, acking and threading all
-happen over MCP, from the session itself, holding its own SPEC-402 session
-secret. Nothing here can send a message or read an inbox *as* somebody —
-there is no route that would let it, which is the whole point of the secret
-(see :mod:`palaia_hub.messenger.service`'s docstring).
+**Reading is read-only, on purpose.** Checking, acking and threading *as a
+session* all happen over MCP, from the session itself, holding its own
+SPEC-402 session secret. Nothing here can read an inbox *as* somebody — no
+route lets it, which is the whole point of the secret (see
+:mod:`palaia_hub.messenger.service`'s docstring).
 
 **Bodies.** The three listing routes (the flows feed, one sender's outbox,
 one thread) return :class:`~palaia_hub.messenger.models.EnvelopeMetadata` —
 the envelope with its body withheld — because a flows feed is a diagram of
-who talked to whom, not a transcript. Exactly one route returns a body: ``GET
-/api/messenger/envelopes/{id}``, the SPEC's "bodies only for the owner via
-the admin surface". ``/api/*`` *is* that admin surface — everything under it
-sits behind :mod:`palaia_hub.admin_session`'s sign-in gate wherever the hub's
-mode requires one (MASTERPLAN §5.5), the same gate that already protects
-note titles on ``/api/events`` and every vault read on ``/api/vaults``.
-Trust rule #7 (MASTERPLAN §5.4): "the human can read along, join in, or shut
-a conversation down" — reading along is this route.
+who talked to whom, not a transcript. Exactly one *listing* route returns a
+body: ``GET /api/messenger/envelopes/{id}``, the SPEC's "bodies only for the
+owner via the admin surface". ``/api/*`` *is* that admin surface — everything
+under it sits behind :mod:`palaia_hub.admin_session`'s sign-in gate wherever
+the hub's mode requires one (MASTERPLAN §5.5), the same gate that already
+protects note titles on ``/api/events`` and every vault read on
+``/api/vaults``.
+
+**Two owner controls live here** (SPEC-405 deliverable #2) — the other two
+thirds of trust rule #7 (MASTERPLAN §5.4): "the human can read along, join
+in, or shut a conversation down". Reading along is every ``GET`` above;
+these two ``POST`` routes are "join in" and "shut down":
+
+* ``POST /send`` — compose and send *as the owner*
+  (:meth:`~palaia_hub.messenger.service.MessengerService.send_as_owner`;
+  the sender always reads :data:`~palaia_hub.messenger.models.OWNER_HANDLE`).
+  No session secret is asked for or accepted here — the admin session gate
+  already proved who is calling, more strongly than a secret would.
+* ``POST /threads/{envelope_id}/end`` — end a conversation
+  (:meth:`~palaia_hub.messenger.service.MessengerService.end_conversation`):
+  expires the thread's still-undelivered envelopes and fires
+  ``message.expired`` for each.
+
+Both are dashboard-only by the SPEC-304 rule this SPEC inherits: neither is
+exposed as an MCP tool, and the session-monitor MCP App
+(:mod:`palaia_hub.gateway.apps.team_app`) deep-links to the dashboard for
+them instead of calling either itself.
 """
 
 from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
 
 from .messenger.models import (
+    MAX_BODY_BYTES,
+    MAX_SUBJECT_CHARS,
+    MAX_TTL_SECONDS,
     DeliveryState,
+    EndConversationResult,
     EnvelopeDetailResult,
     EnvelopeNotFoundError,
     FlowsResult,
     MessageType,
     MessengerError,
+    SendResult,
     ThreadMetadataResult,
+    Urgency,
 )
 from .messenger.service import MessengerService
 from .messenger.store import DEFAULT_FLOW_LIMIT
+
+
+class SendAsOwnerRequest(BaseModel):
+    """``POST /api/messenger/send``'s body — the owner compose form's exact
+    schema (SPEC-405 deliverable #2: "the form IS the schema"). Every field
+    here is the same one :mod:`palaia_hub.gateway.messenger_tools`'s
+    ``messenger_send`` tool takes, minus ``handle``/``session_secret`` (the
+    owner has neither — see this module's docstring)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: MessageType = "inform"
+    to: str
+    subject: str = Field(max_length=MAX_SUBJECT_CHARS)
+    body: str = Field(default="", max_length=MAX_BODY_BYTES)
+    urgency: Urgency = "normal"
+    expects_reply: bool = False
+    refs: list[str] | None = None
+    reply_to: str | None = None
+    ttl_seconds: float | None = Field(default=None, gt=0, le=MAX_TTL_SECONDS)
 
 
 def build_messenger_router(service: MessengerService) -> APIRouter:
@@ -89,7 +134,40 @@ def build_messenger_router(service: MessengerService) -> APIRouter:
         except MessengerError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
+    @router.post("/send", response_model=SendResult)
+    async def send_as_owner(body: SendAsOwnerRequest) -> SendResult:
+        """Compose and send as the owner (SPEC-405 deliverable #2) — the
+        dashboard's compose form's exact POST. See the module docstring for
+        why no session secret appears here."""
+        try:
+            return await service.send_as_owner(
+                message_type=body.type,
+                to=body.to,
+                subject=body.subject,
+                body=body.body,
+                urgency=body.urgency,
+                expects_reply=body.expects_reply,
+                refs=body.refs,
+                reply_to=body.reply_to,
+                ttl_seconds=body.ttl_seconds,
+            )
+        except EnvelopeNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except MessengerError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    @router.post("/threads/{envelope_id}/end", response_model=EndConversationResult)
+    async def end_conversation(envelope_id: str) -> EndConversationResult:
+        """End a conversation (SPEC-405 deliverable #2): expire every
+        still-undelivered envelope in ``envelope_id``'s whole thread."""
+        try:
+            return await service.end_conversation(envelope_id)
+        except EnvelopeNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except MessengerError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
     return router
 
 
-__all__ = ["build_messenger_router"]
+__all__ = ["SendAsOwnerRequest", "build_messenger_router"]

--- a/v3/server/tests/directory/test_service.py
+++ b/v3/server/tests/directory/test_service.py
@@ -148,3 +148,34 @@ async def test_no_publisher_wired_does_not_error(service: DirectoryService) -> N
     result = await service.register(scope="a")
     await service.heartbeat(result.session.handle, result.session_secret)
     await service.deregister(result.session.handle, result.session_secret)
+
+
+# -- admin_deregister: the owner control (SPEC-405 deliverable #2) -----------
+
+
+@pytest.mark.anyio
+async def test_admin_deregister_needs_no_secret(service: DirectoryService) -> None:
+    result = await service.register(scope="a stale session")
+    outcome = await service.admin_deregister(result.session.handle)
+    assert outcome.deregistered is True
+    listed = await service.list()
+    assert result.session.handle not in {s.handle for s in listed.sessions}
+
+
+@pytest.mark.anyio
+async def test_admin_deregister_of_an_already_gone_handle_is_idempotent(
+    service: DirectoryService,
+) -> None:
+    outcome = await service.admin_deregister("no-such-handle")
+    assert outcome.deregistered is False
+
+
+@pytest.mark.anyio
+async def test_admin_deregister_emits_session_deregistered(
+    service: DirectoryService,
+) -> None:
+    result = await service.register(scope="a")
+    events = _captured(service)
+    await service.admin_deregister(result.session.handle)
+    names = [e[0] for e in events]
+    assert "session.deregistered" in names

--- a/v3/server/tests/e2e/golden_stash_tools_snapshot.json
+++ b/v3/server/tests/e2e/golden_stash_tools_snapshot.json
@@ -1,4 +1,25 @@
 {
+  "stash_browse": {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": null
+    },
+    "description": "IDENTITY: this is the stash \u2014 a structured cross-session cache. Use it for data you need to survive between sessions but that is disposable: job state, a rate-limit counter, a work-in-progress draft, dedup markers. It is NOT memory: anything worth remembering \u2014 a fact, a decision, a preference, a rule \u2014 belongs in the memory tools' write, not here. Entries expire (TTL) and can be evicted under the size budget (least-recently-accessed first); never rely on a stash entry surviving indefinitely.\n\nBrowse the stash as an inspection panel: namespace, key, size, and expiry \u2014 never the stored value itself (this is for seeing what is cached and how big it is, not for reading it; use stash_get for that). Call with no namespace for the overview of every namespace and its entry count; pass one of those namespaces back in to see its entries.",
+    "input_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "namespace": {
+          "default": "",
+          "description": "Drill into this namespace's entries, or leave unset for the namespace overview.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
   "stash_del": {
     "annotations": {
       "destructiveHint": true,

--- a/v3/server/tests/gateway/test_apps_shell.py
+++ b/v3/server/tests/gateway/test_apps_shell.py
@@ -52,11 +52,19 @@ from palaia_hub.gateway.apps.hub_status_app import render_hub_status_html
 from palaia_hub.gateway.apps.recall_app import render_recall_explorer_html
 from palaia_hub.gateway.apps.review_app import render_review_queue_html
 from palaia_hub.gateway.apps.shell import render_app_page
+from palaia_hub.gateway.apps.stash_browser_app import render_stash_browser_html
+from palaia_hub.gateway.apps.team_app import render_team_html
 
 _PAGES = {
     "hub_status": render_hub_status_html,
     "recall_explorer": render_recall_explorer_html,
     "review_queue": render_review_queue_html,
+    # SPEC-405's two apps — the same "scripted harness" this module's own
+    # docstring documents (real MCP protocol via fastmcp.Client, elsewhere
+    # in test_apps_team.py/test_apps_stash_browser.py; the shared shell
+    # properties — CSP, theme tokens, self-containment — here).
+    "team": render_team_html,
+    "stash_browser": render_stash_browser_html,
 }
 
 # Constructs that cause a browser to make a network request. Not "https://"

--- a/v3/server/tests/gateway/test_apps_stash_browser.py
+++ b/v3/server/tests/gateway/test_apps_stash_browser.py
@@ -1,0 +1,85 @@
+"""Stash browser MCP App acceptance tests (SPEC-405 deliverable #4).
+
+Same in-memory :class:`fastmcp.Client` pattern as ``test_apps_hub_status.py``
+(see that file's own docstring for why no test here drives a real HTTP
+streamable session), against ``stash_browse`` — the tool
+:mod:`palaia_hub.gateway.stash_tools` adds this SPEC, alongside the four
+already there.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from fastmcp import Client
+
+from palaia_hub.app import create_app
+from palaia_hub.config import HubConfig
+from palaia_hub.gateway.apps.stash_browser_app import collect_stash_browse
+from palaia_hub.gateway.stash_tools import build_stash_server
+from palaia_hub.stash.service import StashService
+from palaia_hub.stash.store import StashStore
+
+
+def _service() -> StashService:
+    return StashService(StashStore(":memory:"))
+
+
+@pytest.mark.anyio
+async def test_the_overview_never_carries_a_value() -> None:
+    service = _service()
+    await service.set("jobs", "job-1", {"secret-ish": "payload"})
+    await service.set("jobs", "job-2", "another value")
+    await service.set("rates", "user-a", 42)
+
+    result = await collect_stash_browse(service)
+
+    assert result.namespace == ""
+    assert result.namespaces == {"jobs": 2, "rates": 1}
+    assert result.total_entries == 3
+    assert result.entries == []
+    assert "payload" not in str(result.model_dump())
+
+
+@pytest.mark.anyio
+async def test_drilling_into_a_namespace_lists_entries_without_their_values() -> None:
+    service = _service()
+    await service.set("jobs", "job-1", {"secret-ish": "payload"}, ttl_seconds=3600)
+
+    result = await collect_stash_browse(service, "jobs")
+
+    assert result.namespace == "jobs"
+    assert [e.key for e in result.entries] == ["job-1"]
+    assert result.entries[0].expires_at is not None
+    assert not hasattr(result.entries[0], "value")
+    assert "payload" not in str(result.model_dump())
+
+
+@pytest.mark.anyio
+async def test_stash_browse_tool_carries_the_ui_resource_and_summarizes_in_text() -> None:
+    service = _service()
+    await service.set("jobs", "job-1", "x")
+    server = build_stash_server(service)
+
+    async with Client(server) as client:
+        tools = await client.list_tools()
+        (browse_tool,) = [t for t in tools if t.name == "stash_browse"]
+        assert browse_tool.meta is not None
+        assert browse_tool.meta["ui"]["resourceUri"] == "ui://palaia/stash_browser.html"
+
+        overview = await client.call_tool("stash_browse", {})
+        drill_down = await client.call_tool("stash_browse", {"namespace": "jobs"})
+        resources = await client.list_resources()
+
+    assert {str(r.uri) for r in resources} == {"ui://palaia/stash_browser.html"}
+    assert "1 entries" in overview.content[0].text or "1 entr" in overview.content[0].text
+    assert "job-1" in drill_down.content[0].text
+
+
+def test_stash_browser_mount_reuses_the_existing_stash_mount() -> None:
+    """The app is served from the *same* ``/mcp/stash`` mount as the rest
+    of the stash family — no second mount to gate separately."""
+    service = _service()
+    app = create_app(HubConfig(), stash_service=service)
+    with TestClient(app) as rest:
+        assert rest.get("/mcp/stash").status_code == 406

--- a/v3/server/tests/gateway/test_apps_team.py
+++ b/v3/server/tests/gateway/test_apps_team.py
@@ -1,0 +1,141 @@
+"""Session-monitor MCP App acceptance tests (SPEC-405 deliverable #3).
+
+Same in-memory :class:`fastmcp.Client` pattern as
+``test_apps_hub_status.py`` (see that file's own docstring for why no test
+here drives a real HTTP streamable session).
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from fastmcp import Client
+
+from palaia_hub.app import create_app
+from palaia_hub.config import HubConfig
+from palaia_hub.directory.service import DirectoryService
+from palaia_hub.directory.store import DirectoryStore
+from palaia_hub.gateway.apps.team_app import (
+    _SCRIPT_JS,
+    TeamAppDeps,
+    build_team_server,
+    collect_team_monitor,
+)
+from palaia_hub.messenger.service import MessengerService
+from palaia_hub.messenger.store import MessengerStore
+
+
+def _deps(dashboard_url: str | None = None) -> TeamAppDeps:
+    directory = DirectoryService(DirectoryStore(":memory:"))
+    messenger = MessengerService(MessengerStore(":memory:"), directory)
+    return TeamAppDeps(
+        directory_service=directory, messenger_service=messenger, dashboard_url=dashboard_url
+    )
+
+
+@pytest.mark.anyio
+async def test_collect_team_monitor_reports_sessions_and_flows() -> None:
+    deps = _deps()
+    a = await deps.directory_service.register(scope="reviewing billing", platform="claude-code")
+    b = await deps.directory_service.register(scope="refactoring billing")
+    await deps.messenger_service.send(
+        sender=a.session.handle,
+        session_secret=a.session_secret,
+        message_type="inform",
+        to=b.session.handle,
+        subject="a note",
+        body="the body a monitor app must never show",
+    )
+
+    result = await collect_team_monitor(deps)
+
+    assert {s.handle for s in result.sessions} == {a.session.handle, b.session.handle}
+    assert [f.subject for f in result.flows] == ["a note"]
+    # Metadata only — no bodies on this surface (an MCP App is not the
+    # owner's admin surface).
+    assert not hasattr(result.flows[0], "body")
+
+
+@pytest.mark.anyio
+async def test_session_monitor_tool_carries_the_ui_resource_and_send_tool() -> None:
+    deps = _deps(dashboard_url="https://hub.example.com")
+    await deps.directory_service.register(scope="reviewing billing")
+    server = build_team_server(deps)
+
+    async with Client(server) as client:
+        tools = await client.list_tools()
+        names = {t.name for t in tools}
+        assert names == {"session_monitor", "messenger_send"}
+        (monitor_tool,) = [t for t in tools if t.name == "session_monitor"]
+        assert monitor_tool.meta is not None
+        assert monitor_tool.meta["ui"]["resourceUri"] == "ui://palaia/team.html"
+
+        result = await client.call_tool("session_monitor", {})
+        resources = await client.list_resources()
+
+    assert {str(r.uri) for r in resources} == {"ui://palaia/team.html"}
+    payload = result.structured_content
+    assert len(payload["sessions"]) == 1
+    assert payload["send_tool"] == "messenger_send"
+    assert payload["dashboard_url"] == "https://hub.example.com"
+    # Plain-text fallback (deliverable #3): a compact directory listing.
+    assert "1 agent(s) registered" in result.content[0].text
+
+
+@pytest.mark.anyio
+async def test_messenger_send_on_the_team_server_actually_delivers() -> None:
+    """The compose form's own tool, proven end to end: sending here lands
+    in the real recipient's inbox — same as sending on ``/mcp/messenger``
+    directly, because it is the same tool (see the module docstring)."""
+    deps = _deps()
+    a = await deps.directory_service.register(scope="composing")
+    b = await deps.directory_service.register(scope="waiting")
+    server = build_team_server(deps)
+
+    async with Client(server) as client:
+        result = await client.call_tool(
+            "messenger_send",
+            {
+                "handle": a.session.handle,
+                "session_secret": a.session_secret,
+                "to": b.session.handle,
+                "subject": "from the team app",
+                "message_type": "inform",
+            },
+        )
+    assert not result.is_error
+
+    delivered = await deps.messenger_service.check(b.session.handle, b.session_secret)
+    assert [e.subject for e in delivered.envelopes] == ["from the team app"]
+
+
+def test_the_page_never_calls_a_server_tool_to_end_or_deregister() -> None:
+    """The SPEC-304 rule this SPEC inherits: destructive owner controls
+    (ending a conversation, deregistering) stay dashboard-only — this
+    page's own script never names either action as a tool call, only a
+    plain deep link out (the same ``target="_blank"`` anchor pattern
+    ``test_apps_market.py`` asserts for its own "Install" control)."""
+    for forbidden in ("directory_deregister", "end_conversation", "/end"):
+        assert forbidden not in _SCRIPT_JS
+    assert 'target="_blank"' in _SCRIPT_JS
+    assert "manageHref" in _SCRIPT_JS
+
+
+def test_team_mount_present_only_with_both_services() -> None:
+    without_either = create_app(HubConfig())
+    with TestClient(without_either) as rest:
+        assert rest.get("/mcp/team").status_code == 404
+
+    directory = DirectoryService(DirectoryStore(":memory:"))
+    only_directory = create_app(HubConfig(), directory_service=directory)
+    with TestClient(only_directory) as rest:
+        assert rest.get("/mcp/team").status_code == 404
+
+    messenger = MessengerService(MessengerStore(":memory:"), directory)
+    both = create_app(
+        HubConfig(), directory_service=directory, messenger_service=messenger
+    )
+    with TestClient(both) as rest:
+        # 406, not 404 — same "the mount exists" proof the hub_status/
+        # market mount tests use (see test_apps_hub_status.py's docstring).
+        assert rest.get("/mcp/team").status_code == 406

--- a/v3/server/tests/messenger/test_owner_controls.py
+++ b/v3/server/tests/messenger/test_owner_controls.py
@@ -1,0 +1,179 @@
+"""Owner controls: send-as-owner and end-a-conversation (SPEC-405
+deliverable #2, MASTERPLAN §5.4 trust rule #7 — "the human can read along,
+join in, or shut a conversation down"). "Reading along" is the existing
+``/api/messenger`` mirror; "join in" is
+:meth:`MessengerService.send_as_owner`; "shut down" is
+:meth:`MessengerService.end_conversation`. Both are exercised here at the
+service layer; :mod:`palaia_hub.messenger_api`'s own routes are covered in
+``server/tests/test_messenger_api.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from palaia_hub.directory.service import DirectoryService
+from palaia_hub.messenger.models import OWNER_HANDLE, EnvelopeNotFoundError
+from palaia_hub.messenger.service import MessengerService
+
+from .conftest import Clock
+
+pytestmark = pytest.mark.anyio
+
+
+async def _register(directory: DirectoryService, *, scope: str = "") -> tuple[str, str]:
+    result = await directory.register(scope=scope, ttl_seconds=60)
+    return result.session.handle, result.session_secret
+
+
+# -- send_as_owner ------------------------------------------------------------
+
+
+async def test_send_as_owner_is_delivered_with_the_owner_handle(
+    service: MessengerService, directory: DirectoryService
+) -> None:
+    recipient, recipient_secret = await _register(directory)
+
+    result = await service.send_as_owner(
+        message_type="inform",
+        to=recipient,
+        subject="a note from the owner",
+        body="reading along",
+    )
+    assert result.envelopes[0].from_ == OWNER_HANDLE
+
+    inbox = await service.check(recipient, recipient_secret)
+    assert [e.subject for e in inbox.envelopes] == ["a note from the owner"]
+    assert inbox.envelopes[0].from_ == OWNER_HANDLE
+
+
+async def test_send_as_owner_needs_no_session_secret(
+    service: MessengerService, directory: DirectoryService
+) -> None:
+    """Unlike an ordinary session, the owner has no directory registration
+    and no secret to present — and none is asked for."""
+    recipient, _ = await _register(directory)
+    # No `session_secret` keyword exists on this call at all; if it needed
+    # one, this call would be a TypeError, not a runtime auth failure.
+    result = await service.send_as_owner(
+        message_type="inform", to=recipient, subject="hi"
+    )
+    assert result.recipients == [recipient]
+
+
+async def test_send_as_owner_may_reply_to_a_thread_it_never_took_part_in(
+    service: MessengerService, directory: DirectoryService
+) -> None:
+    """Trust rule #7's "join in": an ordinary session is fenced to threads
+    it took part in (``test_you_cannot_reply_to_a_stranger_s_envelope`` in
+    ``test_service.py``); the owner is not."""
+    a_handle, a_secret = await _register(directory)
+    b_handle, _ = await _register(directory)
+    sent = await service.send(
+        sender=a_handle,
+        session_secret=a_secret,
+        message_type="question",
+        to=b_handle,
+        subject="a question between a and b",
+    )
+    joined = await service.send_as_owner(
+        message_type="inform",
+        to=a_handle,
+        subject="the owner is reading along",
+        reply_to=sent.envelopes[0].id,
+    )
+    assert joined.envelopes[0].reply_to == sent.envelopes[0].id
+    assert joined.envelopes[0].from_ == OWNER_HANDLE
+
+
+async def test_send_as_owner_still_refuses_an_unknown_recipient(
+    service: MessengerService,
+) -> None:
+    from palaia_hub.messenger.models import UnknownRecipientError
+
+    with pytest.raises(UnknownRecipientError):
+        await service.send_as_owner(message_type="inform", to="nobody", subject="hi")
+
+
+# -- end_conversation ----------------------------------------------------------
+
+
+async def test_end_conversation_expires_only_the_undelivered_copies(
+    service: MessengerService,
+    directory: DirectoryService,
+    clock: Clock,
+    events: list[tuple[str, dict[str, Any]]],
+) -> None:
+    a_handle, a_secret = await _register(directory)
+    b_handle, b_secret = await _register(directory)
+
+    request = await service.send(
+        sender=a_handle,
+        session_secret=a_secret,
+        message_type="request",
+        to=b_handle,
+        subject="please do the thing",
+        expects_reply=True,
+    )
+    request_id = request.envelopes[0].id
+
+    # b checks (delivers) the request but never replies — that copy stays
+    # `delivered`, never `pending`, so ending the conversation must leave it
+    # standing.
+    await service.check(b_handle, b_secret)
+
+    # a sends a second, follow-up message in the same thread that b never
+    # checks — this one stays `pending` and is what "undelivered" means.
+    followup = await service.send(
+        sender=a_handle,
+        session_secret=a_secret,
+        message_type="inform",
+        to=b_handle,
+        subject="also, one more thing",
+        reply_to=request_id,
+    )
+    followup_id = followup.envelopes[0].id
+    events.clear()
+
+    result = await service.end_conversation(request_id)
+
+    assert result.root_id == request_id
+    assert [e.id for e in result.expired] == [followup_id]
+    expired_events = [data for name, data in events if name == "message.expired"]
+    assert [data["id"] for data in expired_events] == [followup_id]
+
+    # The delivered request is untouched: b can still re-read it via thread.
+    thread = await service.thread(b_handle, b_secret, request_id)
+    assert [e.id for e in thread.envelopes] == [request_id]
+
+    # The undelivered follow-up is truly gone, not merely hidden.
+    with pytest.raises(EnvelopeNotFoundError):
+        await service.thread(a_handle, a_secret, followup_id)
+
+
+async def test_end_conversation_on_an_unknown_envelope_is_refused(
+    service: MessengerService,
+) -> None:
+    with pytest.raises(EnvelopeNotFoundError):
+        await service.end_conversation("no-such-id")
+
+
+async def test_end_conversation_needs_no_participant_at_all(
+    service: MessengerService, directory: DirectoryService
+) -> None:
+    """The owner ends conversations it was never part of — that is the
+    whole point of the control being dashboard-only rather than a
+    participant action."""
+    a_handle, a_secret = await _register(directory)
+    b_handle, _ = await _register(directory)
+    sent = await service.send(
+        sender=a_handle,
+        session_secret=a_secret,
+        message_type="inform",
+        to=b_handle,
+        subject="a private matter",
+    )
+    result = await service.end_conversation(sent.envelopes[0].id)
+    assert [e.id for e in result.expired] == [sent.envelopes[0].id]

--- a/v3/server/tests/test_app_directory.py
+++ b/v3/server/tests/test_app_directory.py
@@ -24,9 +24,12 @@ def test_directory_absent_by_default() -> None:
 
 
 def test_directory_rest_mirror_is_read_only() -> None:
-    """Deliverable #4: 'list/query only'. There is no POST/PUT/DELETE on
-    this REST surface at all — mutations only ever come from MCP callers
-    holding their own session secret."""
+    """Deliverable #4: 'list/query only' — this root listing route itself
+    has no write verb; every ordinary mutation still only ever comes from
+    MCP callers holding their own session secret. (SPEC-405 adds exactly
+    one owner-only write elsewhere on this mount —
+    ``POST /{handle}/deregister`` — covered below, and it is not this
+    route.)"""
     service = DirectoryService(DirectoryStore(":memory:"))
     app = create_app(HubConfig(), directory_service=service)
     client = TestClient(app)
@@ -72,3 +75,30 @@ def test_directory_events_are_wired_onto_the_hub_event_bus() -> None:
     assert event.event == "session.registered"
     assert event.origin == "directory"
     assert event.data["handle"] == "abc123"
+
+
+# -- the owner control (SPEC-405 deliverable #2), over the real app ---------
+
+
+def test_admin_deregister_route_needs_no_secret() -> None:
+    service = DirectoryService(DirectoryStore(":memory:"))
+    app = create_app(HubConfig(), directory_service=service)
+    client = TestClient(app)
+
+    result = asyncio.run(service.register(scope="a stale session"))
+    handle = result.session.handle
+
+    response = client.post(f"/api/directory/{handle}/deregister")
+    assert response.status_code == 200
+    assert response.json() == {"handle": handle, "deregistered": True}
+    assert client.get("/api/directory/").json()["sessions"] == []
+
+
+def test_admin_deregister_route_is_idempotent_for_an_already_gone_handle() -> None:
+    service = DirectoryService(DirectoryStore(":memory:"))
+    app = create_app(HubConfig(), directory_service=service)
+    client = TestClient(app)
+
+    response = client.post("/api/directory/no-such-handle/deregister")
+    assert response.status_code == 200
+    assert response.json() == {"handle": "no-such-handle", "deregistered": False}

--- a/v3/server/tests/test_app_messenger.py
+++ b/v3/server/tests/test_app_messenger.py
@@ -70,9 +70,13 @@ def test_messenger_absent_by_default() -> None:
 
 
 def test_messenger_rest_mirror_is_read_only() -> None:
-    """Deliverable #6: a read-only mirror. There is no write verb on this
-    surface at all — sending and checking only ever happen over MCP, from
-    the session itself, holding its own session secret."""
+    """Deliverable #6: the listing surface itself has no write verb —
+    sending and checking *as a session* only ever happen over MCP, from
+    the session itself, holding its own session secret. (SPEC-405 adds two
+    write routes elsewhere on this mount — ``POST /send``, sending *as the
+    owner*, and ``POST /threads/{id}/end`` — covered in
+    ``test_owner_controls.py`` below; neither is this root listing route.)
+    """
     service, _ = _service()
     app = create_app(HubConfig(), messenger_service=service)
     client = TestClient(app)
@@ -193,3 +197,107 @@ def test_messenger_events_are_wired_onto_the_hub_event_bus() -> None:
     assert event.event == "message.received"
     assert event.origin == "messenger"
     assert event.data["id"] == "abc123"
+
+
+# -- owner controls (SPEC-405 deliverable #2), over the real app -------------
+
+
+def test_send_as_owner_route_delivers_with_the_owner_handle() -> None:
+    service, directory = _service()
+    app = create_app(HubConfig(), messenger_service=service, directory_service=directory)
+    client = TestClient(app)
+
+    async def _recipient() -> tuple[str, str]:
+        registered = await directory.register(scope="waiting on the owner")
+        return registered.session.handle, registered.session_secret
+
+    recipient, recipient_secret = asyncio.run(_recipient())
+
+    response = client.post(
+        "/api/messenger/send",
+        json={"to": recipient, "subject": "a note from the owner", "body": "hello"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["envelopes"][0]["from"] == "owner"
+
+    delivered = asyncio.run(service.check(recipient, recipient_secret))
+    assert [e.subject for e in delivered.envelopes] == ["a note from the owner"]
+    assert delivered.envelopes[0].from_ == "owner"
+
+
+def test_send_as_owner_route_rejects_an_over_long_subject() -> None:
+    service, directory = _service()
+    app = create_app(HubConfig(), messenger_service=service, directory_service=directory)
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/messenger/send", json={"to": "someone", "subject": "s" * 300}
+    )
+    assert response.status_code == 422  # the schema itself refuses it
+
+
+def test_send_as_owner_route_names_an_unknown_recipient_in_the_body() -> None:
+    service, directory = _service()
+    app = create_app(HubConfig(), messenger_service=service, directory_service=directory)
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/messenger/send", json={"to": "nobody-registered", "subject": "hi"}
+    )
+    assert response.status_code == 400
+    assert "nobody-registered" in response.json()["detail"]
+
+
+def test_end_conversation_route_expires_the_undelivered_copy() -> None:
+    service, directory = _service()
+    app = create_app(HubConfig(), messenger_service=service, directory_service=directory)
+    client = TestClient(app)
+
+    async def _thread_with_one_undelivered_followup() -> dict[str, str]:
+        a = await directory.register(scope="reviewing")
+        b = await directory.register(scope="refactoring")
+        request = await service.send(
+            sender=a.session.handle,
+            session_secret=a.session_secret,
+            message_type="request",
+            to=b.session.handle,
+            subject="please rename it",
+            expects_reply=True,
+        )
+        request_id = request.envelopes[0].id
+        # b checks (delivers) the request but never replies — this copy
+        # stays `delivered`, so ending the conversation must not touch it.
+        await service.check(b.session.handle, b.session_secret)
+        # b sends a follow-up in the same thread that a never checks — this
+        # one stays `pending`, which is what "undelivered" means.
+        followup = await service.send(
+            sender=b.session.handle,
+            session_secret=b.session_secret,
+            message_type="inform",
+            to=a.session.handle,
+            subject="unread follow-up",
+            reply_to=request_id,
+        )
+        return {"request_id": request_id, "followup_id": followup.envelopes[0].id}
+
+    ids = asyncio.run(_thread_with_one_undelivered_followup())
+
+    response = client.post(f"/api/messenger/threads/{ids['request_id']}/end")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["root_id"] == ids["request_id"]
+    assert [e["id"] for e in payload["expired"]] == [ids["followup_id"]]
+
+    # The already-delivered request is untouched.
+    thread = client.get(f"/api/messenger/threads/{ids['request_id']}")
+    assert [f["id"] for f in thread.json()["flows"]] == [ids["request_id"]]
+
+
+def test_end_conversation_route_on_an_unknown_id_is_404() -> None:
+    service, directory = _service()
+    app = create_app(HubConfig(), messenger_service=service, directory_service=directory)
+    client = TestClient(app)
+
+    response = client.post("/api/messenger/threads/no-such-id/end")
+    assert response.status_code == 404

--- a/v3/server/tests/test_apps_copy_lint.py
+++ b/v3/server/tests/test_apps_copy_lint.py
@@ -1,0 +1,69 @@
+"""No jargon in the two MCP Apps this SPEC adds (SPEC-405 deliverable #5:
+"jargon-free copy (lint, both screens and both apps' visible text)").
+
+``docs/design/system.md`` §3 rule 0 is binding, the same rule
+``test_signin_copy_lint.py`` already lints the sign-in surface against and
+``web/src/routes/Exposure.test.tsx`` lints the exposure wizard against: no
+protocol name, standard, acronym, transport or implementation word in a
+label, heading, button, badge, status line or option name.
+
+Scope: the session-monitor app (:mod:`palaia_hub.gateway.apps.team_app`)
+and the stash browser app (:mod:`palaia_hub.gateway.apps.stash_browser_app`)
+— this SPEC's own two apps. The pre-existing apps (hub status, marketplace,
+recall explorer, review queue) are SPEC-208/304's copy, out of scope here.
+
+Both apps build their visible markup at runtime, inside their own
+``_SCRIPT_JS`` string (there is no server-rendered text beyond the page
+``<title>`` and a "Loading…" placeholder — see
+:mod:`palaia_hub.gateway.apps.shell`). So this scans each app's whole
+script source plus its title for the banned terms — a coarser net than
+scanning rendered DOM nodes (as the dashboard's own vitest lints do), but
+sufficient here: none of these scripts embed a banned term inside a class
+name, attribute, or comment either, so a plain source scan and a
+rendered-DOM scan would catch exactly the same violations.
+"""
+
+from __future__ import annotations
+
+import re
+
+BANNED = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\bmcp\b",
+        r"\boauth\b",
+        r"\boidc\b",
+        r"\bjwt\b",
+        r"\bpkce\b",
+        r"\bcimd\b",
+        r"\bdcr\b",
+        r"\bttl\b",
+        r"\bcsrf\b",
+        r"\basgi\b",
+        r"\brfc\s*\d",
+        r"\bapi\b",
+        r"\bjson\b",
+        r"\buuid\b",
+        r"\bsqlite\b",
+        r"\bbearer\b",
+    )
+]
+
+
+def _assert_plain(text: str, *, source: str) -> None:
+    for pattern in BANNED:
+        assert not pattern.search(text), f"jargon {pattern.pattern!r} in {source}: {text!r}"
+
+
+def test_the_session_monitor_app_has_no_jargon_in_its_copy() -> None:
+    from palaia_hub.gateway.apps.team_app import _SCRIPT_JS, _TITLE
+
+    _assert_plain(_TITLE, source="team_app._TITLE")
+    _assert_plain(_SCRIPT_JS, source="team_app._SCRIPT_JS")
+
+
+def test_the_stash_browser_app_has_no_jargon_in_its_copy() -> None:
+    from palaia_hub.gateway.apps.stash_browser_app import _SCRIPT_JS, _TITLE
+
+    _assert_plain(_TITLE, source="stash_browser_app._TITLE")
+    _assert_plain(_SCRIPT_JS, source="stash_browser_app._SCRIPT_JS")

--- a/v3/web/src/lib/api/client.ts
+++ b/v3/web/src/lib/api/client.ts
@@ -402,6 +402,117 @@ export interface InstalledAddon {
   installed_at: number;
 }
 
+/** SPEC-402/403/405's session directory and messenger — opt-in on the hub
+ * (present only when `directory_service`/`messenger_service` are given to
+ * `create_app`), hand-written for the same reason the token/hook/
+ * automation types above are: the generator runs `create_app(HubConfig())`
+ * with neither wired, so the schema never sees these routes. Mirrors
+ * `palaia_hub.directory.models`/`palaia_hub.messenger.models`. */
+export type SessionStatus = "active" | "idle" | "stale";
+
+export interface SessionRecord {
+  handle: string;
+  scope: string;
+  host: string;
+  platform: string;
+  agent_kind: string;
+  model: string;
+  status: SessionStatus;
+  capabilities: string[];
+  registered_at: number;
+  last_seen_at: number;
+  ttl_seconds: number;
+}
+
+export interface SessionListResult {
+  sessions: SessionRecord[];
+}
+
+export interface DeregisterResult {
+  handle: string;
+  deregistered: boolean;
+}
+
+export type MessageType = "request" | "inform" | "question" | "handoff" | "broadcast";
+export type Urgency = "low" | "normal" | "high";
+export type DeliveryState = "pending" | "delivered" | "acked";
+
+/** An envelope with its body withheld, plus delivery state — the shape
+ * every messenger listing route returns (`palaia_hub.messenger.models.
+ * EnvelopeMetadata`). `from` is a reserved-looking name in the wire shape
+ * (mirroring the Python model's own `from_`/`from` split) but a perfectly
+ * ordinary TypeScript property key. */
+export interface EnvelopeMetadata {
+  id: string;
+  type: MessageType;
+  from: string;
+  to: string;
+  recipient: string;
+  subject: string;
+  urgency: Urgency;
+  expects_reply: boolean;
+  refs: string[];
+  reply_to: string | null;
+  created_at: number;
+  expires_at: number;
+  state: DeliveryState;
+  body_bytes: number;
+}
+
+export interface MessageFlowsResult {
+  flows: EnvelopeMetadata[];
+}
+
+export interface ThreadMetadataResult {
+  root_id: string;
+  flows: EnvelopeMetadata[];
+}
+
+/** The envelope shape a send actually returns (with a body, unlike the
+ * metadata-only listing shapes above) — mirrors
+ * `palaia_hub.messenger.models.Envelope`. */
+export interface Envelope {
+  id: string;
+  type: MessageType;
+  from: string;
+  to: string;
+  subject: string;
+  urgency: Urgency;
+  expects_reply: boolean;
+  body: string;
+  refs: string[];
+  reply_to: string | null;
+  created_at: number;
+  expires_at: number;
+}
+
+export interface SendResult {
+  envelopes: Envelope[];
+  recipients: string[];
+  broadcast_query: string | null;
+}
+
+export interface EndConversationResult {
+  root_id: string;
+  expired: EnvelopeMetadata[];
+}
+
+/** One envelope copy **with** its body — the owner's read (mirrors
+ * `palaia_hub.messenger.models.InboxItem`/`EnvelopeDetailResult`). The one
+ * shape the Agents screen fetches on expanding a message row (deliverable
+ * #1: "metadata first, body on expand — owner-only surface"). */
+export interface InboxItem {
+  envelope: Envelope;
+  recipient: string;
+  state: DeliveryState;
+  delivered_at: number | null;
+  acked_at: number | null;
+}
+
+export interface EnvelopeDetailResult {
+  item: InboxItem;
+}
+
 /** Base URL for API calls. Empty string = same-origin (the hub serves the
  * dashboard build itself, per this SPEC's static-serving deliverable), so
  * this only needs a value in local dev against a hub on another port. */
@@ -751,4 +862,46 @@ export const api = {
     postJson<InstalledAddon>(`/api/market/installed/${upstreamKey}/update`, {}),
   uninstallAddon: (upstreamKey: string) =>
     deleteRequest(`/api/market/installed/${upstreamKey}`),
+
+  // ---- SPEC-402/405: the session directory ----
+  listSessions: (params: { status?: SessionStatus; platform?: string } = {}) =>
+    getJson<SessionListResult>(`/api/directory/${queryString(params)}`),
+  querySessions: (scopeContains: string) =>
+    getJson<SessionListResult>(
+      `/api/directory/query${queryString({ scope_contains: scopeContains })}`,
+    ),
+  /** Owner control (SPEC-405 deliverable #2): deregister a session with no
+   * secret. Idempotent — an already-gone handle answers
+   * `deregistered: false`, not an error. */
+  deregisterSession: (handle: string) =>
+    postJson<DeregisterResult>(`/api/directory/${handle}/deregister`, {}),
+
+  // ---- SPEC-403/405: the messenger ----
+  messageFlows: (
+    params: { handle?: string; type?: MessageType; state?: DeliveryState; limit?: number } = {},
+  ) => getJson<MessageFlowsResult>(`/api/messenger/${queryString(params)}`),
+  messageThread: (envelopeId: string) =>
+    getJson<ThreadMetadataResult>(`/api/messenger/threads/${envelopeId}`),
+  /** The owner's body-bearing read (deliverable #1: "body on expand") —
+   * the one route on this mirror that ever returns a body. */
+  envelopeDetail: (envelopeId: string) =>
+    getJson<EnvelopeDetailResult>(`/api/messenger/envelopes/${envelopeId}`),
+  /** Owner control (SPEC-405 deliverable #2): compose and send as the
+   * owner. No handle/secret in the body — the owner has neither; the
+   * signed-in session and its CSRF token are the proof of identity. */
+  sendAsOwner: (body: {
+    type?: MessageType;
+    to: string;
+    subject: string;
+    body?: string;
+    urgency?: Urgency;
+    expects_reply?: boolean;
+    refs?: string[];
+    reply_to?: string | null;
+    ttl_seconds?: number | null;
+  }) => postJson<SendResult>("/api/messenger/send", body),
+  /** Owner control (SPEC-405 deliverable #2): end a conversation — expires
+   * the thread's still-undelivered envelopes. */
+  endConversation: (envelopeId: string) =>
+    postJson<EndConversationResult>(`/api/messenger/threads/${envelopeId}/end`, {}),
 };

--- a/v3/web/src/lib/events.test.ts
+++ b/v3/web/src/lib/events.test.ts
@@ -82,6 +82,28 @@ describe('useEventStream', () => {
     })
   })
 
+  it('increments agentActivityCount on session.* and message.* events (SPEC-405: no polling loop)', async () => {
+    const { result } = renderHook(() => useEventStream(FakeEventSource as unknown as typeof EventSource))
+    const source = FakeEventSource.instances.at(-1)!
+
+    expect(result.current.agentActivityCount).toBe(0)
+
+    act(() => {
+      source.emit('session.registered', { event: 'session.registered', data: { handle: 'abc' } })
+    })
+    await waitFor(() => expect(result.current.agentActivityCount).toBe(1))
+
+    act(() => {
+      source.emit('message.sent', { event: 'message.sent', data: { id: 'm1' } })
+    })
+    await waitFor(() => expect(result.current.agentActivityCount).toBe(2))
+
+    act(() => {
+      source.emit('session.stale', { event: 'session.stale', data: { handle: 'abc' } })
+    })
+    await waitFor(() => expect(result.current.agentActivityCount).toBe(3))
+  })
+
   it('reports reconnecting after a drop that follows a successful connection', async () => {
     const { result } = renderHook(() => useEventStream(FakeEventSource as unknown as typeof EventSource))
     const source = FakeEventSource.instances.at(-1)!

--- a/v3/web/src/lib/events.ts
+++ b/v3/web/src/lib/events.ts
@@ -53,6 +53,23 @@ export interface VaultChangeEntry {
  * an unbounded log; older entries fall off the end. */
 const RECENT_CHANGES_LIMIT = 20;
 
+/** SPEC-405's directory + messenger events (SPEC-201/402/403's public
+ * vocabulary) — the Agents screen's live-update signal. This hook does not
+ * decode their payloads (the directory/messenger REST mirrors are the
+ * source of truth for that, per SPEC-405 deliverable #1: "no polling
+ * loop" means the Agents screen refetches *on* one of these arriving, not
+ * that it parses the event itself). */
+const AGENT_ACTIVITY_EVENTS = [
+  "session.registered",
+  "session.updated",
+  "session.idle",
+  "session.stale",
+  "session.deregistered",
+  "message.sent",
+  "message.received",
+  "message.expired",
+] as const;
+
 export type ConnectionState = "connecting" | "open" | "reconnecting" | "closed";
 
 export interface EventStreamState {
@@ -69,6 +86,12 @@ export interface EventStreamState {
    * activity feed (SPEC-110 deliverable #4: "recent activity feed
    * (SSE-live)"). Bounded to `RECENT_CHANGES_LIMIT` entries. */
   recentChanges: VaultChangeEntry[];
+  /** Running count of `AGENT_ACTIVITY_EVENTS` seen this session (SPEC-405
+   * deliverable #1: "live updates ... no polling loop") — the Agents
+   * screen watches this number and refetches the directory/message flows
+   * whenever it changes, the same "count as a change signal" shape
+   * `vaultChangeCount` already established for the explorer badge. */
+  agentActivityCount: number;
 }
 
 const INITIAL_STATE: EventStreamState = {
@@ -78,6 +101,7 @@ const INITIAL_STATE: EventStreamState = {
   vaultChangeCount: 0,
   lastVaultChange: null,
   recentChanges: [],
+  agentActivityCount: 0,
 };
 
 /** Build an `EventSource` unless a test/story has already provided one via
@@ -148,6 +172,17 @@ export function useEventStream(
     };
     for (const eventName of MEMORY_ENTRY_EVENTS) {
       source.addEventListener(eventName, onMemoryEntryEvent);
+    }
+
+    const onAgentActivityEvent = () => {
+      setState((prev) => ({
+        ...prev,
+        connection: "open",
+        agentActivityCount: prev.agentActivityCount + 1,
+      }));
+    };
+    for (const eventName of AGENT_ACTIVITY_EVENTS) {
+      source.addEventListener(eventName, onAgentActivityEvent);
     }
 
     return () => {

--- a/v3/web/src/lib/testEventSource.ts
+++ b/v3/web/src/lib/testEventSource.ts
@@ -40,6 +40,14 @@ export class FakeEventSource implements Pick<EventSource, "close" | "url"> {
       | "memory.entry.updated"
       | "memory.entry.deleted"
       | "memory.entry.moved"
+      | "session.registered"
+      | "session.updated"
+      | "session.idle"
+      | "session.stale"
+      | "session.deregistered"
+      | "message.sent"
+      | "message.received"
+      | "message.expired"
       | "open"
       | "error",
     data?: unknown,

--- a/v3/web/src/routes/Agents.test.tsx
+++ b/v3/web/src/routes/Agents.test.tsx
@@ -1,0 +1,350 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { createMemoryRouter, Outlet, RouterProvider } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ToastProvider } from "../components/Toast";
+import type { EnvelopeMetadata, SessionListResult, SessionRecord } from "../lib/api/client";
+import { api } from "../lib/api/client";
+import type { EventStreamState } from "../lib/events";
+import { useEventStream } from "../lib/events";
+import { FakeEventSource } from "../lib/testEventSource";
+import { Agents } from "./Agents";
+
+const ACTIVE_SESSION: SessionRecord = {
+  handle: "abc123handle",
+  scope: "refactoring billing",
+  host: "laptop",
+  platform: "claude-code",
+  agent_kind: "coding assistant",
+  model: "sonnet-5",
+  status: "active",
+  capabilities: [],
+  registered_at: 1_000,
+  last_seen_at: Date.now() / 1000,
+  ttl_seconds: 300,
+};
+
+const STALE_SESSION: SessionRecord = {
+  ...ACTIVE_SESSION,
+  handle: "stalehandle999",
+  scope: "gone quiet",
+  status: "stale",
+};
+
+const A_FLOW: EnvelopeMetadata = {
+  id: "env-1",
+  type: "request",
+  from: "abc123handle",
+  to: "def456handle",
+  recipient: "def456handle",
+  subject: "please rename the model",
+  urgency: "high",
+  expects_reply: true,
+  refs: [],
+  reply_to: null,
+  created_at: 1_000,
+  expires_at: 90_000,
+  state: "pending",
+  body_bytes: 10,
+};
+
+const BASE_STREAM: EventStreamState = {
+  connection: "open",
+  health: null,
+  healthAt: null,
+  vaultChangeCount: 0,
+  lastVaultChange: null,
+  recentChanges: [],
+  agentActivityCount: 0,
+};
+
+function StaticShell({ stream }: { stream: EventStreamState }) {
+  return <Outlet context={stream} />;
+}
+
+function mount(stream: EventStreamState = BASE_STREAM) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/",
+        element: <StaticShell stream={stream} />,
+        children: [{ index: true, element: <Agents /> }],
+      },
+    ],
+    { initialEntries: ["/"] },
+  );
+  return render(
+    <ToastProvider>
+      <RouterProvider router={router} />
+    </ToastProvider>,
+  );
+}
+
+/** A harness that runs the real `useEventStream` hook against a
+ * `FakeEventSource`, so a test can fire a genuine SSE frame and assert the
+ * Agents screen reacts to it — the SPEC-405 acceptance criterion's own
+ * words: "renders live updates from real session.* events (vitest with
+ * SSE fixture)". */
+function LiveShell() {
+  const stream = useEventStream(FakeEventSource as unknown as typeof EventSource);
+  return <Outlet context={stream} />;
+}
+
+function mountLive() {
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/",
+        element: <LiveShell />,
+        children: [{ index: true, element: <Agents /> }],
+      },
+    ],
+    { initialEntries: ["/"] },
+  );
+  return render(
+    <ToastProvider>
+      <RouterProvider router={router} />
+    </ToastProvider>,
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  FakeEventSource.instances.length = 0;
+});
+
+describe("Agents screen", () => {
+  it("renders the directory with a stale agent visibly distinct", async () => {
+    vi.spyOn(api, "listSessions").mockResolvedValue({
+      sessions: [ACTIVE_SESSION, STALE_SESSION],
+    });
+    vi.spyOn(api, "messageFlows").mockResolvedValue({ flows: [] });
+
+    mount();
+
+    await screen.findByText(ACTIVE_SESSION.handle);
+    expect(screen.getByText(STALE_SESSION.handle)).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    // "stale" is never shown verbatim — the plain-language label is what a
+    // person reads (system.md §3 rule 0).
+    expect(screen.getByText("Inactive")).toBeInTheDocument();
+    expect(screen.queryByText(/\bstale\b/i)).not.toBeInTheDocument();
+  });
+
+  it("renders a live update from a real session.* event (SSE fixture)", async () => {
+    const listSessions = vi
+      .spyOn(api, "listSessions")
+      .mockResolvedValueOnce({ sessions: [] } satisfies SessionListResult)
+      .mockResolvedValueOnce({ sessions: [ACTIVE_SESSION] } satisfies SessionListResult);
+    vi.spyOn(api, "messageFlows").mockResolvedValue({ flows: [] });
+
+    mountLive();
+    await screen.findByText(/No agents yet/i);
+    expect(listSessions).toHaveBeenCalledTimes(1);
+
+    const source = FakeEventSource.instances.at(-1)!;
+    act(() => {
+      source.emit("session.registered", {
+        event: "session.registered",
+        data: { handle: ACTIVE_SESSION.handle },
+      });
+    });
+
+    await waitFor(() => expect(listSessions).toHaveBeenCalledTimes(2));
+    await screen.findByText(ACTIVE_SESSION.handle);
+  });
+
+  it("lists message flows and expands a body only on click", async () => {
+    vi.spyOn(api, "listSessions").mockResolvedValue({ sessions: [ACTIVE_SESSION] });
+    vi.spyOn(api, "messageFlows").mockResolvedValue({ flows: [A_FLOW] });
+    const detail = vi.spyOn(api, "envelopeDetail").mockResolvedValue({
+      item: {
+        envelope: {
+          id: A_FLOW.id,
+          type: A_FLOW.type,
+          from: A_FLOW.from,
+          to: A_FLOW.to,
+          subject: A_FLOW.subject,
+          urgency: A_FLOW.urgency,
+          expects_reply: A_FLOW.expects_reply,
+          body: "the actual message text",
+          refs: [],
+          reply_to: null,
+          created_at: A_FLOW.created_at,
+          expires_at: A_FLOW.expires_at,
+        },
+        recipient: A_FLOW.recipient,
+        state: A_FLOW.state,
+        delivered_at: null,
+        acked_at: null,
+      },
+    });
+
+    mount();
+    await screen.findByText(A_FLOW.subject);
+    expect(detail).not.toHaveBeenCalled();
+    expect(screen.queryByText("the actual message text")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText(A_FLOW.subject));
+
+    await screen.findByText("the actual message text");
+    expect(detail).toHaveBeenCalledWith(A_FLOW.id);
+  });
+
+  it("ends a conversation from an expanded message row", async () => {
+    vi.spyOn(api, "listSessions").mockResolvedValue({ sessions: [] });
+    vi.spyOn(api, "messageFlows").mockResolvedValue({ flows: [A_FLOW] });
+    vi.spyOn(api, "envelopeDetail").mockResolvedValue({
+      item: {
+        envelope: {
+          id: A_FLOW.id,
+          type: A_FLOW.type,
+          from: A_FLOW.from,
+          to: A_FLOW.to,
+          subject: A_FLOW.subject,
+          urgency: A_FLOW.urgency,
+          expects_reply: A_FLOW.expects_reply,
+          body: "body",
+          refs: [],
+          reply_to: null,
+          created_at: A_FLOW.created_at,
+          expires_at: A_FLOW.expires_at,
+        },
+        recipient: A_FLOW.recipient,
+        state: A_FLOW.state,
+        delivered_at: null,
+        acked_at: null,
+      },
+    });
+    const endConversation = vi
+      .spyOn(api, "endConversation")
+      .mockResolvedValue({ root_id: A_FLOW.id, expired: [A_FLOW] });
+
+    mount();
+    await screen.findByText(A_FLOW.subject);
+    fireEvent.click(screen.getByText(A_FLOW.subject));
+    fireEvent.click(await screen.findByText("End conversation"));
+    fireEvent.click(await screen.findByText("Yes, end it"));
+
+    await waitFor(() => expect(endConversation).toHaveBeenCalledWith(A_FLOW.id));
+  });
+
+  it("removes an agent from the directory with no secret prompt", async () => {
+    vi.spyOn(api, "listSessions").mockResolvedValue({ sessions: [STALE_SESSION] });
+    vi.spyOn(api, "messageFlows").mockResolvedValue({ flows: [] });
+    const deregister = vi
+      .spyOn(api, "deregisterSession")
+      .mockResolvedValue({ handle: STALE_SESSION.handle, deregistered: true });
+
+    mount();
+    await screen.findByText(STALE_SESSION.handle);
+    fireEvent.click(screen.getByText("Remove"));
+    fireEvent.click(await screen.findByText("Yes, remove"));
+
+    await waitFor(() => expect(deregister).toHaveBeenCalledWith(STALE_SESSION.handle));
+  });
+
+  it("sends as the owner with the composed schema, no handle or secret asked for", async () => {
+    vi.spyOn(api, "listSessions").mockResolvedValue({ sessions: [ACTIVE_SESSION] });
+    vi.spyOn(api, "messageFlows").mockResolvedValue({ flows: [] });
+    vi.spyOn(api, "listVaults").mockResolvedValue([]);
+    const sendAsOwner = vi.spyOn(api, "sendAsOwner").mockResolvedValue({
+      envelopes: [],
+      recipients: [ACTIVE_SESSION.handle],
+      broadcast_query: null,
+    });
+
+    mount();
+    await screen.findByText(ACTIVE_SESSION.handle);
+    fireEvent.click(screen.getByText("Send a message"));
+
+    expect(screen.queryByPlaceholderText(/secret/i)).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText("Agent ID, or *"), {
+      target: { value: ACTIVE_SESSION.handle },
+    });
+    fireEvent.change(screen.getByLabelText("Subject"), {
+      target: { value: "a note from the owner" },
+    });
+    fireEvent.change(screen.getByLabelText("Message"), { target: { value: "hello there" } });
+    fireEvent.click(screen.getByText("Send", { selector: "button" }));
+
+    await waitFor(() =>
+      expect(sendAsOwner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: ACTIVE_SESSION.handle,
+          subject: "a note from the owner",
+          body: "hello there",
+        }),
+      ),
+    );
+  });
+
+  it("refuses to send an over-budget message before it ever reaches the hub", async () => {
+    vi.spyOn(api, "listSessions").mockResolvedValue({ sessions: [] });
+    vi.spyOn(api, "messageFlows").mockResolvedValue({ flows: [] });
+    vi.spyOn(api, "listVaults").mockResolvedValue([]);
+    const sendAsOwner = vi.spyOn(api, "sendAsOwner");
+
+    mount();
+    await screen.findByText(/No agents yet/i);
+    fireEvent.click(screen.getByText("Send a message"));
+
+    fireEvent.change(screen.getByPlaceholderText("Agent ID, or *"), {
+      target: { value: "*" },
+    });
+    fireEvent.change(screen.getByLabelText("Subject"), { target: { value: "s" } });
+    fireEvent.change(screen.getByLabelText("Message"), {
+      target: { value: "x".repeat(5000) },
+    });
+    fireEvent.click(screen.getByText("Send", { selector: "button" }));
+
+    await screen.findByText(/over the limit/i);
+    expect(sendAsOwner).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * SPEC-405 deliverable #5: "jargon-free copy (lint, both screens ...)".
+ * system.md §3 rule 0 — no protocol name, standard, acronym, transport or
+ * implementation word in a label, heading, button, badge, status line or
+ * option name. Same scan shape as `Exposure.test.tsx`'s own lint.
+ */
+describe("Agents screen copy — no jargon in the surface (system.md §3 rule 0)", () => {
+  const BANNED = [
+    /\bmcp\b/i,
+    /\boauth\b/i,
+    /\bjwt\b/i,
+    /\bttl\b/i,
+    /\basgi\b/i,
+    /\bapi\b/i,
+    /\bjson\b/i,
+    /\brfc\s*\d/i,
+    /\bbearer\b/i,
+    /\benvelope\b/i,
+  ];
+
+  it("no heading, button, badge, or field label uses a protocol name or acronym", async () => {
+    vi.spyOn(api, "listSessions").mockResolvedValue({
+      sessions: [ACTIVE_SESSION, STALE_SESSION],
+    });
+    vi.spyOn(api, "messageFlows").mockResolvedValue({ flows: [A_FLOW] });
+
+    mount();
+    await screen.findByText(ACTIVE_SESSION.handle);
+
+    const controls = [
+      ...screen.queryAllByRole("heading"),
+      ...screen.queryAllByRole("button"),
+      ...Array.from(document.querySelectorAll(".badge, .card__title, .field__label")),
+    ];
+
+    expect(controls.length).toBeGreaterThan(5);
+    for (const element of controls) {
+      const text = element.textContent ?? "";
+      for (const pattern of BANNED) {
+        expect(text).not.toMatch(pattern);
+      }
+    }
+  });
+});

--- a/v3/web/src/routes/Agents.tsx
+++ b/v3/web/src/routes/Agents.tsx
@@ -1,0 +1,586 @@
+/**
+ * SPEC-405: the Agents screen — the live directory of agent sessions
+ * connected to this hub, and the messages moving between them.
+ *
+ * MASTERPLAN §5.4 trust rule #7: "the human can read along, join in, or
+ * shut a conversation down." This screen is "read along" (always, live,
+ * no reload); "Send a message" is "join in"; "End conversation" and
+ * "Remove" are "shut down". The last two are the SPEC-304 rule this SPEC
+ * inherits: destructive controls stay dashboard-only, which is exactly
+ * where they are — the session-monitor MCP App only ever links back here
+ * for them.
+ *
+ * Live updates ride the hub's existing SSE bus (`stream.agentActivityCount`,
+ * bumped on every `session.*`/`message.*` event — see ../lib/events.ts) —
+ * there is no polling interval anywhere in this file.
+ */
+import { useEffect, useId, useState } from "react";
+import { useOutletContext } from "react-router-dom";
+
+import { Badge, Button, Card, CardBody, CardHead, Chip, EmptyState, Field, Skeleton, useToast } from "../components";
+import type {
+  EnvelopeMetadata,
+  MessageType,
+  SearchHit,
+  SessionRecord,
+  Urgency,
+  VaultSummary,
+} from "../lib/api/client";
+import { api, ApiError } from "../lib/api/client";
+import type { EventStreamState } from "../lib/events";
+import { AgentsIcon } from "../shell/icons";
+
+const MAX_BODY_BYTES = 4096;
+
+const TYPE_LABEL: Record<MessageType, string> = {
+  request: "Request",
+  inform: "Update",
+  question: "Question",
+  handoff: "Handoff",
+  broadcast: "Announcement to everyone",
+};
+
+const URGENCY_LABEL: Record<Urgency, string> = {
+  low: "Low",
+  normal: "Normal",
+  high: "High",
+};
+
+function describeError(err: unknown): string {
+  if (err instanceof ApiError) {
+    const body = err.body as { detail?: string } | undefined;
+    if (body?.detail) return body.detail;
+    return `The hub answered ${err.status}.`;
+  }
+  return "Could not reach the hub.";
+}
+
+function relativeTime(seconds: number): string {
+  const minutes = Math.max(0, Math.round((Date.now() - seconds * 1000) / 60000));
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.round(hours / 24)}d ago`;
+}
+
+function statusBadgeVariant(status: SessionRecord["status"]): "ok" | "warn" | "risk" {
+  if (status === "stale") return "risk";
+  if (status === "idle") return "warn";
+  return "ok";
+}
+
+function statusLabel(status: SessionRecord["status"]): string {
+  if (status === "stale") return "Inactive";
+  if (status === "idle") return "Idle";
+  return "Active";
+}
+
+function byteLength(text: string): number {
+  return new TextEncoder().encode(text).length;
+}
+
+function AgentRow({ session, onRemoved }: { session: SessionRecord; onRemoved: () => void }) {
+  const toast = useToast();
+  const [confirming, setConfirming] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  async function remove() {
+    setBusy(true);
+    try {
+      await api.deregisterSession(session.handle);
+      toast.show(`${session.handle} removed from the directory.`);
+      onRemoved();
+    } catch (err) {
+      toast.show(describeError(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="listrow">
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div className="listrow__title t-mono">{session.handle}</div>
+        <div className="listrow__meta">{session.scope || "No scope reported"}</div>
+        <div className="listrow__meta">
+          {session.platform || "Unknown platform"}
+          {session.model ? ` · ${session.model}` : ""}
+        </div>
+      </div>
+      <div className="row" style={{ gap: 8, alignItems: "center" }}>
+        <Badge variant={statusBadgeVariant(session.status)}>{statusLabel(session.status)}</Badge>
+        <span
+          className="t-xs t-subtle"
+          title={new Date(session.last_seen_at * 1000).toLocaleString()}
+        >
+          seen {relativeTime(session.last_seen_at)}
+        </span>
+        {confirming ? (
+          <>
+            <Button size="sm" variant="ghost" onClick={() => setConfirming(false)} disabled={busy}>
+              Never mind
+            </Button>
+            <Button size="sm" variant="risk" onClick={remove} disabled={busy}>
+              Yes, remove
+            </Button>
+          </>
+        ) : (
+          <Button size="sm" variant="risk" onClick={() => setConfirming(true)} disabled={busy}>
+            Remove
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function messageStateLabel(state: EnvelopeMetadata["state"]): string {
+  if (state === "pending") return "Waiting";
+  if (state === "delivered") return "Delivered";
+  return "Done";
+}
+
+function messageStateVariant(state: EnvelopeMetadata["state"]): "warn" | "neutral" | "ok" {
+  if (state === "pending") return "warn";
+  if (state === "acked") return "ok";
+  return "neutral";
+}
+
+function MessageRow({ flow, onEnded }: { flow: EnvelopeMetadata; onEnded: () => void }) {
+  const toast = useToast();
+  const [open, setOpen] = useState(false);
+  const [body, setBody] = useState<string | null>(null);
+  const [loadingBody, setLoadingBody] = useState(false);
+  const [ending, setEnding] = useState(false);
+  const [confirmEnd, setConfirmEnd] = useState(false);
+
+  async function toggle() {
+    const next = !open;
+    setOpen(next);
+    if (next && body === null) {
+      setLoadingBody(true);
+      try {
+        const detail = await api.envelopeDetail(flow.id);
+        setBody(detail.item.envelope.body);
+      } catch {
+        setBody("This message could not be read.");
+      } finally {
+        setLoadingBody(false);
+      }
+    }
+  }
+
+  async function end() {
+    setEnding(true);
+    try {
+      const result = await api.endConversation(flow.id);
+      const count = result.expired.length;
+      toast.show(
+        count === 0
+          ? "Nothing was left waiting in this conversation."
+          : `Conversation ended — ${count} unread message${count === 1 ? "" : "s"} will not be delivered.`,
+      );
+      onEnded();
+    } catch (err) {
+      toast.show(describeError(err));
+    } finally {
+      setEnding(false);
+      setConfirmEnd(false);
+    }
+  }
+
+  return (
+    <div className="listrow" style={{ flexDirection: "column", alignItems: "stretch", gap: 8 }}>
+      <button
+        type="button"
+        className="row row--between"
+        onClick={toggle}
+        aria-expanded={open}
+        style={{ width: "100%", cursor: "pointer", background: "none", border: 0, padding: 0 }}
+      >
+        <div style={{ flex: 1, minWidth: 0, textAlign: "left" }}>
+          <div className="listrow__title">{flow.subject}</div>
+          <div className="listrow__meta">
+            {flow.from} &rarr; {flow.recipient} · {TYPE_LABEL[flow.type]} · {URGENCY_LABEL[flow.urgency]}
+          </div>
+        </div>
+        <Badge variant={messageStateVariant(flow.state)}>{messageStateLabel(flow.state)}</Badge>
+      </button>
+      {open ? (
+        <div className="stack stack--2">
+          {loadingBody ? (
+            <Skeleton height={40} />
+          ) : (
+            <p className="t-sm t-muted" style={{ whiteSpace: "pre-wrap" }}>
+              {body || "(no message text — see the linked note)"}
+            </p>
+          )}
+          {flow.refs.length > 0 ? (
+            <p className="t-xs t-subtle">Linked notes: {flow.refs.join(", ")}</p>
+          ) : null}
+          <div className="row">
+            {confirmEnd ? (
+              <>
+                <Button size="sm" variant="ghost" onClick={() => setConfirmEnd(false)} disabled={ending}>
+                  Never mind
+                </Button>
+                <Button size="sm" variant="risk" onClick={end} disabled={ending}>
+                  Yes, end it
+                </Button>
+              </>
+            ) : (
+              <Button size="sm" variant="risk" onClick={() => setConfirmEnd(true)}>
+                End conversation
+              </Button>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function RefPicker({ refs, onChange }: { refs: string[]; onChange: (refs: string[]) => void }) {
+  const [vaults, setVaults] = useState<VaultSummary[]>([]);
+  const [vaultKey, setVaultKey] = useState("");
+  const [query, setQuery] = useState("");
+  const [hits, setHits] = useState<SearchHit[]>([]);
+
+  useEffect(() => {
+    api
+      .listVaults()
+      .then((list) => {
+        setVaults(list);
+        if (list.length > 0) setVaultKey(list[0].key);
+      })
+      .catch(() => setVaults([]));
+  }, []);
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      if (!vaultKey || !query.trim()) {
+        setHits([]);
+        return;
+      }
+      api
+        .search(vaultKey, query)
+        .then(setHits)
+        .catch(() => setHits([]));
+    }, 250);
+    return () => clearTimeout(handle);
+  }, [vaultKey, query]);
+
+  function add(permalink: string) {
+    const ref = `memory://${permalink}`;
+    if (!refs.includes(ref)) onChange([...refs, ref]);
+    setQuery("");
+    setHits([]);
+  }
+
+  if (vaults.length === 0) return null;
+
+  return (
+    <div className="stack stack--2">
+      <span className="field__label">Link a note (optional)</span>
+      <div className="row" style={{ gap: 8 }}>
+        {vaults.length > 1 ? (
+          <select className="input" value={vaultKey} onChange={(event) => setVaultKey(event.target.value)}>
+            {vaults.map((vault) => (
+              <option key={vault.key} value={vault.key}>
+                {vault.key}
+              </option>
+            ))}
+          </select>
+        ) : null}
+        <input
+          className="input"
+          placeholder="Search notes to link…"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+        />
+      </div>
+      {hits.length > 0 ? (
+        <div className="stack stack--2">
+          {hits.slice(0, 5).map((hit) => (
+            <button
+              key={hit.permalink}
+              type="button"
+              className="listrow"
+              style={{ width: "100%", textAlign: "left", cursor: "pointer" }}
+              onClick={() => add(hit.permalink)}
+            >
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div className="listrow__title">{hit.title}</div>
+                <div className="listrow__meta t-mono">{hit.permalink}</div>
+              </div>
+            </button>
+          ))}
+        </div>
+      ) : null}
+      {refs.length > 0 ? (
+        <div className="row row--wrap" style={{ gap: 6 }}>
+          {refs.map((ref) => (
+            <Chip key={ref} mono>
+              {ref}
+              <button
+                type="button"
+                onClick={() => onChange(refs.filter((r) => r !== ref))}
+                aria-label={`Remove ${ref}`}
+                style={{ marginLeft: 6, background: "none", border: 0, cursor: "pointer" }}
+              >
+                &times;
+              </button>
+            </Chip>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ComposePanel({ sessions, onSent }: { sessions: SessionRecord[]; onSent: () => void }) {
+  const toast = useToast();
+  const subjectId = useId();
+  const bodyId = useId();
+  const typeId = useId();
+  const urgencyId = useId();
+  const [open, setOpen] = useState(false);
+  const [to, setTo] = useState("");
+  const [type, setType] = useState<MessageType>("inform");
+  const [subject, setSubject] = useState("");
+  const [body, setBody] = useState("");
+  const [urgency, setUrgency] = useState<Urgency>("normal");
+  const [expectsReply, setExpectsReply] = useState(false);
+  const [refs, setRefs] = useState<string[]>([]);
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const bodyBytes = byteLength(body);
+  const overBody = bodyBytes > MAX_BODY_BYTES;
+
+  function reset() {
+    setTo("");
+    setSubject("");
+    setBody("");
+    setRefs([]);
+    setExpectsReply(false);
+    setError(null);
+  }
+
+  async function send() {
+    setError(null);
+    if (!to.trim() || !subject.trim()) {
+      setError("Fill in who this is for and a subject.");
+      return;
+    }
+    if (overBody) {
+      setError(
+        `The message is ${bodyBytes} bytes; the limit is ${MAX_BODY_BYTES}. Link a note instead of pasting the rest in.`,
+      );
+      return;
+    }
+    setSending(true);
+    try {
+      await api.sendAsOwner({
+        type,
+        to: to.trim(),
+        subject: subject.trim(),
+        body,
+        urgency,
+        expects_reply: expectsReply,
+        refs: refs.length > 0 ? refs : undefined,
+      });
+      toast.show("Sent.");
+      setOpen(false);
+      reset();
+      onSent();
+    } catch (err) {
+      setError(describeError(err));
+    } finally {
+      setSending(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <Button variant="primary" onClick={() => setOpen(true)}>
+        Send a message
+      </Button>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHead title="Send a message" />
+      <CardBody className="stack stack--3">
+        <Field label="To" hint="An agent's ID, or * for everyone">
+          <input
+            className="input"
+            list="agent-handles"
+            placeholder="Agent ID, or *"
+            value={to}
+            onChange={(event) => setTo(event.target.value)}
+          />
+          <datalist id="agent-handles">
+            {sessions.map((session) => (
+              <option key={session.handle} value={session.handle} />
+            ))}
+            <option value="*">Everyone</option>
+          </datalist>
+        </Field>
+        <div className="row row--wrap" style={{ gap: 12 }}>
+          <Field label={<label htmlFor={typeId}>Type</label>}>
+            <select
+              id={typeId}
+              className="input"
+              value={type}
+              onChange={(event) => setType(event.target.value as MessageType)}
+            >
+              {Object.entries(TYPE_LABEL).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label={<label htmlFor={urgencyId}>Priority</label>}>
+            <select
+              id={urgencyId}
+              className="input"
+              value={urgency}
+              onChange={(event) => setUrgency(event.target.value as Urgency)}
+            >
+              {Object.entries(URGENCY_LABEL).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </Field>
+        </div>
+        <Field label={<label htmlFor={subjectId}>Subject</label>}>
+          <input
+            id={subjectId}
+            className="input"
+            maxLength={200}
+            value={subject}
+            onChange={(event) => setSubject(event.target.value)}
+          />
+        </Field>
+        <Field
+          label={<label htmlFor={bodyId}>Message</label>}
+          hint={overBody ? undefined : `${bodyBytes} / ${MAX_BODY_BYTES} bytes`}
+          error={overBody ? `${bodyBytes} / ${MAX_BODY_BYTES} bytes — over the limit.` : undefined}
+        >
+          <textarea
+            id={bodyId}
+            className="input"
+            rows={4}
+            value={body}
+            onChange={(event) => setBody(event.target.value)}
+          />
+        </Field>
+        <RefPicker refs={refs} onChange={setRefs} />
+        <label className="row" style={{ gap: 8 }}>
+          <input
+            type="checkbox"
+            checked={expectsReply}
+            onChange={(event) => setExpectsReply(event.target.checked)}
+          />
+          <span className="t-sm">Needs a reply</span>
+        </label>
+        {error ? <p className="field__error">{error}</p> : null}
+        <div className="row">
+          <Button variant="primary" onClick={send} disabled={sending}>
+            {sending ? "Sending…" : "Send"}
+          </Button>
+          <Button variant="ghost" onClick={() => setOpen(false)} disabled={sending}>
+            Cancel
+          </Button>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}
+
+export function Agents() {
+  const stream = useOutletContext<EventStreamState>();
+  const [sessions, setSessions] = useState<SessionRecord[] | null>(null);
+  const [flows, setFlows] = useState<EnvelopeMetadata[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  function refresh() {
+    api
+      .listSessions()
+      .then((result) => setSessions(result.sessions))
+      .catch((err) => {
+        setSessions([]);
+        setError(describeError(err));
+      });
+    api
+      .messageFlows({ limit: 50 })
+      .then((result) => setFlows(result.flows))
+      .catch(() => setFlows([]));
+  }
+
+  // No polling loop (deliverable #1): this refetches once on mount, then
+  // again only when the SSE stream reports a session.*/message.* event.
+  useEffect(() => {
+    refresh();
+  }, [stream.agentActivityCount]);
+
+  return (
+    <section className="stack stack--4">
+      <p className="t-sm t-muted" style={{ maxWidth: 620 }}>
+        Every agent connected to this hub, and the messages moving between them — updates live, no
+        need to reload.
+      </p>
+
+      {error ? (
+        <div className="banner banner--warn">
+          <p className="t-sm t-muted">{error}</p>
+        </div>
+      ) : null}
+
+      <div className="stack stack--2">
+        <span className="field__label">Agents</span>
+        {sessions === null ? (
+          <Skeleton height={60} />
+        ) : sessions.length === 0 ? (
+          <EmptyState mark={<AgentsIcon className="icon--lg" />} title="No agents yet.">
+            Connect a client and have it register with the directory to see it here.
+          </EmptyState>
+        ) : (
+          <Card>
+            {sessions.map((session) => (
+              <AgentRow key={session.handle} session={session} onRemoved={refresh} />
+            ))}
+          </Card>
+        )}
+      </div>
+
+      <div className="stack stack--2">
+        <span className="field__label">Messages</span>
+        {flows === null ? (
+          <Skeleton height={60} />
+        ) : flows.length === 0 ? (
+          <EmptyState mark={<AgentsIcon className="icon--lg" />} title="No messages yet.">
+            Nothing has been sent between agents on this hub.
+          </EmptyState>
+        ) : (
+          <Card>
+            {flows.map((flow) => (
+              <MessageRow key={flow.id} flow={flow} onEnded={refresh} />
+            ))}
+          </Card>
+        )}
+      </div>
+
+      <div className="stack stack--2">
+        <span className="field__label">Send as yourself</span>
+        <ComposePanel sessions={sessions ?? []} onSent={refresh} />
+      </div>
+    </section>
+  );
+}

--- a/v3/web/src/routes/index.tsx
+++ b/v3/web/src/routes/index.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter } from "react-router-dom";
 
 import { AppShell } from "../shell/AppShell";
 import { NAV_GROUPS } from "../shell/navConfig";
+import { Agents } from "./Agents";
 import { Automations } from "./Automations";
 import { Clients } from "./Clients";
 import { ComingSoon } from "./ComingSoon";
@@ -26,6 +27,7 @@ const BUILT_PATHS = new Set([
   "/settings",
   "/tools",
   "/marketplace",
+  "/agents",
 ]);
 
 const placeholderRoutes = NAV_GROUPS.flatMap((group) => group.items)
@@ -52,6 +54,7 @@ export const router = createBrowserRouter([
       { path: "settings", element: <Settings /> },
       { path: "tools", element: <ToolProfiles /> },
       { path: "marketplace", element: <Marketplace /> },
+      { path: "agents", element: <Agents /> },
       ...placeholderRoutes,
     ],
   },

--- a/v3/web/src/shell/icons.tsx
+++ b/v3/web/src/shell/icons.tsx
@@ -203,3 +203,15 @@ export function MarketplaceIcon(props: SVGProps<SVGSVGElement>) {
     </Icon>
   );
 }
+
+/** SPEC-405: the agents nav item — two linked presence dots (the directory
+ * plus the messenger flow between them). */
+export function AgentsIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <Icon {...props}>
+      <circle cx="8" cy="8" r="3" />
+      <circle cx="16" cy="16" r="3" />
+      <path d="M10.2 10.2 13.8 13.8" />
+    </Icon>
+  );
+}

--- a/v3/web/src/shell/navConfig.tsx
+++ b/v3/web/src/shell/navConfig.tsx
@@ -1,6 +1,7 @@
 import type { ComponentType, SVGProps } from "react";
 
 import {
+  AgentsIcon,
   AutomationsIcon,
   ClientsIcon,
   ExplorerIcon,
@@ -52,6 +53,7 @@ export const NAV_GROUPS: NavGroupConfig[] = [
       { path: "/clients", label: "Clients", icon: ClientsIcon },
       { path: "/tools", label: "Tools & skills", icon: ToolsIcon },
       { path: "/marketplace", label: "Marketplace", icon: MarketplaceIcon },
+      { path: "/agents", label: "Agents", icon: AgentsIcon },
     ],
   },
   {


### PR DESCRIPTION
## SPEC-405: Team observability

Implements the dashboard "Agents" screen, two owner controls on the messenger/directory REST surfaces, the session-monitor MCP App, and a stash-browse tool + app — MASTERPLAN §5.4 trust rule #7 ("the human can read along, join in, or shut a conversation down") and the §5.7 Phase-4 rows for "Session monitor / messenger" and "Stash browser".

### Deliverables

1. **Dashboard "Agents" screen** (`v3/web/src/routes/Agents.tsx`): the live directory (scope, platform, model, status, idle time — `stale` shown as plain-language "Inactive", visually distinct) and message flows (metadata first, body fetched only on expand — the owner-only surface). Live via the existing SSE bus (`stream.agentActivityCount`, bumped on `session.*`/`message.*`) — no polling loop.
2. **Owner controls**, plain language:
   - **End a conversation** — `POST /api/messenger/threads/{id}/end` expires the thread's still-undelivered envelopes and fires `message.expired`. Delivered/acked copies are left standing.
   - **Deregister a stale agent** — `POST /api/directory/{handle}/deregister`, no session secret required (the admin session + CSRF gate is the stronger proof).
   - **Send as owner** — `POST /api/messenger/send`, the compose form's exact schema (type, subject, urgency, expects-reply, a 4KB-byte-counted body, a ref picker wired to real recall search). Sender always reads `owner`.
3. **Session-monitor MCP App** (`/mcp/team`, mounted when both the directory and messenger services are wired): read-only directory + flows (no bodies), plus a compose form that calls the *same* `messenger_send` tool a session would call directly — not the owner routes above. Destructive controls (ending a conversation, deregistering) are a plain deep link to the dashboard, never a tool call.
4. **Stash browser MCP App**: a new `stash_browse` tool on the existing `/mcp/stash` mount — namespace → entries, size/expiry/staleness, never a stored value.
5. Lume/jargon-free copy throughout, linted (both screens and both apps).

### One documented deviation

`register_messenger_send_tool` is factored out of `gateway/messenger_tools.py` so the team app's own `FastMCP` instance can register the *identical* `messenger_send` tool. This was necessary because the MCP Apps bridge (`app.callServerTool`) only ever reaches a tool on the same server that served the calling page's `ui://` resource — it cannot call across to `/mcp/messenger`. Both mounts run exactly the same function against the same `MessengerService`, so this is one implementation running twice, not a fork.

### Acceptance criteria
- [x] directory screen renders live updates from real `session.*` events (vitest with an SSE fixture driving the real `useEventStream` hook); stale sessions visually distinct
- [x] owner compose posts a valid envelope e2e (REST → store → recipient's `messenger_check` sees it, sender shown as `owner`)
- [x] end-conversation expires the thread's undelivered envelopes and fires `message.expired`
- [x] session-monitor app renders in the existing SPEC-208 "scripted harness" (`test_apps_shell.py`); its destructive controls are links to the dashboard, not tool calls
- [x] stash browser app lists real entries via the app bridge (real `fastmcp.Client` round trip)
- [x] jargon lint green on all new copy (both screens and both apps)

### Verification (from `v3/`)
- `uv run ruff check server` — clean
- `uv run mypy server/src` — clean, 185 source files
- `uv run pytest server/tests -q` — **1979 passed, 16 skipped**, 0 failed
- `cd web && npm run typecheck` — clean
- `cd web && npx vitest run` — **93 passed** (19 files)
- `cd web && npm run lint` — clean (pre-existing warnings elsewhere only)
- `cd web && npm run build` — succeeds
- `golden_stash_tools_snapshot.json` regenerated via the documented command in `test_stash_tool_schema_drift.py` (the only golden snapshot touched; directory/messenger snapshots are unaffected since no tool was added to either family's own server)
- `web/src/lib/api/schema.gen.ts` re-run via `npm run gen:api` and confirmed byte-identical (the new directory/messenger REST routes are opt-in on the hub, same reason the token/hook/automation REST types are hand-written rather than generated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790258756&installation_model_id=428086&pr_number=256&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F256&signature=f4f943f6e62449a38f113a5f284b27c535a3a41853552b918bf8ae0cb62f2e90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->