### PR TITLE
feat(v3): SPEC-505 v2 sunset messaging + migration path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,18 @@ ___________  |  | _____  |__|____
 
 ---
 
-> **palaia v3 is in the making.** A ground-up rewrite — self-hosted infrastructure that
-> unifies memory, MCP tools, and agent communication across AI providers — is being
-> planned under [`v3/`](v3/MASTERPLAN.md). palaia v2 (this README) remains the stable
-> release line; hotfixes continue on the [`v2-maintenance`](https://github.com/byte5ai/palaia/tree/v2-maintenance) branch.
+> **palaia v3 is on its way — a ground-up rewrite.** A self-hosted hub that
+> unifies memory, MCP tools, and agent communication across AI providers, replacing
+> the package-per-machine install below. Track progress in
+> [`v3/MASTERPLAN.md`](v3/MASTERPLAN.md).
+>
+> **v2 (this README) is now maintenance-only.** It stays fully installable and keeps
+> receiving hotfixes (security, data loss, broken release) on the
+> [`v2-maintenance`](https://github.com/byte5ai/palaia/tree/v2-maintenance) branch —
+> no new features land here. Nobody is stranded: when v3 is ready for you,
+> [the migration guide](v3/docs/migrate-from-v2.md) covers what carries over
+> (all of it — one command imports your existing knowledge, unchanged), what
+> changes, what v3 doesn't have yet, and how to roll back if you change your mind.
 
 ---
 

--- a/v3/docs/migrate-from-v2.md
+++ b/v3/docs/migrate-from-v2.md
@@ -1,0 +1,133 @@
+# Moving from palaia v2 to v3
+
+> User-facing companion to [`import-mappings.md`](import-mappings.md), the
+> field-by-field mapping the importer implements. This page answers "should
+> I move, and what happens when I do" in plain language; the other page is
+> the reference for exactly how each field lands.
+
+## The short version
+
+palaia v3 is a full rewrite: one self-hosted hub your AI tools all connect
+to, instead of a Python package each machine installs separately. v2 still
+works and still gets hotfixes — nobody has to move today. When you're ready,
+your existing knowledge comes with you: one command reads your old store and
+writes every entry into a new v3 memory library, unchanged, alongside its
+full history of where it came from.
+
+v2's own [README](../../README.md) has the current support policy and the
+link back to this page.
+
+## What carries over
+
+Everything you saved. The importer reads your v2 store (the `hot/`, `warm/`,
+`cold/` folders — whichever database it used to index them doesn't matter,
+the entries themselves live in those folders) and writes each one into a
+v3 memory library as its own file, with its title, tags, body, and where it
+came from all preserved. Run it with:
+
+```bash
+palaia-hub import v2 /path/to/.palaia --vault /path/to/new/vault --vault-name personal
+```
+
+Add `--dry-run --json` first to get a report of exactly what would be
+created — and what can't be, with a reason for each — before anything is
+written. Drop `--dry-run` to actually write. The full field-by-field mapping
+(what a v2 "memory" becomes, how tiers and scopes translate, what happens to
+an unrecognized entry type) is in
+[`import-mappings.md`](import-mappings.md#palaia-v2--v3).
+
+Running the same command again is safe and does nothing new — every entry
+already imported is recognized and skipped, so re-running after saving a few
+more things in v2 only brings over what's new.
+
+## What changes
+
+- **One hub, not one install per machine.** v2 was a Python package each
+  project or machine installed on its own. v3 is a single server you run
+  once (self-hosted, on your own hardware); every AI tool connects to it
+  over the network instead of loading a local package.
+- **Every tool reconnects on its own.** There's no single "migrate my
+  setup" switch — each AI tool (Claude Desktop, Claude Code, Codex, and the
+  rest) gets pointed at the new hub individually, the same way you first
+  connected it to v2. The hub's own setup pages walk through each one by
+  name.
+- **New credentials.** v2's access, where it had any, doesn't carry over.
+  Each tool gets its own new sign-in to the hub, so one tool losing its
+  credential never affects another.
+- **The browser view moved and grew up.** v2's optional, localhost-only
+  browser explorer is replaced by the hub's always-on web dashboard —
+  reachable from any device on your network, not just the machine it runs
+  on, and it is where sign-in, the memory library, and every tool's
+  connection status now live.
+
+## What v3 doesn't have yet
+
+This list is built by checking off every command in v2's own
+[CLI reference](../../docs/cli-reference.md) against what v3 ships today —
+not written from memory. "Carried" means the same capability exists, though
+often reached a different way (a screen in the dashboard, or a tool your AI
+calls, rather than a line you type). "Missing" means it plain doesn't exist
+yet; don't move a workflow that depends on one of these until it lands.
+
+| v2 command | Status in v3 | Notes |
+|---|---|---|
+| `palaia write`, `query`, `get`, `list`, `edit` | Carried, changed | Your AI tools save and search through their own built-in connection to the hub; the dashboard's memory library also lists, opens, and edits entries by hand. No standalone command-line equivalent. |
+| `palaia init`, `setup claude-code`, `setup --multi-agent` | Carried, changed | The hub's first-run setup screen and per-tool connect pages replace these; nothing to run per machine. |
+| `palaia ui` | Carried, changed | Always-on web dashboard, reachable from any device on the network — not a localhost-only, opt-in extra. |
+| `palaia status`, `upgrade` | Carried, changed | Health lives in the dashboard; updates are one click from there instead of a command. |
+| `palaia curate analyze`, `curate apply` | Carried | The curator runs the same two-pass review, now on a schedule or on demand via `palaia-hub curator run` / `curator apply`. |
+| `palaia project create/list/show/write/query/set-scope/set-owner/delete` | Carried, changed | Multiple memory libraries and their access scopes are a dashboard/config concern now, not a `project` subcommand. |
+| `palaia memo send/broadcast/inbox/ack/gc` | Carried, changed | Replaced by the built-in agent-to-agent messenger (structured handoffs between sessions), not a like-for-like command. |
+| `palaia config list/get/set/set-chain/set-alias/get-aliases/remove-alias` | Carried, changed | One `config.yaml` plus dashboard settings screens; no `set-chain`/alias equivalent — v3's embedding setup is one choice, not a fallback chain. |
+| `palaia warmup`, `embed-server` | Carried, changed | Indexing and embeddings run inside the hub process; there's no separate server to start or index to pre-warm by hand. |
+| `palaia mcp-server --read-only` | Carried, changed | Read-only access is a scope on a tool's own credential, granted when it's connected — not a server flag. |
+| `palaia doctor` | **Missing** | No guided diagnose-and-fix pass yet. The dashboard surfaces connection and health problems as they occur, but nothing walks you through fixing them. |
+| `palaia prune`, `gc` (knowledge cleanup, decay-based) | **Missing** | v3 records the same tiering data on import (`import.tier`, `import.decay_seed`) but nothing yet recomputes or prunes by it — see the honest scope note in [`import-mappings.md`](import-mappings.md#cold-embed-as-a-background-job-honest-scope-note). |
+| `palaia priorities` (injection budget control) | **Missing** | No equivalent yet. |
+| `palaia ingest <source>` (document indexing) | **Missing** | No bulk "index this folder of documents" command yet. |
+| `palaia sync export/import` (git-based exchange) | Carried, changed | Every v3 memory library already keeps its own version history as it's written — nothing separate to export or import. |
+| `palaia package export/import/info` (portable bundles) | **Missing** | No portable-bundle format yet; a memory library is moved by moving/copying its files directly. |
+| `palaia process list/run` | **Missing** | No equivalent yet. |
+| `palaia lock/unlock` | **Missing** | No equivalent yet — nothing in v3 currently needs a project-level lock. |
+| `palaia instance set/get/clear` (session identity) | Carried, changed | Each tool's own hub credential is its identity; no separate instance concept. |
+| `palaia recover` | **Missing** | No equivalent yet; the version history every memory library keeps is the closest safety net today. |
+| `palaia detect` (provider detection) | **Missing** | Providers are configured explicitly rather than auto-detected. |
+| `palaia skill` | Carried, changed | Each AI tool gets its own connect-and-teach package from the hub's setup pages, in that tool's own format — not one printed file. |
+
+If something you rely on is marked **Missing** above, stay on v2 for that
+workflow — it keeps getting hotfixes on `v2-maintenance` — and re-check this
+page later; it's kept current as v3 gains ground.
+
+## Rolling back
+
+The importer only ever *reads* your v2 store. It never opens it for writing,
+never deletes an entry, and never touches its database — nothing about your
+v2 install changes by running it, whether you `--dry-run` or actually apply.
+If a v3 import doesn't look right, delete the `imported/v2/` folder it wrote
+inside your new memory library (or just discard the whole new library) and
+try again — v2 is exactly as it was before you started, still fully
+installed and fully usable, and importing again later picks up right where
+it left off.
+
+## Support timeline
+
+<!-- DECISION NEEDED (owner): fill in real dates before this page ships
+     publicly. The structure below is fixed by this page's own plan; the dates are not.
+     Until filled in, treat every bracketed line as a placeholder, not a
+     commitment. -->
+
+- v2 is in **maintenance mode now**: no new features, hotfixes only
+  (security, data loss, a broken release), landing on `v2-maintenance`.
+- **[DECISION: date]** — target date by which v3 reaches feature parity
+  with the items marked Missing above that the owner considers
+  release-blocking.
+- **[DECISION: date]** — earliest date v2 hotfixes are expected to stop.
+  Not before the parity date above, and not without advance notice on the
+  v2 README and in this document.
+- **[DECISION: policy]** — how much advance notice a support-ending change
+  gets (e.g., "at least N months," announced in the v2 README banner and
+  the project's release notes).
+
+No entry in this list is enforced by anything in this repository; it is
+prose the owner is expected to fill in and keep current, not a promise the
+software makes on its own.

--- a/v3/server/tests/test_migration_guide_copy_lint.py
+++ b/v3/server/tests/test_migration_guide_copy_lint.py
@@ -1,0 +1,25 @@
+"""SPEC-505 acceptance criterion "jargon lint on all new prose", applied to
+the migration guide this SPEC adds.
+
+Reuses the one shared blocklist (:mod:`palaia_addon_sdk.jargon` — see that
+module's docstring: "the SDK now owns the canonical copy"), the same list
+``skill_lint.py`` checks skills against and SPEC-503 commits to running over
+the docs site's prose. Fenced code blocks, inline code and table rows are
+stripped first (the same exemption those callers use): a table cell naming
+the real v2 command (``palaia curate analyze``) or a code block showing the
+real import invocation is not jargon, it is the string a reader has to type.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from palaia_addon_sdk.jargon import find_jargon
+
+DOC = Path(__file__).resolve().parents[2] / "docs" / "migrate-from-v2.md"
+
+
+def test_migration_guide_prose_has_no_jargon() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    hits = find_jargon(text)
+    assert hits == [], f"jargon found in {DOC}: {hits}"

--- a/v3/server/tests/test_migration_guide_import_roundtrip.py
+++ b/v3/server/tests/test_migration_guide_import_roundtrip.py
@@ -1,0 +1,78 @@
+"""SPEC-505 acceptance criterion: "migration guide's import command
+round-trips a real v2 fixture store" — reuses SPEC-111's golden fixtures
+(``server/tests/fixtures/import-v2``, the same store ``test_v2_import.py``
+and ``test_cli_import.py`` exercise) and runs the exact command line
+published in ``docs/migrate-from-v2.md``, byte for byte, so the doc can
+never drift from what the CLI actually accepts.
+
+Also verifies the guide's rollback claim ("the importer only ever *reads*
+your v2 store... nothing about your v2 install changes") for real: every
+file under the fixture store is hashed before and after both the dry run
+and the real apply, and nothing may differ.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+
+import pytest
+
+from palaia_hub.cli import main
+
+DOC = Path(__file__).resolve().parents[2] / "docs" / "migrate-from-v2.md"
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "import-v2"
+
+#: Pulled out of the doc itself (inside its fenced ```bash block) rather than
+#: retyped here, so a change to the published command is caught the moment
+#: the doc and the CLI's actual argument parsing disagree.
+_COMMAND_RE = re.compile(r"```bash\n(palaia-hub import v2 [^\n]+)\n```")
+
+
+def _published_command() -> list[str]:
+    text = DOC.read_text(encoding="utf-8")
+    match = _COMMAND_RE.search(text)
+    assert match, f"no `palaia-hub import v2 ...` fenced command found in {DOC}"
+    return match.group(1).split()
+
+
+def _tree_hashes(root: Path) -> dict[str, str]:
+    return {
+        str(path.relative_to(root)): hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def test_published_command_round_trips_the_golden_v2_fixture(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    argv = _published_command()
+    # argv[3] is the placeholder source path ("/path/to/.palaia"); swap in
+    # the real golden fixture, same as a reader would swap in their own path.
+    assert argv[:3] == ["palaia-hub", "import", "v2"]
+    argv[3] = str(FIXTURE)
+    vault_root = tmp_path / "vault"
+    vault_index = argv.index("--vault")
+    argv[vault_index + 1] = str(vault_root)
+
+    before = _tree_hashes(FIXTURE)
+
+    main(argv[1:])  # main() takes argv without the program name
+    first_run = capsys.readouterr().out
+
+    after_apply = _tree_hashes(FIXTURE)
+    assert after_apply == before, "the v2 fixture store must never be modified by import"
+
+    assert (vault_root / "imported" / "v2").is_dir()
+    assert "created" in first_run
+
+    # Re-running the identical published command is the guide's idempotence
+    # claim ("does nothing new") — every permalink already resolves.
+    main(argv[1:])
+    second_run = capsys.readouterr().out
+    assert "created: 0" in second_run or "\"created\": 0" in second_run
+
+    after_second = _tree_hashes(FIXTURE)
+    assert after_second == before, "a re-run must also never modify the v2 fixture store"

--- a/v3/site/docs/astro.config.mjs
+++ b/v3/site/docs/astro.config.mjs
@@ -28,6 +28,14 @@ export default defineConfig({
             { label: "What is palaia?", slug: "index" },
             { label: "Install it", slug: "install" },
             { label: "Your first shared memory", slug: "first-shared-memory" },
+            {
+              label: "Moving from v2?",
+              // The guide itself lives with the rest of the engineering docs
+              // (v3/docs/), not in this site's own content — same pattern as
+              // the "For developers" links below, one canonical copy.
+              link: "https://github.com/byte5ai/palaia/blob/main/v3/docs/migrate-from-v2.md",
+              attrs: { target: "_blank", rel: "noreferrer" },
+            },
           ],
         },
         {

--- a/v3/site/docs/src/content/docs/developers.md
+++ b/v3/site/docs/src/content/docs/developers.md
@@ -64,6 +64,14 @@ shapes and the safe subset of conditions an automation can express (never
 a general scripting language — a deliberate limit) are documented at
 [`v3/docs/events.md`](https://github.com/byte5ai/palaia/blob/main/v3/docs/events.md).
 
+## Coming from the previous version
+
+The version before this one is still fully supported, on its own separate
+branch, for anyone not ready to move. If you're one of its users, start
+with the [migration guide](https://github.com/byte5ai/palaia/blob/main/v3/docs/migrate-from-v2.md)
+instead — it covers what carries over, what changes, and what this version
+doesn't do yet.
+
 ## Running the server yourself
 
 The hub itself — the program this whole site is documentation *for* — is


### PR DESCRIPTION
## Summary

Completes SPEC-505 (v2 sunset messaging + migration path), deliverables 1, 2, and 4. Deliverable 3 (v2-maintenance banner/notice) is a **separate PR** targeting `v2-maintenance` per AGENTS.md's two-track rules — see below.

This finishes work a prior agent left uncommitted in this worktree. I verified its claims against the SPEC, found the substance complete and correct, added the one missing piece (the docs-site nav link), merged the base branch forward, and ran full verification before committing.

- Top-level `README.md`: v3 launch pointer + v2 sunset statement (maintenance-only, hotfixes via `v2-maintenance`, link to the migration guide). This is the one sanctioned root-level cross-reference (AGENTS.md).
- `v3/docs/migrate-from-v2.md`: full migration guide — what carries over (`palaia-hub import v2`, real command), what changes, a v2 command/feature gap table built by comparing against v2's own CLI reference (not hand-waved), rollback story (verified: importer never modifies the v2 store), and a support-timeline template with owner decision points clearly flagged (`[DECISION: ...]`).
- Docs-site nav slot for the guide, which was missing: a "Moving from v2?" link under **Start here** in `v3/site/docs/astro.config.mjs`, plus a short pointer section on the **For developers** page — both linking to the canonical copy in `v3/docs/` rather than forking the content into the site.
- Two new tests: the guide's published import command round-trips SPEC-111's golden v2 fixture store (including idempotence and a before/after file-hash check proving the v2 store is untouched), and the guide's prose passes the shared jargon blocklist.

**Diff scope verified**: this PR touches only `README.md` outside `v3/` — confirmed directly from `git diff --stat` against the merge base, no other root files change.

## Checklist (honest)

- [x] `main`-branch (this PR's base is the v3 integration branch) diff touches only the top-level README + `v3/` files
- [x] migration guide's import command round-trips a real v2 fixture store (test added, passing)
- [x] v2 gap list generated by comparison against v2's CLI reference, not memory
- [ ] v2-maintenance PR (deliverable 3) — separate PR, see below, not part of this diff
- [x] jargon lint green on all new prose (migration guide + the two docs-site edits)
- [x] support timeline ships as a template with decision points, not invented dates (owner's call, per SPEC non-goals)

## Verification

Run from `v3/` in a fresh worktree after merging `origin/claude/palaia-major-rewrite-lj5v9x` (fast-forward, no conflicts — grepped for `<<<<<<<` before committing, none found):

```
uv sync
uv run ruff check server        # All checks passed!
uv run mypy server/src          # Success: no issues found in 191 source files
uv run pytest server/tests -q   # 2150 passed, 23 skipped, 138 warnings
```

The two migration-specific tests and the full `docs_site` jargon-lint suite (now covering the new nav copy) pass on their own too:

```
uv run pytest server/tests/test_migration_guide_copy_lint.py \
  server/tests/test_migration_guide_import_roundtrip.py \
  server/tests/docs_site -q
# 23 passed
```

## Notes

- This completes a prior agent's uncommitted work (README + migration guide + two tests were written but never committed). I re-verified all of it against the SPEC rather than trusting the "done" claim at face value, and it held up — the one gap was the docs-site nav link, which I added.
- Deliverable 3 (v2's own README banner, once-per-day CLI deprecation notice, SKILL.md pointers) is intentionally **not** in this diff — it's a separate PR against `v2-maintenance`, opened alongside this one, per the hard separation rules.
- The support-timeline section in the migration guide ships with real `[DECISION: ...]` placeholders for the owner to fill in dates/policy — nothing here invents a sunset date, matching the SPEC's non-goals.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790298696&installation_model_id=428086&pr_number=268&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F268&signature=e05e8bbe09966a67e32246a1c5b436ea547e0a86044384106e9566ec989e44ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->