### PR TITLE
fix: v2 sunset banner, once-per-day deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ ___________  |  | _____  |__|____
 
 ---
 
+> **This version (v2) is in maintenance mode.** It stays fully installable and
+> keeps receiving hotfixes (security, data loss, a broken release) — no new
+> features land here. A ground-up rewrite, v3, is under active development;
+> when you're ready to move, [the migration guide](https://github.com/byte5ai/palaia/blob/main/v3/docs/migrate-from-v2.md)
+> covers what carries over, what changes, and how to roll back if you change
+> your mind. Nobody has to move today.
+
+---
+
 ## What palaia Does
 
 AI agents are stateless by default. Every session starts from scratch — no memory of past decisions, no shared knowledge between agents, no context that survives a restart.

--- a/SKILL.md
+++ b/SKILL.md
@@ -829,4 +829,10 @@ If `palaia doctor --fix` cannot resolve an issue, report the full error output t
 
 ---
 
+## Moving to v3
+
+This is palaia v2 — in maintenance mode: it stays fully installable and keeps getting hotfixes, but no new features. A ground-up rewrite, v3, is under active development. See the [migration guide](https://github.com/byte5ai/palaia/blob/main/v3/docs/migrate-from-v2.md) for what carries over, what changes, and how to roll back if you change your mind.
+
+---
+
 (c) 2026 byte5 GmbH -- MIT License

--- a/packages/openclaw-plugin/skill/SKILL.md
+++ b/packages/openclaw-plugin/skill/SKILL.md
@@ -829,4 +829,10 @@ If `palaia doctor --fix` cannot resolve an issue, report the full error output t
 
 ---
 
+## Moving to v3
+
+This is palaia v2 — in maintenance mode: it stays fully installable and keeps getting hotfixes, but no new features. A ground-up rewrite, v3, is under active development. See the [migration guide](https://github.com/byte5ai/palaia/blob/main/v3/docs/migrate-from-v2.md) for what carries over, what changes, and how to roll back if you change your mind.
+
+---
+
 (c) 2026 byte5 GmbH -- MIT License

--- a/palaia/SKILL.md
+++ b/palaia/SKILL.md
@@ -829,4 +829,10 @@ If `palaia doctor --fix` cannot resolve an issue, report the full error output t
 
 ---
 
+## Moving to v3
+
+This is palaia v2 — in maintenance mode: it stays fully installable and keeps getting hotfixes, but no new features. A ground-up rewrite, v3, is under active development. See the [migration guide](https://github.com/byte5ai/palaia/blob/main/v3/docs/migrate-from-v2.md) for what carries over, what changes, and how to roll back if you change your mind.
+
+---
+
 (c) 2026 byte5 GmbH -- MIT License

--- a/palaia/cli.py
+++ b/palaia/cli.py
@@ -34,6 +34,7 @@ from palaia.cli_commands import (  # noqa: E402
     cmd_status,
 )
 from palaia.cli_helpers import (  # noqa: E402, I001
+    check_v2_sunset_notice,
     check_version_nag,
     detect_current_agent as _detect_current_agent,
     json_out as _json_out,
@@ -1585,6 +1586,8 @@ def main():
     if not args.command:
         parser.print_help()
         return 1
+
+    check_v2_sunset_notice(args)
 
     # Gatekeeper: block store commands without valid init
     if not _check_gatekeeper(args.command):

--- a/palaia/cli_helpers.py
+++ b/palaia/cli_helpers.py
@@ -17,6 +17,45 @@ from palaia.config import (
 )
 
 
+def check_v2_sunset_notice(args) -> None:
+    """Print a one-line reminder that v2 is maintenance-only, at most once
+    per calendar day (SPEC-505 deliverable 3).
+
+    Skipped entirely in JSON mode, so it never lands in a script's parsed
+    output. The "last shown" marker lives under the home directory (or
+    ``PALAIA_HOME``, the same override :func:`palaia.config.find_palaia_root`
+    honors — this keeps test runs and alternate installs from touching a
+    developer's real home directory) rather than a project's own store, so
+    the once-per-day limit holds across every store on the machine, not
+    per-project — and it still works before a store has been initialized
+    at all.
+    """
+    if getattr(args, "json", False):
+        return
+    try:
+        import datetime
+
+        today = datetime.date.today().isoformat()
+        env_home = os.environ.get("PALAIA_HOME")
+        base = Path(env_home) if env_home else Path.home() / ".palaia"
+        marker = base / ".v2_sunset_notice_shown"
+        if marker.exists() and marker.read_text().strip() == today:
+            return
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(today)
+    except Exception:
+        return
+    from palaia.ui import info_msg
+
+    print(
+        info_msg(
+            "palaia v2 is in maintenance mode. v3 is a ground-up rewrite — "
+            "see the migration guide: https://github.com/byte5ai/palaia/blob/main/v3/docs/migrate-from-v2.md"
+        ),
+        file=sys.stderr,
+    )
+
+
 def json_out(data, args):
     """Print JSON if --json flag is set, return True if printed."""
     if getattr(args, "json", False):

--- a/skills/palaia/SKILL.md
+++ b/skills/palaia/SKILL.md
@@ -829,4 +829,10 @@ If `palaia doctor --fix` cannot resolve an issue, report the full error output t
 
 ---
 
+## Moving to v3
+
+This is palaia v2 — in maintenance mode: it stays fully installable and keeps getting hotfixes, but no new features. A ground-up rewrite, v3, is under active development. See the [migration guide](https://github.com/byte5ai/palaia/blob/main/v3/docs/migrate-from-v2.md) for what carries over, what changes, and how to roll back if you change your mind.
+
+---
+
 (c) 2026 byte5 GmbH -- MIT License


### PR DESCRIPTION
## Summary

SPEC-505 deliverable 3 — the v2-maintenance half of v2 sunset messaging, kept in its own PR per AGENTS.md's two-track rules (never merges into `main` or the v3 branch).

- `README.md`: a maintenance-status banner (still fully installable, still gets hotfixes — no new features) with a link to the v3 migration guide on `main`.
- `palaia/cli.py` / `palaia/cli_helpers.py`: a new `check_v2_sunset_notice()` prints one line pointing at the migration guide on CLI startup, **at most once per calendar day** — tracked by a marker file under the home directory (or `PALAIA_HOME`, the same override `find_palaia_root()` already honors). Skipped entirely in `--json` mode so it never lands in a script's parsed output.
- All four `SKILL.md` copies (`SKILL.md`, `palaia/SKILL.md`, `skills/palaia/SKILL.md`, `packages/openclaw-plugin/skill/SKILL.md` — kept byte-identical, verified with `diff` before and after) gain the same pointer under a new "Moving to v3" section.

No functional v2 behavior changes — this is messaging only.

## Test plan

- [x] `python3 -m pytest tests/ -q` run from a fresh clone of `v2-maintenance` with this branch checked out
- [x] Targeted re-run of every test file touching the changed code (`test_init_gatekeeper.py`, `test_nudge_tracker.py`, `test_skill.py`, `test_doctor.py`, `test_ux_improvements.py`, `test_multi_agent.py`, `test_config_detection.py`) — **161 passed, 2 skipped**, clean
- [x] `ruff check palaia/cli.py palaia/cli_helpers.py` — clean
- [x] Manual smoke test of the once-per-day notice: shows on the first command of the day, silent on the second, marker file correctly stamped with the date

### Honest note on the full suite

`python3 -m pytest tests/ -q` on this branch reports **4 failed, 1183 passed, 38 skipped, 5 xpassed, 17 errors**. All of it is pre-existing and unrelated to this diff — confirmed by running the identical test files against the unmodified `v2-maintenance` tip (`git stash` this PR's changes, same failures, same errors):

- `tests/test_mcp_server.py` (2 failed + 15 errors): the installed `mcp` SDK resolved to `2.x` in this environment, and v2's code is written against the `mcp<2` `FastMCP` API (`mcp.server.fastmcp` no longer exists in 2.x). An environment/dependency-pinning issue, not a code regression from this PR.
- `tests/test_webui.py` (2 failed): `test_filter_by_source_manual` and `test_manual_entries_rank_above_auto_at_equal_decay` — pre-existing assertion failures in auto-capture tagging/ranking logic, untouched by this diff.

Not fixing either — out of scope for a messaging-only sunset PR, and the task instructions are explicit about reporting pre-existing failures honestly rather than patching unrelated v2 code.

## Notes

This is SPEC-505 deliverable 3. Deliverables 1, 2, and 4 are in a separate PR against the v3 integration branch (top-level README pointer + the full `v3/docs/migrate-from-v2.md` migration guide this PR links to).


---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790298991&installation_model_id=428086&pr_number=269&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F269&signature=5fd6afaf8ebcf93f65bbcf9b2fda9815d783c22af63d36aa694caab632cca614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->