### PR TITLE
docs: record the P5 gate held 2026-08-26

### DIFF
--- a/v3/IMPLEMENTATION.md
+++ b/v3/IMPLEMENTATION.md
@@ -306,7 +306,7 @@ protocol).
   of those. **This paragraph is a draft: the architect holds the gate** —
   it records what was run and observed, not a verdict on whether Phase 4's
   exit criterion is met or what Phase 5 should be.
-- **Gate P5 (3.0 release candidate; DRAFT, 2026-08-26):** every Phase-5
+- **Gate P5 (3.0 release candidate; held 2026-08-26):** every Phase-5
   ship merged and integrated (SPECs 501–505: app-store distribution +
   channels + self-update, a hardening pass + external-review brief, the
   docs site + onboarding page, v2 sunset messaging), full suite green.
@@ -353,7 +353,18 @@ protocol).
   final, non-candidate `3.0.0` tag, with every owner-only step (the
   external security review, the real usability session, store
   submissions, DNS/hosting, the migration guide's `[DECISION:]` dates)
-  marked as such. **This paragraph is a draft: the architect holds the
-  gate** — it records what was run and observed, not a verdict on
-  whether the Phase-5 exit criterion is met or that `3.0.0-rc1` is ready
-  to become `3.0.0`.
+  marked as such. **Architect's verdict (2026-08-26): gate held,
+  conditionally.** The scriptable half of the exit criterion is met: the
+  funnel e2e was independently re-run during integration (green, docker
+  smoke env-skipped with the same fallback evidence), the full suite was
+  independently green on every Phase-5 PR before merge (2210–2215 passed
+  depending on env-gated skips; identical collected totals), and the
+  release plumbing (VERSION, drift test, changelog, dry-run, RELEASING.md)
+  is in place and verified. `3.0.0-rc1` stands as the release candidate.
+  The gate's two open conditions are exactly `v3/RELEASING.md` §1: the
+  real non-developer usability session (protocol shipped, owner runs it)
+  and the external security review (brief shipped, owner procures it).
+  Neither is waived — `3.0.0` final must not be tagged until both are
+  done; RELEASING.md sequences this and no automation in this repository
+  can bypass it. Phase 5 is thereby complete as a development phase; what
+  remains on the road to `3.0.0` is owner work, not engineering scope.


### PR DESCRIPTION
Turns SPEC-506's draft Phase-5 gate paragraph in `v3/IMPLEMENTATION.md` §6 into the held gate record.

Verdict: **gate held, conditionally.** The scriptable half of the exit criterion ("a non-developer completes install → first shared memory unaided") is met and was independently re-verified during integration (funnel e2e green twice, timed well under the 5-minute target; full suite green on every Phase-5 PR before merge). `3.0.0-rc1` stands as the release candidate.

Two hard preconditions remain before a final `3.0.0` tag, both owner actions sequenced in `v3/RELEASING.md` §1: the real non-developer usability session (protocol shipped) and the external security review (brief shipped). Neither is waived.

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790306002&installation_model_id=428086&pr_number=275&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F275&signature=92acede6e664a4c0cae142c723eaf30fc4b08f64a603a4a3406a4dac8987d845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->