### PR TITLE
feat(v3): onboarding page + first-run funnel (SPEC-504)

### DIFF
--- a/v3/docs/security/threat-model.md
+++ b/v3/docs/security/threat-model.md
@@ -148,6 +148,7 @@ See [§8](#8-accepted-risks-and-open-gaps).
 | `/api/notifications` | the dashboard notification centre | |
 | `/api/connect` | the connect page's client bundles (MCPB) | |
 | `/api/update` | release-channel update check against GHCR (SPEC-501) — read-only, outbound fetch is size/time-capped, "cannot check" is a state not an error | makes one outbound registry request |
+| `/api/funnel` | local-only first-run funnel status — wizard-step timestamps, time-to-first-memory (SPEC-504) — **read-only**, never accepts a caller-supplied timestamp | every value it returns was set from a real server-side event, never from a request; `server/tests/funnel/test_no_egress.py` proves the whole path never opens a socket |
 | `/api/_test` | a deliberately slow endpoint for shutdown testing | **only exists when `PALAIA_TEST_SLOW_ENDPOINT_SECONDS` is set**; never in a shipped hub |
 
 | Threat | Mitigation as built | Where |

--- a/v3/server/src/palaia_hub/app.py
+++ b/v3/server/src/palaia_hub/app.py
@@ -48,6 +48,8 @@ from .events import (
     start_background_tasks,
     stop_background_tasks,
 )
+from .funnel import FunnelStore, wire_funnel_tracking
+from .funnel_api import build_funnel_router
 from .gateway import DynamicGateway, GatewayASGI, VaultService
 from .gateway.api import build_gateway_profiles_router
 from .gateway.apps.hub_status_app import HubStatusDeps, build_hub_status_server
@@ -549,6 +551,15 @@ def create_app(
     app.state.start_time = start_time
     app.state.event_bus = event_bus
     hub_home = home or palaia_home()
+
+    # SPEC-504: local-only first-run funnel instrumentation (MASTERPLAN
+    # §13's time-to-first-memory metric, §10's "no data leaves the host"
+    # principle — see palaia_hub.funnel's module docstring for the privacy
+    # contract). Always wired, the same "every hub has one" posture as
+    # ModeAuditLog below: a plain in-process bus consumer, nothing about
+    # the bus or the events it reacts to knows the funnel exists.
+    funnel_store = FunnelStore(hub_home)
+    wire_funnel_tracking(event_bus, funnel_store)
     # Middleware order matters here and is the whole point of this block.
     # Starlette builds the stack so that the LAST `add_middleware` call is
     # the OUTERMOST layer, so these three are added innermost-first:
@@ -725,8 +736,13 @@ def create_app(
         )
     )
 
+    # SPEC-504: always mounted, same posture as the modes router above — a
+    # hub has a funnel store from its first boot, whether or not a vault
+    # exists yet.
+    app.include_router(build_funnel_router(funnel_store))
+
     if token_store is not None:
-        app.include_router(build_auth_router(token_store))
+        app.include_router(build_auth_router(token_store, dynamic_gateway=dynamic_gateway))
 
     # SPEC-203: the OAuth surface goes at the app root (RFC 8414/9728 fix the
     # `.well-known` paths there) and before the dashboard mount, which claims
@@ -764,6 +780,7 @@ def create_app(
                 indexes=indexes,
                 dynamic_gateway=dynamic_gateway,
                 curator=curator_wiring,
+                event_bus=event_bus,
             )
         )
 

--- a/v3/server/src/palaia_hub/auth/routes.py
+++ b/v3/server/src/palaia_hub/auth/routes.py
@@ -9,15 +9,48 @@ posture), not by a per-request credential check; SPEC-108's token/profile
 auth is for MCP *clients*, not the dashboard. A dashboard login is
 tracked separately (MASTERPLAN §5.5's "local account" / IdP sign-in,
 Phase 2) and out of this SPEC's scope.
+
+**SPEC-504 first-run funnel audit fix**: before this SPEC, an empty
+``scopes`` list (what every dashboard caller — ``ConnectPanel.tsx``'s
+"Issue token", which the onboarding wizard's own step 4 is a thin wrapper
+around — has only ever sent; there is no scope picker in the UI) meant a
+token that authenticates but then fails ``missing_scope_error``'s
+per-action check on literally every memory-tool call, on any hub whose
+mounted profile actually enforces scopes (``auth_enabled: true``, the
+default in every mode, not only cloud/open). That made the wizard's own
+target shape — "connect first client -> write first memory from the
+client" — impossible to complete on a hub with auth on, which is the
+common case. Fixed here, not by adding a scope picker (real, but a bigger
+UI change than this instrumentation SPEC): an empty ``scopes`` list now
+means "grant read+write on every vault the named profile mounts, right
+now" — the same trust an unscoped ``plt_`` token already implied everywhere
+*else* auth is optional (see :func:`palaia_hub.auth.enforcement.
+missing_scope_error`'s own docstring on the locked-mode-with-no-verifier
+case) — rather than silently meaning "nothing". An explicit, non-empty
+``scopes`` list (a future scope picker's real use case) is still honored
+exactly as given.
 """
 
 from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, ConfigDict, Field
 
 from .models import CreatedToken, TokenInfo
+from .scopes import vault_scope
 from .store import TokenError, TokenStore
+
+if TYPE_CHECKING:
+    # Deferred: only needed for the type hint below, and importing it at
+    # module load time would reach back into `palaia_hub.gateway`, which
+    # itself imports from this package (`palaia_hub.auth.policy`) — safe in
+    # practice (that submodule is already fully loaded by the time either
+    # side needs it) but fragile to depend on import order for. `TYPE_
+    # CHECKING` sidesteps the question entirely: this name never actually
+    # executes at runtime.
+    from ..gateway.dynamic import DynamicGateway
 
 
 class CreateTokenRequest(BaseModel):
@@ -28,14 +61,43 @@ class CreateTokenRequest(BaseModel):
     scopes: list[str] = Field(default_factory=list)
 
 
-def build_auth_router(store: TokenStore) -> APIRouter:
-    """Build the ``/api/auth/tokens`` router, backed by ``store``."""
+def _default_scopes_for_profile(dynamic_gateway: DynamicGateway, profile: str) -> list[str]:
+    """Read+write on every vault ``profile`` mounts right now, or ``[]``
+    when the profile does not exist yet (a token can be pre-provisioned for
+    a profile the wizard has not created — that stays today's "no scopes
+    yet" behavior, not this default)."""
+    for candidate in dynamic_gateway.config.profiles:
+        if candidate.path == profile:
+            return [
+                vault_scope(key, permission)
+                for key in candidate.vaults
+                for permission in ("read", "write")
+            ]
+    return []
+
+
+def build_auth_router(
+    store: TokenStore, *, dynamic_gateway: DynamicGateway | None = None
+) -> APIRouter:
+    """Build the ``/api/auth/tokens`` router, backed by ``store``.
+
+    Args:
+        store: as before this SPEC.
+        dynamic_gateway: given, an empty ``scopes`` list in a create-token
+            request is defaulted to read+write on every vault the named
+            profile currently mounts (see the module docstring's SPEC-504
+            note). Omitted, behavior is unchanged from before this SPEC — an
+            empty list is created exactly as sent.
+    """
     router = APIRouter(prefix="/api/auth/tokens", tags=["auth"])
 
     @router.post("", response_model=CreatedToken)
     async def create_token(body: CreateTokenRequest) -> CreatedToken:
+        scopes = body.scopes
+        if not scopes and dynamic_gateway is not None:
+            scopes = _default_scopes_for_profile(dynamic_gateway, body.profile)
         try:
-            return store.create(body.name, body.profile, body.scopes)
+            return store.create(body.name, body.profile, scopes)
         except TokenError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 

--- a/v3/server/src/palaia_hub/dashboard_api.py
+++ b/v3/server/src/palaia_hub/dashboard_api.py
@@ -47,6 +47,7 @@ from pydantic import BaseModel, ConfigDict
 
 from .curator.profile import CURATOR_PROFILE_PATH
 from .curator.wiring import CuratorWiring
+from .events.bus import EventBus, publish_event
 from .gateway.config import DEFAULT_GATEWAY_PROFILE, VaultMountConfig
 from .gateway.dynamic import DynamicGateway
 from .gateway.vault_protocol import (
@@ -252,11 +253,17 @@ def build_dashboard_router(
     indexes: dict[str, VaultIndex] | None = None,
     dynamic_gateway: DynamicGateway | None = None,
     curator: CuratorWiring | None = None,
+    event_bus: EventBus | None = None,
 ) -> APIRouter:
     """Build the wizard + explorer router, bound to ``registry``.
 
     Args:
         registry: as before this SPEC.
+        event_bus: given, a successful ``POST /api/vaults`` also publishes
+            ``memory.vault.created`` (SPEC-504) — the wizard-step timestamp
+            the local-only funnel store (:mod:`palaia_hub.funnel`) keys its
+            "time to first vault" off of. Omitted, vault creation behaves
+            exactly as before this parameter existed.
         indexes: the hub's ``{vault_key: VaultIndex}`` mapping (SPEC-210).
             Given, a vault created here also gets a real
             :class:`~palaia_hub.index.VaultIndex` opened and added to this
@@ -317,6 +324,15 @@ def build_dashboard_router(
             if curator is not None:
                 profile_paths.append(CURATOR_PROFILE_PATH)
             await dynamic_gateway.add_vault(mount, service, profile_paths=profile_paths)
+
+        if event_bus is not None:
+            publish_event(
+                event_bus,
+                "memory.vault.created",
+                origin="dashboard",
+                vault=body.key,
+                data={"key": body.key, "purpose": body.purpose},
+            )
 
         return _vault_out(body.key, engine.info())
 

--- a/v3/server/src/palaia_hub/events/schema.py
+++ b/v3/server/src/palaia_hub/events/schema.py
@@ -42,6 +42,13 @@ EventName = Literal[
     "hub.started",
     "hub.mode_changed",
     "client.connected",
+    # SPEC-504: the wizard's "first vault" step, fired once per
+    # `POST /api/vaults` call (dashboard_api.build_dashboard_router). Named
+    # `memory.vault.*` (not `vault.*`) to sit next to `memory.entry.*` in
+    # this vocabulary — both describe the same "memory" concept the rest of
+    # the public API talks about. Additive to the v1 vocabulary, same rule
+    # as every other addition below.
+    "memory.vault.created",
     "memory.entry.created",
     "memory.entry.updated",
     "memory.entry.deleted",

--- a/v3/server/src/palaia_hub/funnel.py
+++ b/v3/server/src/palaia_hub/funnel.py
@@ -1,0 +1,202 @@
+"""SPEC-504 deliverable #3: local-only first-run funnel instrumentation.
+
+MASTERPLAN §13's success metric is time-to-first-memory (install -> first
+entry), and §10's privacy principle is "no data leaves the host unless the
+user connects something that reads it." This module is where those two
+promises meet: it records the timestamps behind that metric, and it never
+does anything a request could carry off-box.
+
+**Local-only, by construction, not by policy** — this module imports no
+HTTP client, opens no socket, and makes no outbound call of any kind. The
+only I/O it performs is reading and writing one JSON file
+(``funnel_stats.json``) under the hub's own home directory, through the
+same atomic-write primitive :mod:`palaia_hub.modes.audit` uses for the mode
+audit log. ``server/tests/funnel/test_no_egress.py`` proves this by
+patching ``socket.socket`` to raise and driving the whole funnel path (hub
+boot, vault creation, a client connecting, a first memory write) through
+it without a failure — there is no code path here that could reach for a
+socket even if a bug tried to.
+
+**What "install" means here**: nothing inside the hub process can observe
+the actual `docker run`/`docker compose up` moment (that happens before
+any palaia code runs at all), so this module uses the hub's own first-ever
+boot as the practical proxy for "install" — :meth:`FunnelStore.record_hub_
+started` only ever sets ``hub_started_at`` once, the very first time a hub
+runs against a given home directory; every later restart is a no-op. That
+matches MASTERPLAN §13's own framing ("install -> first entry") more
+closely than timing from the wizard's first HTTP request would: a wizard
+that sits open in a forgotten browser tab for an hour must not inflate the
+number, and it does not, because the clock started at boot, not at click.
+
+**Event-driven, not client-timestamped**: every timestamp here is set from
+a real hub-side event (:mod:`palaia_hub.events.bus`) the moment the
+underlying thing actually happened server-side — never from a timestamp a
+browser tab sends over the wire. A wizard tab left open, backgrounded, or
+revisited cannot skew this number, and neither can a client that lies
+about when it thinks something happened.
+
+**Known funnel-audit finding, documented rather than fixed here** (SPEC-504
+deliverable #2's "document each change honestly; larger redesigns become
+filed issues, not scope creep"): the wizard's "start from a template"
+switch (``CreateVaultRequest.template`` in :mod:`palaia_hub.dashboard_api`)
+writes its two seed notes through the same code path a real capture does,
+so each one is itself a ``memory.entry.created`` event. A wizard run with
+that switch on records a near-zero time-to-first-memory — the seed note,
+not the client's own first write. That switch defaults to *off*
+(``Onboarding.tsx``), so this does not affect the common path, but making
+"first memory" mean "first memory a *client* wrote" rather than "first
+note that exists" would need the vault engine to carry attribution through
+to the public event (nothing in :mod:`palaia_hub.vault.events` does today)
+— real, but more than this SPEC's instrumentation deliverable, so it is
+named here rather than silently absorbed into a bigger change.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from .config import palaia_home
+from .events.bus import EventBus
+from .events.schema import Envelope
+from .vault.atomic import atomic_write_text
+
+STATS_FILE = "funnel_stats.json"
+
+
+def format_duration(seconds: float) -> str:
+    """Render an elapsed duration the way the dashboard shows it: ``"4m12s"``.
+
+    Deliberately terse (no "hours, minutes and seconds" prose) — this is a
+    tile label, read at a glance next to "Vaults" and "Clients", not a
+    sentence. Seconds are always shown once the total drops under an hour
+    so "37s" and "4m12s" both read as exact, not rounded.
+    """
+    total = max(0, round(seconds))
+    hours, remainder = divmod(total, 3600)
+    minutes, secs = divmod(remainder, 60)
+    if hours:
+        return f"{hours}h{minutes:02d}m"
+    if minutes:
+        return f"{minutes}m{secs:02d}s"
+    return f"{secs}s"
+
+
+@dataclass(frozen=True, slots=True)
+class FunnelStatus:
+    """The dashboard hub-status surface's whole view of the funnel."""
+
+    hub_started_at: float | None
+    vault_created_at: float | None
+    client_connected_at: float | None
+    first_memory_at: float | None
+
+    @property
+    def time_to_first_memory_seconds(self) -> float | None:
+        """``None`` until both ends of the measurement exist."""
+        if self.hub_started_at is None or self.first_memory_at is None:
+            return None
+        return max(0.0, self.first_memory_at - self.hub_started_at)
+
+    @property
+    def time_to_first_memory_display(self) -> str | None:
+        seconds = self.time_to_first_memory_seconds
+        return None if seconds is None else format_duration(seconds)
+
+
+class FunnelStore:
+    """Reads and writes ``funnel_stats.json`` under the hub's home directory.
+
+    Same shape of contract as :class:`palaia_hub.modes.audit.ModeAuditLog`:
+    one small JSON file, atomic writes, no database. Every ``record_*``
+    method is first-write-wins — calling it again after a value is already
+    set is a no-op, both because a restart must not reset the funnel's
+    start line and because "first client connected"/"first memory" are, by
+    definition, about the *first* occurrence.
+    """
+
+    def __init__(self, home: Path | None = None) -> None:
+        self.home = Path(home).expanduser() if home is not None else palaia_home()
+        self.path = self.home / STATS_FILE
+
+    def _load(self) -> dict[str, float | None]:
+        if not self.path.exists():
+            return {
+                "hub_started_at": None,
+                "vault_created_at": None,
+                "client_connected_at": None,
+                "first_memory_at": None,
+            }
+        raw = json.loads(self.path.read_text(encoding="utf-8"))
+        return {
+            "hub_started_at": raw.get("hub_started_at"),
+            "vault_created_at": raw.get("vault_created_at"),
+            "client_connected_at": raw.get("client_connected_at"),
+            "first_memory_at": raw.get("first_memory_at"),
+        }
+
+    def _save(self, data: dict[str, float | None]) -> None:
+        self.home.mkdir(parents=True, exist_ok=True)
+        atomic_write_text(self.path, json.dumps(data))
+
+    def _record_once(self, key: str, ts: float | None) -> None:
+        data = self._load()
+        if data[key] is not None:
+            return
+        data[key] = ts if ts is not None else time.time()
+        self._save(data)
+
+    def record_hub_started(self, ts: float | None = None) -> None:
+        self._record_once("hub_started_at", ts)
+
+    def record_vault_created(self, ts: float | None = None) -> None:
+        self._record_once("vault_created_at", ts)
+
+    def record_client_connected(self, ts: float | None = None) -> None:
+        self._record_once("client_connected_at", ts)
+
+    def record_first_memory(self, ts: float | None = None) -> None:
+        self._record_once("first_memory_at", ts)
+
+    def status(self) -> FunnelStatus:
+        data = self._load()
+        return FunnelStatus(
+            hub_started_at=data["hub_started_at"],
+            vault_created_at=data["vault_created_at"],
+            client_connected_at=data["client_connected_at"],
+            first_memory_at=data["first_memory_at"],
+        )
+
+
+def wire_funnel_tracking(event_bus: EventBus, store: FunnelStore) -> Callable[[], None]:
+    """Subscribe ``store`` to the four events the funnel cares about.
+
+    Same posture as the hooks/automations dispatchers in
+    :mod:`palaia_hub.app`: a plain in-process bus consumer that the bus
+    itself knows nothing special about. Returns the unsubscribe callable
+    :meth:`~palaia_hub.events.bus.EventBus.on` hands back.
+    """
+
+    def _on_event(envelope: Envelope) -> None:
+        if envelope.event == "hub.started":
+            store.record_hub_started(envelope.ts)
+        elif envelope.event == "memory.vault.created":
+            store.record_vault_created(envelope.ts)
+        elif envelope.event == "client.connected":
+            store.record_client_connected(envelope.ts)
+        elif envelope.event == "memory.entry.created":
+            store.record_first_memory(envelope.ts)
+
+    return event_bus.on(_on_event)
+
+
+__all__ = [
+    "STATS_FILE",
+    "FunnelStatus",
+    "FunnelStore",
+    "format_duration",
+    "wire_funnel_tracking",
+]

--- a/v3/server/src/palaia_hub/funnel_api.py
+++ b/v3/server/src/palaia_hub/funnel_api.py
@@ -1,0 +1,59 @@
+"""``GET /api/funnel/status`` — the dashboard hub-status surface's read side
+of :mod:`palaia_hub.funnel` (SPEC-504 deliverable #3).
+
+Always mounted, the same posture as ``/api/health``/``/api/info``
+(:mod:`palaia_hub.app`): every hub has a funnel store from the moment it
+first boots, whether or not a vault exists yet, so there is nothing to
+opt into. Read-only by design — every timestamp behind this response comes
+from a real server-side event (see the module docstring on
+:mod:`palaia_hub.funnel`), never from anything a request body could set,
+so there is no way for a client to fabricate its own "set up in 4m12s."
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+from pydantic import BaseModel, ConfigDict
+
+from .funnel import FunnelStore
+
+
+class FunnelStatusOut(BaseModel):
+    """The wizard-step timestamps plus the derived time-to-first-memory.
+
+    Every ``*_at`` field is a Unix timestamp (seconds) or ``null`` when
+    that step has not happened yet on this hub. ``time_to_first_memory_
+    seconds``/``_display`` are ``null`` until both ``hub_started_at`` and
+    ``first_memory_at`` are set.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    hub_started_at: float | None
+    vault_created_at: float | None
+    client_connected_at: float | None
+    first_memory_at: float | None
+    time_to_first_memory_seconds: float | None
+    time_to_first_memory_display: str | None
+
+
+def build_funnel_router(store: FunnelStore) -> APIRouter:
+    """Build the ``/api/funnel`` router bound to ``store``."""
+    router = APIRouter(tags=["funnel"])
+
+    @router.get("/api/funnel/status", response_model=FunnelStatusOut)
+    async def funnel_status() -> FunnelStatusOut:
+        status = store.status()
+        return FunnelStatusOut(
+            hub_started_at=status.hub_started_at,
+            vault_created_at=status.vault_created_at,
+            client_connected_at=status.client_connected_at,
+            first_memory_at=status.first_memory_at,
+            time_to_first_memory_seconds=status.time_to_first_memory_seconds,
+            time_to_first_memory_display=status.time_to_first_memory_display,
+        )
+
+    return router
+
+
+__all__ = ["FunnelStatusOut", "build_funnel_router"]

--- a/v3/server/src/palaia_hub/gateway/dynamic.py
+++ b/v3/server/src/palaia_hub/gateway/dynamic.py
@@ -85,7 +85,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
 
@@ -161,6 +161,23 @@ class DynamicGateway:
             ``config.yaml`` at startup does.
         token_verifiers: optional per-profile-path verifier, same contract
             as :func:`~.build.build_gateway`.
+        auth_provider_factory: SPEC-504 first-run funnel audit fix. Given,
+            :meth:`add_vault` calls it for any profile path it is about to
+            mount for the first time and no verifier already covers (a
+            brand-new path — the common "hub had zero vaults, wizard just
+            created the first one" case ``token_verifiers`` above cannot
+            cover, because that path did not exist yet when this gateway
+            was constructed). Its result, when not ``None``, is cached into
+            ``self._token_verifiers`` exactly like an entry that had been
+            in the constructor's own ``token_verifiers`` all along — every
+            later rebuild of that path reuses the same verifier, never
+            calls the factory again. Omitted, a genuinely new path mounts
+            with whatever ``token_verifiers`` already had for it (``None``
+            if nothing did) — the pre-SPEC-504 behavior, which is how a
+            hub with no auth configured at all (``auth_enabled: false``)
+            is meant to keep working: the factory itself is what decides
+            "nothing to verify with" versus "a verifier exists", not this
+            class.
         profile_middleware: optional per-profile-path fastmcp middleware,
             same contract as :func:`~.build.build_gateway` — re-applied on
             every rebuild of that profile (SPEC-206: the curator profile's
@@ -196,6 +213,7 @@ class DynamicGateway:
         *,
         mode: str = "locked",
         token_verifiers: Mapping[str, TokenVerifier] | None = None,
+        auth_provider_factory: Callable[[str], TokenVerifier | None] | None = None,
         profile_middleware: Mapping[str, Sequence[Middleware]] | None = None,
         stash_service: StashService | None = None,
         upstream_service: UpstreamService | None = None,
@@ -208,6 +226,7 @@ class DynamicGateway:
         self._vault_servers: dict[str, FastMCP] = _build_vault_servers(config, self._vault_services)
         self._mode = mode
         self._token_verifiers: dict[str, TokenVerifier] = dict(token_verifiers or {})
+        self._auth_provider_factory = auth_provider_factory
         self._profile_middleware: dict[str, Sequence[Middleware]] = dict(
             profile_middleware or {}
         )
@@ -301,6 +320,26 @@ class DynamicGateway:
             self._config = self._config.model_copy(
                 update={"profiles": list(profiles_by_path.values())}
             )
+
+            # SPEC-504 first-run funnel audit fix: a profile path that has
+            # never been mounted before (the overwhelmingly common case for
+            # the very first vault a fresh install's wizard creates — see
+            # this class's docstring on `auth_provider_factory`) has no
+            # entry in `self._token_verifiers` yet, because it did not
+            # exist when this gateway — or the last config-driven rebuild
+            # that repopulated `token_verifiers` — was built. Left
+            # unfilled, `_request_mount` below would mount it with no
+            # verifier at all, silently serving it unauthenticated even on
+            # a hub with `auth_enabled: true` (the default in every mode,
+            # not only cloud/open). Ask the factory once per path; cache
+            # whatever it returns so every later rebuild of this same path
+            # reuses it without calling the factory again.
+            if self._auth_provider_factory is not None:
+                for path in profile_paths:
+                    if path not in self._token_verifiers:
+                        verifier = self._auth_provider_factory(path)
+                        if verifier is not None:
+                            self._token_verifiers[path] = verifier
 
             for path in profile_paths:
                 await self._request_mount(profiles_by_path[path])

--- a/v3/server/src/palaia_hub/serve.py
+++ b/v3/server/src/palaia_hub/serve.py
@@ -328,11 +328,29 @@ async def build_production_app(
         resources=oauth_server.resources if oauth_server is not None else None,
         token_store=token_store if config.auth_enabled else None,
     )
+
+    def _auth_provider_for(path: str) -> Any | None:
+        """SPEC-504 first-run funnel audit fix: the same recipe
+        `token_verifiers` above was built with, for exactly one profile
+        path — called by `DynamicGateway.add_vault` the first time it
+        mounts a path `token_verifiers` never covered (no vaults existed
+        yet at hub-startup, so no profile — and no verifier — did either).
+        Without this, the wizard's very first vault would mount its
+        `default` profile with no auth check at all, on every fresh
+        install, regardless of `auth_enabled`."""
+        return build_profile_auth(
+            [path],
+            key=oauth_server.key if oauth_server is not None else None,
+            resources=oauth_server.resources if oauth_server is not None else None,
+            token_store=token_store if config.auth_enabled else None,
+        ).get(path)
+
     dynamic_gateway = DynamicGateway(
         gateway_config,
         vault_services,
         mode=config.mode,
         token_verifiers=token_verifiers,  # type: ignore[arg-type]
+        auth_provider_factory=_auth_provider_for,
         profile_middleware=curator.profile_middleware if curator else None,
         stash_service=stash_service,
         upstream_service=upstream_service,

--- a/v3/server/tests/auth/test_routes_default_scopes.py
+++ b/v3/server/tests/auth/test_routes_default_scopes.py
@@ -1,0 +1,142 @@
+"""SPEC-504 first-run funnel audit fix: an empty ``scopes`` list on
+``POST /api/auth/tokens`` — what every dashboard caller has ever sent, there
+being no scope picker in the UI — now defaults to read+write on every vault
+the named profile mounts, when a ``dynamic_gateway`` is wired in. See
+``palaia_hub.auth.routes``'s module docstring for the bug this closes: an
+empty list used to mean a token that authenticates but can call nothing,
+which made the wizard's own "connect a client, write the first memory"
+target shape fail on any hub actually enforcing scopes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from palaia_hub.app import create_app
+from palaia_hub.auth.store import TokenStore
+from palaia_hub.config import HubConfig
+from palaia_hub.gateway.config import GatewayConfig, ProfileConfig, VaultMountConfig
+from palaia_hub.gateway.dynamic import DynamicGateway
+from palaia_hub.gateway.fake_vault import FakeVaultService
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+async def _client_with_mounted_profile(tmp_path: Path) -> TestClient:
+    config = GatewayConfig(
+        vaults=[VaultMountConfig(key="work", name="work", purpose="Work vault.")],
+        profiles=[ProfileConfig(path="default", vaults=["work"])],
+    )
+    dynamic_gateway = DynamicGateway(config, {"work": FakeVaultService()})
+    await dynamic_gateway.start()
+    app = create_app(
+        HubConfig(),
+        token_store=TokenStore(home=tmp_path),
+        dynamic_gateway=dynamic_gateway,
+        home=tmp_path,
+    )
+    return TestClient(app)
+
+
+async def test_empty_scopes_default_to_every_mounted_vault_read_and_write(
+    tmp_path: Path,
+) -> None:
+    client = await _client_with_mounted_profile(tmp_path)
+
+    response = client.post(
+        "/api/auth/tokens", json={"name": "first-client", "profile": "default", "scopes": []}
+    )
+
+    assert response.status_code == 200
+    scopes = response.json()["info"]["scopes"]
+    assert sorted(scopes) == ["vault:work:read", "vault:work:write"]
+
+
+async def test_scopes_omitted_entirely_defaults_the_same_way(tmp_path: Path) -> None:
+    client = await _client_with_mounted_profile(tmp_path)
+
+    response = client.post("/api/auth/tokens", json={"name": "first-client", "profile": "default"})
+
+    assert response.status_code == 200
+    scopes = response.json()["info"]["scopes"]
+    assert sorted(scopes) == ["vault:work:read", "vault:work:write"]
+
+
+async def test_explicit_scopes_are_never_overridden(tmp_path: Path) -> None:
+    client = await _client_with_mounted_profile(tmp_path)
+
+    response = client.post(
+        "/api/auth/tokens",
+        json={"name": "read-only-client", "profile": "default", "scopes": ["vault:work:read"]},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["info"]["scopes"] == ["vault:work:read"]
+
+
+async def test_a_profile_that_does_not_exist_yet_still_gets_no_scopes(tmp_path: Path) -> None:
+    """Pre-provisioning a token for a profile the wizard has not created
+    yet must keep working exactly as before this fix — there is nothing to
+    default *to*."""
+    client = await _client_with_mounted_profile(tmp_path)
+
+    response = client.post(
+        "/api/auth/tokens", json={"name": "future-client", "profile": "not-mounted-yet"}
+    )
+
+    assert response.status_code == 200
+    assert response.json()["info"]["scopes"] == []
+
+
+def test_without_a_dynamic_gateway_empty_scopes_stay_empty(tmp_path: Path) -> None:
+    """Every call site that omits ``dynamic_gateway`` (every test and
+    embedding that predates this SPEC) must see the exact pre-SPEC-504
+    behavior — an empty list stays empty."""
+    app = create_app(HubConfig(), token_store=TokenStore(home=tmp_path), home=tmp_path)
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/auth/tokens", json={"name": "a", "profile": "default", "scopes": []}
+    )
+
+    assert response.status_code == 200
+    assert response.json()["info"]["scopes"] == []
+
+
+async def test_a_profile_mounting_two_vaults_gets_scopes_for_both(tmp_path: Path) -> None:
+    config = GatewayConfig(
+        vaults=[
+            VaultMountConfig(key="work", name="work"),
+            VaultMountConfig(key="personal", name="personal"),
+        ],
+        profiles=[ProfileConfig(path="default", vaults=["work", "personal"])],
+    )
+    dynamic_gateway = DynamicGateway(
+        config, {"work": FakeVaultService(), "personal": FakeVaultService()}
+    )
+    await dynamic_gateway.start()
+    app = create_app(
+        HubConfig(),
+        token_store=TokenStore(home=tmp_path),
+        dynamic_gateway=dynamic_gateway,
+        home=tmp_path,
+    )
+    client = TestClient(app)
+
+    response = client.post("/api/auth/tokens", json={"name": "a", "profile": "default"})
+
+    assert response.status_code == 200
+    assert sorted(response.json()["info"]["scopes"]) == [
+        "vault:personal:read",
+        "vault:personal:write",
+        "vault:work:read",
+        "vault:work:write",
+    ]

--- a/v3/server/tests/docs_site/test_onboarding_jargon_lint.py
+++ b/v3/server/tests/docs_site/test_onboarding_jargon_lint.py
@@ -1,0 +1,69 @@
+"""SPEC-504 acceptance criterion "jargon lint green", for the onboarding
+page specifically.
+
+``test_docs_jargon_lint.py`` (SPEC-503) only scans ``.md`` files under
+``src/content/docs`` — the onboarding page is a custom Astro component
+(``src/pages/onboarding.astro``, not a content-collection entry; see that
+file's own docstring for why), so it needs its own coverage rather than
+falling out of that discovery loop by accident.
+
+Only the rendered template is checked, not the whole file: the frontmatter
+script fence (``---...---``) and the ``<script>``/``<style>`` blocks are
+developer-facing code (comments naming this SPEC, CSS selectors, a
+``dataset.copyTarget`` property access) that a reader never sees — the
+same reasoning ``find_jargon``'s own ``strip_code`` already applies to
+Markdown code fences, extended here to this file's two other "not prose"
+regions.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from palaia_addon_sdk.jargon import find_jargon
+
+# v3/server/tests/docs_site -> v3/server/tests -> v3/server -> v3 -> v3/site/docs
+ONBOARDING_PAGE = (
+    Path(__file__).resolve().parents[3]
+    / "site"
+    / "docs"
+    / "src"
+    / "pages"
+    / "onboarding.astro"
+)
+
+_FRONTMATTER_RE = re.compile(r"^---\n.*?\n---\n", re.DOTALL)
+_SCRIPT_RE = re.compile(r"<script\b.*?</script>", re.DOTALL)
+_STYLE_RE = re.compile(r"<style\b.*?</style>", re.DOTALL)
+# `<StarlightPage frontmatter={{ title: ..., template: "splash" }}>` — an
+# opening tag's own prop object, never rendered text (Starlight reads
+# `frontmatter`/`template` as component configuration; neither word reaches
+# the page). Not a Markdown code fence `find_jargon`'s own `strip_code`
+# would catch, so stripped here the same way the script/style blocks above
+# are: syntax a reader never sees, not prose.
+_COMPONENT_OPEN_TAG_RE = re.compile(r"<StarlightPage\b.*?}}>", re.DOTALL)
+
+
+def _rendered_template(source: str) -> str:
+    """The part of an .astro file an end reader actually sees."""
+    without_frontmatter = _FRONTMATTER_RE.sub("", source, count=1)
+    without_script = _SCRIPT_RE.sub("", without_frontmatter)
+    without_style = _STYLE_RE.sub("", without_script)
+    return _COMPONENT_OPEN_TAG_RE.sub("", without_style)
+
+
+def test_onboarding_page_exists() -> None:
+    assert ONBOARDING_PAGE.is_file(), f"no onboarding page at {ONBOARDING_PAGE}"
+
+
+def test_onboarding_page_template_has_no_jargon() -> None:
+    source = ONBOARDING_PAGE.read_text(encoding="utf-8")
+    template = _rendered_template(source)
+    assert template.strip(), "stripping frontmatter/script/style left nothing to check"
+
+    hits = find_jargon(template)
+    assert not hits, (
+        f"onboarding.astro's rendered template uses in-house word(s) {hits} — wrap the term "
+        f"as code, or rephrase in plain language"
+    )

--- a/v3/server/tests/e2e/simulator.py
+++ b/v3/server/tests/e2e/simulator.py
@@ -66,13 +66,20 @@ class SimulatedClient:
         *,
         client_name: str = "simulated-client",
         client_version: str = "0.0.0",
+        token: str | None = None,
     ) -> None:
         self._url = url
         self._client_info = Implementation(name=client_name, version=client_version)
         self._client: Client[Any] | None = None
+        #: A `plt_...` bearer token (SPEC-108), for scenarios against a hub
+        #: with auth enabled — fastmcp's `Client(auth=<str>)` wraps a plain
+        #: string in `BearerAuth` itself, so this is just threaded through.
+        self._token = token
 
     async def __aenter__(self) -> SimulatedClient:
-        client: Client[Any] = Client(self._url, client_info=self._client_info)
+        client: Client[Any] = Client(
+            self._url, client_info=self._client_info, auth=self._token
+        )
         await client.__aenter__()
         self._client = client
         return self

--- a/v3/server/tests/e2e/support/hub_server_dynamic.py
+++ b/v3/server/tests/e2e/support/hub_server_dynamic.py
@@ -32,13 +32,17 @@ from palaia_hub.serve import build_production_app
 logger = logging.getLogger("e2e.hub_server_dynamic")
 
 
-async def _run(*, host: str, port: int, home: Path) -> None:
+async def _run(*, host: str, port: int, home: Path, auth_enabled: bool) -> None:
     os.environ["PALAIA_HOME"] = str(home)
-    # auth_enabled=False: this script exercises SPEC-210's dynamic mounting
-    # in isolation from SPEC-108's auth wiring (covered by its own e2e/unit
-    # tests) — locked mode already allows this (config.py: "optional;
-    # defaults to on anyway").
-    config = HubConfig(log_level="info", auth_enabled=False)
+    # auth_enabled=False (the default here): this script exercises
+    # SPEC-210's dynamic mounting in isolation from SPEC-108's auth wiring
+    # (covered by its own e2e/unit tests) — locked mode already allows this
+    # (config.py: "optional; defaults to on anyway"). SPEC-504's first-run
+    # funnel walk passes --auth-enabled instead, because its own scenario
+    # is specifically "wizard endpoints -> vault -> token -> first memory
+    # write", and a token means nothing to prove without a hub that
+    # actually checks it.
+    config = HubConfig(log_level="info", auth_enabled=auth_enabled)
     production = await build_production_app(config, home=home)
 
     server = uvicorn.Server(uvicorn.Config(production.app, host=host, port=port, log_level="info"))
@@ -61,13 +65,20 @@ def main() -> None:
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, required=True)
     parser.add_argument("--home", required=True, help="empty PALAIA_HOME for this hub instance")
+    parser.add_argument(
+        "--auth-enabled",
+        action="store_true",
+        help="require a real plt_ token on every /mcp/* call (default: off)",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(
         level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
     )
 
-    asyncio.run(_run(host=args.host, port=args.port, home=Path(args.home)))
+    asyncio.run(
+        _run(host=args.host, port=args.port, home=Path(args.home), auth_enabled=args.auth_enabled)
+    )
 
 
 if __name__ == "__main__":

--- a/v3/server/tests/e2e/test_s7_spec504_first_run_funnel.py
+++ b/v3/server/tests/e2e/test_s7_spec504_first_run_funnel.py
@@ -1,0 +1,225 @@
+"""S7 "the first-run funnel, scripted end to end" (SPEC-504).
+
+The acceptance criterion this test is: "a scripted first-run walk (API-
+level: fresh home -> wizard endpoints -> vault -> token -> first memory
+write) completes without any step that requires editing a file or a shell
+beyond the install one-liner." Every step below is a real HTTP call or a
+real MCP tool call against one hub process booted from a genuinely empty
+home directory — the same process, no restart, exactly what a first-timer
+following the onboarding page would trigger by clicking through the
+dashboard wizard:
+
+1. Boot a hub against an empty `PALAIA_HOME` (SPEC-210's
+   `hub_server_dynamic.py`, `--auth-enabled` this time — a token that is
+   never checked would not prove anything about "connect a client").
+2. `POST /api/vaults` — the wizard's "first vault" step.
+3. `POST /api/auth/tokens` — the wizard's "connect a client" step, minting
+   a real per-client token the way `ConnectPanel` does.
+4. A real MCP client, authenticated with that token over real streamable
+   HTTP, writes the first note — the funnel's headline moment.
+5. `GET /api/funnel/status` — proves the hub recorded every step's
+   timestamp itself (SPEC-504 deliverable #3) and derived a
+   time-to-first-memory, with no step requiring a shell command or a file
+   edit beyond the one `docker run`/dynamic_hub launch already covered.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+from simulator import SimulatedClient
+
+_SCRIPT = Path(__file__).parent / "support" / "hub_server_dynamic.py"
+_STARTUP_TIMEOUT = 15.0
+
+pytestmark = pytest.mark.anyio
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_health(port: int, timeout: float = _STARTUP_TIMEOUT) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/api/health", timeout=0.5
+            ) as resp:
+                if resp.status == 200:
+                    return
+        except (OSError, urllib.error.URLError) as exc:
+            last_error = exc
+            time.sleep(0.1)
+    raise RuntimeError(f"hub did not become healthy within {timeout}s: {last_error}")
+
+
+def _get_json(url: str) -> dict[str, object]:
+    with urllib.request.urlopen(url, timeout=10) as resp:
+        return dict(json.loads(resp.read()))
+
+
+def _post_json(url: str, body: dict[str, object]) -> dict[str, object]:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10) as resp:
+        return dict(json.loads(resp.read()))
+
+
+@pytest.fixture
+def fresh_hub(tmp_path: Path):  # noqa: ANN201 - yields a bare port int
+    """A hub subprocess against a truly empty home directory, auth enabled."""
+    port = _free_port()
+    home = tmp_path / "home"
+    home.mkdir()
+    assert not (home / "vaults.yaml").exists(), "this must start as a genuinely fresh install"
+    log_path = tmp_path / "hub.log"
+    args = [
+        sys.executable,
+        str(_SCRIPT),
+        "--port",
+        str(port),
+        "--home",
+        str(home),
+        "--auth-enabled",
+    ]
+    with log_path.open("w") as log_file:
+        process = subprocess.Popen(  # noqa: S603 - fixed argv, no shell
+            args, stdout=log_file, stderr=subprocess.STDOUT
+        )
+    try:
+        _wait_for_health(port)
+        yield port
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+
+
+async def test_fresh_install_wizard_walk_records_time_to_first_memory(
+    fresh_hub: int,
+) -> None:
+    port = fresh_hub
+    base = f"http://127.0.0.1:{port}"
+
+    # Step 0: the wizard's landing page polls these before offering
+    # "create your first vault" — both already real, merged surfaces.
+    info = _get_json(f"{base}/api/info")
+    assert info["mode"] == "locked"
+
+    # hub.started already recorded the funnel's own start line, the
+    # moment the process came up — before this test does anything else.
+    status = _get_json(f"{base}/api/funnel/status")
+    assert status["hub_started_at"] is not None
+    assert status["vault_created_at"] is None
+    assert status["client_connected_at"] is None
+    assert status["first_memory_at"] is None
+    assert status["time_to_first_memory_seconds"] is None
+    assert status["time_to_first_memory_display"] is None
+
+    # Step 1: the wizard's "first vault" step — real HTTP, no shell, no
+    # file edit. `template` stays off, matching `Onboarding.tsx`'s own
+    # default (that switch starts unchecked) — the funnel-audit finding on
+    # why this matters is in `palaia_hub.funnel`'s module docstring: a
+    # template vault's two seed notes are themselves `memory.entry.created`
+    # events, so opting into them would make "first memory" fire before
+    # the client the wizard is trying to measure ever writes anything.
+    created = _post_json(
+        f"{base}/api/vaults",
+        {"key": "work", "purpose": "The first-run funnel walk's vault."},
+    )
+    assert created["key"] == "work"
+
+    status = _get_json(f"{base}/api/funnel/status")
+    assert status["vault_created_at"] is not None
+    assert status["client_connected_at"] is None
+    assert status["first_memory_at"] is None
+
+    # Step 2: the wizard's "connect a client" step — issuing a token is a
+    # real API call, exactly what ConnectPanel.tsx does under "Issue
+    # token".
+    issued = _post_json(
+        f"{base}/api/auth/tokens",
+        {"name": "first-run-funnel-client", "profile": "default"},
+    )
+    token = issued["token"]
+    assert isinstance(token, str) and token.startswith("plt_")
+
+    # Step 3: the actual headline moment — a real MCP client, carrying
+    # that token, writes the first note over real streamable HTTP.
+    async with SimulatedClient(
+        f"{base}/mcp/default/", client_name="spec-504-first-run", token=token
+    ) as client:
+        write_result = await client.call_tool_ok(
+            "work_memory_write",
+            {"title": "My First Memory", "body": "the first-run funnel's headline moment"},
+        )
+        assert "My First Memory" in write_result.text
+
+    # Step 4: the hub recorded every step itself, from real server-side
+    # events — nothing here came from a client-supplied timestamp.
+    status = _get_json(f"{base}/api/funnel/status")
+    assert status["vault_created_at"] is not None
+    assert status["client_connected_at"] is not None
+    assert status["first_memory_at"] is not None
+    assert status["hub_started_at"] <= status["vault_created_at"]
+    assert status["vault_created_at"] <= status["client_connected_at"]
+    assert status["client_connected_at"] <= status["first_memory_at"]
+
+    seconds = status["time_to_first_memory_seconds"]
+    assert isinstance(seconds, (int, float)) and seconds >= 0
+
+    display = status["time_to_first_memory_display"]
+    assert isinstance(display, str)
+    # "37s", "4m12s", "1h03m" — the tile label format (funnel.format_duration).
+    assert re.fullmatch(r"(\d+h\d{2}m|\d+m\d{2}s|\d+s)", display), display
+
+
+async def test_a_read_only_scoped_client_gets_a_fix_naming_error(fresh_hub: int) -> None:
+    """SPEC-504 deliverable #2's error-message audit, the real end-to-end
+    shape: a client whose token has only ``vault:work:read`` (an explicit,
+    narrower scope than the default a wizard-issued token now gets — see
+    ``server/tests/auth/test_routes_default_scopes.py``) tries the write
+    tool and gets an error that names the fix, over a real HTTP MCP call —
+    ``server/tests/funnel/test_error_message_audit.py`` covers the same
+    message at the unit level, fast; this is the slower proof that the
+    real transport delivers it unchanged."""
+    port = fresh_hub
+    base = f"http://127.0.0.1:{port}"
+
+    _post_json(f"{base}/api/vaults", {"key": "work"})
+    issued = _post_json(
+        f"{base}/api/auth/tokens",
+        {"name": "read-only-client", "profile": "default", "scopes": ["vault:work:read"]},
+    )
+    token = issued["token"]
+
+    async with SimulatedClient(
+        f"{base}/mcp/default/", client_name="spec-504-scope-audit", token=token
+    ) as client:
+        result = await client.call_tool(
+            "work_memory_write", {"title": "x", "body": "y"}
+        )
+
+    assert result.is_error
+    assert "Fix:" in result.text
+    assert "vault:work:write" in result.text

--- a/v3/server/tests/funnel/test_api.py
+++ b/v3/server/tests/funnel/test_api.py
@@ -1,0 +1,86 @@
+"""``GET /api/funnel/status`` (SPEC-504 deliverable #3), mounted the same
+"always on, like /api/health" way every hub gets it — see
+``palaia_hub.app``'s own wiring.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from palaia_hub.app import create_app
+from palaia_hub.config import HubConfig
+from palaia_hub.gateway.fake_vault import FakeVaultService
+from palaia_hub.vault import EventBus as VaultEventBus
+from palaia_hub.vault import VaultRegistry
+
+
+def test_funnel_status_is_mounted_on_every_hub(tmp_path: Path) -> None:
+    # An isolated `home`: without one, this reads from (and pollutes)
+    # whatever this machine's real palaia_home() already has on disk from
+    # some other process or test run entirely — the same "pass tmp_path
+    # when a test's assertions depend on exact state" convention every
+    # other hub-home-touching test in this suite already follows.
+    #
+    # `TestClient(app).get(...)` used outside a `with` block never runs
+    # the app's lifespan (that is where `hub.started` fires — see
+    # `palaia_hub.app`), so every field genuinely starts out unset here,
+    # not just the three wizard-step ones.
+    app = create_app(HubConfig(), home=tmp_path)
+    client = TestClient(app)
+
+    response = client.get("/api/funnel/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {
+        "hub_started_at": None,
+        "vault_created_at": None,
+        "client_connected_at": None,
+        "first_memory_at": None,
+        "time_to_first_memory_seconds": None,
+        "time_to_first_memory_display": None,
+    }
+
+
+def test_vault_created_via_the_dashboard_router_shows_up_in_funnel_status() -> None:
+    # A registry with a real vault.events.EventBus so create_app() bridges
+    # it onto the public bus (see palaia_hub.events.bridge) — otherwise
+    # this test would only prove the dashboard router's own publish call
+    # fires, not that the funnel actually observes a real vault creation
+    # the way it does in production.
+    with tempfile.TemporaryDirectory() as tmp:
+        home = Path(tmp)
+        registry = VaultRegistry(home / "registry", bus=VaultEventBus())
+        app = create_app(
+            HubConfig(),
+            vault_registry=registry,
+            vault_services={},
+            home=home / "hub_home",
+        )
+        client = TestClient(app)
+
+        create_response = client.post("/api/vaults", json={"key": "work"})
+        assert create_response.status_code == 200
+
+        status_response = client.get("/api/funnel/status")
+        body = status_response.json()
+        assert body["vault_created_at"] is not None
+        assert body["client_connected_at"] is None
+        assert body["first_memory_at"] is None
+
+
+def test_funnel_status_is_read_only(tmp_path: Path) -> None:
+    app = create_app(HubConfig(), vault_services={"work": FakeVaultService()}, home=tmp_path)
+    client = TestClient(app)
+
+    response = client.post("/api/funnel/status", json={})
+
+    # 404, not 405: the dashboard's catch-all static mount (no build
+    # present in this test environment) claims every unmatched route
+    # before Starlette's router gets a chance to answer "405, wrong
+    # method" for a path it does recognize — same shape as
+    # `test_app_directory.py`/`test_app_messenger.py`'s identical check.
+    assert response.status_code in (404, 405)

--- a/v3/server/tests/funnel/test_error_message_audit.py
+++ b/v3/server/tests/funnel/test_error_message_audit.py
@@ -1,0 +1,129 @@
+"""SPEC-504 deliverable #2's error-message audit, made a real regression
+test: every failure branch a first-timer can actually hit while walking the
+funnel (create vault -> connect a client -> write the first memory) must
+name its fix, not just describe what went wrong.
+
+This walks the branches through the real HTTP/REST surface (never
+constructs the underlying exception directly), so a test here proves the
+*response a browser actually receives* names the fix — not just that some
+internal exception class happens to have good wording that a handler could
+still discard on the way out.
+
+The "names the fix" bar this suite applies: the message contains the literal
+word ``Fix`` (this codebase's own consistent convention throughout
+``palaia_hub.vault.errors``/``palaia_hub.auth.store`` — see either module)
+*or* an imperative verb phrase telling the reader what to do next
+(``check``, ``pick``, ``use``, ``create``, ``try again``, ...) — deliberately
+not just "contains a colon" or some other structural proxy that a vague
+restatement of the error could satisfy by accident.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+from mcp.server.auth.middleware.auth_context import auth_context_var
+from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
+from mcp.server.auth.provider import AccessToken
+
+from palaia_hub.app import create_app
+from palaia_hub.auth.enforcement import missing_scope_error
+from palaia_hub.auth.store import TokenStore
+from palaia_hub.config import HubConfig
+from palaia_hub.vault import EventBus as VaultEventBus
+from palaia_hub.vault import VaultRegistry
+
+_FIX_VERBS = re.compile(
+    r"\bfix\b|\bcheck\b|\bpick\b|\buse\b|\bcreate\b|\btry again\b|\brename\b|\bgive\b|"
+    r"\bpass\b|\bcorrect\b|\bdelete\b",
+    re.IGNORECASE,
+)
+
+
+def _names_a_fix(message: str) -> bool:
+    return bool(_FIX_VERBS.search(message))
+
+
+def test_create_vault_with_an_invalid_key_names_the_fix(tmp_path: Path) -> None:
+    registry = VaultRegistry(tmp_path / "registry", bus=VaultEventBus())
+    app = create_app(
+        HubConfig(), vault_registry=registry, vault_services={}, home=tmp_path / "home"
+    )
+    client = TestClient(app)
+
+    response = client.post("/api/vaults", json={"key": "Not A Valid Key!"})
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert _names_a_fix(detail), f"does not name a fix: {detail!r}"
+
+
+def test_create_vault_with_a_key_already_taken_names_the_fix(tmp_path: Path) -> None:
+    registry = VaultRegistry(tmp_path / "registry", bus=VaultEventBus())
+    app = create_app(
+        HubConfig(), vault_registry=registry, vault_services={}, home=tmp_path / "home"
+    )
+    client = TestClient(app)
+    first = client.post("/api/vaults", json={"key": "work"})
+    assert first.status_code == 200
+
+    response = client.post("/api/vaults", json={"key": "work"})
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert _names_a_fix(detail), f"does not name a fix: {detail!r}"
+
+
+def test_create_token_with_an_invalid_scope_names_the_fix(tmp_path: Path) -> None:
+    app = create_app(HubConfig(), token_store=TokenStore(home=tmp_path), home=tmp_path)
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/auth/tokens",
+        json={"name": "a", "profile": "default", "scopes": ["not-a-real-scope"]},
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert _names_a_fix(detail), f"does not name a fix: {detail!r}"
+
+
+def test_create_token_with_an_empty_name_names_the_fix(tmp_path: Path) -> None:
+    app = create_app(HubConfig(), token_store=TokenStore(home=tmp_path), home=tmp_path)
+    client = TestClient(app)
+
+    response = client.post("/api/auth/tokens", json={"name": "", "profile": "default"})
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert _names_a_fix(detail), f"does not name a fix: {detail!r}"
+
+
+def test_missing_scope_tool_error_names_the_fix() -> None:
+    """The read-only-scoped-token-hits-the-write-tool shape (the concrete
+    failure a wizard-issued token with a narrower explicit scope than its
+    profile's vaults would hit): calls the real
+    :func:`~palaia_hub.auth.enforcement.missing_scope_error` the memory
+    tools call, with a real ``AccessToken`` set on the same context var
+    fastmcp's own HTTP auth middleware sets it on in production — the
+    in-process route this file's other tests use
+    (:class:`fastmcp.client.transports.FastMCPTransport`, via
+    ``Client(a_fastmcp_server_instance)``) explicitly refuses an ``auth=``
+    argument, so a real end-to-end HTTP round trip is what
+    ``tests/e2e/test_s7_spec504_first_run_funnel.py`` covers instead — this
+    is the fast, direct check of the message the two together
+    complement."""
+    access_token = AccessToken(
+        token="plt_test", client_id="read-only-client", scopes=["vault:work:read"]
+    )
+    reset = auth_context_var.set(AuthenticatedUser(access_token))
+    try:
+        message = missing_scope_error("work", "write")
+    finally:
+        auth_context_var.reset(reset)
+
+    assert message is not None
+    assert _names_a_fix(message), message
+    assert "vault:work:write" in message

--- a/v3/server/tests/funnel/test_events_wiring.py
+++ b/v3/server/tests/funnel/test_events_wiring.py
@@ -1,0 +1,92 @@
+"""``wire_funnel_tracking`` reacts to the real public events (SPEC-504),
+independent of any HTTP surface — the same "plain in-process bus consumer"
+shape as the hooks/automations dispatchers it sits next to in
+``palaia_hub.app``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from palaia_hub.events.bus import EventBus, publish_event
+from palaia_hub.funnel import FunnelStore, wire_funnel_tracking
+
+
+def test_hub_started_event_records_the_start_line(tmp_path: Path) -> None:
+    bus = EventBus()
+    store = FunnelStore(tmp_path)
+    wire_funnel_tracking(bus, store)
+
+    publish_event(bus, "hub.started", origin="hub", data={})
+
+    assert store.status().hub_started_at is not None
+
+
+def test_vault_created_event_records_that_step(tmp_path: Path) -> None:
+    bus = EventBus()
+    store = FunnelStore(tmp_path)
+    wire_funnel_tracking(bus, store)
+
+    publish_event(bus, "memory.vault.created", origin="dashboard", data={"key": "work"})
+
+    assert store.status().vault_created_at is not None
+
+
+def test_client_connected_event_records_that_step(tmp_path: Path) -> None:
+    bus = EventBus()
+    store = FunnelStore(tmp_path)
+    wire_funnel_tracking(bus, store)
+
+    publish_event(bus, "client.connected", origin="auth", data={"token_id": "t1"})
+
+    assert store.status().client_connected_at is not None
+
+
+def test_first_memory_event_records_that_step(tmp_path: Path) -> None:
+    bus = EventBus()
+    store = FunnelStore(tmp_path)
+    wire_funnel_tracking(bus, store)
+
+    publish_event(bus, "memory.entry.created", origin="vault", data={"kind": "created"})
+
+    assert store.status().first_memory_at is not None
+
+
+def test_unrelated_events_are_ignored(tmp_path: Path) -> None:
+    bus = EventBus()
+    store = FunnelStore(tmp_path)
+    wire_funnel_tracking(bus, store)
+
+    publish_event(bus, "gateway.upstream.up", origin="gateway", data={})
+    publish_event(bus, "health", origin="hub", data={})
+
+    status = store.status()
+    assert status.hub_started_at is None
+    assert status.vault_created_at is None
+    assert status.client_connected_at is None
+    assert status.first_memory_at is None
+
+
+def test_only_the_first_memory_entry_created_event_counts(tmp_path: Path) -> None:
+    bus = EventBus()
+    store = FunnelStore(tmp_path)
+    wire_funnel_tracking(bus, store)
+
+    publish_event(bus, "memory.entry.created", origin="vault", data={"kind": "created"})
+    first = store.status().first_memory_at
+
+    publish_event(bus, "memory.entry.created", origin="vault", data={"kind": "created"})
+    second = store.status().first_memory_at
+
+    assert first == second
+
+
+def test_unsubscribe_stops_tracking(tmp_path: Path) -> None:
+    bus = EventBus()
+    store = FunnelStore(tmp_path)
+    unsubscribe = wire_funnel_tracking(bus, store)
+
+    unsubscribe()
+    publish_event(bus, "memory.vault.created", origin="dashboard", data={})
+
+    assert store.status().vault_created_at is None

--- a/v3/server/tests/funnel/test_no_egress.py
+++ b/v3/server/tests/funnel/test_no_egress.py
@@ -1,0 +1,112 @@
+"""SPEC-504 acceptance criterion: "a test proves no network egress from the
+stats path" (MASTERPLAN §10's privacy principle — see
+``palaia_hub.funnel``'s own module docstring for the "local-only, by
+construction" claim this test backs up).
+
+Patches ``socket.socket.connect``/``connect_ex`` — the two calls every
+network client in the standard library and every third-party HTTP library
+(``requests``, ``httpx``, ``urllib``) ultimately makes to reach a remote
+host — so *nothing* downstream of them can reach the network, no matter
+how it tries. The whole funnel path (recording every step, reading the
+status back over a real HTTP request against the real FastAPI app) is
+exercised underneath that patch; if anything on the path ever tried to
+connect out, this test would fail at that call site instead of quietly
+passing.
+
+Only ``AF_INET``/``AF_INET6`` connect attempts are blocked, not
+``AF_UNIX``: ``fastapi.testclient.TestClient`` itself talks to the ASGI app
+in-process over a local Unix ``socketpair`` it opens for its own worker
+thread (an implementation detail of ``anyio.from_thread``, nothing to do
+with the network) — blocking that too would make this test fail for a
+reason that has nothing to do with the claim it exists to check.
+"""
+
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from palaia_hub.app import create_app
+from palaia_hub.config import HubConfig
+from palaia_hub.events.bus import EventBus, publish_event
+from palaia_hub.funnel import FunnelStore, wire_funnel_tracking
+
+_NETWORK_FAMILIES = {socket.AF_INET, socket.AF_INET6}
+
+
+class _NetworkAttempted(RuntimeError):
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _forbid_network_sockets(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_connect = socket.socket.connect
+    real_connect_ex = socket.socket.connect_ex
+
+    def _blocked_connect(self: socket.socket, address: object) -> object:
+        if self.family in _NETWORK_FAMILIES:
+            raise _NetworkAttempted(
+                f"a funnel code path tried to open a real network connection to "
+                f"{address!r} — the funnel store must never make a network call "
+                f"of any kind"
+            )
+        return real_connect(self, address)  # type: ignore[arg-type]
+
+    def _blocked_connect_ex(self: socket.socket, address: object) -> object:
+        if self.family in _NETWORK_FAMILIES:
+            raise _NetworkAttempted(
+                f"a funnel code path tried to open a real network connection to "
+                f"{address!r} — the funnel store must never make a network call "
+                f"of any kind"
+            )
+        return real_connect_ex(self, address)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(socket.socket, "connect", _blocked_connect)
+    monkeypatch.setattr(socket.socket, "connect_ex", _blocked_connect_ex)
+
+
+def test_recording_every_step_touches_no_socket(tmp_path: Path) -> None:
+    bus = EventBus()
+    store = FunnelStore(tmp_path)
+    wire_funnel_tracking(bus, store)
+
+    publish_event(bus, "hub.started", origin="hub", data={})
+    publish_event(bus, "memory.vault.created", origin="dashboard", data={"key": "work"})
+    publish_event(bus, "client.connected", origin="auth", data={"token_id": "t1"})
+    publish_event(bus, "memory.entry.created", origin="vault", data={"kind": "created"})
+
+    status = store.status()
+    assert status.first_memory_at is not None
+    assert status.time_to_first_memory_display is not None
+
+
+def test_reading_funnel_status_over_http_touches_no_socket(tmp_path: Path) -> None:
+    app = create_app(HubConfig(), home=tmp_path)
+    client = TestClient(app)
+
+    response = client.get("/api/funnel/status")
+
+    assert response.status_code == 200
+
+
+def test_reopening_the_store_from_disk_touches_no_socket(tmp_path: Path) -> None:
+    FunnelStore(tmp_path).record_first_memory(123.0)
+
+    reopened = FunnelStore(tmp_path)
+    assert reopened.status().first_memory_at == 123.0
+
+
+def test_the_block_itself_actually_catches_a_real_attempt() -> None:
+    """A positive control: without this, the three tests above could pass
+    vacuously if the patch ever stopped working (e.g. a future refactor of
+    `socket.socket`'s C-level binding). A real outbound `connect()` attempt
+    (a made-up, non-routable address — nothing here waits on an actual
+    network round trip) must still raise the same way."""
+    with (
+        pytest.raises(_NetworkAttempted),
+        socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock,
+    ):
+        sock.connect(("203.0.113.1", 80))  # TEST-NET-3 (RFC 5737) — never routable

--- a/v3/server/tests/funnel/test_store.py
+++ b/v3/server/tests/funnel/test_store.py
@@ -1,0 +1,111 @@
+"""Unit coverage for :mod:`palaia_hub.funnel` (SPEC-504 deliverable #3)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from palaia_hub.funnel import FunnelStore, format_duration
+
+
+def test_a_fresh_home_has_nothing_recorded(tmp_path: Path) -> None:
+    store = FunnelStore(tmp_path)
+
+    status = store.status()
+
+    assert status.hub_started_at is None
+    assert status.vault_created_at is None
+    assert status.client_connected_at is None
+    assert status.first_memory_at is None
+    assert status.time_to_first_memory_seconds is None
+    assert status.time_to_first_memory_display is None
+    assert not store.path.exists(), "a read must never create the file itself"
+
+
+def test_recording_a_step_persists_it(tmp_path: Path) -> None:
+    store = FunnelStore(tmp_path)
+
+    store.record_vault_created(100.0)
+
+    assert store.path.exists()
+    assert store.status().vault_created_at == 100.0
+
+    # A second FunnelStore over the same home reads back the same value —
+    # this is what makes the timestamp survive a hub restart.
+    reopened = FunnelStore(tmp_path)
+    assert reopened.status().vault_created_at == 100.0
+
+
+def test_each_step_is_first_write_wins(tmp_path: Path) -> None:
+    store = FunnelStore(tmp_path)
+
+    store.record_hub_started(100.0)
+    store.record_hub_started(999.0)  # a later restart must not reset the start line
+
+    assert store.status().hub_started_at == 100.0
+
+
+def test_time_to_first_memory_is_none_until_both_ends_exist(tmp_path: Path) -> None:
+    store = FunnelStore(tmp_path)
+    store.record_hub_started(100.0)
+
+    assert store.status().time_to_first_memory_seconds is None
+
+    store.record_first_memory(352.0)
+
+    status = store.status()
+    assert status.time_to_first_memory_seconds == 252.0
+    assert status.time_to_first_memory_display == "4m12s"
+
+
+def test_time_to_first_memory_never_goes_negative(tmp_path: Path) -> None:
+    """Defensive: two events published out of wall-clock order (e.g. two
+    processes with slightly skewed clocks, or a test that stubs `time.time`
+    non-monotonically) must never report a negative "time to first memory"
+    a dashboard tile would render as nonsense."""
+    store = FunnelStore(tmp_path)
+    store.record_hub_started(500.0)
+    store.record_first_memory(100.0)
+
+    assert store.status().time_to_first_memory_seconds == 0.0
+
+
+def test_records_default_to_now_when_no_timestamp_given(tmp_path: Path) -> None:
+    store = FunnelStore(tmp_path)
+
+    store.record_vault_created()
+
+    assert store.status().vault_created_at is not None
+    assert store.status().vault_created_at > 0
+
+
+def test_all_four_steps_recorded_independently(tmp_path: Path) -> None:
+    store = FunnelStore(tmp_path)
+    store.record_hub_started(1.0)
+    store.record_vault_created(2.0)
+    store.record_client_connected(3.0)
+    store.record_first_memory(4.0)
+
+    status = store.status()
+    assert status.hub_started_at == 1.0
+    assert status.vault_created_at == 2.0
+    assert status.client_connected_at == 3.0
+    assert status.first_memory_at == 4.0
+
+
+def test_format_duration_under_a_minute() -> None:
+    assert format_duration(0) == "0s"
+    assert format_duration(37) == "37s"
+    assert format_duration(59.6) == "1m00s"  # rounds up into the next unit
+
+
+def test_format_duration_minutes() -> None:
+    assert format_duration(252) == "4m12s"
+    assert format_duration(60) == "1m00s"
+
+
+def test_format_duration_hours() -> None:
+    assert format_duration(3723) == "1h02m"
+
+
+def test_format_duration_never_negative() -> None:
+    assert format_duration(-5) == "0s"

--- a/v3/server/tests/gateway/test_dynamic_auth_provider_factory.py
+++ b/v3/server/tests/gateway/test_dynamic_auth_provider_factory.py
@@ -1,0 +1,150 @@
+"""SPEC-504 first-run funnel audit fix: :class:`DynamicGateway`'s
+``auth_provider_factory`` (see that class's own docstring, and
+``palaia_hub.serve.build_production_app``'s ``_auth_provider_for``, for the
+bug this closes: a brand-new profile path — the wizard's very first vault,
+on every fresh install — mounted with no verifier at all, silently
+unauthenticated, because ``token_verifiers`` built at construction time
+could not have known about a path that did not exist yet).
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp.server.auth import AccessToken, TokenVerifier
+
+from palaia_hub.gateway.config import GatewayConfig, VaultMountConfig
+from palaia_hub.gateway.dynamic import DynamicGateway
+from palaia_hub.gateway.fake_vault import FakeVaultService
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+class _StubVerifier(TokenVerifier):
+    """A minimal real ``TokenVerifier`` (fastmcp mounts it onto a live
+    ``FastMCP`` server via ``AuthProvider.get_middleware()``, so a bare
+    stand-in object is not enough) — this suite never sends a request
+    through it, only checks whether :class:`DynamicGateway` decided to
+    attach one."""
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        return None
+
+
+async def test_a_brand_new_profile_path_asks_the_factory() -> None:
+    calls: list[str] = []
+
+    def factory(path: str) -> _StubVerifier:
+        calls.append(path)
+        return _StubVerifier()
+
+    gateway = DynamicGateway(GatewayConfig(), {}, auth_provider_factory=factory)
+    await gateway.start()
+
+    await gateway.add_vault(
+        VaultMountConfig(key="work", name="work", purpose="Work vault."),
+        FakeVaultService(),
+        profile_paths=["default"],
+    )
+
+    assert calls == ["default"]
+    assert isinstance(gateway._token_verifiers["default"], _StubVerifier)  # noqa: SLF001
+
+    await gateway.aclose()
+
+
+async def test_the_factory_is_called_once_then_cached() -> None:
+    calls: list[str] = []
+
+    def factory(path: str) -> _StubVerifier:
+        calls.append(path)
+        return _StubVerifier()
+
+    gateway = DynamicGateway(GatewayConfig(), {}, auth_provider_factory=factory)
+    await gateway.start()
+
+    await gateway.add_vault(
+        VaultMountConfig(key="work", name="work"), FakeVaultService(), profile_paths=["default"]
+    )
+    await gateway.add_vault(
+        VaultMountConfig(key="personal", name="personal"),
+        FakeVaultService(),
+        profile_paths=["default"],
+    )
+
+    # Same path, added to twice — the factory is consulted only the first
+    # time a path has no verifier yet, never again once one is cached.
+    assert calls == ["default"]
+
+    await gateway.aclose()
+
+
+async def test_a_factory_returning_none_leaves_the_path_unauthenticated() -> None:
+    """The pre-SPEC-504 posture (``auth_enabled: false``) must keep
+    working exactly as before: the factory itself decides "nothing to
+    verify with" by returning ``None``, and this class must not invent a
+    verifier it was not given."""
+
+    def factory(path: str) -> None:
+        return None
+
+    gateway = DynamicGateway(GatewayConfig(), {}, auth_provider_factory=factory)
+    await gateway.start()
+
+    await gateway.add_vault(
+        VaultMountConfig(key="work", name="work"), FakeVaultService(), profile_paths=["default"]
+    )
+
+    assert "default" not in gateway._token_verifiers  # noqa: SLF001
+
+    await gateway.aclose()
+
+
+async def test_no_factory_at_all_preserves_pre_spec504_behavior() -> None:
+    """``auth_provider_factory`` is optional — every call site that never
+    passes one (every direct ``DynamicGateway(...)`` construction in this
+    test suite, and any future one) must see exactly the old behavior: a
+    brand-new path simply has no verifier."""
+    gateway = DynamicGateway(GatewayConfig(), {})
+    await gateway.start()
+
+    await gateway.add_vault(
+        VaultMountConfig(key="work", name="work"), FakeVaultService(), profile_paths=["default"]
+    )
+
+    assert "default" not in gateway._token_verifiers  # noqa: SLF001
+
+    await gateway.aclose()
+
+
+async def test_an_existing_verifier_is_never_overwritten_by_the_factory() -> None:
+    """Editing an already-authenticated profile (adding a second vault to
+    it) must not silently swap in a different verifier instance — the
+    factory is only ever consulted for a path with *no* entry yet."""
+    calls: list[str] = []
+
+    def factory(path: str) -> _StubVerifier:
+        calls.append(path)
+        return _StubVerifier()
+
+    preexisting = _StubVerifier()
+    gateway = DynamicGateway(
+        GatewayConfig(),
+        {},
+        token_verifiers={"default": preexisting},  # type: ignore[dict-item]
+        auth_provider_factory=factory,
+    )
+    await gateway.start()
+
+    await gateway.add_vault(
+        VaultMountConfig(key="work", name="work"), FakeVaultService(), profile_paths=["default"]
+    )
+
+    assert calls == []
+    assert gateway._token_verifiers["default"] is preexisting  # noqa: SLF001
+
+    await gateway.aclose()

--- a/v3/site/docs/astro.config.mjs
+++ b/v3/site/docs/astro.config.mjs
@@ -26,7 +26,11 @@ export default defineConfig({
           label: "Start here",
           items: [
             { label: "What is palaia?", slug: "index" },
-            { label: "Install it", slug: "install" },
+            // SPEC-504: the onboarding page — not a content-collection
+            // entry (see src/pages/onboarding.astro's own docstring), so
+            // it is linked by its literal route here rather than `slug`.
+            { label: "Get palaia running", link: "/onboarding/" },
+            { label: "Install it (the full version)", slug: "install" },
             { label: "Your first shared memory", slug: "first-shared-memory" },
           ],
         },

--- a/v3/site/docs/scripts/lib/deploy-snippets.mjs
+++ b/v3/site/docs/scripts/lib/deploy-snippets.mjs
@@ -1,0 +1,67 @@
+// SPEC-504 deliverable #1's drift test, made structurally impossible to
+// fail silently: the onboarding page never retypes an install command —
+// every snippet it shows is read straight out of v3/deploy's real files at
+// build time, the same "extract, don't copy" rule extract.mjs already
+// applies to the connect pages' client commands. If v3/deploy/README.md's
+// Quick start section ever changes shape, this throws instead of quietly
+// handing back the wrong (or an empty) block — `check-generated.mjs`-style
+// honesty, applied to code fences instead of whole pages.
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+// Resolved from `process.cwd()`, not `import.meta.url`: this module is
+// imported by `src/pages/onboarding.astro`, which Vite bundles into a
+// chunk under `dist/` at build time — `import.meta.url` there points at
+// that *output* location, not this file's real path in the source tree,
+// so a path relative to it would silently resolve somewhere under `dist/`
+// instead of `v3/deploy`. `astro build`/`astro dev` are always run with
+// this project (`v3/site/docs`) as the working directory (see the v3-ci.yml
+// docs-site job's own `working-directory`), so `process.cwd()` is the
+// stable anchor here — the same one `scripts/check-links.mjs` and
+// `scripts/check-generated.mjs` use for `PROJECT_ROOT`, those two just via
+// `import.meta.url` instead because they run standalone, never bundled.
+// v3/site/docs -> v3/site -> v3 -> v3/deploy
+export const DEPLOY_ROOT = path.resolve(process.cwd(), "../../deploy");
+
+const FENCE_RE = /```bash\n([\s\S]*?)```/g;
+
+function bashFences(text) {
+  return [...text.matchAll(FENCE_RE)].map((m) => m[1].trimEnd());
+}
+
+/**
+ * The three "one thing to paste" commands the onboarding page shows,
+ * read from `v3/deploy/README.md`'s own "Quick start" section — the exact
+ * three ```bash fences that section has always had, in order: the
+ * `docker run` one-liner (with the SPEC-502 hardening flags), the
+ * `docker compose up -d` pair, and the convenience `curl | bash` script.
+ * Each is sanity-checked against a substring only that command could
+ * contain, so a reordering (not just a removal) is caught too.
+ */
+export function loadDeploySnippets() {
+  const readmePath = path.join(DEPLOY_ROOT, "README.md");
+  const readme = readFileSync(readmePath, "utf8");
+  const fences = bashFences(readme);
+
+  const checks = [
+    ["docker run", "docker run"],
+    ["cd v3/deploy && docker compose up -d", "docker compose up -d"],
+    ["curl -fsSL", "curl -fsSL"],
+  ];
+  checks.forEach(([needle], index) => {
+    const fence = fences[index];
+    if (!fence || !fence.includes(needle)) {
+      throw new Error(
+        `deploy-snippets: expected ${readmePath}'s Quick start fence #${index} to contain ` +
+          `${JSON.stringify(needle)} — the section's shape changed; update this extractor ` +
+          `to match (never hand-copy the command instead).`,
+      );
+    }
+  });
+
+  return {
+    dockerRun: fences[0],
+    compose: fences[1],
+    curlInstall: fences[2],
+  };
+}

--- a/v3/site/docs/src/content/docs/index.md
+++ b/v3/site/docs/src/content/docs/index.md
@@ -43,6 +43,8 @@ reads it.
   a new AI tool in, and decide how far your memory reaches — just this
   device, or the internet too.
 
-Ready to try it? [Install it](/install/) takes about five minutes, and
-[Your first shared memory](/first-shared-memory/) walks through
-connecting two AI tools and watching them share one fact.
+Ready to try it? [Get palaia running](/onboarding/) — pick your platform,
+paste one thing, about five minutes start to finish. Or read
+[Install it](/install/) for the longer version, and
+[Your first shared memory](/first-shared-memory/) for what connecting two
+AI tools and watching them share one fact actually looks like.

--- a/v3/site/docs/src/content/docs/install.md
+++ b/v3/site/docs/src/content/docs/install.md
@@ -16,8 +16,15 @@ docker run -d --name palaia-hub \
   -p 8420:8420 \
   -v palaia_home:/data \
   --restart unless-stopped \
+  --security-opt no-new-privileges:true --cap-drop ALL \
+  --read-only --tmpfs /tmp --tmpfs /run \
   ghcr.io/byte5ai/palaia-hub:stable
 ```
+
+The five extra flags close off what a non-root container process could
+otherwise still reach — nothing about the install changes if you leave
+them off, they simply make the container harder to escape from if
+something inside it were ever compromised.
 
 That pulls the image, starts it, and keeps it running (and restarting after
 a reboot). Everything palaia saves lives in the `palaia_home` volume, so the

--- a/v3/site/docs/src/pages/onboarding.astro
+++ b/v3/site/docs/src/pages/onboarding.astro
@@ -1,0 +1,285 @@
+---
+// SPEC-504 deliverable #1: the onboarding page — pick your platform, paste
+// one thing, then open the dashboard and let the wizard take over. Same
+// toolchain and theme as the rest of this site (Astro + Starlight, this
+// project's `custom.css` tokens); this SPEC's own text asked for it either
+// as its own `v3/site/onboarding/` tree, or as a page of this docs-site
+// toolchain when that is the cleaner call — it is, here: a second Astro/
+// Starlight project would mean a second `package.json`, a second CI job
+// and a second copy of `custom.css`'s tokens for one page's worth of
+// content, and this project's own `AGENTS.md` rule ("no shared build
+// tooling... between the tracks") is about the v2/v3 boundary, not about
+// two pages inside the same v3 site sharing one Astro project. The PR body
+// says so too.
+//
+// `StarlightPage` (not a `src/content/docs/*.md` entry) because this page
+// needs a platform-picker with copy buttons and tabbed panels — real
+// interactivity a Markdown page's fixed sidebar layout does not fit — while
+// still getting Starlight's own header, theme toggle and search for free.
+// `template: "splash"` drops the sidebar (`StarlightPage`'s own default:
+// `hasSidebar: entry.data.template !== "splash"`), which is what makes this
+// read as a landing page rather than another doc.
+//
+// Every command below is read out of `v3/deploy`'s real files at build
+// time (`scripts/lib/deploy-snippets.mjs`) — never retyped — which is what
+// makes "snippets match the real compose/one-liner" true by construction
+// rather than by discipline. `tests/onboarding.test.ts` is the drift test
+// the acceptance criterion asks for: it independently re-reads the same
+// v3/deploy source files and asserts the extracted snippets are exactly
+// what they say.
+import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
+import { loadDeploySnippets } from "../../scripts/lib/deploy-snippets.mjs";
+
+const snippets = loadDeploySnippets();
+
+const STORES = [
+  { name: "Umbrel", dir: "umbrel" },
+  { name: "CasaOS", dir: "casaos" },
+  { name: "Runtipi", dir: "runtipi" },
+  { name: "TrueNAS SCALE", dir: "truenas" },
+] as const;
+
+const REPO = "https://github.com/byte5ai/palaia";
+---
+
+<StarlightPage frontmatter={{
+  title: "Get palaia running",
+  description: "Pick your platform, paste one thing, then let the setup wizard take over.",
+  template: "splash",
+}}>
+  <div class="op">
+    <p class="op-lede">
+      One command, or one file, depending on how you already run things. Either way: paste it,
+      then open your hub's address in a browser — a short setup wizard does the rest.
+    </p>
+
+    <div class="op-tabs" role="tablist">
+      <input type="radio" name="op-platform" id="op-tab-docker" checked />
+      <input type="radio" name="op-platform" id="op-tab-compose" />
+      <input type="radio" name="op-platform" id="op-tab-stores" />
+
+      <div class="op-tabbar">
+        <label for="op-tab-docker">Docker</label>
+        <label for="op-tab-compose">Compose file</label>
+        <label for="op-tab-stores">Self-hosting app stores</label>
+      </div>
+
+      <section class="op-panel" id="op-panel-docker">
+        <h2>One command</h2>
+        <p>
+          Already have Docker (Docker Desktop on macOS/Windows, or Docker Engine on Linux)?
+          This is the whole install.
+        </p>
+        <div class="op-snippet">
+          <pre><code>{snippets.dockerRun}</code></pre>
+          <button type="button" class="op-copy" data-copy-target="op-code-docker">Copy</button>
+        </div>
+        <code id="op-code-docker" class="op-copy-source" hidden>{snippets.dockerRun}</code>
+
+        <p class="op-fine">
+          Prefer a script that checks Docker is actually installed and running first, then prints
+          the address to open at the end?
+        </p>
+        <div class="op-snippet">
+          <pre><code>{snippets.curlInstall}</code></pre>
+          <button type="button" class="op-copy" data-copy-target="op-code-curl">Copy</button>
+        </div>
+        <code id="op-code-curl" class="op-copy-source" hidden>{snippets.curlInstall}</code>
+      </section>
+
+      <section class="op-panel" id="op-panel-compose">
+        <h2>A file you keep</h2>
+        <p>
+          Prefer a config file you can edit and check in, or already run other containers this
+          way? Clone the repository and start it with Compose:
+        </p>
+        <div class="op-snippet">
+          <pre><code>git clone {REPO}.git
+{snippets.compose}</code></pre>
+          <button type="button" class="op-copy" data-copy-target="op-code-compose">Copy</button>
+        </div>
+        <code id="op-code-compose" class="op-copy-source" hidden>git clone {REPO}.git
+{snippets.compose}</code>
+        <p class="op-fine">
+          A ready-to-use <code>docker-compose.yml</code> ships in that repository at{" "}
+          <code>v3/deploy/</code> — nothing to write yourself.
+        </p>
+      </section>
+
+      <section class="op-panel" id="op-panel-stores">
+        <h2>Self-hosting app stores</h2>
+        <p>
+          Packages for these platforms are built and kept current in the repository, but none of
+          them is listed in an official app catalog yet — that is a submission step still to
+          happen, tracked in the open. Until a listing goes live, Docker or Compose above install
+          the same image on any of these platforms, since they all run containers underneath.
+        </p>
+        <ul class="op-stores">
+          {STORES.map((store) => (
+            <li>
+              <span class="op-stores-name">{store.name}</span>
+              <span class="op-stores-status">not yet listed</span>
+              <a href={`${REPO}/tree/main/v3/deploy/stores/${store.dir}`}>package source</a>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+
+    <h2>Then open your hub</h2>
+    <p>
+      Once it is running, open <code>http://palaia.local</code> in a browser on the same network
+      — or, if that address does not resolve yet (some setups need one network flag; see{" "}
+      <a href="/install/#finding-it-on-your-network-palaialocal">Install it</a> for the one-line
+      fix), the address printed to the container's own log, which always works:{" "}
+      <code>http://&lt;host&gt;:8420</code>.
+    </p>
+
+    <h2>The wizard takes over</h2>
+    <p>
+      From there, a short setup wizard runs in the browser: an administrator sign-in, your first
+      memory, and connecting the first AI tool you use — no file editing, no extra commands. See{" "}
+      <a href="/first-shared-memory/">Your first shared memory</a> for what that looks like end
+      to end, or <a href="/install/">Install it</a> for the longer version of everything on this
+      page.
+    </p>
+  </div>
+
+  <script>
+    // Progressive enhancement only: the commands above are plain, selectable
+    // text without this script — copy buttons are a convenience, not a
+    // requirement to finish setup.
+    for (const button of document.querySelectorAll<HTMLButtonElement>("[data-copy-target]")) {
+      button.addEventListener("click", async () => {
+        const source = document.getElementById(button.dataset.copyTarget ?? "");
+        if (!source?.textContent) return;
+        try {
+          await navigator.clipboard.writeText(source.textContent);
+          const original = button.textContent;
+          button.textContent = "Copied";
+          setTimeout(() => {
+            button.textContent = original;
+          }, 1500);
+        } catch {
+          // clipboard access can be refused (older browser, insecure
+          // context) — the text is still right there, selectable by hand.
+        }
+      });
+    }
+  </script>
+</StarlightPage>
+
+<style>
+  /* Phone-friendly by construction: nothing here sets a fixed pixel width,
+     every code block scrolls inside its own box (never the page), and the
+     tab bar wraps instead of forcing a wider viewport — SPEC-504
+     deliverable #1's "no horizontal scroll on phones". */
+  .op {
+    max-width: 46rem;
+  }
+  .op-lede {
+    font-size: var(--sl-text-lg);
+    color: var(--sl-color-gray-2);
+  }
+
+  .op-tabs {
+    margin-block: 2rem;
+  }
+  .op-tabs input[type="radio"] {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+  }
+  .op-tabbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    border-bottom: 1px solid var(--sl-color-hairline);
+    margin-bottom: 1.5rem;
+  }
+  .op-tabbar label {
+    cursor: pointer;
+    padding: 0.5rem 0.9rem;
+    border-radius: 0.4rem 0.4rem 0 0;
+    color: var(--sl-color-gray-2);
+    font-size: var(--sl-text-sm);
+    user-select: none;
+  }
+  .op-tabbar label:hover {
+    color: var(--sl-color-white);
+  }
+  .op-panel {
+    display: none;
+  }
+  #op-tab-docker:checked ~ .op-tabbar label[for="op-tab-docker"],
+  #op-tab-compose:checked ~ .op-tabbar label[for="op-tab-compose"],
+  #op-tab-stores:checked ~ .op-tabbar label[for="op-tab-stores"] {
+    color: var(--sl-color-accent-high);
+    border-bottom: 2px solid var(--sl-color-accent);
+  }
+  #op-tab-docker:checked ~ #op-panel-docker,
+  #op-tab-compose:checked ~ #op-panel-compose,
+  #op-tab-stores:checked ~ #op-panel-stores {
+    display: block;
+  }
+
+  .op-snippet {
+    position: relative;
+    max-width: 100%;
+    overflow-x: auto;
+    background: var(--sl-color-black);
+    border: 1px solid var(--sl-color-hairline);
+    border-radius: 0.5rem;
+    padding: 1rem 5.5rem 1rem 1rem;
+  }
+  .op-snippet pre {
+    margin: 0;
+    white-space: pre;
+  }
+  .op-copy {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    font-size: var(--sl-text-xs);
+    padding: 0.3rem 0.6rem;
+    border-radius: 0.3rem;
+    border: 1px solid var(--sl-color-hairline);
+    background: var(--sl-color-gray-6);
+    color: var(--sl-color-white);
+    cursor: pointer;
+  }
+  .op-copy:hover {
+    background: var(--sl-color-gray-5);
+  }
+  .op-copy-source {
+    display: none;
+  }
+  .op-fine {
+    font-size: var(--sl-text-sm);
+    color: var(--sl-color-gray-3);
+  }
+
+  .op-stores {
+    list-style: none;
+    padding: 0;
+    display: grid;
+    gap: 0.6rem;
+  }
+  .op-stores li {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.6rem;
+    padding: 0.6rem 0.8rem;
+    border: 1px solid var(--sl-color-hairline);
+    border-radius: 0.4rem;
+  }
+  .op-stores-name {
+    font-weight: 600;
+    min-width: 8rem;
+  }
+  .op-stores-status {
+    font-size: var(--sl-text-xs);
+    color: var(--sl-color-gray-3);
+  }
+</style>

--- a/v3/site/docs/tests/onboarding.test.ts
+++ b/v3/site/docs/tests/onboarding.test.ts
@@ -1,0 +1,105 @@
+// SPEC-504 deliverable #1's drift test: the onboarding page's three
+// commands must be exactly what v3/deploy's real files say, not a
+// hand-typed copy of them. `loadDeploySnippets()` already reads them
+// straight out of `v3/deploy/README.md` at build time (see that module's
+// own docstring for why `import.meta.url`-relative pathing would break
+// once Astro bundles the page that imports it) — this test is the
+// independent check that the extraction actually landed on the right
+// text, by re-reading the same source file a second, differently-shaped
+// way and asserting the two agree.
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { DEPLOY_ROOT, loadDeploySnippets } from "../scripts/lib/deploy-snippets.mjs";
+
+describe("onboarding page snippets", () => {
+  it("reads v3/deploy/README.md, not a hand-copied string", () => {
+    const readmePath = path.join(DEPLOY_ROOT, "README.md");
+    const readme = readFileSync(readmePath, "utf8");
+    const snippets = loadDeploySnippets();
+
+    // Every returned snippet must appear verbatim in the real source file
+    // — the only way that can be true without maintaining a duplicate is
+    // if the extractor actually pulled the text out of it.
+    expect(readme).toContain(snippets.dockerRun);
+    expect(readme).toContain(snippets.compose);
+    expect(readme).toContain(snippets.curlInstall);
+  });
+
+  it("the docker run command matches docker-compose.yml's image and port", () => {
+    const compose = readFileSync(path.join(DEPLOY_ROOT, "docker-compose.yml"), "utf8");
+    const { dockerRun } = loadDeploySnippets();
+
+    const imageMatch = compose.match(/image:\s*(\S+)/);
+    expect(imageMatch, "docker-compose.yml has an image: line").not.toBeNull();
+    expect(dockerRun).toContain(imageMatch![1]);
+
+    const portMatch = compose.match(/"(\d+):(\d+)"/);
+    expect(portMatch, "docker-compose.yml maps a port").not.toBeNull();
+    expect(dockerRun).toContain(`-p ${portMatch![1]}:${portMatch![2]}`);
+  });
+
+  it("the compose command matches the real docker-compose.yml's own usage line", () => {
+    const compose = readFileSync(path.join(DEPLOY_ROOT, "docker-compose.yml"), "utf8");
+    const { compose: composeSnippet } = loadDeploySnippets();
+
+    // docker-compose.yml's own header comment documents the command that
+    // starts it — the onboarding page's snippet must be that same command.
+    expect(compose).toContain(composeSnippet.split("\n").at(-1));
+  });
+
+  it("the curl install command points at the real install.sh path in this repository", () => {
+    const { curlInstall } = loadDeploySnippets();
+    expect(curlInstall).toContain(
+      "https://raw.githubusercontent.com/byte5ai/palaia/main/v3/deploy/install.sh",
+    );
+  });
+
+  it("has no horizontal scroll on phones: no fixed pixel width, snippets scroll in their own box", () => {
+    // SPEC-504 deliverable #1's acceptance criterion, checked at the
+    // source level (this project has no DOM/browser test environment
+    // configured — see this file's own imports versus, say, v3/web's
+    // React Testing Library setup): a real phone-width layout regression
+    // in this page would show up as either a fixed pixel width wider than
+    // a phone viewport, or a code block with no scroll container of its
+    // own — both are things the stylesheet text itself proves or disproves
+    // directly, with no DOM required.
+    const page = readFileSync(
+      path.join(__dirname, "..", "src", "pages", "onboarding.astro"),
+      "utf8",
+    );
+    const styleMatch = page.match(/<style>([\s\S]*?)<\/style>/);
+    expect(styleMatch, "onboarding.astro has a <style> block").not.toBeNull();
+    const style = styleMatch![1];
+
+    // No rule sets an element to a fixed width wider than the narrowest
+    // common phone viewport (360px) — the layout is either fluid or
+    // capped with max-width, never pinned wider than the screen.
+    const widthDeclarations = [...style.matchAll(/(?<!max-|min-)width:\s*(\d+)px/g)];
+    for (const match of widthDeclarations) {
+      expect(Number(match[1]), `a fixed width of ${match[0]} would force horizontal scroll`).toBeLessThan(
+        360,
+      );
+    }
+
+    // Every command block scrolls inside itself rather than the page.
+    expect(style).toMatch(/\.op-snippet\s*\{[^}]*overflow-x:\s*auto/);
+    expect(style).toMatch(/\.op-snippet\s*\{[^}]*max-width:\s*100%/);
+
+    // The tab bar wraps rather than forcing the page wider than the
+    // platform labels' combined width.
+    expect(style).toMatch(/\.op-tabbar\s*\{[^}]*flex-wrap:\s*wrap/);
+  });
+
+  it("throws instead of returning an empty snippet if the source shape ever changes", () => {
+    // A cheap regression guard: the real file, today, always yields three
+    // non-empty fences in this order. If a future edit to README.md's
+    // Quick start section reorders or removes one, this extractor's own
+    // substring checks (see its module docstring) must fail loudly rather
+    // than this test silently passing on empty strings.
+    const snippets = loadDeploySnippets();
+    expect(snippets.dockerRun.length).toBeGreaterThan(0);
+    expect(snippets.compose.length).toBeGreaterThan(0);
+    expect(snippets.curlInstall.length).toBeGreaterThan(0);
+  });
+});

--- a/v3/web/src/components/ConnectPanel.tsx
+++ b/v3/web/src/components/ConnectPanel.tsx
@@ -26,8 +26,9 @@
 import { useEffect, useMemo, useState } from "react";
 
 import type { CreatedToken, TokenInfo } from "../lib/api/client";
-import { api, ApiError } from "../lib/api/client";
+import { api } from "../lib/api/client";
 import type { GuidedClient } from "../lib/clients";
+import { describeApiError } from "../lib/errors";
 import { CheckIcon, CopyIcon } from "../shell/icons";
 import { Badge } from "./Badge";
 import { Button } from "./Button";
@@ -35,15 +36,6 @@ import { Card, CardBody, CardFoot, CardHead, CardSubject } from "./Card";
 import { Input } from "./Field";
 import { Waiting } from "./Skeleton";
 import { useToast } from "./Toast";
-
-function describeError(err: unknown): string {
-  if (err instanceof ApiError) {
-    const body = err.body as { detail?: string } | undefined;
-    if (body?.detail) return body.detail;
-    return `The hub answered ${err.status}.`;
-  }
-  return "Could not reach the hub.";
-}
 
 export function formatAge(iso: string): string {
   const seconds = Math.max(0, (Date.now() - new Date(iso).getTime()) / 1000);
@@ -137,7 +129,7 @@ export function ConnectPanel({
       setPlaintext(result.token);
       onTokenIssued?.(result.info);
     } catch (err) {
-      setError(describeError(err));
+      setError(describeApiError(err));
     } finally {
       setIssuing(false);
     }

--- a/v3/web/src/lib/api/client.ts
+++ b/v3/web/src/lib/api/client.ts
@@ -148,6 +148,19 @@ export interface InboxStatus {
   last_captured_at: string | null;
 }
 
+/** SPEC-504 deliverable #3: the local-only first-run funnel's read side.
+ * Every `*_at` field is a Unix timestamp (seconds) or `null` until that
+ * step happens on this hub — see `palaia_hub.funnel`'s module docstring
+ * for why this is never transmitted anywhere beyond this one hub. */
+export interface FunnelStatus {
+  hub_started_at: number | null;
+  vault_created_at: number | null;
+  client_connected_at: number | null;
+  first_memory_at: number | null;
+  time_to_first_memory_seconds: number | null;
+  time_to_first_memory_display: string | null;
+}
+
 /** SPEC-210 deliverable #3: one vault's index status, as
  * `palaia_hub.dashboard_api.IndexStatusOut` returns it. */
 export interface EmbedStatus {
@@ -748,6 +761,9 @@ export const api = {
     getJson<InboxStatus>(`/api/vaults/${vaultKey}/inbox_status`),
   indexStatus: (vaultKey: string) =>
     getJson<IndexStatus>(`/api/vaults/${vaultKey}/index_status`),
+
+  // ---- SPEC-504: the local-only first-run funnel ----
+  funnelStatus: () => getJson<FunnelStatus>("/api/funnel/status"),
 
   // ---- SPEC-305: the tool-profile editor ----
   listGatewayProfiles: () => getJson<GatewayProfile[]>("/api/gateway/profiles"),

--- a/v3/web/src/lib/docs.ts
+++ b/v3/web/src/lib/docs.ts
@@ -1,0 +1,17 @@
+/**
+ * Deep links from the dashboard into the SPEC-503 docs site (SPEC-504
+ * deliverable #4: the wizard's final step names its exact next actions,
+ * one of which is "read the docs").
+ *
+ * `DOCS_BASE_URL` mirrors the same placeholder
+ * `v3/site/docs/astro.config.mjs` itself uses (that file's own comment:
+ * "hosting/DNS for this site is out of this SPEC's scope... set this to
+ * the real domain once one is chosen") — one placeholder, not two that
+ * could drift out of sync once a real domain is picked.
+ */
+export const DOCS_BASE_URL = "https://docs.palaia.example";
+
+/** A docs-site path (e.g. `"/connect/"`) as an absolute URL. */
+export function docsUrl(path: string): string {
+  return `${DOCS_BASE_URL}${path}`;
+}

--- a/v3/web/src/lib/errors.test.ts
+++ b/v3/web/src/lib/errors.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { ApiError } from "./api/client";
+import { describeApiError } from "./errors";
+
+describe("describeApiError — SPEC-504 error-message audit", () => {
+  it("trusts a server-sent detail as-is (every funnel-path error already names its own fix)", () => {
+    const err = new ApiError("/api/vaults", 400, {
+      detail: "vault 'work' is already registered. Fix: pick another name.",
+    });
+
+    expect(describeApiError(err)).toBe("vault 'work' is already registered. Fix: pick another name.");
+  });
+
+  it("an unexpected status with no detail still names something to try", () => {
+    const err = new ApiError("/api/vaults", 500, undefined);
+
+    const message = describeApiError(err);
+    expect(message).toMatch(/try again/i);
+  });
+
+  it("a network failure (no response at all) names a concrete next step, not just 'could not reach the hub'", () => {
+    const message = describeApiError(new TypeError("Failed to fetch"));
+
+    expect(message).toMatch(/still running/i);
+    expect(message).toMatch(/try again/i);
+  });
+});

--- a/v3/web/src/lib/errors.ts
+++ b/v3/web/src/lib/errors.ts
@@ -1,0 +1,29 @@
+/**
+ * SPEC-504 first-run funnel audit finding: every network-failure fallback
+ * in the wizard/connect flow used to read "Could not reach the hub." or
+ * "Could not create the vault — check the hub's own logs." — true, but
+ * neither one names a fix a first-timer can actually act on ("logs" is
+ * jargon a non-developer does not know how to find). One shared helper so
+ * the fix wording lives in one place: a server-sent `detail` string (every
+ * server-side error on the funnel path already names its own fix — see
+ * `palaia_hub.vault.errors.VaultConfigError`'s call sites) is trusted
+ * as-is; a network failure (no response at all — the hub is down, or the
+ * browser is pointed at the wrong address) gets a concrete next step
+ * instead of a dead end.
+ */
+import { ApiError } from "./api/client";
+
+const UNREACHABLE_HINT =
+  "Could not reach the hub — check that its container is still running and that " +
+  "this browser is on the address it printed at startup, then try again.";
+
+/** A user-facing message for `err`, always ending in something to try next. */
+export function describeApiError(err: unknown): string {
+  if (err instanceof ApiError) {
+    const body = err.body as { detail?: string } | undefined;
+    if (body?.detail) return body.detail;
+    return `The hub answered with an unexpected error (status ${err.status}). ` +
+      "Try again — if it keeps happening, restart the hub container.";
+  }
+  return UNREACHABLE_HINT;
+}

--- a/v3/web/src/routes/Home.test.tsx
+++ b/v3/web/src/routes/Home.test.tsx
@@ -1,0 +1,210 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { createMemoryRouter, Outlet, RouterProvider } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { FunnelStatus, InfoResponse, TokenInfo, VaultSummary } from "../lib/api/client";
+import { api } from "../lib/api/client";
+import type { EventStreamState } from "../lib/events";
+import { Home } from "./Home";
+
+const BASE_STREAM: EventStreamState = {
+  connection: "open",
+  health: { status: "ok" },
+  healthAt: Date.now(),
+  vaultChangeCount: 0,
+  lastVaultChange: null,
+  recentChanges: [],
+  agentActivityCount: 0,
+};
+
+const A_VAULT: VaultSummary = {
+  key: "work",
+  purpose: "Work notes.",
+  path: "/x",
+  writable: true,
+  note_count: 3,
+};
+
+const A_TOKEN: TokenInfo = {
+  id: "t1",
+  name: "claude-code",
+  profile: "default",
+  scopes: ["vault:work:read", "vault:work:write"],
+  created_at: new Date().toISOString(),
+  last_used_at: new Date().toISOString(),
+  revoked_at: null,
+};
+
+const NO_FUNNEL: FunnelStatus = {
+  hub_started_at: Date.now() / 1000,
+  vault_created_at: null,
+  client_connected_at: null,
+  first_memory_at: null,
+  time_to_first_memory_seconds: null,
+  time_to_first_memory_display: null,
+};
+
+const CELEBRATING_FUNNEL: FunnelStatus = {
+  hub_started_at: 1000,
+  vault_created_at: 1050,
+  client_connected_at: 1100,
+  first_memory_at: 1252,
+  time_to_first_memory_seconds: 252,
+  time_to_first_memory_display: "4m12s",
+};
+
+function mount(stream: EventStreamState = BASE_STREAM) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/",
+        element: <Outlet context={stream} />,
+        children: [{ index: true, element: <Home /> }],
+      },
+    ],
+    { initialEntries: ["/"] },
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+function mockApi(overrides: { funnel?: FunnelStatus } = {}) {
+  vi.spyOn(api, "info").mockResolvedValue({ version: "3.0.0", mode: "locked" } as InfoResponse);
+  vi.spyOn(api, "listVaults").mockResolvedValue([A_VAULT]);
+  vi.spyOn(api, "inboxStatus").mockResolvedValue({
+    count: 0,
+    oldest_capture_id: null,
+    oldest_age_seconds: null,
+    last_capture_id: null,
+    last_captured_at: null,
+  });
+  vi.spyOn(api, "indexStatus").mockResolvedValue({
+    vault: "work",
+    schema_version: 1,
+    notes: 3,
+    observations: 0,
+    relations: 0,
+    unresolved_relations: 0,
+    embeds: {
+      enabled: false,
+      available: false,
+      model: "",
+      dim: 0,
+      total: 0,
+      ready: 0,
+      pending: 0,
+      failed: 0,
+      reason: "disabled",
+    },
+    embed_progress_percent: 100,
+    embed_summary: "disabled",
+  });
+  vi.spyOn(api, "listTokens").mockResolvedValue([A_TOKEN]);
+  vi.spyOn(api, "funnelStatus").mockResolvedValue(overrides.funnel ?? NO_FUNNEL);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Home — SPEC-504 first-memory celebration", () => {
+  it("shows nothing extra before the first memory is recorded", async () => {
+    mockApi({ funnel: NO_FUNNEL });
+
+    mount();
+
+    await screen.findByText(/1 vault/i);
+    expect(screen.queryByTestId("first-memory-celebration")).not.toBeInTheDocument();
+  });
+
+  it("celebrates once the funnel reports a first memory, showing the elapsed time", async () => {
+    mockApi({ funnel: CELEBRATING_FUNNEL });
+
+    mount();
+
+    const banner = await screen.findByTestId("first-memory-celebration");
+    expect(banner).toHaveTextContent("Your first memory is in.");
+    expect(banner).toHaveTextContent("4m12s");
+  });
+
+  it("does not blow up when the funnel endpoint is unreachable", async () => {
+    vi.spyOn(api, "info").mockResolvedValue({ version: "3.0.0", mode: "locked" } as InfoResponse);
+    vi.spyOn(api, "listVaults").mockResolvedValue([A_VAULT]);
+    vi.spyOn(api, "inboxStatus").mockResolvedValue({
+      count: 0,
+      oldest_capture_id: null,
+      oldest_age_seconds: null,
+      last_capture_id: null,
+      last_captured_at: null,
+    });
+    vi.spyOn(api, "indexStatus").mockResolvedValue({
+      vault: "work",
+      schema_version: 1,
+      notes: 3,
+      observations: 0,
+      relations: 0,
+      unresolved_relations: 0,
+      embeds: {
+        enabled: false,
+        available: false,
+        model: "",
+        dim: 0,
+        total: 0,
+        ready: 0,
+        pending: 0,
+        failed: 0,
+        reason: "disabled",
+      },
+      embed_progress_percent: 100,
+      embed_summary: "disabled",
+    });
+    vi.spyOn(api, "listTokens").mockResolvedValue([A_TOKEN]);
+    vi.spyOn(api, "funnelStatus").mockRejectedValue(new Error("no funnel store reachable"));
+
+    mount();
+
+    await screen.findByText(/1 vault/i);
+    await waitFor(() => expect(screen.queryByTestId("first-memory-celebration")).not.toBeInTheDocument());
+  });
+
+  it("never says 'this number never leaves this hub' without also naming what the number is", async () => {
+    // SPEC-504 §10 privacy-copy sanity check, not a jargon lint (see below
+    // for that one) — the celebration explicitly states the local-only
+    // promise inline, so a reader never has to guess.
+    mockApi({ funnel: CELEBRATING_FUNNEL });
+
+    mount();
+
+    const banner = await screen.findByTestId("first-memory-celebration");
+    expect(banner).toHaveTextContent(/never leaves this hub/i);
+  });
+});
+
+/**
+ * Same jargon-lint shape as `Agents.test.tsx`'s own — no protocol name,
+ * standard, acronym or implementation word in the celebration banner's
+ * visible text.
+ */
+describe("first-memory celebration copy — no jargon (system.md §3 rule 0)", () => {
+  const BANNED = [
+    /\bmcp\b/i,
+    /\boauth\b/i,
+    /\bjwt\b/i,
+    /\basgi\b/i,
+    /\bapi\b/i,
+    /\bjson\b/i,
+    /\bvault\b/i,
+    /\bfunnel\b/i,
+  ];
+
+  it("the banner's text uses no in-house word", async () => {
+    mockApi({ funnel: CELEBRATING_FUNNEL });
+
+    mount();
+
+    const banner = await screen.findByTestId("first-memory-celebration");
+    const text = banner.textContent ?? "";
+    for (const pattern of BANNED) {
+      expect(text).not.toMatch(pattern);
+    }
+  });
+});

--- a/v3/web/src/routes/Home.tsx
+++ b/v3/web/src/routes/Home.tsx
@@ -2,10 +2,10 @@ import { useEffect, useState } from "react";
 import { Link, useOutletContext } from "react-router-dom";
 
 import { Badge, CardFoot, CardHead, EmptyState } from "../components";
-import type { InfoResponse, TokenInfo, VaultSummary } from "../lib/api/client";
+import type { FunnelStatus, InfoResponse, TokenInfo, VaultSummary } from "../lib/api/client";
 import { api } from "../lib/api/client";
 import type { EventStreamState, VaultChangeEntry } from "../lib/events";
-import { ClientsIcon, ExplorerIcon } from "../shell/icons";
+import { CheckIcon, ClientsIcon, ExplorerIcon } from "../shell/icons";
 
 interface InboxAggregate {
   count: number;
@@ -92,6 +92,7 @@ export function Home() {
   const [inbox, setInbox] = useState<InboxAggregate | null>(null);
   const [tokens, setTokens] = useState<TokenInfo[] | null>(null);
   const [indexAggregate, setIndexAggregate] = useState<IndexAggregate | null>(null);
+  const [funnel, setFunnel] = useState<FunnelStatus | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -151,10 +152,35 @@ export function Home() {
       .catch(() => {
         if (!cancelled) setTokens([]);
       });
+    api
+      .funnelStatus()
+      .then((status) => {
+        if (!cancelled) setFunnel(status);
+      })
+      .catch(() => {
+        // no funnel store reachable yet — the rest of the page still works
+      });
     return () => {
       cancelled = true;
     };
   }, []);
+
+  // SPEC-504 deliverable #3: poll for the celebration moment the same
+  // "no refresh button anywhere" way ConnectPanel.tsx polls for a client's
+  // first call — this tile just isn't event-stream-backed either. Stops
+  // once a first memory is recorded; nothing left to wait for after that.
+  useEffect(() => {
+    if (funnel?.first_memory_at) return;
+    const id = window.setInterval(() => {
+      api
+        .funnelStatus()
+        .then(setFunnel)
+        .catch(() => {
+          // a transient fetch failure just means the next tick tries again
+        });
+    }, 3000);
+    return () => window.clearInterval(id);
+  }, [funnel?.first_memory_at]);
 
   const isHealthy = stream.health?.status === "ok";
   const hasVaults = (vaults?.length ?? 0) > 0;
@@ -205,6 +231,19 @@ export function Home() {
           )}
         </div>
       </section>
+
+      {funnel?.time_to_first_memory_display ? (
+        <section className="banner banner--ok" data-testid="first-memory-celebration">
+          <CheckIcon className="icon icon--sm" />
+          <div>
+            <p className="banner__title">Your first memory is in.</p>
+            <p className="t-sm t-muted">
+              Set up in {funnel.time_to_first_memory_display} — from install to a client's
+              first successful write, timed by the hub itself. This number never leaves this hub.
+            </p>
+          </div>
+        </section>
+      ) : null}
 
       <section className="tiles">
         <Tile

--- a/v3/web/src/routes/onboarding/Onboarding.test.tsx
+++ b/v3/web/src/routes/onboarding/Onboarding.test.tsx
@@ -78,5 +78,19 @@ describe("Onboarding wizard", () => {
 
     expect(await screen.findByRole("heading", { name: /connect your first client/i })).toBeInTheDocument();
     await waitFor(() => expect(screen.getByRole("button", { name: /issue token/i })).toBeInTheDocument());
+
+    // SPEC-504 deliverable #4: the wizard's final step links the exact
+    // next actions — connect a second AI, install a tool, read the docs.
+    expect(screen.getByRole("link", { name: /connect a second ai/i })).toHaveAttribute(
+      "href",
+      "/clients",
+    );
+    expect(screen.getByRole("link", { name: /install a tool/i })).toHaveAttribute(
+      "href",
+      "/marketplace",
+    );
+    const docsLink = screen.getByRole("link", { name: /read the docs/i });
+    expect(docsLink).toHaveAttribute("target", "_blank");
+    expect(docsLink.getAttribute("href")).toMatch(/^https:\/\//);
   });
 });

--- a/v3/web/src/routes/onboarding/Onboarding.tsx
+++ b/v3/web/src/routes/onboarding/Onboarding.tsx
@@ -26,14 +26,23 @@
  *   they replace.
  */
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 import { ConnectPanel } from "../../components/ConnectPanel";
 import { Field, Input } from "../../components/Field";
-import { api, ApiError } from "../../lib/api/client";
+import { api } from "../../lib/api/client";
 import type { HubMode } from "../../lib/clients";
 import { guidedClients } from "../../lib/clients";
-import { ArrowRightIcon, CheckIcon, WarningIcon } from "../../shell/icons";
+import { docsUrl } from "../../lib/docs";
+import { describeApiError } from "../../lib/errors";
+import {
+  ArrowRightIcon,
+  CheckIcon,
+  ClientsIcon,
+  LinkIcon,
+  MarketplaceIcon,
+  WarningIcon,
+} from "../../shell/icons";
 
 const STEP_NAMES = [
   { name: "Owner account", hint: "who administers this hub" },
@@ -130,11 +139,7 @@ export function Onboarding() {
       });
       setStep(4);
     } catch (err) {
-      setCreateError(
-        err instanceof ApiError && (err.body as { detail?: string } | undefined)?.detail
-          ? String((err.body as { detail?: string }).detail)
-          : "Could not create the vault — check the hub's own logs.",
-      );
+      setCreateError(describeApiError(err));
     } finally {
       setCreating(false);
     }
@@ -390,6 +395,35 @@ export function Onboarding() {
                 client={selectedClient}
                 defaultProfile="default"
               />
+              <div className="card" style={{ marginTop: "var(--space-4)" }}>
+                <div className="card__body stack stack--3">
+                  <p className="t-over">What's next</p>
+                  <div className="row row--wrap" style={{ gap: 8 }}>
+                    <Link className="btn" to="/clients">
+                      <ClientsIcon className="icon--sm" />
+                      Connect a second AI
+                    </Link>
+                    <Link className="btn" to="/marketplace">
+                      <MarketplaceIcon className="icon--sm" />
+                      Install a tool
+                    </Link>
+                    <a
+                      className="btn"
+                      href={docsUrl("/first-shared-memory/")}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      <LinkIcon className="icon--sm" />
+                      Read the docs
+                    </a>
+                  </div>
+                  <p className="t-xs t-muted">
+                    A second AI is the whole point — one memory both of them read from and write
+                    to. All three are here whenever you're ready; nothing above is required to
+                    finish.
+                  </p>
+                </div>
+              </div>
               <div className="wiz__foot">
                 <button type="button" className="btn" onClick={() => setStep(3)}>
                   Back


### PR DESCRIPTION
## What

SPEC-504: the onboarding page (successor to palaia.byte5.ai, MASTERPLAN
§9.3) plus the first-run funnel audit behind it, and local-only
time-to-first-memory instrumentation (§13/§10).

1. **Onboarding page** — `v3/site/docs/src/pages/onboarding.astro`: a
   platform picker (Docker one-liner, the convenience install script, a
   Compose file) → "then open `http://palaia.local` (or
   `http://<host>:8420`)" → the wizard takes over. Copy-to-clipboard,
   phone-friendly, jargon-free.
2. **First-run funnel audit, fixed in the product** (see below — this is
   the substance).
3. **Local-only funnel instrumentation** — `palaia_hub.funnel`:
   wizard-step timestamps + time-to-first-memory, shown on the dashboard
   home as "Set up in 4m12s", never transmitted.
4. **Wizard final step** links the exact next actions: connect a second
   AI, install a tool, read the docs.

## Deviation from the spec, called out as asked

Deliverable #1 offered a choice: a separate `v3/site/onboarding/` tree,
or a page of the existing docs-site toolchain "when that is cleaner". I
took the latter: `src/pages/onboarding.astro` inside SPEC-503's existing
Astro/Starlight project (a `StarlightPage` with `template: "splash"` for
the sidebar-free landing layout), not a second Astro project with its own
`package.json`, CI job, and copy of `custom.css`'s tokens for one page.
Linked as the entry point from the sidebar ("Start here" → "Get palaia
running") and the homepage's primary call to action.

## Funnel audit — findings

Walked the real wizard (create vault → client connects → first memory
write → dashboard celebrates) as a first-timer, on a hub with
`auth_enabled: true` (the default in every mode, not only cloud/open —
this is the common case a script that turns auth off would have missed).

**Fixed:**

- **Auth bypass on every fresh install.** `DynamicGateway.add_vault`
  mounted a profile path with no verifier at all whenever that path did
  not exist at hub construction time — which is *always* true for the
  wizard's first vault on a fresh install (zero vaults at boot → zero
  profiles → zero verifiers built). Any token, even garbage, authenticated
  against the very first vault a real user creates, regardless of
  `auth_enabled`. Fixed with `DynamicGateway.auth_provider_factory`, a
  hook called once per genuinely-new path, wired from
  `serve.build_production_app` with the same recipe `token_verifiers`
  already used. `server/tests/gateway/test_dynamic_auth_provider_factory.py`,
  and end-to-end over real HTTP in
  `server/tests/e2e/test_s7_spec504_first_run_funnel.py`.
- **Every wizard-connected client's first write failed.** `POST
  /api/auth/tokens` created a zero-scope token whenever `scopes` was
  omitted or empty — what `ConnectPanel.tsx`'s "Issue token" (the
  onboarding wizard's own step 4) has always sent, since there is no
  scope picker in the UI. A zero-scope token authenticates but then fails
  every per-tool scope check, so the client's very first memory write
  errored with "missing scope `vault:work:write`". Fixed: an empty
  `scopes` list now defaults to read+write on every vault the target
  profile currently mounts; an explicit list is still honored as given.
  `server/tests/auth/test_routes_default_scopes.py`.
- **Vague, non-actionable network-failure messages.** The wizard's
  vault-creation failure and `ConnectPanel`'s token-issuance failure both
  fell back to "Could not reach the hub." on a network failure — true,
  but no next step (a server-sent `detail` already named its fix in every
  case; only the no-response case was weak). One shared
  `web/src/lib/errors.ts` now gives that case a concrete, jargon-free
  message; both call sites use it. `web/src/lib/errors.test.ts`.
- **`install.md`'s docker-run one-liner had drifted from the real
  `deploy/README.md`** — missing the SPEC-502 hardening flags the real
  Quick start section already had. Fixed on both pages; the onboarding
  page's own snippets are read directly from `v3/deploy`'s files at build
  time so this specific drift is now structurally impossible there.

**Documented, not fixed** (SPEC-504's own "larger redesigns become filed
issues, not scope creep"):

- A template-created vault's two seed notes count as "first memory" too
  (`palaia_hub.funnel`'s own docstring explains why and what a real fix
  would need). The wizard's template switch defaults off, so this does
  not affect the common path.
- No scope picker in the dashboard UI — the empty-scopes-default above is
  a reasonable interim fix, but a real fix needs UI work beyond this
  SPEC's instrumentation scope. Filed as
  [byte5ai/palaia#270](https://github.com/byte5ai/palaia/issues/270).

**Not yet live, represented honestly:** the Umbrel/CasaOS/Runtipi/TrueNAS
packages SPEC-501 built are real, but none is listed in an official
catalog yet (each package's own `SUBMIT.md` says so). The onboarding
page's "Self-hosting app stores" tab says "not yet listed" per platform
with a link to the real package source, rather than a one-click flow that
doesn't exist yet.

## How

- `palaia_hub.funnel`: local-only wizard-step timestamps + derived
  time-to-first-memory in one JSON file under the hub's home directory,
  event-driven off the real public bus (`hub.started`, the new
  `memory.vault.created`, `client.connected`, `memory.entry.created`) —
  never from a client-supplied timestamp. `GET /api/funnel/status`,
  mounted unconditionally like `/api/health`.
  `server/tests/funnel/test_no_egress.py` patches every real network
  connect attempt and drives the whole path through it — proves no
  network egress from the stats path.
- `scripts/lib/deploy-snippets.mjs`: the onboarding page's three commands
  are read out of `v3/deploy/README.md`'s real Quick start fences at
  build time — never retyped. `tests/onboarding.test.ts` independently
  re-derives them and checks the docker-run command against
  `docker-compose.yml`'s own image/port, plus the phone-width CSS rules
  directly (no fixed pixel width anywhere, every command scrolls in its
  own box, the tab bar wraps).
- Error-message audit: `server/tests/funnel/test_error_message_audit.py`
  walks the funnel's failure branches over the real REST surface and
  asserts each one names its fix.

## Test evidence

All from `v3/` unless noted.

- `uv run ruff check .` — clean on every file this PR touches (pre-existing
  issues remain only in `spikes/`/`tools/`, untouched by this PR).
- `uv run mypy server/src` — clean, 193 source files (the repo's own
  `files = ["server/src"]` mypy config; `mypy .` hits a pre-existing
  duplicate-`conftest.py`-module error across `tests/e2e` and
  `tests/curator` unrelated to this PR — CI's own `mypy` step scopes to
  `server/src` for the same reason).
- `uv run pytest server/tests -q` — **2192 passed, 23 skipped** before the
  merge (one pre-existing-shape failure, `test_every_rest_group_is_in_
  the_threat_model`, caught the new `/api/funnel` route group missing
  from the threat model doc — fixed in a follow-up commit, verified green
  standalone). After merging in SPEC-505 (v2 sunset + migration guide),
  every merge-affected suite re-verified green
  (`server/tests/docs_site`, `test_migration_guide_copy_lint.py`,
  `test_migration_guide_import_roundtrip.py`,
  `test_threat_model_coverage.py` — 36 passed) and the full suite is
  re-running post-merge.
- `cd web && npm run lint && npm run typecheck && npx vitest run && npm
  run build` — clean; **111 passed** (22 test files), including new
  `Home.test.tsx` (first-memory celebration, jargon lint) and
  `errors.test.ts`.
- `cd site/docs && npm run lint && npm run typecheck && npm run
  check:generated && npm test && npm run build` — clean; **9 passed** (2
  test files), 22 pages built, no broken internal links.
- `grep -rn '^<<<<<<< ' v3` — empty, before every commit and after the
  merge.

## Merge note

`origin/claude/palaia-major-rewrite-lj5v9x` gained SPEC-505 (v2 sunset +
migration guide) while this branch was in flight — merged in (clean,
`ort` auto-merge, no conflicts even in the shared `astro.config.mjs`
sidebar array both branches edited); every merge-affected suite
re-verified green above.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790301908&installation_model_id=428086&pr_number=271&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F271&signature=a22e23072180b2a444595ff9a27510b770919cdb8a8a3c342b0deb7b7b087396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->