### PR TITLE
fix: doctor stale-tasks must respect scope visibility (port of #189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Fixed
 - **ContextEngine: `ownsCompaction: true`** — palaia now declares compaction ownership, preventing OpenClaw's built-in Pi auto-compaction from running in parallel with `palaia gc`. Without this flag, both compaction mechanisms could interfere with each other, leading to unpredictable context truncation.
-- **Doctor phantom stale-tasks warning** — `_check_stale_unassigned_tasks` now reads entries through `Store.all_entries_unfiltered()` instead of scanning `.md` files directly. The previous approach could report entries invisible to `palaia list` (e.g. entries with empty/invalid scope), causing the doctor to warn about tasks that the user cannot see or act on.
+- **Doctor phantom stale-tasks warning** — `_check_stale_unassigned_tasks` now uses `Store.all_entries()` with agent scope filtering (not `all_entries_unfiltered()`). The doctor only reports entries that `palaia list` can actually see — private-scoped entries from other agents are no longer counted as phantom warnings.
 - **Scope: empty/unknown scope no longer hides entries** — `can_access()` now treats empty or unrecognized scope values as `"team"` instead of returning `False`. Entries with missing or malformed scope are no longer silently invisible.
 
 ---

--- a/palaia/doctor/checks.py
+++ b/palaia/doctor/checks.py
@@ -1864,9 +1864,9 @@ def _check_claude_code_config(palaia_root: Path | None) -> dict[str, Any]:
 def _check_stale_unassigned_tasks(palaia_root: Path | None) -> dict[str, Any]:
     """Check for auto-captured tasks without assignee/due_date older than 7 days.
 
-    Uses Store.all_entries_unfiltered() to ensure consistent entry discovery
-    with `palaia list`. Previous implementation scanned .md files directly,
-    which could report entries invisible to the user (scope filtering mismatch).
+    Uses Store.all_entries() with agent scope filtering to ensure the doctor
+    only reports entries visible to `palaia list`. Entries hidden by scope
+    (e.g. private entries from a different agent) are excluded.
     """
     if palaia_root is None:
         return {
@@ -1878,6 +1878,7 @@ def _check_stale_unassigned_tasks(palaia_root: Path | None) -> dict[str, Any]:
 
     from datetime import datetime, timezone
 
+    from palaia.config import resolve_agent as resolve_agent_identity
     from palaia.store import Store
 
     now = datetime.now(tz=timezone.utc)
@@ -1885,7 +1886,8 @@ def _check_stale_unassigned_tasks(palaia_root: Path | None) -> dict[str, Any]:
 
     try:
         store = Store(palaia_root)
-        all_entries = store.all_entries_unfiltered(include_cold=False)
+        agent = resolve_agent_identity(palaia_root)
+        all_entries = store.all_entries(include_cold=False, agent=agent)
     except Exception:
         return {
             "name": "stale_unassigned_tasks",

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -438,6 +438,36 @@ Elliot will fix the caching bug."""
         result = _check_stale_unassigned_tasks(palaia_root)
         assert result["status"] == "ok"
 
+    def test_ignores_private_tasks_from_other_agent(self, palaia_root, monkeypatch):
+        """Regression: doctor must not report private-scoped entries from a
+        different agent.  This was the exact user-reported bug — doctor showed
+        4 stale tasks that ``palaia list`` didn't because scope filtering was
+        bypassed (all_entries_unfiltered instead of all_entries).
+        """
+        from datetime import datetime, timedelta, timezone
+
+        from palaia.doctor import _check_stale_unassigned_tasks
+
+        old_date = (datetime.now(tz=timezone.utc) - timedelta(days=10)).isoformat()
+        entry_content = f"""---
+id: private-other-agent-001
+type: task
+tags: auto-capture,commitment
+created: {old_date}
+scope: private
+agent: agent-a
+title: Task only visible to agent-a
+---
+This task belongs to agent-a and must be invisible to agent-b."""
+        (palaia_root / "hot" / "private-other-agent-001.md").write_text(entry_content)
+
+        # Doctor runs as agent-b → private entry from agent-a must be invisible
+        monkeypatch.setenv("PALAIA_AGENT", "agent-b")
+        result = _check_stale_unassigned_tasks(palaia_root)
+        assert result["status"] == "ok", (
+            f"Doctor reported private entry from agent-a while running as agent-b: {result}"
+        )
+
     def test_ignores_manual_tasks(self, palaia_root):
         from datetime import datetime, timedelta, timezone
 


### PR DESCRIPTION
Ports #189 to `v2-maintenance` (its original target, `main`, is frozen for v2 changes under the two-track rules — and now carries v3).

Cherry-picked from `fix/doctor-scope-filtering`, original authorship preserved:
- `fix: doctor stale-tasks must respect scope visibility` — doctor now uses `Store.all_entries()` with resolved agent identity instead of `all_entries_unfiltered()`, so `scope: private` entries from other agents no longer surface as phantom stale tasks.
- `test: regression test for doctor phantom stale tasks`

Deliberately NOT ported: the branch's third commit (an AGENTS.md rule) — AGENTS.md has been fully rewritten since April; grafting the old edit would conflict with the current two-track document.

Verified on this branch: `tests/test_doctor.py` + scope tests — 73 passed, 1 skipped. Applied cleanly on top of the v2-sunset commit.

Closes #189's underlying bug; the original PR will be closed with a pointer here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790763346&installation_model_id=428086&pr_number=278&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F278&signature=354905594d6dc5138b8ca1f4177e266feafe898f1be6ca8b3111bf7252198f2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->