### PR TITLE
docs(v3): Synology walkthrough without a terminal (SPEC-602)

### DIFF
--- a/v3/site/docs/README.md
+++ b/v3/site/docs/README.md
@@ -57,6 +57,20 @@ See `scripts/lib/extract.mjs` (the bundler that reads the TypeScript
 source without a copy) and `scripts/lib/render.mjs` (turns one catalog
 entry into a page) for how this actually works.
 
+## `install-synology.md` is also generated
+
+The Synology Container Manager walkthrough pastes the real
+[`v3/deploy/docker-compose.yml`](../../deploy/docker-compose.yml) into the
+page rather than a hand-typed copy of it, the same "extract, don't copy"
+rule as above.
+
+- Changed `docker-compose.yml`? Run `npm run gen:synology` from here and
+  commit the result.
+- `npm run check:generated` covers this page too, alongside the connect
+  pages.
+- Never hand-edit `src/content/docs/install-synology.md` — edit
+  `scripts/lib/synology.mjs` instead and regenerate.
+
 ## Tests and checks
 
 ```bash

--- a/v3/site/docs/SHOTLIST.md
+++ b/v3/site/docs/SHOTLIST.md
@@ -42,6 +42,9 @@ it as a marker until a real screenshot exists.
 | 5 | `first-shared-memory.md` | The memory explorer showing the note this walkthrough creates ("Fieldnotes"), with the connected-clients list visible showing both tools that touched it | Best captured by literally running the walkthrough once and screenshotting the result |
 | 6 | `automations.md` | The automations editor with one rule open, its three cards (when / if / then) visible (SPEC-307 deliverable #4) | One of the canned recipes is an easy, presentable choice |
 | 7 | `agents-messages.md` | The Agents screen: live directory on one side, a message thread open on the other (SPEC-405 deliverable #1) | Needs at least two active sessions and one exchanged message to look like anything |
+| 8 | `install-synology.md` | Container Manager's own overview screen right after opening it, showing the left-hand navigation (Project, Container, Image, Registry) (SPEC-602) | Capture on a real Synology device running Container Manager — see this page's own owner checklist (an HTML comment at the bottom of the generated file). This page is generated from `scripts/lib/synology.mjs` — edit the marker text there, not the `.md` file, then run `npm run gen:synology` |
+| 9 | `install-synology.md` | The project-creation step with the page's compose file pasted into Container Manager's text box, before continuing to the next step (SPEC-602) | Same device; the compose text should be exactly what the generated page shows — do not retype it. Generated page, see note above |
+| 10 | `install-synology.md` | The finished project showing status Running, with its one container (`palaia-hub`) listed (SPEC-602) | Same device, after starting the project. Generated page, see note above |
 
 ## Format guidance, once a screenshot exists
 

--- a/v3/site/docs/astro.config.mjs
+++ b/v3/site/docs/astro.config.mjs
@@ -31,6 +31,10 @@ export default defineConfig({
             // it is linked by its literal route here rather than `slug`.
             { label: "Get palaia running", link: "/onboarding/" },
             { label: "Install it (the full version)", slug: "install" },
+            // SPEC-602: generated (see scripts/lib/synology.mjs) — its
+            // pasted compose block comes straight out of
+            // v3/deploy/docker-compose.yml, never a hand-typed copy.
+            { label: "Synology (no terminal)", slug: "install-synology" },
             { label: "Your first shared memory", slug: "first-shared-memory" },
             {
               label: "Moving from v2?",

--- a/v3/site/docs/package.json
+++ b/v3/site/docs/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "astro dev",
     "gen:connect": "node scripts/generate-connect-pages.mjs",
+    "gen:synology": "node scripts/generate-synology-page.mjs",
     "check:generated": "node scripts/check-generated.mjs",
     "build": "astro build && node scripts/check-links.mjs",
     "preview": "astro preview",

--- a/v3/site/docs/scripts/check-generated.mjs
+++ b/v3/site/docs/scripts/check-generated.mjs
@@ -1,41 +1,55 @@
 #!/usr/bin/env node
 // The drift test SPEC-503's acceptance criteria demand: regenerate every
-// "Connect your AI" page in memory and diff it against what is checked
-// in. A red exit here means clients.ts or skills.ts changed and someone
-// forgot `npm run gen:connect` — never means "the source of truth
-// disagrees with itself", because both sides of this comparison come
-// from the exact same render call (scripts/lib/pages.mjs).
+// "Connect your AI" page (and the Synology guide, SPEC-602) in memory and
+// diff each against what is checked in. A red exit here means one of the
+// sources changed (clients.ts, skills.ts, or docker-compose.yml) and
+// someone forgot to regenerate — never means "the source of truth
+// disagrees with itself", because both sides of every comparison come
+// from the exact same render calls (scripts/lib/pages.mjs,
+// scripts/lib/synology.mjs).
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildGeneratedPages } from "./lib/pages.mjs";
+import { buildSynologyPages } from "./lib/synology.mjs";
 
 const PROJECT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 async function main() {
-  const expected = await buildGeneratedPages();
-  const problems = [];
+  // Each entry owns the pages one generator built, plus the one command
+  // that regenerates just those — so a stale page always points at the
+  // right fix, not a generic "regenerate something" shrug.
+  const generators = [
+    { pages: await buildGeneratedPages(), command: "npm run gen:connect", label: "connect" },
+    { pages: await buildSynologyPages(), command: "npm run gen:synology", label: "synology" },
+  ];
 
-  for (const [relPath, contents] of expected) {
-    const fullPath = path.join(PROJECT_ROOT, relPath);
-    if (!existsSync(fullPath)) {
-      problems.push(`missing: ${relPath} (run \`npm run gen:connect\`)`);
-      continue;
-    }
-    const onDisk = readFileSync(fullPath, "utf8");
-    if (onDisk !== contents) {
-      problems.push(`stale: ${relPath} does not match clients.ts/skills.ts — regenerate it`);
+  const problems = [];
+  let total = 0;
+
+  for (const { pages, command, label } of generators) {
+    total += pages.size;
+    for (const [relPath, contents] of pages) {
+      const fullPath = path.join(PROJECT_ROOT, relPath);
+      if (!existsSync(fullPath)) {
+        problems.push(`missing: ${relPath} (run \`${command}\`)`);
+        continue;
+      }
+      const onDisk = readFileSync(fullPath, "utf8");
+      if (onDisk !== contents) {
+        problems.push(`stale: ${relPath} does not match its source (run \`${command}\`) [${label}]`);
+      }
     }
   }
 
   if (problems.length > 0) {
-    console.error("Generated connect pages are out of date:\n");
+    console.error("Generated pages are out of date:\n");
     for (const problem of problems) console.error(`  - ${problem}`);
-    console.error("\nRun `npm run gen:connect` from v3/site/docs and commit the result.");
+    console.error("\nRegenerate with the command each line above names and commit the result.");
     process.exitCode = 1;
     return;
   }
-  console.log(`Generated connect pages are up to date (${expected.size} page(s)).`);
+  console.log(`Generated pages are up to date (${total} page(s)).`);
 }
 
 main().catch((err) => {

--- a/v3/site/docs/scripts/generate-synology-page.mjs
+++ b/v3/site/docs/scripts/generate-synology-page.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+// Regenerates the Synology Container Manager walkthrough from
+// v3/deploy/docker-compose.yml. Run this after changing that file — the
+// drift check (scripts/check-generated.mjs) fails CI if you forget.
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildSynologyPages } from "./lib/synology.mjs";
+
+const PROJECT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+async function main() {
+  const pages = await buildSynologyPages();
+  for (const [relPath, contents] of pages) {
+    const fullPath = path.join(PROJECT_ROOT, relPath);
+    mkdirSync(path.dirname(fullPath), { recursive: true });
+    writeFileSync(fullPath, contents, "utf8");
+  }
+  console.log(`Wrote ${pages.size} generated page(s) under ${PROJECT_ROOT}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/v3/site/docs/scripts/lib/deploy-snippets.mjs
+++ b/v3/site/docs/scripts/lib/deploy-snippets.mjs
@@ -65,3 +65,29 @@ export function loadDeploySnippets() {
     curlInstall: fences[2],
   };
 }
+
+/**
+ * The Synology guide pastes `v3/deploy/docker-compose.yml` into Container
+ * Manager's project editor verbatim — the whole point being that a reader
+ * pastes the same file this repository actually ships, never a hand-typed
+ * approximation of it. Sanity-checked against substrings only the real
+ * file has, so a shape change (a renamed service, a moved volume) is
+ * caught the same way `loadDeploySnippets()`'s own checks are, rather than
+ * silently handing back a stale or empty file.
+ */
+export function loadComposeFile() {
+  const composePath = path.join(DEPLOY_ROOT, "docker-compose.yml");
+  const compose = readFileSync(composePath, "utf8").trimEnd();
+
+  const checks = ["services:", "hub:", "image: ghcr.io/byte5ai/palaia-hub:stable", "palaia_home:/data", "volumes:"];
+  for (const needle of checks) {
+    if (!compose.includes(needle)) {
+      throw new Error(
+        `deploy-snippets: expected ${composePath} to contain ${JSON.stringify(needle)} — ` +
+          "the file's shape changed; update this extractor to match (never hand-copy the file instead).",
+      );
+    }
+  }
+
+  return compose;
+}

--- a/v3/site/docs/scripts/lib/synology.mjs
+++ b/v3/site/docs/scripts/lib/synology.mjs
@@ -1,0 +1,160 @@
+// Generates the Synology Container Manager walkthrough
+// (`src/content/docs/install-synology.md`) — the no-terminal path for
+// Synology NAS owners: open Container Manager, create a project, paste
+// the compose file, choose a folder for it, start it, open the hub.
+//
+// The pasted compose file is never hand-typed here: it is read straight
+// out of `v3/deploy/docker-compose.yml` at generation time
+// (`deploy-snippets.mjs`'s `loadComposeFile()`), the same "extract, don't
+// copy" rule `scripts/lib/render.mjs` already applies to the connect
+// pages and `src/pages/onboarding.astro` applies to its own commands.
+// Regenerate with `npm run gen:synology` after editing this file or after
+// `docker-compose.yml` changes; `npm run check:generated` fails loudly if
+// the two ever disagree.
+import path from "node:path";
+import { loadComposeFile } from "./deploy-snippets.mjs";
+
+export const SYNOLOGY_PAGE_PATH = path.join("src", "content", "docs", "install-synology.md");
+
+const GENERATED_NOTE =
+  "# Generated from v3/deploy/docker-compose.yml by " +
+  "v3/site/docs/scripts/generate-synology-page.mjs. Do not hand-edit the\n" +
+  "# compose block below — change docker-compose.yml and run " +
+  "`npm run gen:synology` from v3/site/docs.";
+
+function frontmatter(title, description) {
+  const esc = (s) => s.replace(/"/g, '\\"');
+  return `---\n${GENERATED_NOTE}\ntitle: "${esc(title)}"\ndescription: "${esc(description)}"\n---\n`;
+}
+
+/** Collapse the incidental double-blank-lines that fall out of joining
+ * sections (each already ending in "\n") — cosmetic only, Markdown treats
+ * a run of blank lines as one either way. */
+function tidy(markdown) {
+  return markdown.replace(/\n{3,}/g, "\n\n");
+}
+
+export function renderSynologyPage() {
+  const compose = loadComposeFile();
+
+  const parts = [
+    frontmatter(
+      "Synology (no terminal)",
+      "Run palaia on a Synology NAS through Container Manager — paste one file, nothing typed at a command line.",
+    ),
+    "Synology's Container Manager app runs the same container image every other install page on this site " +
+      "uses — you just get there by pasting a file into a form instead of running a command. Nothing below " +
+      "needs the NAS's command line.",
+    "",
+    "## What you need",
+    "",
+    "- A Synology NAS running DSM 7.2 or later, with **Container Manager** installed (Package Center → " +
+      "search \"Container Manager\" → Install, if it isn't already).",
+    "- A few minutes and a browser open to your NAS's own web interface — the same one you used to install " +
+      "Container Manager.",
+    "",
+    "<!-- screenshot: Container Manager's own overview screen right after opening it, showing the left-hand " +
+      "navigation (Project, Container, Image, Registry) -->",
+    "",
+    "## Open Container Manager and start a new project",
+    "",
+    "1. Open **Container Manager** from DSM's main menu.",
+    "2. Go to the **Project** section in the left-hand navigation.",
+    "3. Use the button that creates a new project (in current versions of Container Manager this is labeled " +
+      "**Create**).",
+    "4. Give it a name — `palaia` is fine, and does not need to match anything else.",
+    "5. Choose or create the shared folder Container Manager should keep this project's files in. The folder " +
+      "name doesn't matter either; this is just where Container Manager stores the file you paste next, not " +
+      "where palaia keeps what you save in it (more on that below).",
+    "",
+    "## Paste the compose file",
+    "",
+    "Container Manager's next step asks how you want to provide the project's setup. Look for the option " +
+      "that lets you type or paste a compose file directly, rather than uploading one — depending on your " +
+      "version this is labeled something close to **Create docker-compose.yml**. Paste the file below into " +
+      "that box exactly as it is, then continue.",
+    "",
+    "<!-- screenshot: the project-creation step with this page's compose file pasted into Container Manager's " +
+      "text box, before continuing to the next step -->",
+    "",
+    "```yaml",
+    compose,
+    "```",
+    "",
+    "This is the same file the [Install it](/install/) page's Compose option uses — nothing Synology-specific " +
+      "has been changed, so it stays correct as that file does.",
+    "",
+    "## About that shared folder, and where your memory actually lives",
+    "",
+    "The folder you picked two steps ago holds the project's own compose file — it is not where palaia keeps " +
+      "what you save. That lives in the `palaia_home` volume the pasted file declares at its bottom, which " +
+      "Docker manages on its own and keeps around even if you delete the project and recreate it later. You " +
+      "don't need to do anything about this; it's mentioned here only so deleting the project folder later " +
+      "doesn't look like it should have deleted your memory too — it doesn't.",
+    "",
+    "## Start it",
+    "",
+    "Continue past any remaining setup screens (Container Manager may offer to also set up quick web access " +
+      "— safe to skip, it isn't needed) and finish creating the project. Container Manager pulls the image " +
+      "and starts the container; the project's status shows **Running** once it has.",
+    "",
+    "<!-- screenshot: the finished project showing status Running, with its one container (palaia-hub) listed -->",
+    "",
+    "If it doesn't reach **Running**, open the container's log from Container Manager itself — the " +
+      "**Container** section, select `palaia-hub`, then its **Log** (or **Details**) tab — rather than a " +
+      "terminal; the same startup message [Install it](/install/) describes shows up there.",
+    "",
+    "## Open the hub",
+    "",
+    "You reached Container Manager just now through your NAS's own address in a browser — the same address, " +
+      "with `:8420` instead of DSM's own port, reaches palaia:",
+    "",
+    "```text",
+    "http://<your-NAS-address>:8420",
+    "```",
+    "",
+    "The container also tries to advertise itself as `http://palaia.local` on your network, the same as every " +
+      "other install path — whether that resolves depends on how Synology's own networking handles it, the " +
+      "same caveat [Install it](/install/)'s network section covers for other setups. Either way, the address " +
+      "above always works.",
+    "",
+    "From there, a short setup wizard takes over — see [Get palaia running](/onboarding/) for what that looks " +
+      "like, or [Your first shared memory](/first-shared-memory/) for the full walkthrough once it's done.",
+    "",
+    "## Later: updating",
+    "",
+    "Open the project in Container Manager and use the action that rebuilds it from the compose file — " +
+      "usually an **Action** menu or **Build** button on the project's own page. If your version doesn't pull " +
+      "a fresh image on its own, delete the project and recreate it the same way as above: your memory is " +
+      "untouched either way, since it lives in the separate `palaia_home` volume, not the project's folder.",
+    "",
+    "Something not covered here? [Troubleshooting & FAQ](/troubleshooting/) covers the issues people actually " +
+      "hit, or the project's [issue tracker](https://github.com/byte5ai/palaia) for anything new.",
+    "",
+    // A single HTML comment: HTML comments do not nest, so this block must
+    // never contain the literal four-character sequence "-->" anywhere in
+    // its body (including inside this note) — that would close it early
+    // and spill the rest as rendered text. Referring to the screenshot
+    // markers by what they say ("screenshot: ...") rather than quoting
+    // their full "<!-- ... -->" syntax keeps that true.
+    "<!--",
+    "Owner verification checklist (for whoever owns a real Synology device — not part of the guide above):",
+    "- [ ] Walk through every numbered step on an actual Synology NAS running Container Manager, and fix any",
+    "      step whose wording no longer matches what's on screen.",
+    "- [ ] Confirm the compose block above still pastes cleanly into Container Manager's project editor with",
+    "      no manual edits needed.",
+    "- [ ] Replace each screenshot marker above (the \"screenshot: ...\" comments) with a real image,",
+    "      following SHOTLIST.md's instructions, then delete that marker's row from SHOTLIST.md.",
+    "- [ ] Once every marker above is replaced, delete this comment block too.",
+    "-->",
+    "",
+  ];
+
+  return tidy(parts.join("\n"));
+}
+
+export async function buildSynologyPages() {
+  const pages = new Map();
+  pages.set(SYNOLOGY_PAGE_PATH, renderSynologyPage());
+  return pages;
+}

--- a/v3/site/docs/src/content/docs/install-synology.md
+++ b/v3/site/docs/src/content/docs/install-synology.md
@@ -1,0 +1,143 @@
+---
+# Generated from v3/deploy/docker-compose.yml by v3/site/docs/scripts/generate-synology-page.mjs. Do not hand-edit the
+# compose block below — change docker-compose.yml and run `npm run gen:synology` from v3/site/docs.
+title: "Synology (no terminal)"
+description: "Run palaia on a Synology NAS through Container Manager — paste one file, nothing typed at a command line."
+---
+
+Synology's Container Manager app runs the same container image every other install page on this site uses — you just get there by pasting a file into a form instead of running a command. Nothing below needs the NAS's command line.
+
+## What you need
+
+- A Synology NAS running DSM 7.2 or later, with **Container Manager** installed (Package Center → search "Container Manager" → Install, if it isn't already).
+- A few minutes and a browser open to your NAS's own web interface — the same one you used to install Container Manager.
+
+<!-- screenshot: Container Manager's own overview screen right after opening it, showing the left-hand navigation (Project, Container, Image, Registry) -->
+
+## Open Container Manager and start a new project
+
+1. Open **Container Manager** from DSM's main menu.
+2. Go to the **Project** section in the left-hand navigation.
+3. Use the button that creates a new project (in current versions of Container Manager this is labeled **Create**).
+4. Give it a name — `palaia` is fine, and does not need to match anything else.
+5. Choose or create the shared folder Container Manager should keep this project's files in. The folder name doesn't matter either; this is just where Container Manager stores the file you paste next, not where palaia keeps what you save in it (more on that below).
+
+## Paste the compose file
+
+Container Manager's next step asks how you want to provide the project's setup. Look for the option that lets you type or paste a compose file directly, rather than uploading one — depending on your version this is labeled something close to **Create docker-compose.yml**. Paste the file below into that box exactly as it is, then continue.
+
+<!-- screenshot: the project-creation step with this page's compose file pasted into Container Manager's text box, before continuing to the next step -->
+
+```yaml
+# palaia v3 hub — compose deployment.
+#
+# Usage:
+#   cd v3/deploy && docker compose up -d
+#   docker compose logs -f      # prints the reachable URL on startup
+#
+# Data (vault, index, config) lives in the `palaia_home` named volume, so it
+# survives `docker compose down` / container recreation — only
+# `docker compose down -v` discards it.
+services:
+  hub:
+    image: ghcr.io/byte5ai/palaia-hub:stable
+    container_name: palaia-hub
+    ports:
+      - "8420:8420"
+    volumes:
+      - palaia_home:/data
+    environment:
+      PALAIA_MODE: locked
+      # SPEC-501: tells the dashboard's "Update available" banner which
+      # instructions to show — this file, so "run `palaia-hub update`,
+      # then `docker compose pull && docker compose up -d`" rather than a
+      # store's own update button. Leave this as-is; it describes this
+      # file, not a preference to change.
+      PALAIA_DEPLOYMENT: compose
+    restart: unless-stopped
+    # SPEC-502 container posture. The image already runs as a non-root user
+    # (see Dockerfile: `USER palaia`); this block closes what is left.
+    #
+    # - `no-new-privileges` stops any setuid binary inside the image from
+    #   regaining root — nothing in the image needs to, and an add-on
+    #   someone installs later must not be able to.
+    # - Every Linux capability is dropped. The hub binds 8421 and nginx
+    #   binds 8420, both above 1024, so NET_BIND_SERVICE is not needed
+    #   either; nothing here wants a capability.
+    # - The root filesystem is read-only. Everything the container writes
+    #   at runtime goes to one of the two tmpfs mounts below or to the
+    #   `palaia_home` volume: nginx renders its config and keeps its temp
+    #   paths under /tmp/nginx (see entrypoint.sh and nginx.conf.template),
+    #   and /run is there for anything expecting a runtime directory.
+    #   If you add a service that needs to write elsewhere in the image,
+    #   give it a tmpfs rather than turning this off.
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /run
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8420/api/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 20s
+      retries: 3
+    # mDNS (advertising http://palaia.local) needs multicast to reach the
+    # LAN, which Docker's default bridge network does not forward. On a
+    # Linux host, uncomment the line below to put the container directly on
+    # the host's network stack so palaia.local resolves for other devices
+    # on the LAN. Not supported this way on Docker Desktop (macOS/Windows);
+    # the printed URL in `docker compose logs` always works there instead.
+    # When enabled, also remove the `ports:` mapping above — host
+    # networking exposes PALAIA_PORT directly.
+    # network_mode: host
+
+volumes:
+  palaia_home:
+```
+
+This is the same file the [Install it](/install/) page's Compose option uses — nothing Synology-specific has been changed, so it stays correct as that file does.
+
+## About that shared folder, and where your memory actually lives
+
+The folder you picked two steps ago holds the project's own compose file — it is not where palaia keeps what you save. That lives in the `palaia_home` volume the pasted file declares at its bottom, which Docker manages on its own and keeps around even if you delete the project and recreate it later. You don't need to do anything about this; it's mentioned here only so deleting the project folder later doesn't look like it should have deleted your memory too — it doesn't.
+
+## Start it
+
+Continue past any remaining setup screens (Container Manager may offer to also set up quick web access — safe to skip, it isn't needed) and finish creating the project. Container Manager pulls the image and starts the container; the project's status shows **Running** once it has.
+
+<!-- screenshot: the finished project showing status Running, with its one container (palaia-hub) listed -->
+
+If it doesn't reach **Running**, open the container's log from Container Manager itself — the **Container** section, select `palaia-hub`, then its **Log** (or **Details**) tab — rather than a terminal; the same startup message [Install it](/install/) describes shows up there.
+
+## Open the hub
+
+You reached Container Manager just now through your NAS's own address in a browser — the same address, with `:8420` instead of DSM's own port, reaches palaia:
+
+```text
+http://<your-NAS-address>:8420
+```
+
+The container also tries to advertise itself as `http://palaia.local` on your network, the same as every other install path — whether that resolves depends on how Synology's own networking handles it, the same caveat [Install it](/install/)'s network section covers for other setups. Either way, the address above always works.
+
+From there, a short setup wizard takes over — see [Get palaia running](/onboarding/) for what that looks like, or [Your first shared memory](/first-shared-memory/) for the full walkthrough once it's done.
+
+## Later: updating
+
+Open the project in Container Manager and use the action that rebuilds it from the compose file — usually an **Action** menu or **Build** button on the project's own page. If your version doesn't pull a fresh image on its own, delete the project and recreate it the same way as above: your memory is untouched either way, since it lives in the separate `palaia_home` volume, not the project's folder.
+
+Something not covered here? [Troubleshooting & FAQ](/troubleshooting/) covers the issues people actually hit, or the project's [issue tracker](https://github.com/byte5ai/palaia) for anything new.
+
+<!--
+Owner verification checklist (for whoever owns a real Synology device — not part of the guide above):
+- [ ] Walk through every numbered step on an actual Synology NAS running Container Manager, and fix any
+      step whose wording no longer matches what's on screen.
+- [ ] Confirm the compose block above still pastes cleanly into Container Manager's project editor with
+      no manual edits needed.
+- [ ] Replace each screenshot marker above (the "screenshot: ..." comments) with a real image,
+      following SHOTLIST.md's instructions, then delete that marker's row from SHOTLIST.md.
+- [ ] Once every marker above is replaced, delete this comment block too.
+-->

--- a/v3/site/docs/src/pages/onboarding.astro
+++ b/v3/site/docs/src/pages/onboarding.astro
@@ -142,7 +142,9 @@ const REPO = "https://github.com/byte5ai/palaia";
       </li>
       <li>
         <strong>Synology NAS</strong> — its Container Manager runs the <em>Compose file</em> tab's
-        file as a "project"; no terminal needed on the NAS itself.
+        file as a "project"; no terminal needed on the NAS itself. See the{" "}
+        <a href="/install-synology/">step-by-step Synology walkthrough</a> for exactly where to
+        click.
       </li>
       <li>
         <strong>A rented server</strong> (also over Tailscale or another private network) — the{" "}

--- a/v3/site/docs/tests/synology.test.ts
+++ b/v3/site/docs/tests/synology.test.ts
@@ -1,0 +1,63 @@
+// SPEC-602 acceptance criterion "the pasted compose content is drift-tested
+// against v3/deploy": the Synology guide's pasted compose block must be
+// exactly what `v3/deploy/docker-compose.yml` says, not a hand-typed copy
+// of it — the same shape of check `tests/onboarding.test.ts` already runs
+// for the onboarding page's own commands, and `tests/generated-pages.test.ts`
+// runs for the connect pages.
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { DEPLOY_ROOT, loadComposeFile } from "../scripts/lib/deploy-snippets.mjs";
+import { buildSynologyPages, renderSynologyPage, SYNOLOGY_PAGE_PATH } from "../scripts/lib/synology.mjs";
+
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+
+describe("Synology guide", () => {
+  it("the generated page on disk matches what the source produces right now", async () => {
+    const pages = await buildSynologyPages();
+    expect(pages.size).toBe(1);
+    for (const [relPath, contents] of pages) {
+      const fullPath = path.join(PROJECT_ROOT, relPath);
+      expect(existsSync(fullPath), `${relPath} is missing — run \`npm run gen:synology\``).toBe(true);
+      const onDisk = readFileSync(fullPath, "utf8");
+      expect(onDisk, `${relPath} is stale — run \`npm run gen:synology\``).toBe(contents);
+    }
+  });
+
+  it("pastes the real docker-compose.yml, not a hand-typed copy", () => {
+    const compose = readFileSync(path.join(DEPLOY_ROOT, "docker-compose.yml"), "utf8").trimEnd();
+    expect(loadComposeFile()).toBe(compose);
+
+    const page = renderSynologyPage();
+    expect(page).toContain(compose);
+  });
+
+  it("throws instead of silently returning a wrong or empty file if docker-compose.yml's shape changes", () => {
+    const compose = loadComposeFile();
+    expect(compose.length).toBeGreaterThan(0);
+    expect(compose).toContain("services:");
+    expect(compose).toContain("image: ghcr.io/byte5ai/palaia-hub:stable");
+  });
+
+  it("has a screenshot marker for each step a reader can't do without seeing the real UI, and no fake images", () => {
+    const page = renderSynologyPage();
+    const markers = [...page.matchAll(/<!--\s*screenshot:[^>]*-->/g)];
+    expect(markers.length).toBeGreaterThanOrEqual(3);
+    // Never a real (or stock/placeholder) image file in a generated page —
+    // only the site's own established marker convention.
+    expect(page).not.toMatch(/!\[[^\]]*\]\([^)]*\.(png|jpg|jpeg|gif|webp)\)/i);
+  });
+
+  it("has an explicit owner verification checklist at the bottom", () => {
+    const page = renderSynologyPage();
+    const lastHeadingIndex = page.lastIndexOf("\n## ");
+    const tail = page.slice(lastHeadingIndex);
+    expect(tail).toMatch(/owner verification checklist/i);
+    expect(tail).toMatch(/real Synology device/i);
+    expect(tail).toMatch(/screenshot/i);
+  });
+
+  it("only ever writes the one path it declares", () => {
+    expect(SYNOLOGY_PAGE_PATH).toBe(path.join("src", "content", "docs", "install-synology.md"));
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `/install-synology/`: a no-terminal walkthrough for Synology NAS owners — open Container Manager, create a project, paste the compose file, choose a folder for it, start it, open the hub. Written against Container Manager's real UI flow, with robust ("the button that creates a new project") phrasing anywhere the exact label may drift across DSM versions.
- The pasted compose block is never hand-typed: `scripts/lib/synology.mjs` (+ `scripts/generate-synology-page.mjs`) reads `v3/deploy/docker-compose.yml` at generation time, the same "extract, don't copy" rule the connect pages and the onboarding page already follow. `npm run check:generated` (extended to cover this page too) and a new `tests/synology.test.ts` both fail if the generated page ever drifts from the real file.
- Links the new page from the sidebar (`astro.config.mjs`) and from the onboarding page's existing Synology entry (`src/pages/onboarding.astro`).
- Screenshot slots use the site's existing invisible-comment convention (`<!-- screenshot: ... -->`); three new rows added to `SHOTLIST.md` for turning them into real images later.
- An explicit owner verification checklist sits at the bottom of the generated page (an HTML comment, invisible to readers, present in the page source) per the spec's acceptance criteria: walk every step on a real device, confirm the pasted compose block still works, replace the screenshot markers, then remove the checklist.

Per instructions, `v3/specs/SPEC-602-synology-guide.md` itself is **not** included in this branch — it lands separately via `docs/v3-phase6-specs`.

## Test plan

From `v3/site/docs`:
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — 0 errors/warnings/hints
- [x] `npm run check:generated` — 11 pages up to date (connect pages + the new Synology page)
- [x] `npm test` — 4 files, 22 tests passed
- [x] `npm run build` — 23 pages built, `check-links.mjs` found no broken internal links

From `v3`:
- [x] `uv run pytest server/tests/docs_site -q` — 24 passed (jargon lint green, including the new page)

- [x] `grep -rn '^<<<<<<< ' v3` — empty

## Deviations / notes

- The spec's step list mentions "choose the data folder"; Container Manager's project creation actually asks for a shared folder to hold the project's own compose file, not a folder for `palaia`'s data (which lives in the `palaia_home` named Docker volume the compose file declares, managed by Docker itself). The page explains this distinction explicitly rather than conflating the two, so deleting the project folder later doesn't read as if it deletes the user's memory too.
- Exact Container Manager button/field labels ("Create", "Create docker-compose.yml") are stated as best-known current labels but phrased defensively per instructions, since DSM's UI has shifted wording across versions and this sandbox has no real Synology device to verify against — flagged explicitly in the page's own owner checklist as the first thing to verify on a real device.
- Chose to generate-and-commit the page (mirroring the `connect/` pages' architecture) rather than a runtime-embedded Astro component (mirroring `onboarding.astro`) — this keeps the compose content readable in a plain `.md` diff and lets the existing Python jargon-lint suite (which only scans `src/content/docs/*.md`) cover it automatically, with no separate test file needed the way `onboarding.astro` required one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790768834&installation_model_id=428086&pr_number=283&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F283&signature=893ddc6f3f07995827f317548fd9be8ba56dacadf774a77f134409544d9ac250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->