### PR TITLE
docs(site): onboarding names Mac/Windows, Pi, Synology, rented servers

### DIFF
--- a/v3/site/docs/src/pages/onboarding.astro
+++ b/v3/site/docs/src/pages/onboarding.astro
@@ -126,6 +126,33 @@ const REPO = "https://github.com/byte5ai/palaia";
       </section>
     </div>
 
+    <h2>Looking for your machine?</h2>
+    <p>The tabs above cover all of these — here is which one is yours:</p>
+    <ul class="op-machines">
+      <li>
+        <strong>Mac or Windows</strong> — install{" "}
+        <a href="https://www.docker.com/products/docker-desktop/">Docker Desktop</a> once, then
+        the <em>Docker</em> tab's one command is the whole install.
+      </li>
+      <li>
+        <strong>Raspberry Pi</strong> (or another small always-on box) — works today with the
+        64-bit Raspberry Pi OS and Docker installed, then the same one command. A
+        flash-and-boot card image that skips even those steps is{" "}
+        <a href={`${REPO}/issues/280`}>planned and tracked in the open</a>.
+      </li>
+      <li>
+        <strong>Synology NAS</strong> — its Container Manager runs the <em>Compose file</em> tab's
+        file as a "project"; no terminal needed on the NAS itself.
+      </li>
+      <li>
+        <strong>A rented server</strong> (also over Tailscale or another private network) — the{" "}
+        <em>Docker</em> tab's one command, unchanged. Only the address differs:{" "}
+        <code>http://palaia.local</code> works on home networks, so use the server's own name or
+        address with <code>:8420</code> instead, and pick the guarded remote setting when the
+        wizard asks how far your hub should reach.
+      </li>
+    </ul>
+
     <h2>Then open your hub</h2>
     <p>
       Once it is running, open <code>http://palaia.local</code> in a browser on the same network
@@ -281,5 +308,17 @@ const REPO = "https://github.com/byte5ai/palaia";
   .op-stores-status {
     font-size: var(--sl-text-xs);
     color: var(--sl-color-gray-3);
+  }
+
+  .op-machines {
+    list-style: none;
+    padding: 0;
+    display: grid;
+    gap: 0.6rem;
+  }
+  .op-machines li {
+    padding: 0.6rem 0.8rem;
+    border: 1px solid var(--sl-color-hairline);
+    border-radius: 0.4rem;
   }
 </style>


### PR DESCRIPTION
Owner UX review (2026-08-31): the onboarding page's tabs technically cover a Mac, a Raspberry Pi, a Synology NAS, and a rented server (they all run the same image), but never *name* them — someone landing with "I have a Pi" didn't find themselves. Adds a "Looking for your machine?" section mapping each to its tab, with the two real caveats stated honestly (`palaia.local` is home-network-only; the Pi still needs Docker until the flash-and-boot image lands — tracked as #280, filed from the same review).

Verified: jargon lint + docs-site tests green (23 + 16), build with zero broken links, phone-safe markup (same list pattern as the existing stores list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790766877&installation_model_id=428086&pr_number=281&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F281&signature=ba2dc892d950e4443dfac247817bb08befef4815960d227374cb654d748f3320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->