### PR TITLE
fix(docs): remove nonexistent security email from reporting policy

### DIFF
--- a/v3/RELEASING.md
+++ b/v3/RELEASING.md
@@ -39,10 +39,12 @@ whoever holds it.
       task is not automatically a blocker — judge it the way every other
       gate in this project has: does it undermine the exit criterion, or
       is it a polish item that becomes a filed issue?
-- [ ] **[OWNER]** Confirm `SECURITY.md`'s reporting contact
-      (`security@byte5.de` and the GitHub private-vulnerability-reporting
-      button) is actually monitored before a wider audience sees this
-      release — nothing in this repository can verify an inbox is read.
+- [ ] **[OWNER]** Confirm `SECURITY.md`'s reporting channel (the GitHub
+      private-vulnerability-reporting button — the owner confirmed on
+      2026-08-26 that no security email address exists, so the button is
+      the only channel) actually notifies someone who reads it before a
+      wider audience sees this release. Adding a real, monitored security
+      email later means one edit to `SECURITY.md`.
 
 ## 2. Owner decisions this repository left open on purpose
 

--- a/v3/SECURITY.md
+++ b/v3/SECURITY.md
@@ -24,14 +24,10 @@ no long-term-support branches.
 
 **Please do not open a public issue for a security problem.**
 
-Two ways, either is fine:
-
-1. **GitHub private vulnerability reporting** — the "Report a vulnerability"
-   button under this repository's *Security* tab. This is the preferred
-   route: it keeps the report, the discussion and the eventual advisory in
-   one place.
-2. **Email** — security@byte5.de. Say "palaia v3" in the subject so it is
-   routed correctly.
+Use **GitHub private vulnerability reporting** — the "Report a
+vulnerability" button under this repository's *Security* tab. It keeps the
+report, the discussion and the eventual advisory in one place, and it is
+currently the only monitored channel; there is no security email address.
 
 Please include, as far as you have it:
 

--- a/v3/server/tests/security/test_threat_model_coverage.py
+++ b/v3/server/tests/security/test_threat_model_coverage.py
@@ -209,7 +209,12 @@ def test_the_security_policy_exists_and_says_how_to_report() -> None:
     text = SECURITY_POLICY.read_text(encoding="utf-8")
     assert "## Reporting a vulnerability" in text
     assert "## Supported versions" in text
-    assert "@" in text, "no contact address in the security policy"
+    # The one monitored channel (the owner confirmed 2026-08-26 that no
+    # security email inbox exists, so an "@" is exactly what must NOT be
+    # promised here): GitHub's private vulnerability reporting.
+    assert "private vulnerability reporting" in text, (
+        "the security policy no longer names its reporting channel"
+    )
 
 
 def test_the_readme_links_the_security_policy() -> None:


### PR DESCRIPTION
The owner confirmed `security@byte5.de` does not exist. A dead reporting address is worse than none — vulnerability reports would silently go nowhere.

- `v3/SECURITY.md`: GitHub private vulnerability reporting is now the only named channel; the policy states explicitly that no security email exists.
- `v3/RELEASING.md`: the owner checklist item follows suit (confirm the button notifies someone who reads it; adding a real email later is one edit).
- `test_threat_model_coverage.py`: the policy test now asserts the reporting channel is named, instead of requiring an `@` — an email address is exactly what must not be promised here.

Security suite green (89 passed), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790424534&installation_model_id=428086&pr_number=277&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F277&signature=7400f5a253ab08ccdd0e15c6d9f987e62fa8dbf127d8a6628cbfdf372f7d1d68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->