### PR TITLE
feat(v3): cloud-init VPS install with Tailscale (SPEC-601)

### DIFF
--- a/v3/deploy/README.md
+++ b/v3/deploy/README.md
@@ -33,6 +33,73 @@ Or the convenience script (never required — see `install.sh`):
 curl -fsSL https://raw.githubusercontent.com/byte5ai/palaia/main/v3/deploy/install.sh | bash
 ```
 
+## Cloud-init (rented servers)
+
+SPEC-601. For a server you rent rather than a machine you already own —
+Hetzner Cloud, DigitalOcean, AWS, or similar — the vehicle is
+[`cloud-init.yaml`](cloud-init.yaml): paste the whole file into the
+provider's server-creation user-data field (Hetzner Cloud calls it "Cloud
+config"; DigitalOcean and AWS call it "User data"), enter one Tailscale
+auth key first, and the server finishes its own setup with no terminal
+session needed. The onboarding page's "A rented server" entry shows the
+same file with a copy button; this is the file it copies from — never a
+second, hand-typed one.
+
+What it does, in order: installs Docker and Tailscale, joins your tailnet
+with the key you provided, then starts the hub with the exact hardening
+flags [`install.sh`](install.sh) uses (`--security-opt
+no-new-privileges:true --cap-drop ALL --read-only --tmpfs /tmp --tmpfs
+/run` — never a forked copy of that list, checked by
+`server/tests/deploy/test_cloud_init.py`'s drift test) and binds its
+published port to the tailnet address only, backed by a `ufw` rule that
+denies the same port on every other interface. The hub is reachable from
+your own devices on the tailnet and nowhere else — never the public
+internet.
+
+**Where the data lives.** Same as every other install path: the
+`palaia_home` named Docker volume, holding everything under `/data`
+(config, vault, index). Nothing about running the hub this way changes
+where or how that volume is managed — `docker volume inspect
+palaia_home`, `docker exec palaia-hub ls /data`, and ordinary Docker
+volume backup tooling all work exactly as they do for the compose or
+one-liner install.
+
+**Updating.** The file only runs its install step once, on first boot
+(cloud-init's own rule). To update the hub afterward, connect over the
+tailnet (SSH, or Tailscale SSH if you enabled it) and use the same two
+commands any other install uses — `docker pull` the new image tag, then
+recreate the container — or run `palaia-hub update` from the dashboard's
+own update banner (see "Updates" above); nothing here needs re-pasting.
+
+**Backing up.** `docker run --rm -v palaia_home:/data -v
+$(pwd):/backup alpine tar czf /backup/palaia-backup.tar.gz -C /data .`
+from the server itself (over the tailnet, or a provider console),
+run any time.
+
+**The one thing cloud-init cannot prove by itself.** Everything above is
+checked in CI at the file level — the config parses
+(`cloud-init schema --config-file`), its `docker run` flags never drift
+from `install.sh`'s, the one placeholder stays the only one. Whether a
+real, freshly created VPS actually finishes this and serves the wizard is
+inherently something only booting a real server proves — the same
+reasoning as this file's "Manual verification" section above, applied to
+a cloud instance instead of a local VM. That is an owner action, not
+something CI claims:
+
+- [ ] Create a server on a real provider (Hetzner Cloud, DigitalOcean, or
+      similar), pasting `cloud-init.yaml` with a real Tailscale auth key
+      into its user-data field.
+- [ ] Wait for the server to finish booting (a couple of minutes is
+      typical for the package installs plus image pull).
+- [ ] From a device already on the same tailnet, open
+      `http://<tailnet-address>:8420/` and confirm the setup wizard
+      loads.
+- [ ] Confirm the same address is *not* reachable from a device that is
+      not on the tailnet (e.g. a phone on mobile data).
+- [ ] If anything above did not come up, `/var/log/cloud-init-output.log`
+      on the server (reachable over the tailnet, or the provider's own
+      console) has the full log of what ran.
+
 ## What's in the image
 
 Multi-stage build (`Dockerfile`):

--- a/v3/deploy/cloud-init.yaml
+++ b/v3/deploy/cloud-init.yaml
@@ -1,0 +1,138 @@
+#cloud-config
+# palaia v3 — VPS install (SPEC-601). Paste this whole file into your
+# provider's server-creation user-data field — Hetzner Cloud calls it
+# "Cloud config", DigitalOcean and AWS call it "User data" — then create
+# the server. Everything below runs itself: no terminal, no SSH session
+# needed to finish setup.
+#
+# ONE THING TO EDIT — find this line further down and replace the
+# placeholder with a real key from
+# https://login.tailscale.com/admin/settings/keys (a reusable, ephemeral
+# key works well here — this file re-runs safely, see below):
+#
+#     TAILSCALE_AUTH_KEY="tskey-REPLACE_ME"
+#
+# Nothing else in this file needs to change.
+#
+# What it does: installs Docker and Tailscale, joins your private network
+# (tailnet) with the key above, starts the hub with the exact same
+# hardened container flags v3/deploy/install.sh uses (never a second,
+# hand-copied list — see server/tests/deploy/test_cloud_init.py's drift
+# check), and binds the hub's published port to the tailnet address only
+# plus a firewall rule that denies it everywhere else — so the hub is
+# never reachable from the public internet, only from your own devices on
+# the tailnet. See v3/deploy/README.md's "Cloud-init" section for what
+# the data volume holds and how to back it up or move it.
+#
+# This step (installing Docker/Tailscale/the hub itself) only runs once
+# per server — cloud-init's own rule, not this file's. The script it
+# writes below is still written so that running it a second time by hand
+# (`sudo bash /opt/palaia/cloud-init-setup.sh`) changes nothing that is
+# already in place, in case you ever need to re-apply it.
+#
+# Everything this does is also logged to /var/log/cloud-init-output.log —
+# check there first if the hub does not come up.
+package_update: true
+packages:
+  - ca-certificates
+  - curl
+  - ufw
+write_files:
+  - path: /opt/palaia/cloud-init-setup.sh
+    permissions: "0700"
+    owner: root:root
+    content: |
+      #!/usr/bin/env bash
+      # Written by cloud-init.yaml — see that file for the one thing to
+      # edit. Every step below is guarded so re-running this script (a
+      # second cloud-init boot, or by hand) changes nothing already done.
+      set -euo pipefail
+
+      log() { echo "palaia cloud-init: $*"; }
+
+      TAILSCALE_AUTH_KEY="tskey-REPLACE_ME"
+      IMAGE="ghcr.io/byte5ai/palaia-hub:stable"
+      CONTAINER_NAME="palaia-hub"
+      VOLUME="palaia_home"
+      PORT=8420
+
+      if [ "${TAILSCALE_AUTH_KEY}" = "tskey-REPLACE_ME" ]; then
+          log "ERROR: edit this file's TAILSCALE_AUTH_KEY before pasting it —"
+          log "  see https://login.tailscale.com/admin/settings/keys"
+          exit 1
+      fi
+
+      # --- Docker --------------------------------------------------------
+      if ! command -v docker >/dev/null 2>&1; then
+          log "installing Docker ..."
+          curl -fsSL https://get.docker.com | sh
+      else
+          log "Docker already installed, skipping."
+      fi
+      systemctl enable --now docker
+
+      # --- Tailscale -------------------------------------------------------
+      # A different private network entirely? Swap this install step and
+      # the `tailscale up`/`tailscale0` lines below for your VPN's own join
+      # step and interface name — the firewall rule further down is the
+      # only other line that names it.
+      if ! command -v tailscale >/dev/null 2>&1; then
+          log "installing Tailscale ..."
+          curl -fsSL https://tailscale.com/install.sh | sh
+      else
+          log "Tailscale already installed, skipping."
+      fi
+      systemctl enable --now tailscaled
+
+      log "joining the tailnet ..."
+      tailscale up --auth-key="${TAILSCALE_AUTH_KEY}" --hostname="palaia-hub"
+      TAILSCALE_IP="$(tailscale ip -4)"
+      log "tailnet address: ${TAILSCALE_IP}"
+
+      # --- Firewall: the hub port, reachable via the tailnet only -----------
+      # Two independent layers, so one weak spot does not undo the other:
+      # binding docker's published port to the tailnet address itself
+      # (below, in the `docker run` line) means nothing is even listening
+      # on the public interface; this ufw rule denies the port there too,
+      # for anything that ever changes that bind.
+      if command -v ufw >/dev/null 2>&1; then
+          ufw allow OpenSSH >/dev/null 2>&1 || true
+          ufw allow in on tailscale0 to any port "${PORT}" proto tcp \
+              comment 'palaia hub, tailnet only'
+          ufw --force enable
+          log "ufw enabled: ${PORT}/tcp reachable on the tailscale0 interface only."
+      else
+          log "ufw not found — skipping the firewall rule; the docker publish"
+          log "  below already binds to the tailnet address only, regardless."
+      fi
+
+      # --- The hub -----------------------------------------------------------
+      if docker inspect "${CONTAINER_NAME}" >/dev/null 2>&1; then
+          log "container '${CONTAINER_NAME}' already exists, leaving it as-is."
+      else
+          log "pulling ${IMAGE} ..."
+          docker pull "${IMAGE}"
+          log "starting ${CONTAINER_NAME} on ${TAILSCALE_IP}:${PORT} (tailnet only) ..."
+          # Hardening flags mirror install.sh / docker-compose.yml
+          # (SPEC-502) verbatim — checked by
+          # server/tests/deploy/test_cloud_init.py's drift test. Only the
+          # `-p` bind address differs from install.sh's own, on purpose:
+          # binding to the tailnet address (not `0.0.0.0`) is what keeps
+          # the hub off the public internet.
+          docker run -d \
+              --name "${CONTAINER_NAME}" \
+              -p "${TAILSCALE_IP}:${PORT}:8420" \
+              -v "${VOLUME}:/data" \
+              --restart unless-stopped \
+              --security-opt no-new-privileges:true \
+              --cap-drop ALL \
+              --read-only \
+              --tmpfs /tmp \
+              --tmpfs /run \
+              "${IMAGE}"
+      fi
+
+      log "done. Open http://${TAILSCALE_IP}:${PORT}/ from any device on your tailnet."
+
+runcmd:
+  - [bash, /opt/palaia/cloud-init-setup.sh]

--- a/v3/server/tests/deploy/test_cloud_init.py
+++ b/v3/server/tests/deploy/test_cloud_init.py
@@ -1,0 +1,152 @@
+"""SPEC-601: the cloud-init VPS install template.
+
+Three things this file proves, matching the SPEC's own acceptance
+criteria:
+
+1. ``v3/deploy/cloud-init.yaml`` parses as a valid cloud-config document
+   (``cloud-init schema --config-file``, run in CI — see
+   :func:`test_cloud_init_schema_validates`'s own docstring for why that
+   needs ``uvx`` rather than a plain ``pip install``).
+2. Its ``docker run`` command never forks ``install.sh``'s hardening flag
+   list — the same "extract, don't hand-copy" drift-test pattern
+   ``v3/site/docs/tests/onboarding.test.ts`` already applies to the
+   onboarding page's snippets, and
+   ``server/tests/e2e/test_docker_one_liner_smoke.py`` already applies to
+   its own smoke-test invocation.
+3. The one placeholder the SPEC promises ("the Tailscale auth key is the
+   ONE placeholder... no other editing required") really is the only one,
+   and the hub port is bound so it is reachable over the tailnet only,
+   never the public internet.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# v3/server/tests/deploy -> v3/server/tests -> v3/server -> v3 -> v3/deploy
+DEPLOY_ROOT = Path(__file__).resolve().parents[3] / "deploy"
+CLOUD_INIT_PATH = DEPLOY_ROOT / "cloud-init.yaml"
+
+# The exact pinned tag `test_cloud_init_schema_validates` installs cloud-init
+# from. 24.1.3 is the last tagged release still shipping a setuptools
+# `pyproject.toml`/`build-backend` — cloud-init's own `main` branch moved to
+# a meson build with an intentionally empty `build-backend` ("to avoid RTD
+# builds"), which `pip`/`uv` cannot build a wheel from at all. 24.1.3 is
+# also the version Ubuntu 24.04 ("noble")'s own `cloud-init` apt package is
+# built from, so pinning it here validates against the same real tool a
+# fresh Ubuntu VPS actually runs, not an arbitrary snapshot.
+CLOUD_INIT_PYPI_REF = "cloud-init @ git+https://github.com/canonical/cloud-init@24.1.3"
+
+#: The block of `docker run` flags in install.sh between the volume mount
+#: and the image argument — everything that is *not* specific to a single
+#: container instance (`--name`/`-p`/`-v`), i.e. the SPEC-502 hardening set.
+#: Extracted from install.sh's own text rather than retyped here, so this
+#: test cannot silently drift from the real flag list on either side.
+_HARDENING_BLOCK_RE = re.compile(r"--restart unless-stopped.*?--tmpfs /run", re.DOTALL)
+
+
+def _extract_hardening_flags(install_sh_text: str) -> list[str]:
+    match = _HARDENING_BLOCK_RE.search(install_sh_text)
+    assert match, (
+        "install.sh's docker run block no longer has the expected shape "
+        "(looked for '--restart unless-stopped' ... '--tmpfs /run') — "
+        "update this extractor to match, never hand-copy the flag list instead"
+    )
+    lines = [line.strip().rstrip("\\").strip() for line in match.group(0).splitlines()]
+    return [line for line in lines if line]
+
+
+def test_cloud_init_yaml_exists() -> None:
+    assert CLOUD_INIT_PATH.is_file(), f"no cloud-init template at {CLOUD_INIT_PATH}"
+    assert CLOUD_INIT_PATH.read_text(encoding="utf-8").startswith("#cloud-config"), (
+        "cloud-init.yaml must open with the '#cloud-config' header or cloud-init ignores it"
+    )
+
+
+def test_hardening_flags_match_install_sh_verbatim() -> None:
+    """Drift test: cloud-init.yaml's docker run must reuse install.sh's own
+    hardening flags verbatim, never a second, separately-maintained copy."""
+    install_sh = (DEPLOY_ROOT / "install.sh").read_text(encoding="utf-8")
+    cloud_init = CLOUD_INIT_PATH.read_text(encoding="utf-8")
+
+    flags = _extract_hardening_flags(install_sh)
+    assert flags, "no hardening flags extracted from install.sh"
+    for flag in flags:
+        assert flag in cloud_init, (
+            f"cloud-init.yaml's docker run command is missing install.sh's own {flag!r} "
+            "flag — the two must never fork this list"
+        )
+
+
+def test_tailscale_auth_key_is_the_only_placeholder() -> None:
+    cloud_init = CLOUD_INIT_PATH.read_text(encoding="utf-8")
+
+    assert "tskey-REPLACE_ME" in cloud_init, (
+        "the Tailscale auth key placeholder must be clearly marked as 'tskey-REPLACE_ME'"
+    )
+    # Every occurrence of the word "REPLACE_ME" is part of that one marker
+    # (the header comment names it, the script itself sets it and checks
+    # for it) — none stand alone as a second, different placeholder.
+    stray = [
+        m.start()
+        for m in re.finditer("REPLACE_ME", cloud_init)
+        if not cloud_init[: m.start()].endswith("tskey-")
+    ]
+    assert not stray, f"a 'REPLACE_ME' not part of 'tskey-REPLACE_ME' at offset(s) {stray}"
+    assert not re.search(r"CHANGE_?ME|YOUR_[A-Z_]+", cloud_init), (
+        "found a second placeholder-looking marker besides the Tailscale auth key"
+    )
+
+
+def test_hub_port_is_bound_to_the_tailnet_address_only() -> None:
+    """SPEC-601: 'firewalls the hub port so it is reachable via the tailnet
+    only' — checked two ways, matching the file's own two layers."""
+    cloud_init = CLOUD_INIT_PATH.read_text(encoding="utf-8")
+
+    # Layer 1: the docker publish itself binds to the tailnet address, not
+    # every interface (`-p 8420:8420` / `-p 0.0.0.0:8420:8420` would expose
+    # it publicly).
+    assert '-p "${TAILSCALE_IP}:${PORT}:8420"' in cloud_init
+    assert "-p 0.0.0.0" not in cloud_init
+    assert '-p "${PORT}:8420"' not in cloud_init
+
+    # Layer 2: a firewall rule scoped to the tailscale interface.
+    assert "tailscale0" in cloud_init
+    assert "ufw allow in on tailscale0" in cloud_init
+
+
+def test_cloud_init_schema_validates() -> None:
+    """SPEC-601 acceptance: 'cloud-init file passes `cloud-init schema
+    --config-file` validation in CI'.
+
+    cloud-init is not on PyPI under a name pip can install directly off its
+    current `main` branch (see ``CLOUD_INIT_PYPI_REF``'s comment above for
+    why 24.1.3 is pinned instead). ``uvx --from <git ref>`` installs it into
+    a throwaway tool environment for exactly this one subprocess call — no
+    dependency added to this project's own `pyproject.toml`/lockfile, which
+    is the SPEC's own "cheapest clean way" instruction.
+    """
+    if shutil.which("uvx") is None:
+        pytest.skip("uvx not on PATH in this environment")
+
+    result = subprocess.run(
+        [
+            "uvx",
+            "--from",
+            CLOUD_INIT_PYPI_REF,
+            "cloud-init",
+            "schema",
+            "--config-file",
+            str(CLOUD_INIT_PATH),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Valid schema" in result.stdout, result.stdout + result.stderr

--- a/v3/site/docs/scripts/lib/deploy-snippets.mjs
+++ b/v3/site/docs/scripts/lib/deploy-snippets.mjs
@@ -65,3 +65,33 @@ export function loadDeploySnippets() {
     curlInstall: fences[2],
   };
 }
+
+/**
+ * SPEC-601: the whole `v3/deploy/cloud-init.yaml` file, read verbatim —
+ * the rented-server onboarding entry's "paste this file" snippet is this
+ * text and nothing else, never a hand-copied excerpt. Unlike the three
+ * commands above (fences lifted out of README.md's prose), this is the one
+ * snippet that is itself a real file meant to be pasted whole into a cloud
+ * provider's user-data field, so it is read directly rather than extracted
+ * from a fence.
+ */
+export function loadCloudInitTemplate() {
+  const cloudInitPath = path.join(DEPLOY_ROOT, "cloud-init.yaml");
+  const cloudInit = readFileSync(cloudInitPath, "utf8").trimEnd();
+
+  if (!cloudInit.startsWith("#cloud-config")) {
+    throw new Error(
+      `deploy-snippets: ${cloudInitPath} no longer opens with '#cloud-config' — cloud-init ` +
+        `would ignore it; update this extractor's expectation to match a real change, never ` +
+        `paste a different opening line here instead.`,
+    );
+  }
+  if (!cloudInit.includes("tskey-REPLACE_ME")) {
+    throw new Error(
+      `deploy-snippets: ${cloudInitPath} no longer contains the 'tskey-REPLACE_ME' placeholder ` +
+        `the onboarding page tells readers to look for — update both together.`,
+    );
+  }
+
+  return cloudInit;
+}

--- a/v3/site/docs/src/pages/onboarding.astro
+++ b/v3/site/docs/src/pages/onboarding.astro
@@ -28,9 +28,10 @@
 // v3/deploy source files and asserts the extracted snippets are exactly
 // what they say.
 import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
-import { loadDeploySnippets } from "../../scripts/lib/deploy-snippets.mjs";
+import { loadCloudInitTemplate, loadDeploySnippets } from "../../scripts/lib/deploy-snippets.mjs";
 
 const snippets = loadDeploySnippets();
+const cloudInit = loadCloudInitTemplate();
 
 const STORES = [
   { name: "Umbrel", dir: "umbrel" },
@@ -144,12 +145,23 @@ const REPO = "https://github.com/byte5ai/palaia";
         <strong>Synology NAS</strong> — its Container Manager runs the <em>Compose file</em> tab's
         file as a "project"; no terminal needed on the NAS itself.
       </li>
-      <li>
-        <strong>A rented server</strong> (also over Tailscale or another private network) — the{" "}
-        <em>Docker</em> tab's one command, unchanged. Only the address differs:{" "}
-        <code>http://palaia.local</code> works on home networks, so use the server's own name or
-        address with <code>:8420</code> instead, and pick the guarded remote setting when the
-        wizard asks how far your hub should reach.
+      <li class="op-machine-rented">
+        <strong>A rented server</strong> (Hetzner Cloud, DigitalOcean, AWS, or similar) — paste
+        this file into the "user data" or "cloud config" field the provider offers when you create
+        the server, after editing the one line it marks clearly. It installs everything and joins
+        your own private network by itself, so the server never has to accept connections from the
+        open internet — only from your own devices.
+        <div class="op-snippet op-snippet-file">
+          <pre><code>{cloudInit}</code></pre>
+          <button type="button" class="op-copy" data-copy-target="op-code-cloud-init">Copy</button>
+        </div>
+        <code id="op-code-cloud-init" class="op-copy-source" hidden>{cloudInit}</code>
+        <p class="op-fine">
+          A server that already exists, running some other way? The <em>Docker</em> tab's one
+          command above still works there, unchanged — only the address differs: use the server's
+          own name or address with <code>:8420</code> instead of <code>http://palaia.local</code>,
+          and pick the guarded remote setting when the wizard asks how far your hub should reach.
+        </p>
       </li>
     </ul>
 
@@ -284,6 +296,16 @@ const REPO = "https://github.com/byte5ai/palaia";
   .op-fine {
     font-size: var(--sl-text-sm);
     color: var(--sl-color-gray-3);
+  }
+
+  /* The cloud-init file is much longer than the other snippets — scrolls
+     inside its own fixed-height box instead of stretching the page. */
+  .op-snippet-file {
+    max-height: 16rem;
+    overflow-y: auto;
+  }
+  .op-machine-rented .op-snippet {
+    margin-block: 0.75rem;
   }
 
   .op-stores {

--- a/v3/site/docs/tests/onboarding.test.ts
+++ b/v3/site/docs/tests/onboarding.test.ts
@@ -10,7 +10,7 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { DEPLOY_ROOT, loadDeploySnippets } from "../scripts/lib/deploy-snippets.mjs";
+import { DEPLOY_ROOT, loadCloudInitTemplate, loadDeploySnippets } from "../scripts/lib/deploy-snippets.mjs";
 
 describe("onboarding page snippets", () => {
   it("reads v3/deploy/README.md, not a hand-copied string", () => {
@@ -89,6 +89,43 @@ describe("onboarding page snippets", () => {
     // The tab bar wraps rather than forcing the page wider than the
     // platform labels' combined width.
     expect(style).toMatch(/\.op-tabbar\s*\{[^}]*flex-wrap:\s*wrap/);
+  });
+
+  it("SPEC-601: the cloud-init snippet reads v3/deploy/cloud-init.yaml, not a hand-copied string", () => {
+    const cloudInitPath = path.join(DEPLOY_ROOT, "cloud-init.yaml");
+    const realFile = readFileSync(cloudInitPath, "utf8");
+    const cloudInit = loadCloudInitTemplate();
+
+    // Same proof shape as the "reads README.md" test above: this can only
+    // be true without a duplicate copy if the extractor actually read the
+    // real file.
+    expect(realFile).toContain(cloudInit);
+    expect(cloudInit).toContain("#cloud-config");
+    expect(cloudInit).toContain("tskey-REPLACE_ME");
+  });
+
+  it("SPEC-601: the cloud-init snippet's docker run reuses install.sh's hardening flags verbatim", () => {
+    // The authoritative drift test is server/tests/deploy/test_cloud_init.py
+    // (it also proves the file validates against `cloud-init schema`); this
+    // is the same "read the real files, never a second hand-typed list"
+    // check applied on the onboarding-page side, so a change to either file
+    // that breaks the pairing fails loudly here too, not only in the Python
+    // suite.
+    const installSh = readFileSync(path.join(DEPLOY_ROOT, "install.sh"), "utf8");
+    const cloudInit = loadCloudInitTemplate();
+
+    for (const flag of [
+      "--security-opt no-new-privileges:true",
+      "--cap-drop ALL",
+      "--read-only",
+      "--tmpfs /tmp",
+      "--tmpfs /run",
+    ]) {
+      expect(installSh, `install.sh should still contain ${JSON.stringify(flag)}`).toContain(flag);
+      expect(cloudInit, `cloud-init.yaml should reuse install.sh's ${JSON.stringify(flag)}`).toContain(
+        flag,
+      );
+    }
   });
 
   it("throws instead of returning an empty snippet if the source shape ever changes", () => {


### PR DESCRIPTION
## What

Implements SPEC-601 (the spec itself lands separately via `docs/v3-phase6-specs`, not part of this PR):

- **`v3/deploy/cloud-init.yaml`** — a self-contained cloud-config file to paste into a cloud provider's server-creation user-data field (Hetzner Cloud "Cloud config", DigitalOcean/AWS "User data"). It installs Docker and Tailscale, joins the tailnet with the operator's own auth key (the **one** clearly-marked placeholder: `tskey-REPLACE_ME`), then starts the hub with `install.sh`'s exact SPEC-502 hardening flags (`--security-opt no-new-privileges:true --cap-drop ALL --read-only --tmpfs /tmp --tmpfs /run`) — reused verbatim via a drift test, never a forked copy. The hub's published port is bound to the tailnet address only (`-p "${TAILSCALE_IP}:${PORT}:8420"`, not `0.0.0.0`) plus a `ufw` rule denying it on every other interface, so the hub is reachable from the tailnet only, never the public internet. Every step is guarded so re-running the script changes nothing already in place.
- **Onboarding page** (`v3/site/docs/src/pages/onboarding.astro`) — the "A rented server" entry now leads with this file (paste-and-copy, same snippet/copy-button pattern the Docker/Compose panels already use), with the existing `docker run` one-liner kept as the alternative for a server that already exists. `deploy-snippets.mjs` gained `loadCloudInitTemplate()` so the page reads the real file, never a hand-copied excerpt — with its own drift assertions (opens with `#cloud-config`, contains the placeholder).
- **`v3/deploy/README.md`** — a new "Cloud-init" section: what the file does, where the data lives, how to update/back up, and the boot-test checklist as an explicit **owner action** (create a real server, paste, wait, open — never claimed as CI-proven), matching the section's existing "Manual verification" honesty pattern.
- **`v3/server/tests/deploy/test_cloud_init.py`** — new drift/validation test:
  - `cloud-init.yaml` parses via `cloud-init schema --config-file`, run in CI through `uvx --from <pinned git tag>` (see below for why)
  - the docker-run hardening flags are extracted from `install.sh`'s own text and checked verbatim inside `cloud-init.yaml` — same pattern as the existing onboarding-snippets drift test and `test_docker_one_liner_smoke.py`'s own flag check
  - the Tailscale auth key is the only placeholder in the file
  - the hub port is bound to the tailnet address, never `0.0.0.0`
- Mirrored drift assertions added to `v3/site/docs/tests/onboarding.test.ts` (reads the real file; the docker-run flags match `install.sh`), so a break shows up on the JS side too, not only in the Python suite.

## Why

Owner decision 2026-08-31: every install path should reach "onboarding and operation maximally easy." For a rented cloud server, cloud-init is the standard mechanism to finish unattended setup with zero terminal access, while keeping the hub off the public internet by construction (Tailscale + an interface-scoped bind + a firewall rule, not "remember to configure a firewall later").

**On "pip-installable":** cloud-init is not published to PyPI under a name pip can build off its current `main` branch — that branch moved to a meson-only build with a deliberately empty `build-backend` ("to avoid RTD builds"). The last tagged release still shipping a `setuptools` `pyproject.toml` is `24.1.3` — also the exact version Ubuntu 24.04's own `cloud-init` apt package is built from — so the test pins `uvx --from "cloud-init @ git+https://github.com/canonical/cloud-init@24.1.3"`: no dependency added to this project's own `pyproject.toml`/lockfile, matching the spec's "cheapest clean way," and verified working locally (`cloud-init 24.1.3`, `Valid schema ...`).

No CI workflow change was needed: the new test lives under `server/tests/deploy/`, already picked up by the existing `python` job's `uv run pytest --ignore=server/tests/e2e` step, and `uv`'s setup action already puts `uvx` on `PATH` alongside it.

## Test evidence (from `v3/`)

- `uv run ruff check server` — clean
- `uv run mypy server/src` — `Success: no issues found in 193 source files`
- `uv run pytest server/tests -q` — **2218 passed, 24 skipped** (pre-existing environment-gated skips: no docker daemon, etc. — none introduced by this change)
- `v3/site/docs`: `npm run lint` clean, `npm run typecheck` 0 errors/warnings, `npm test` — **18 passed** (3 files), `npm run build` — 22 pages built, no broken internal links
- `grep -rn '^<<<<<<< ' v3` — empty
- Local: `cloud-init schema --config-file v3/deploy/cloud-init.yaml` → `Valid schema ...`; `bash -n` on the extracted embedded script → clean

## Owner boot-test checklist

Lives in `v3/deploy/README.md`'s new "Cloud-init" section (bottom of it) — create a real server on a provider, paste the file with a real Tailscale key, wait, confirm the wizard opens over the tailnet and is unreachable off it. Not run here; explicitly an owner action per the spec's non-goals.

## Deviations

- Added a defense-in-depth `ufw` rule alongside the tailnet-only port bind (the spec asks only that the port "is reachable via the tailnet only" — the bind alone achieves that; the firewall rule is redundant coverage in case the bind is ever changed).
- Pinned cloud-init's validator to `24.1.3` instead of `main`/`latest`, for the pip-buildability reason above — noted inline in the test file's own comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp


---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790769504&installation_model_id=428086&pr_number=284&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F284&signature=cd290fc1ee0def93e3254aff37f4d2a278f481f76844ad5cb482e9a9205d0a82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->