### PR TITLE
feat(v3): SPEC-407 Phase-4 gate evidence — cross-provider handoff

### DIFF
--- a/v3/IMPLEMENTATION.md
+++ b/v3/IMPLEMENTATION.md
@@ -248,3 +248,44 @@ different providers hand off work through palaia*).
   and the #242 dashboard-sign-in work carried into Phase 4's hardening
   scope. Reviewer: **Fable 5** (writes the Phase-4 SPECs at this gate) +
   owner (UX pass over marketplace/profiles/automations screens).
+- **Gate P4→P5 (draft — the architect holds the gate; SPEC-407 evidence,
+  2026-08-25):** every Phase-4 ship merged and integrated (SPECs 401–406:
+  dashboard sign-in, session directory, messenger core, messaging skills +
+  push adapters, team observability, add-on SDK). Exit criterion *"two
+  agents on different providers hand off work through palaia"* demonstrated
+  with SPEC-407's evidence
+  (`v3/docs/client-matrix-results.md` §8 has the full trace): the real
+  `claude` CLI (OAuth, profile `default`) registered, saved a fact to
+  memory, discovered a live peer through the session directory by a scope
+  query — never a hardcoded handle, provably so, since directory handles
+  are fresh random tokens the CLI's prompt/config never carried — and sent
+  it a `handoff` envelope carrying a `memory://` reference instead of the
+  fact itself; a scripted `fastmcp.Client` carrying a real SPEC-108 `plt_`
+  token, on the `mobile` profile, checked its own inbox and followed that
+  reference with `recall`, and its real recall output contained A's exact
+  fact. Run four times in a row, no flakes. This sandbox has no `codex`
+  binary, so the second party is a second-provider-*shaped* scripted
+  client rather than a second real vendor CLI — the same wire-level
+  substitution SPEC-209 and SPEC-308 already made and this SPEC's own task
+  explicitly sanctioned; the envelope shape, the directory query grammar
+  and the session-secret authorization it exercises are all
+  provider-agnostic protocol, not anything the real `claude` CLI gets
+  specially. A real quirk was found and fixed in the same PR
+  ([#257](https://github.com/byte5ai/palaia/issues/257)): a `plt_` token
+  could not be minted with `directory:*`/`messenger:*` scopes at all
+  through the real REST surface — the `plt_`-side twin of the OAuth
+  scope-ceiling bug SPEC-403 had already fixed on the OAuth side. The
+  skill-driven variant (SPEC-404's harness, `PALAIA_EFFECTIVENESS=1`, 3 real
+  runs per probe — this SPEC's stated budget) found the unprompted handoff
+  firing 3/3 times and the unprompted inbox-check firing 3/3 times as well
+  (`v3/docs/client-matrix-results.md` §8.4 has the full trace and cost),
+  reported honestly as a rate rather than hard-asserted per the SPEC's own
+  instruction — six real runs total, not a claim about the general-case
+  rate. What this
+  evidence does **not** cover, honestly: a real second AI provider's own
+  binary (no `codex` in this sandbox), a real public tunnel, and every gap
+  §6/§7.4 above already carry (the dashboard's own UI, Claude Desktop's
+  MCPB dialog, the owner's phone test) — SPEC-407 adds nothing new to any
+  of those. **This paragraph is a draft: the architect holds the gate** —
+  it records what was run and observed, not a verdict on whether Phase 4's
+  exit criterion is met or what Phase 5 should be.

--- a/v3/docs/client-matrix-results.md
+++ b/v3/docs/client-matrix-results.md
@@ -395,3 +395,163 @@ live, exactly as the HTTP paths do.
   combination (SPEC-301) and the marketplace install flow (SPEC-304) both
   worked exactly as documented on the first real run against two profiles
   at once.
+
+## 8. Phase-4 gate: messenger (SPEC-407, 2026-08-25)
+
+The Phase-4 exit criterion is **two agents on different providers hand off
+work through palaia**: a handoff envelope with a vault reference, sent by
+one, picked up and acted on by the other. Scripted evidence lives in
+[`v3/server/tests/e2e/test_spec407_phase4_gate.py`](../server/tests/e2e/test_spec407_phase4_gate.py),
+against a new hub subprocess,
+[`support/hub_server_messenger.py`](../server/tests/e2e/support/hub_server_messenger.py),
+that wires `palaia_hub.serve.build_production_app` exactly the way
+`palaia-hub serve` does — real `VaultEngine`, real `AuthorizationServer`,
+real directory/messenger services, two gateway profiles (`default`,
+`mobile`) both carrying the one shared vault plus `directory: true`/
+`messenger: true` — over a real `uvicorn` socket.
+
+### 8.1 What was actually run
+
+```
+$ cd v3 && uv run pytest server/tests/e2e/test_spec407_phase4_gate.py -q
+.                                                                        [100%]
+1 passed in 33.36s
+```
+Run four times in a row (33.36s, 37.85s, 32.59s, 33.44s), no flakes. The
+full `tests/e2e/` directory (36 tests total, including SPEC-209's,
+SPEC-306's and SPEC-308's own suites) was also run once end-to-end with
+this new file added: green, 36 passed in 186.85s — no regression in any
+pre-existing harness. The full `server/tests` suite (1986 tests) was also
+run green, 1986 passed / 23 skipped in 429.13s.
+
+### 8.2 The two-agents handoff, and the directory half
+
+`test_two_agents_on_different_providers_hand_off_work_through_palaia`:
+
+1. **Session B** — a scripted `fastmcp.Client` carrying a real SPEC-108
+   `plt_` token, minted through `POST /api/auth/tokens` — registers first,
+   on the `mobile` profile, with `scope="the Q3 billing rate-limiter
+   incident"`. This sandbox has no `codex` binary, so a second-provider-
+   shaped scripted client is the honest stand-in for "the other provider"
+   here, the same wire-level substitution SPEC-209 already pinned for "a
+   client that is not the real claude CLI".
+2. **Session A** — the real `claude` CLI, over a real scripted OAuth 2.1 +
+   PKCE code flow (SPEC-209's own machinery, reused verbatim, no `scope`
+   requested — see §8.4 on what that exercises), against the `default`
+   profile — is driven by one mechanical task prompt: register with the
+   directory, save a specific fact to memory with the vault's `write`
+   tool, find the peer via `directory_query(scope_contains="the Q3 billing
+   rate-limiter incident")` (**never told B's handle anywhere** — not in
+   the prompt, not in `--mcp-config`, not in the environment: directory
+   handles are fresh, random 16-character tokens, so the only way A's
+   `messenger_send` call can address B correctly is to have actually
+   called `directory_query` and read the handle back out of the result),
+   then `messenger_send` a `type="handoff"` envelope to that discovered
+   handle with `refs=["memory://<the permalink just written>"]` and a body
+   that does **not** repeat the fact.
+3. **Session B** calls `messenger_check` on its own handle/secret, finds
+   the handoff, and follows `refs[0]` with `recall` — a full
+   `memory://...` reference, the exact form `recall`'s own tool
+   description says it accepts.
+4. The assertion that matters: B's real, literal `recall` output contains
+   A's exact fact string
+   (`"The billing retry batch is capped at 200 items because a larger
+   batch trips the downstream rate limiter; raising it needs the request
+   queue split first."`) — the handoff carried knowledge, not just an
+   envelope, and B found it through the directory, not a hardcoded handle.
+
+### 8.3 A real quirk, fixed in this PR: [#257](https://github.com/byte5ai/palaia/issues/257)
+
+Minting session B's `plt_` token with `directory:read`/`directory:write`/
+`messenger:read`/`messenger:send` scopes failed outright on the first real
+run: `POST /api/auth/tokens` rejected every one of them as an "invalid
+scope", because `palaia_hub.auth.store._validate_scopes`'s regex had only
+ever matched `vault:<key>:read|write` — even though the gateway's own
+enforcement layer has recognized `directory:*`/`messenger:*` (and
+`stash:*`) scopes since SPEC-402/403. This is the `plt_`-token-side twin of
+the OAuth scope-ceiling bug `palaia_hub.cli._profile_scopes`'s own
+docstring already documents fixing on the OAuth side (found during
+SPEC-403) — the twin bug meant no non-OAuth client could ever be minted a
+token that could use the directory or messenger at all, through the real
+REST surface. Fixed in this PR (`server/src/palaia_hub/auth/store.py`,
+regression test in `server/tests/auth/test_store.py`); this SPEC's own
+acceptance depended on the fix, so it went straight in rather than into a
+follow-up — see the issue for the full trace.
+
+### 8.4 Skill-driven variant (SPEC-404's harness, env-gated)
+
+SPEC-407 deliverable #3 asks a harder question than §8.2's scripted
+mechanism proof: with only the task and the `palaia-messenger` skill
+loaded — the prompt never names a tool, "the messenger", or "the
+directory" — does a real agent reach for the handoff on its own? Reusing
+SPEC-404's own harness (`server/tests/effectiveness/messaging_harness.py`,
+its `HANDOFF_PROMPT`/`CHECK_PROMPT` probes) rather than inventing a second
+one, run for real via
+`server/tests/effectiveness/test_spec407_skill_driven_handoff.py`
+(`PALAIA_EFFECTIVENESS=1`, this SPEC's stated budget of 3 real attempts per
+probe) — reported as a rate, per the SPEC's own instruction, **not
+hard-asserted** either way (SPEC-404's own suite already hard-asserts "at
+least one hit in N attempts" for the same prompts; this run is gate
+evidence about the unprompted rate, not a second regression test for the
+skill):
+
+```
+$ cd v3 && PALAIA_EFFECTIVENESS=1 uv run pytest \
+    server/tests/effectiveness/test_spec407_skill_driven_handoff.py -s -v
+...
+### SPEC-407 gate evidence — skill-driven handoff, unprompted
+- attempts: 3
+- registered with the directory: 3/3
+- sent a handoff carrying a memory:// ref (not a pasted copy): 3/3
+...
+### SPEC-407 gate evidence — skill-driven check-on-start, unprompted
+- attempts: 3
+- checked its inbox unprompted: 3/3
+2 passed in 231.09s (0:03:51)
+```
+
+Run once, for real, on 2026-08-25 (real model calls, real money — $0.9767
+total across the six attempts: three handoff attempts at $0.1225/$0.1178/
+$0.1185, three check-on-start attempts at $0.2486/$0.1852/$0.1842). Both
+probes hit every single attempt:
+
+- **Handoff probe** (task: "end of your shift ... hand the branch off to
+  whichever other session is already working on the billing service" —
+  never names a tool): all three attempts called `directory_register`,
+  `directory_query`, then `messenger_send` with `message_type="handoff"`
+  and a `memory://inbox/...` reference in `refs` (never the fact pasted
+  into the body) — 3/3 registered, 3/3 handed off with a real reference.
+- **Check-on-start probe** (task: "another session ... may have left you
+  something ... get yourself oriented" — never says "message" or
+  "inbox"): all three attempts called `messenger_check` before doing
+  anything else — 3/3.
+
+Six real runs is a small sample, honestly — the SPEC's own stated budget
+is 3 attempts per probe, and this is exactly that, not a claim that the
+skill fires 100% of the time in general. SPEC-404's own effectiveness
+suite (`test_messenger_effectiveness.py`, a separate, already-green
+regression test with its own hard assert) is the place a lower future rate
+would first show up as a real regression; this run is Phase-4 gate
+evidence about the unprompted rate on one real day, not a substitute for
+that suite.
+
+### 8.5 Honest gaps
+
+- **A real second provider (e.g. a real `codex` binary)** was not part of
+  this evidence — this sandbox has none, and none of palaia's own protocol
+  surface (the envelope shape, the directory query grammar, the session
+  secret) is provider-specific, so a scripted `fastmcp.Client` is the same
+  substitution SPEC-209/308 already made for "not the real claude CLI",
+  reused here for "not a second real provider" too.
+- **A real public tunnel** in front of the hub was not part of this
+  evidence, for the same reason §2's and §7.4's notes give.
+- **Claude Desktop's/claude.ai's own UI** was not exercised here — §6/§7.4
+  already carry that gap, and SPEC-407 adds nothing new to it; the owner's
+  standing phone test remains the item that would close it, per this
+  SPEC's own non-goals.
+- **Claude Code's `claude/channel` push capability** (a live push into an
+  already-open session rather than pull-based `messenger_check`) is not
+  exercised — `docs/messenger.md` §8 already says why: the pinned `fastmcp`
+  3.4.7 has no support for declaring it. Pull-based delivery (`messenger_
+  check`) is what both §8.2 and §8.4 exercise, and it is the universal
+  baseline the SPEC itself treats as sufficient.

--- a/v3/server/src/palaia_hub/auth/store.py
+++ b/v3/server/src/palaia_hub/auth/store.py
@@ -45,12 +45,24 @@ logger = logging.getLogger("palaia_hub.auth.store")
 TOKENS_FILE = "tokens.yaml"
 TOKEN_PREFIX = "plt"
 
-# vault:<key>:read|write — the only scope shape store.create() accepts.
-# Deliberately not importing the gateway's key charset validator: the auth
-# package must not depend on the gateway package (see the module docstring
-# of palaia_hub.gateway.vault_protocol for the mirror-image rule), so this
-# is its own narrow, self-contained check.
-_SCOPE_RE = re.compile(r"^vault:[a-z0-9_-]+:(read|write)$")
+# vault:<key>:read|write, plus the hub-level families' own scope shapes
+# (stash:read|write, directory:read|write, messenger:read|send) — the only
+# scope strings store.create() accepts. Found during SPEC-407: this regex
+# still only matched the per-vault shape after SPEC-402/403/cli.py's own
+# `_profile_scopes` had already grown the hub-level families, which meant a
+# plt_ token could never be minted with a stash/directory/messenger scope
+# through the real `POST /api/auth/tokens` surface at all — the OAuth side
+# of that same ceiling was fixed for `_profile_scopes` (see its docstring),
+# but this plt_-token-side twin of it was missed. Kept as its own narrow,
+# self-contained check rather than importing `palaia_hub.auth.scopes`'s
+# action lists: the auth package must not depend on the gateway package
+# (see the module docstring of palaia_hub.gateway.vault_protocol for the
+# mirror-image rule), and this file only needs the scope *shape*, not the
+# per-action mapping that lives there.
+_SCOPE_RE = re.compile(
+    r"^(?:vault:[a-z0-9_-]+:(?:read|write)|stash:(?:read|write)"
+    r"|directory:(?:read|write)|messenger:(?:read|send))$"
+)
 
 _TOKEN_RE = re.compile(rf"^{TOKEN_PREFIX}_([A-Za-z0-9_-]{{8,}})\.([A-Za-z0-9_-]{{16,}})$")
 
@@ -72,8 +84,11 @@ def _validate_scopes(scopes: Sequence[str]) -> list[str]:
     bad = [s for s in scopes if not _SCOPE_RE.match(s)]
     if bad:
         raise TokenError(
-            f"invalid scope(s) {bad!r}. Fix: use 'vault:<key>:read' or "
-            f"'vault:<key>:write' — see palaia_hub.auth.scopes.vault_scope()."
+            f"invalid scope(s) {bad!r}. Fix: use 'vault:<key>:read'/'vault:<key>:write' "
+            "for a vault, 'stash:read'/'stash:write' for the stash, "
+            "'directory:read'/'directory:write' for the session directory, or "
+            "'messenger:read'/'messenger:send' for the messenger — see "
+            "palaia_hub.auth.scopes."
         )
     return list(scopes)
 

--- a/v3/server/tests/auth/test_store.py
+++ b/v3/server/tests/auth/test_store.py
@@ -110,6 +110,32 @@ def test_invalid_scope_format_is_rejected(tmp_path: Path) -> None:
         store.create("client", "default", ["not-a-real-scope"])
 
 
+def test_hub_level_family_scopes_are_accepted(tmp_path: Path) -> None:
+    """SPEC-407 regression: a plt_ token must be mintable with the
+    hub-level families' own scopes (stash/directory/messenger), not just
+    ``vault:<key>:read|write`` — the plt_-token-side twin of the OAuth
+    scope-ceiling fix ``palaia_hub.cli._profile_scopes`` already carries.
+    Found while building SPEC-407's two-agent handoff e2e: minting a plt_
+    token for a session that needs to register itself and use the
+    messenger failed outright before this fix, with every one of these
+    scopes rejected as 'invalid'."""
+    store = TokenStore(home=tmp_path)
+    scopes = [
+        "vault:work:read",
+        "vault:work:write",
+        "stash:read",
+        "stash:write",
+        "directory:read",
+        "directory:write",
+        "messenger:read",
+        "messenger:send",
+    ]
+
+    created = store.create("client", "default", scopes)
+
+    assert created.info.scopes == scopes
+
+
 def test_empty_name_or_profile_is_rejected(tmp_path: Path) -> None:
     store = TokenStore(home=tmp_path)
     with pytest.raises(TokenError):

--- a/v3/server/tests/e2e/support/hub_server_messenger.py
+++ b/v3/server/tests/e2e/support/hub_server_messenger.py
@@ -1,0 +1,177 @@
+"""SPEC-407 e2e hub process: a real hub wired the exact way ``palaia-hub
+serve`` wires one (:func:`palaia_hub.serve.build_production_app`, same
+convention as ``hub_server_oauth.py``/``hub_server_market.py`` and
+``cli.py`` itself), mounting the session directory and messenger tool
+families (SPEC-402/403) *inside* two gateway profiles alongside one shared
+vault — the shape the Phase-4 gate's exit criterion needs: two agents, on
+two different profiles, with two different credential shapes, sharing one
+vault through a handoff.
+
+Two profiles, both carrying the same vault, both with ``directory: true``
+and ``messenger: true`` (:class:`palaia_hub.config.GatewayProfileSettings`)
+so a client on either one gets the vault's memory tools plus
+``directory_*``/``messenger_*`` behind its own MCP mount:
+
+- ``default`` — OAuth only, no requested ``scope`` (so the authorization
+  code grant issues this profile's *full* grantable set — vault
+  read/write, ``directory:*``, ``messenger:*`` — the scope-ceiling fix this
+  SPEC's own task names: before it, an OAuth client could never be granted
+  the directory/messenger scopes at all, only a ``plt_`` token could).
+  Session A (the real ``claude`` CLI) connects here.
+- ``mobile`` — accepts both OAuth and SPEC-108 ``plt_`` tokens (same
+  ``build_profile_auth`` combination every other profile gets — nothing
+  hub-side distinguishes the two credential shapes). Session B (a scripted
+  ``fastmcp.Client`` carrying a ``plt_`` token — this sandbox has no
+  ``codex`` binary, so this is the second-provider-shaped stand-in;
+  SPEC-209 pinned the same wire-level equivalence for exactly this reason)
+  connects here.
+
+The directory and the messenger are each exactly one hub-wide store
+(:mod:`palaia_hub.serve`'s own module docstring), shared across every
+profile that mounts them — which is *why* this design proves a
+cross-provider handoff at all: A registers and sends on ``default``, B
+registers and checks on ``mobile``, and both land in the one directory/
+messenger the hub actually runs, never two independent toy stores.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from pathlib import Path
+
+import uvicorn
+
+from palaia_hub.config import GatewayProfileSettings, GatewaySettings, HubConfig, OAuthSettings
+from palaia_hub.gateway.config import DEFAULT_GATEWAY_PROFILE
+from palaia_hub.gateway.config import ProfileConfig as _ProfileConfig
+from palaia_hub.gateway.settings_bridge import resolve_full_gateway_profiles
+from palaia_hub.oauth import AuthorizationServer, now_seconds, set_owner_password
+from palaia_hub.serve import build_production_app
+from palaia_hub.vault import VaultRegistry
+
+logger = logging.getLogger("e2e.hub_server_messenger")
+
+VAULT_KEY = "work"
+
+
+def _profile_scopes(profiles: list[_ProfileConfig]) -> dict[str, list[str]]:
+    """Verbatim copy of ``palaia_hub.cli._profile_scopes`` (vault +
+    directory + messenger scopes per profile) — the real function is
+    private to the CLI module, and this file's house style (every other
+    ``tests/e2e/support/hub_server_*.py`` script) is a standalone script,
+    not a shared import from ``cli.py``. A contract test elsewhere
+    (SPEC-403's own tests) pins ``cli.py``'s real version; this copy would
+    only drift from it silently if that vocabulary itself changed, at
+    which point every OAuth-scoped e2e test in this directory would need
+    the same edit.
+    """
+
+    def scopes_for(profile: _ProfileConfig) -> list[str]:
+        scopes = [
+            scope
+            for key in profile.vaults
+            for scope in (f"vault:{key}:read", f"vault:{key}:write")
+        ]
+        if profile.stash:
+            scopes += ["stash:read", "stash:write"]
+        if profile.directory:
+            scopes += ["directory:read", "directory:write"]
+        if profile.messenger:
+            scopes += ["messenger:read", "messenger:send"]
+        return scopes
+
+    return {profile.path: scopes_for(profile) for profile in profiles}
+
+
+async def _run(
+    *,
+    host: str,
+    port: int,
+    home: Path,
+    vault_dir: Path,
+    username: str,
+    password: str,
+    profiles: list[str],
+) -> None:
+    registry = VaultRegistry(home)
+    await registry.create(
+        VAULT_KEY,
+        vault_dir,
+        purpose="SPEC-407 phase4-gate e2e vault: shared work knowledge.",
+    )
+
+    issuer = f"http://{host}:{port}"
+    gateway = GatewaySettings(
+        profiles=[
+            GatewayProfileSettings(path=p, vaults=[VAULT_KEY], directory=True, messenger=True)
+            for p in profiles
+        ]
+    )
+    config = HubConfig(
+        mode="cloud",
+        host=host,
+        port=port,
+        oauth=OAuthSettings(enabled=True, issuer=issuer),
+        gateway=gateway,
+    )
+
+    resolved_profiles = resolve_full_gateway_profiles(
+        config, [VAULT_KEY], default_profile=DEFAULT_GATEWAY_PROFILE
+    )
+    oauth_server = AuthorizationServer.build(config, _profile_scopes(resolved_profiles), home=home)
+    set_owner_password(oauth_server.store, username, password, now=now_seconds())
+
+    production = await build_production_app(config, home=home, oauth_server=oauth_server)
+
+    uv_server = uvicorn.Server(
+        uvicorn.Config(production.app, host=host, port=port, log_level="info")
+    )
+    try:
+        await uv_server.serve()
+    finally:
+        for index in production.indexes.values():
+            await index.close()
+        if production.stash_store is not None:
+            production.stash_store.close()
+        if production.directory_store is not None:
+            production.directory_store.close()
+        if production.messenger_store is not None:
+            production.messenger_store.close()
+        await production.dynamic_gateway.aclose()
+        oauth_server.store.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--home", required=True, help="empty PALAIA_HOME for this hub instance")
+    parser.add_argument("--vault-dir", required=True)
+    parser.add_argument("--username", default="owner")
+    parser.add_argument("--password", default="a-long-enough-passphrase")
+    parser.add_argument(
+        "--profiles", default="default,mobile", help="comma-separated gateway profile paths"
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+    )
+
+    asyncio.run(
+        _run(
+            host=args.host,
+            port=args.port,
+            home=Path(args.home),
+            vault_dir=Path(args.vault_dir),
+            username=args.username,
+            password=args.password,
+            profiles=[p.strip() for p in args.profiles.split(",") if p.strip()],
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/v3/server/tests/e2e/test_spec407_phase4_gate.py
+++ b/v3/server/tests/e2e/test_spec407_phase4_gate.py
@@ -1,0 +1,437 @@
+"""SPEC-407 Phase-4 gate evidence: "two agents on different providers hand
+off work through palaia".
+
+The scenario, literally: **session A** is the real ``claude`` CLI (OAuth,
+profile ``default``) driven by a mechanical task prompt — register, save a
+fact to memory, find the other session already working on the same thing
+*through the directory* (never told its handle), hand it off with a
+``memory://`` reference instead of pasting the fact into the message body.
+**Session B** is a scripted ``fastmcp.Client`` carrying a real SPEC-108
+``plt_`` token on the ``mobile`` profile — this sandbox has no ``codex``
+binary, so a second-provider-shaped scripted client is the honest stand-in
+here, the same substitution SPEC-209 already pinned at the wire level for
+"a client that is not the real claude CLI". B checks its own inbox, follows
+A's ``memory://`` ref with ``recall``, and the test asserts B's *real,
+literal* recall output contains A's exact fact — proving the handoff
+carried knowledge, not just an envelope.
+
+Both agents connect to the same real hub subprocess
+(``support/hub_server_messenger.py`` — real ``VaultEngine``, real
+``AuthorizationServer``, real ``build_production_app`` wiring exactly as
+``palaia-hub serve`` runs it, real ``uvicorn`` socket), on two different
+gateway profiles that both carry the one shared vault plus
+``directory: true``/``messenger: true`` — the directory and the messenger
+are each exactly one hub-wide store (see the hub script's docstring), so a
+registration/send on ``default`` and a check/recall on ``mobile`` are
+provably talking to the same live directory and the same live mailbox, not
+two independent stand-ins.
+
+**Discovery, not a hardcoded handle** (SPEC-407 deliverable #2): every
+session directory handle is a fresh, random 16-character token
+(:data:`palaia_hub.directory.store.HANDLE_CHARS`), minted only at
+``directory_register`` time. Session B's handle is never passed to the
+``claude`` CLI anywhere — not in its prompt, not in its ``--mcp-config``,
+not in its environment. The only way session A's ``messenger_send`` call
+can address B correctly is to have actually called ``directory_query``
+against the live directory and read the handle back out of the result
+(exactly the pattern ``tests/gateway/test_messenger_tools.py``'s
+``test_two_real_client_sessions_exchange_request_and_reply`` already
+established for two scripted clients — this test's news is that one side
+is now a real model). A passing run is therefore proof of discovery by
+construction, not merely evidence consistent with it.
+
+Needs the real ``claude`` CLI on PATH; skipped, not failed, otherwise.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
+
+import anyio
+import httpx
+import pytest
+from fastmcp import Client
+from fastmcp.client.auth import BearerAuth
+
+_CLAUDE = shutil.which("claude")
+
+_HUB_SCRIPT = Path(__file__).parent / "support" / "hub_server_messenger.py"
+
+_STARTUP_TIMEOUT = 20.0
+_CLAUDE_TIMEOUT = 180.0
+
+OWNER_USERNAME = "owner"
+OWNER_PASSWORD = "a-long-enough-passphrase"  # noqa: S105 - test fixture
+VERIFIER = "scripted-client-code-verifier-with-enough-entropy-x"
+CALLBACK = "http://127.0.0.1:9999/callback"
+
+#: What session B registers as, *before* session A's CLI process ever
+#: starts — the live peer A has to find through the directory, exactly the
+#: role ``messaging_harness.py``'s ``seed_peer_scope`` plays for the
+#: SPEC-404 effectiveness probes, except this peer is a real, live,
+#: scripted MCP client instead of a placeholder nobody talks back to.
+B_SCOPE = "the Q3 billing rate-limiter incident"
+
+#: The fact session A must save to memory and hand off a *reference* to,
+#: never its full text, in the message body. Distinctive enough that it
+#: cannot appear in B's recall output by any route except having actually
+#: followed the ref into the vault A wrote it into.
+HANDOFF_FACT = (
+    "The billing retry batch is capped at 200 items because a larger batch "
+    "trips the downstream rate limiter; raising it needs the request queue "
+    "split first."
+)
+
+A_PROMPT = f"""You have a four-step task using the palaia MCP tools. Follow the steps \
+in order, using each tool's real output as the input to the next step — never invent \
+or guess a value.
+
+Step 1: Call directory_register with scope="investigating {B_SCOPE}" and \
+platform="claude-code". Keep the handle and session_secret it returns — you will \
+need both for every later step.
+
+Step 2: Call the memory write tool (the tool whose name ends in "_write") with \
+title="billing retry batch cap" and body set to exactly this text, unchanged: \
+"{HANDOFF_FACT}". Keep the permalink it returns.
+
+Step 3: Call directory_query with scope_contains="{B_SCOPE}". This returns exactly \
+one other session. Use its handle for step 4 — do not use any handle typed in this \
+prompt, because none is; the only correct handle is the one that tool call returns.
+
+Step 4: Call messenger_send with handle=<your own handle from step 1>, \
+session_secret=<your own session_secret from step 1>, to=<the handle from step 3>, \
+subject="billing retry cap handoff", message_type="handoff", \
+body="see the reference for the capped-batch decision and why", \
+refs=["memory://<the permalink from step 2>"].
+
+When all four steps succeed, reply with exactly one line: \
+DONE <your handle> <the handle from step 3> <the permalink from step 2>
+"""
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_health(port: int, timeout: float = _STARTUP_TIMEOUT) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/api/health", timeout=0.5
+            ) as resp:
+                if resp.status == 200:
+                    return
+        except (OSError, urllib.error.URLError) as exc:
+            last_error = exc
+            time.sleep(0.1)
+    raise RuntimeError(f"hub did not become healthy within {timeout}s: {last_error}")
+
+
+@dataclass
+class MessengerHub:
+    """A live SPEC-407 hub subprocess: real OAuth + plt_, two profiles
+    (``default``, ``mobile``), both carrying the same vault plus the
+    directory and messenger tool families."""
+
+    port: int
+    base_url: str
+    _process: subprocess.Popen[bytes]
+
+    def stop(self) -> None:
+        self._process.terminate()
+        try:
+            self._process.wait(timeout=10)
+        except subprocess.TimeoutExpired:  # pragma: no cover - defensive
+            self._process.kill()
+            self._process.wait(timeout=5)
+
+
+@pytest.fixture
+def messenger_hub(tmp_path: Path) -> Iterator[MessengerHub]:
+    port = _free_port()
+    home = tmp_path / "home"
+    home.mkdir()
+    log_path = tmp_path / "hub.log"
+    args = [
+        sys.executable,
+        str(_HUB_SCRIPT),
+        "--port",
+        str(port),
+        "--home",
+        str(home),
+        "--vault-dir",
+        str(tmp_path / "vault"),
+        "--username",
+        OWNER_USERNAME,
+        "--password",
+        OWNER_PASSWORD,
+        "--profiles",
+        "default,mobile",
+    ]
+    with log_path.open("w") as log_file:
+        process = subprocess.Popen(  # noqa: S603 - fixed argv, no shell
+            args, stdout=log_file, stderr=subprocess.STDOUT
+        )
+    try:
+        _wait_for_health(port)
+    except Exception:
+        process.terminate()
+        process.wait(timeout=5)
+        raise
+
+    hub = MessengerHub(port=port, base_url=f"http://127.0.0.1:{port}", _process=process)
+    try:
+        yield hub
+    finally:
+        hub.stop()
+
+
+def _csrf_and_sign_in(client: httpx.Client, base_url: str) -> None:
+    login_form = client.get(f"{base_url}/oauth/login")
+    match = re.search(r'name="csrf_token"\s+value="([^"]+)"', login_form.text)
+    assert match is not None, login_form.text
+    signed_in = client.post(
+        f"{base_url}/oauth/login",
+        data={
+            "username": OWNER_USERNAME,
+            "password": OWNER_PASSWORD,
+            "csrf_token": match.group(1),
+            "next": "",
+        },
+    )
+    assert signed_in.status_code == 303, signed_in.text
+    assert "palaia_oauth_session" in client.cookies
+
+
+def _admin_client(base_url: str) -> httpx.Client:
+    client = httpx.Client(base_url=base_url, timeout=15.0)
+    _csrf_and_sign_in(client, base_url)
+    client.headers["X-Palaia-CSRF"] = client.cookies["palaia_oauth_csrf"]
+    return client
+
+
+def _mint_plt_token(base_url: str, *, name: str, profile: str) -> str:
+    """A real SPEC-108 per-client token for session B, over the real
+    ``POST /api/auth/tokens`` REST surface — the credential shape any
+    non-OAuth client (a phone app, a scripted integration, a different
+    provider's agent runtime) carries instead of an OAuth token."""
+    client = _admin_client(base_url)
+    response = client.post(
+        "/api/auth/tokens",
+        json={
+            "name": name,
+            "profile": profile,
+            "scopes": [
+                "vault:work:read",
+                "vault:work:write",
+                "directory:read",
+                "directory:write",
+                "messenger:read",
+                "messenger:send",
+            ],
+        },
+    )
+    assert response.status_code == 200, response.text
+    return str(response.json()["token"])
+
+
+# --------------------------------------------------- OAuth PKCE (SPEC-209)
+
+
+def _challenge_for(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode()).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+
+
+def _get_real_access_token(base_url: str, profile: str) -> str:
+    """A scripted OAuth 2.1 + PKCE code-flow client, over a real socket —
+    identical protocol steps to ``test_spec209_client_matrix.py``'s and
+    ``test_spec308_phase3_gate.py``'s own ``_get_real_access_token``, kept
+    as its own copy here per this directory's house style: each
+    ``tests/e2e/`` file is a standalone script. No ``scope`` is requested,
+    so the authorization server issues this profile's full grantable set —
+    including ``directory:*``/``messenger:*`` now that they are part of
+    ``_profile_scopes`` (the scope-ceiling fix this SPEC's task named:
+    before it, an OAuth client could never be granted those scopes at all,
+    only a ``plt_`` token could)."""
+    client = httpx.Client(base_url=base_url, follow_redirects=False, timeout=10.0)
+
+    response = client.get(f"/mcp/{profile}/")
+    assert response.status_code == 401, response.text
+    challenge = response.headers["www-authenticate"]
+    metadata_url = challenge.split('resource_metadata="', 1)[1].split('"', 1)[0]
+
+    resource_metadata = client.get(urlsplit(metadata_url).path).json()
+    as_metadata = client.get("/.well-known/oauth-authorization-server").json()
+
+    registered = client.post(
+        urlsplit(as_metadata["registration_endpoint"]).path,
+        json={"client_name": "spec-407-scripted", "redirect_uris": [CALLBACK]},
+    )
+    assert registered.status_code == 201, registered.text
+    client_id = registered.json()["client_id"]
+
+    _csrf_and_sign_in(client, "")
+
+    authorized = client.get(
+        urlsplit(as_metadata["authorization_endpoint"]).path,
+        params={
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": CALLBACK,
+            "code_challenge": _challenge_for(VERIFIER),
+            "code_challenge_method": "S256",
+            "state": "opaque-state",
+            "resource": resource_metadata["resource"],
+        },
+    )
+    assert authorized.status_code == 303, authorized.text
+    code = parse_qs(urlsplit(authorized.headers["location"]).query)["code"][0]
+
+    tokens = client.post(
+        urlsplit(as_metadata["token_endpoint"]).path,
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": client_id,
+            "redirect_uri": CALLBACK,
+            "code_verifier": VERIFIER,
+        },
+    )
+    assert tokens.status_code == 200, tokens.text
+    return str(tokens.json()["access_token"])
+
+
+def _run_claude(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    assert _CLAUDE is not None
+    return subprocess.run(
+        [_CLAUDE, *args], cwd=cwd, capture_output=True, text=True, timeout=_CLAUDE_TIMEOUT
+    )
+
+
+# ------------------------------------------------------------------ the test
+
+
+@pytest.mark.skipif(_CLAUDE is None, reason="claude CLI not on PATH")
+def test_two_agents_on_different_providers_hand_off_work_through_palaia(
+    messenger_hub: MessengerHub, tmp_path: Path
+) -> None:
+    """SPEC-407's exit criterion, literally: session A (the real ``claude``
+    CLI, OAuth, profile ``default``) registers, saves a fact to memory,
+    discovers session B through the directory (never told its handle), and
+    hands it off with a ``memory://`` reference. Session B (a scripted
+    ``fastmcp.Client``, a real SPEC-108 ``plt_`` token, profile ``mobile``)
+    checks its inbox and follows the reference — the assertion is on B's
+    real recall output, not on A's transcript."""
+
+    # --- B registers first: the live peer A has to find through the
+    # directory, never told to A by name.
+    plt_token = _mint_plt_token(messenger_hub.base_url, name="second-provider-b", profile="mobile")
+
+    async def _register_b() -> tuple[str, str]:
+        transport = f"{messenger_hub.base_url}/mcp/mobile/"
+        async with Client(transport, auth=BearerAuth(plt_token)) as client:
+            result = await client.call_tool(
+                "directory_register",
+                {
+                    "scope": B_SCOPE,
+                    "platform": "second-provider-shaped-client (scripted fastmcp.Client; "
+                    "this sandbox has no codex binary — SPEC-209's own wire-level "
+                    "equivalence pin applies here too)",
+                    "agent_kind": "reviewer",
+                },
+            )
+            assert not result.is_error, result.content
+            session = result.structured_content["session"]
+            return str(session["handle"]), str(result.structured_content["session_secret"])
+
+    b_handle, b_secret = anyio.run(_register_b)
+
+    # --- A: the real claude CLI, over a real OAuth 2.1 + PKCE code flow,
+    # against the "default" profile. Never told b_handle anywhere.
+    access_token = _get_real_access_token(messenger_hub.base_url, "default")
+    work_dir = tmp_path / "claude-project"
+    work_dir.mkdir()
+    mcp_config = json.dumps(
+        {
+            "mcpServers": {
+                "palaia": {
+                    "type": "http",
+                    "url": f"{messenger_hub.base_url}/mcp/default/",
+                    "headers": {"Authorization": f"Bearer {access_token}"},
+                }
+            }
+        }
+    )
+
+    completed = _run_claude(
+        [
+            "-p",
+            A_PROMPT,
+            "--mcp-config",
+            mcp_config,
+            "--strict-mcp-config",
+            "--allowedTools",
+            "mcp__palaia",
+            "--output-format",
+            "json",
+        ],
+        cwd=work_dir,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout)
+    assert payload.get("is_error") is False, payload
+
+    # --- B checks its own inbox (its own handle/secret — never A's) and
+    # should find exactly the handoff A just sent.
+    async def _check_and_recall() -> tuple[list[dict[str, object]], str]:
+        transport = f"{messenger_hub.base_url}/mcp/mobile/"
+        async with Client(transport, auth=BearerAuth(plt_token)) as client:
+            inbox = await client.call_tool(
+                "messenger_check", {"handle": b_handle, "session_secret": b_secret}
+            )
+            assert not inbox.is_error, inbox.content
+            envelopes = inbox.structured_content["envelopes"]
+            assert envelopes, (
+                "B's inbox was empty — A never sent (or never discovered B). "
+                f"claude's reply was: {payload.get('result')!r}"
+            )
+            handoffs = [e for e in envelopes if e["type"] == "handoff"]
+            assert handoffs, f"no handoff envelope arrived: {envelopes}"
+            envelope = handoffs[0]
+            assert envelope["to"] == b_handle
+            refs = envelope["refs"]
+            assert refs, f"handoff carried no memory:// ref: {envelope}"
+
+            recalled = await client.call_tool("work_memory_recall", {"ref": refs[0]})
+            assert not recalled.is_error, recalled.content
+            return envelopes, str(recalled.structured_content)
+
+    envelopes, recalled_repr = anyio.run(_check_and_recall)
+
+    # The assertion that matters: B's real, literal recall output contains
+    # A's exact fact — the handoff carried knowledge, not just an envelope.
+    assert HANDOFF_FACT in recalled_repr, (
+        f"B's recall output did not contain A's fact.\n"
+        f"envelopes B received: {envelopes}\n"
+        f"recall result: {recalled_repr}\n"
+        f"claude's own reply: {payload.get('result')!r}"
+    )

--- a/v3/server/tests/effectiveness/test_spec407_skill_driven_handoff.py
+++ b/v3/server/tests/effectiveness/test_spec407_skill_driven_handoff.py
@@ -1,0 +1,122 @@
+"""SPEC-407 deliverable #3: the Phase-4 gate's skill-driven variant.
+
+The scripted e2e in ``server/tests/e2e/test_spec407_phase4_gate.py`` proves
+the *mechanism* works: told exactly what to do, session A can register,
+save a fact, discover a peer through the directory and hand off a
+``memory://`` reference — every one of the four steps spelled out. This
+suite asks a different, harder question: with **only the task and the
+skills loaded — the prompt never mentions the messenger, the directory, or
+any tool by name — does a real agent reach for the handoff on its own?**
+
+That question can only be answered by running a model, never by reading the
+skill (see ``harness.py``'s module docstring), and the honest way to run it
+is the one already built for exactly this in SPEC-404:
+``messaging_harness.py``'s ``HANDOFF_PROMPT``/``CHECK_PROMPT`` probes, its
+``sent_handoff_with_ref``/``registered`` predicates, and its seeded live
+peer. This file adds nothing to that machinery — it runs it again, ``PALAIA_
+EFFECTIVENESS_ATTEMPTS`` (default 3, this SPEC's stated budget) real times
+per probe, and reports the rate **without a hard assert on the behaviour**.
+
+This is the one difference from ``test_messenger_effectiveness.py``
+(SPEC-404's own suite, which *does* hard-assert "at least one of N attempts
+hit"): SPEC-407 asks for this evidence to be recorded honestly, as a rate,
+"not a hard assert" — deliberately weaker than SPEC-404's own bar, because
+this is gate evidence about how often the behaviour happens unprompted, not
+a regression test for whether the skill still works at all (SPEC-404's
+suite already is that test, stays green, and is not touched here). Every
+run is still asserted to have actually completed (a non-empty reply) —
+that is the harness working, not the skill.
+
+Same opt-in gate as every effectiveness suite — real model calls, real
+money, a CLI not every runner has::
+
+    PALAIA_EFFECTIVENESS=1 uv run pytest \\
+        server/tests/effectiveness/test_spec407_skill_driven_handoff.py -s -v
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from .harness import ProbeResult, default_attempts, skip_reason
+from .messaging_harness import (
+    CHECK_PROMPT,
+    HANDOFF_PROMPT,
+    SEED_PEER_SCOPE,
+    hit_rate,
+    registered,
+    run_messaging_series,
+    sent_handoff_with_ref,
+)
+
+_SKIP = skip_reason()
+pytestmark = pytest.mark.skipif(_SKIP is not None, reason=_SKIP or "")
+
+
+def _report(label: str, results: list[ProbeResult]) -> None:
+    print(f"\n## {label}")
+    for result in results:
+        print(result.summary())
+
+
+def test_skill_driven_handoff_rate_is_recorded_honestly(tmp_path: Path) -> None:
+    """SPEC-407 deliverable #3, session A's half: given only an end-of-shift
+    task (never mentioning a tool by name) and the memory + messenger
+    skills, how often does a real agent register itself *and* hand off with
+    a memory:// reference, unprompted? Reported as a rate; not asserted
+    either way — a low number is exactly as much this gate's evidence as a
+    high one."""
+    attempts = default_attempts()
+    results = run_messaging_series(
+        label="SPEC-407 skill-driven handoff",
+        prompt=HANDOFF_PROMPT,
+        workdir=tmp_path / "runs",
+        skills=("palaia-memory", "palaia-messenger"),
+        mount_vault=True,
+        seed_peer_scope=SEED_PEER_SCOPE,
+        attempts=attempts,
+    )
+    _report("skill-driven handoff", results)
+    registered_rate = hit_rate(results, registered)
+    handoff_rate = hit_rate(results, sent_handoff_with_ref)
+    print("\n### SPEC-407 gate evidence — skill-driven handoff, unprompted")
+    print(f"- attempts: {attempts}")
+    print(f"- registered with the directory: {registered_rate}")
+    print(f"- sent a handoff carrying a memory:// ref (not a pasted copy): {handoff_rate}")
+
+    assert len(results) == attempts
+    for result in results:
+        assert result.reply.strip(), (
+            f"a run produced no reply at all — the harness itself is broken, "
+            f"not just a miss. Tools seen: {result.tools_used}"
+        )
+
+
+def test_skill_driven_check_rate_is_recorded_honestly(tmp_path: Path) -> None:
+    """SPEC-407 deliverable #3, session B's half: given only a "get
+    oriented" task that never says "message", "inbox" or "check", how often
+    does a real agent check its inbox unprompted? Reported as a rate, not
+    asserted."""
+    attempts = default_attempts()
+    results = run_messaging_series(
+        label="SPEC-407 skill-driven check-on-start",
+        prompt=CHECK_PROMPT,
+        workdir=tmp_path / "runs",
+        skills=("palaia-messenger",),
+        mount_vault=False,
+        attempts=attempts,
+    )
+    _report("skill-driven check-on-start", results)
+    checked_rate = hit_rate(results, lambda r: r.called("messenger_check"))
+    print("\n### SPEC-407 gate evidence — skill-driven check-on-start, unprompted")
+    print(f"- attempts: {attempts}")
+    print(f"- checked its inbox unprompted: {checked_rate}")
+
+    assert len(results) == attempts
+    for result in results:
+        assert result.reply.strip(), (
+            f"a run produced no reply at all — the harness itself is broken, "
+            f"not just a miss. Tools seen: {result.tools_used}"
+        )


### PR DESCRIPTION
## Summary

SPEC-407 Phase-4 gate evidence: **two agents on different providers hand off work through palaia**.

- **Two-agent handoff e2e** (`server/tests/e2e/test_spec407_phase4_gate.py`, new hub script `support/hub_server_messenger.py`): the real `claude` CLI (OAuth, profile `default`) registers, saves a fact to memory, discovers a live peer through the session directory by a scope query — **never a hardcoded handle**, provably so since directory handles are fresh random 16-char tokens the CLI's prompt/config never carries — and hands it off with a `memory://` reference instead of the fact itself. A scripted `fastmcp.Client` (real SPEC-108 `plt_` token, profile `mobile`) checks its inbox and follows the reference with `recall`; the assertion is on B's real, literal recall output containing A's exact fact.
- **A real quirk found and fixed in this PR**: [byte5ai/palaia#257](https://github.com/byte5ai/palaia/issues/257) — minting a `plt_` token with `directory:*`/`messenger:*` scopes was rejected outright by `POST /api/auth/tokens` (`palaia_hub/auth/store.py`'s scope regex only ever matched `vault:<key>:read|write`). This is the `plt_`-side twin of the OAuth scope-ceiling bug SPEC-403 already fixed on the OAuth side. Fixed here because this SPEC's own acceptance depended on it (session B cannot register/check its inbox without it); regression test added.
- **Skill-driven variant** (`server/tests/effectiveness/test_spec407_skill_driven_handoff.py`, reusing SPEC-404's own harness, env-gated `PALAIA_EFFECTIVENESS=1`, real model calls): 3 real attempts per probe (this SPEC's stated budget) — unprompted handoff-with-ref 3/3, unprompted check-on-start 3/3 — reported as a rate, **not hard-asserted**, per the SPEC.
- **Docs**: `docs/client-matrix-results.md` §8 (dated evidence, full trace, honest gaps) and a draft Phase-4 gate paragraph appended to `IMPLEMENTATION.md` §6, marked "(draft — the architect holds the gate)".

## Acceptance checklist

- [x] the two-agents handoff e2e passes and asserts knowledge transfer (A's fact in B's output) — run **four** times, no flakes (33.36s, 37.85s, 32.59s, 33.44s)
- [x] discovery via directory query, not hardcoded handles — proven by construction (B's handle is a random token never passed to the CLI anywhere)
- [x] skill-driven rate documented from ≥3 real runs — 3/3 and 3/3, real money spent ($0.9767 total), reported honestly
- [x] docs updated with dated evidence (`client-matrix-results.md` §8, 2026-08-25); full suite green at the end

## Verification evidence

```
$ cd v3 && uv sync                                    # ok
$ uv run ruff check server                            # All checks passed!
$ uv run mypy server/src                               # Success: no issues found in 185 source files
$ uv run pytest server/tests -q
1986 passed, 23 skipped in 429.13s

$ uv run pytest server/tests/e2e/test_spec407_phase4_gate.py -q   # x4
1 passed in 33.36s / 37.85s / 32.59s / 33.44s — no flakes

$ uv run pytest server/tests/e2e -q     # 36 tests, no regression
36 passed in 186.85s

$ PALAIA_EFFECTIVENESS=1 uv run pytest server/tests/effectiveness/test_spec407_skill_driven_handoff.py -s -v
2 passed in 231.09s — handoff 3/3, check-on-start 3/3
```

## Honest gaps (see `client-matrix-results.md` §8.5 for the full list)

- No real second AI provider binary in this sandbox (no `codex`) — session B is a second-provider-*shaped* scripted `fastmcp.Client`, the same wire-level substitution SPEC-209/308 already made.
- No real public tunnel in front of the hub (same standing gap as §2/§7.4).
- Claude Desktop's/claude.ai's own UI, and the owner's phone test, remain exactly as unverified as before — out of this SPEC's non-goals.
- Claude Code's `claude/channel` push capability is not exercised (pinned `fastmcp` 3.4.7 has no support for declaring it — `docs/messenger.md` §8 already says so); pull-based `messenger_check` is what's exercised, which is the universal baseline the SPEC treats as sufficient.
- The skill-driven rate (3/3, 3/3) is six real runs, not a claim about the general-case rate — SPEC-404's own regression suite is where a lower future rate would show up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790261734&installation_model_id=428086&pr_number=258&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F258&signature=ed0074803f4edba33e60abd8d9f9e92c0593cd12205814aa756a86a2f96bbb4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->