### PR TITLE
docs: document PALAIA_UI_UNSAFE_BIND (port of #190)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -454,7 +454,15 @@ palaia ui --port 9000      # Custom port (auto-fallback if busy)
 palaia ui --no-browser     # Don't auto-open browser
 ```
 
-Browse, search, create, edit, and delete entries in the browser. Manual entries are highlighted with a gold border (1.3× recall boost). Tasks are post-its: clicking ✓ deletes them. The health pill in the header shows doctor status with actionable warnings. Localhost only — no authentication, no network exposure.
+Browse, search, create, edit, and delete entries in the browser. Manual entries are highlighted with a gold border (1.3× recall boost). Tasks are post-its: clicking ✓ deletes them. The health pill in the header shows doctor status with actionable warnings.
+
+**Security:** Binds to `127.0.0.1` (localhost) by default — no authentication, no network exposure. For remote access (e.g. headless server via Tailscale/SSH):
+
+```bash
+PALAIA_UI_UNSAFE_BIND=0.0.0.0 palaia ui --no-browser --port 8384
+```
+
+This binds to all interfaces. The env var (not a CLI flag) is intentional — prevents accidental network exposure from copy-pasted commands. A warning is printed on startup. Consider an SSH tunnel or reverse proxy with auth for untrusted networks.
 
 ### `palaia doctor` — Diagnostics and auto-fix
 

--- a/packages/openclaw-plugin/skill/SKILL.md
+++ b/packages/openclaw-plugin/skill/SKILL.md
@@ -454,7 +454,15 @@ palaia ui --port 9000      # Custom port (auto-fallback if busy)
 palaia ui --no-browser     # Don't auto-open browser
 ```
 
-Browse, search, create, edit, and delete entries in the browser. Manual entries are highlighted with a gold border (1.3× recall boost). Tasks are post-its: clicking ✓ deletes them. The health pill in the header shows doctor status with actionable warnings. Localhost only — no authentication, no network exposure.
+Browse, search, create, edit, and delete entries in the browser. Manual entries are highlighted with a gold border (1.3× recall boost). Tasks are post-its: clicking ✓ deletes them. The health pill in the header shows doctor status with actionable warnings.
+
+**Security:** Binds to `127.0.0.1` (localhost) by default — no authentication, no network exposure. For remote access (e.g. headless server via Tailscale/SSH):
+
+```bash
+PALAIA_UI_UNSAFE_BIND=0.0.0.0 palaia ui --no-browser --port 8384
+```
+
+This binds to all interfaces. The env var (not a CLI flag) is intentional — prevents accidental network exposure from copy-pasted commands. A warning is printed on startup. Consider an SSH tunnel or reverse proxy with auth for untrusted networks.
 
 ### `palaia doctor` — Diagnostics and auto-fix
 

--- a/palaia/SKILL.md
+++ b/palaia/SKILL.md
@@ -454,7 +454,15 @@ palaia ui --port 9000      # Custom port (auto-fallback if busy)
 palaia ui --no-browser     # Don't auto-open browser
 ```
 
-Browse, search, create, edit, and delete entries in the browser. Manual entries are highlighted with a gold border (1.3× recall boost). Tasks are post-its: clicking ✓ deletes them. The health pill in the header shows doctor status with actionable warnings. Localhost only — no authentication, no network exposure.
+Browse, search, create, edit, and delete entries in the browser. Manual entries are highlighted with a gold border (1.3× recall boost). Tasks are post-its: clicking ✓ deletes them. The health pill in the header shows doctor status with actionable warnings.
+
+**Security:** Binds to `127.0.0.1` (localhost) by default — no authentication, no network exposure. For remote access (e.g. headless server via Tailscale/SSH):
+
+```bash
+PALAIA_UI_UNSAFE_BIND=0.0.0.0 palaia ui --no-browser --port 8384
+```
+
+This binds to all interfaces. The env var (not a CLI flag) is intentional — prevents accidental network exposure from copy-pasted commands. A warning is printed on startup. Consider an SSH tunnel or reverse proxy with auth for untrusted networks.
 
 ### `palaia doctor` — Diagnostics and auto-fix
 

--- a/palaia/cli_args.py
+++ b/palaia/cli_args.py
@@ -292,7 +292,11 @@ def build_parser() -> argparse.ArgumentParser:
     sub.add_parser("upgrade", help="Upgrade palaia to latest version (auto-detects install method and extras)")
 
     # ui — local WebUI memory explorer (localhost only, no auth)
-    p_ui = sub.add_parser("ui", help="Launch the palaia WebUI in the browser")
+    p_ui = sub.add_parser(
+        "ui",
+        help="Launch the palaia WebUI in the browser",
+        epilog="Remote access: set PALAIA_UI_UNSAFE_BIND=0.0.0.0 to bind to all interfaces (no auth — use with care).",
+    )
     p_ui.add_argument("--port", type=int, default=8384, help="Port to bind (default: 8384, will fall back if busy)")
     p_ui.add_argument("--no-browser", action="store_true", help="Do not auto-open the browser")
 

--- a/skills/palaia/SKILL.md
+++ b/skills/palaia/SKILL.md
@@ -454,7 +454,15 @@ palaia ui --port 9000      # Custom port (auto-fallback if busy)
 palaia ui --no-browser     # Don't auto-open browser
 ```
 
-Browse, search, create, edit, and delete entries in the browser. Manual entries are highlighted with a gold border (1.3× recall boost). Tasks are post-its: clicking ✓ deletes them. The health pill in the header shows doctor status with actionable warnings. Localhost only — no authentication, no network exposure.
+Browse, search, create, edit, and delete entries in the browser. Manual entries are highlighted with a gold border (1.3× recall boost). Tasks are post-its: clicking ✓ deletes them. The health pill in the header shows doctor status with actionable warnings.
+
+**Security:** Binds to `127.0.0.1` (localhost) by default — no authentication, no network exposure. For remote access (e.g. headless server via Tailscale/SSH):
+
+```bash
+PALAIA_UI_UNSAFE_BIND=0.0.0.0 palaia ui --no-browser --port 8384
+```
+
+This binds to all interfaces. The env var (not a CLI flag) is intentional — prevents accidental network exposure from copy-pasted commands. A warning is printed on startup. Consider an SSH tunnel or reverse proxy with auth for untrusted networks.
 
 ### `palaia doctor` — Diagnostics and auto-fix
 


### PR DESCRIPTION
Ports #190 to `v2-maintenance` (its original target, `main`, is frozen for v2 changes under the two-track rules — and now carries v3).

Cherry-picked from `fix/document-ui-remote-access`, original authorship preserved: documents the `PALAIA_UI_UNSAFE_BIND` env var (existed since v2.7, only discoverable in source) in all 4 SKILL.md copies and the `palaia ui --help` epilog.

Verified on this branch: `palaia ui --help` shows the remote-access hint; all 4 SKILL.md copies remain byte-identical; skill/ux test files green (29 passed). Applied cleanly on top of the v2-sunset commit.

The original PR will be closed with a pointer here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790763350&installation_model_id=428086&pr_number=279&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F279&signature=8c9ccb6714a9dc349f60c69360357bd56981b8e0a9a79529d5ceca90d7d28376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->