### PR TITLE
fix(v3): fire client.connected for OAuth clients (#272)

### DIFF
--- a/v3/server/src/palaia_hub/gateway/api.py
+++ b/v3/server/src/palaia_hub/gateway/api.py
@@ -41,7 +41,7 @@ from ..config import (
 )
 from ..events import EventBus, publish_event
 from ..oauth import AuthorizationServer
-from ..oauth.verifier import build_profile_auth
+from ..oauth.verifier import build_profile_auth, oauth_client_connected_hook
 from .build import GatewayConfigError
 from .config import (
     CURATOR_PROFILE_PATH,
@@ -290,12 +290,17 @@ def build_gateway_profiles_router(
 
     def _new_profile_auth(profile_path: str) -> AuthProvider | None:
         """The verifier a genuinely new profile should get, mirroring
-        exactly how ``build_production_app`` builds one at startup."""
+        exactly how ``build_production_app`` builds one at startup —
+        including firing ``client.connected`` on its first OAuth verify
+        (issue #272), when there is a bus to publish it on."""
         providers = build_profile_auth(
             [profile_path],
             key=oauth_server.key if oauth_server is not None else None,
             resources=oauth_server.resources if oauth_server is not None else None,
             token_store=token_store if config.auth_enabled else None,
+            on_oauth_verified=(
+                oauth_client_connected_hook(event_bus) if event_bus is not None else None
+            ),
         )
         return providers.get(profile_path)
 

--- a/v3/server/src/palaia_hub/oauth/__init__.py
+++ b/v3/server/src/palaia_hub/oauth/__init__.py
@@ -40,7 +40,11 @@ Public surface:
 - :func:`~palaia_hub.oauth.verifier.build_profile_auth` — the resource side:
   per-profile fastmcp ``JWTVerifier`` (SPEC-108's upgrade seam), combined via
   ``MultiAuth`` with the SPEC-108 ``plt_`` verifier so both credentials keep
-  working on every profile.
+  working on every profile. Its ``on_oauth_verified`` fires SPEC-201's
+  ``client.connected`` on a JWT's first verify this process, the same
+  milestone :class:`~palaia_hub.auth.store.TokenStore` already fires for
+  ``plt_`` tokens (issue #272) — see
+  :func:`~palaia_hub.oauth.verifier.oauth_client_connected_hook`.
 - :func:`~palaia_hub.oauth.clients.provision_machine_client` — the only way a
   confidential (secret-bearing, audience-pinned) client comes into existence.
 - :func:`~palaia_hub.oauth.login.set_owner_password` — the local owner
@@ -83,9 +87,11 @@ from .service import (
 )
 from .store import OAuthStore
 from .verifier import (
+    OnOAuthVerified,
     build_jwt_verifier,
     build_profile_auth,
     log_profile_auth,
+    oauth_client_connected_hook,
     summarize_profile_auth,
 )
 
@@ -108,6 +114,7 @@ __all__ = [
     "LoginThrottle",
     "OAuthError",
     "OAuthStore",
+    "OnOAuthVerified",
     "OidcIdpProvider",
     "ProvisionedMachineClient",
     "PruneReport",
@@ -123,6 +130,7 @@ __all__ = [
     "log_profile_auth",
     "normalize_issuer",
     "now_seconds",
+    "oauth_client_connected_hook",
     "provision_machine_client",
     "register_dcr_client",
     "set_owner_password",

--- a/v3/server/src/palaia_hub/oauth/verifier.py
+++ b/v3/server/src/palaia_hub/oauth/verifier.py
@@ -35,18 +35,101 @@ OAuth on, so trying it first avoids paying an argon2 verify on the hot path.
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 
-from fastmcp.server.auth import AuthProvider, MultiAuth, TokenVerifier
+from fastmcp.server.auth import AccessToken, AuthProvider, MultiAuth, TokenVerifier
 from fastmcp.server.auth.providers.jwt import JWTVerifier
 from pydantic import AnyHttpUrl
 
 from ..auth.store import TokenStore
 from ..auth.verifier import PalaiaTokenVerifier
+from ..events import EventBus, publish_event
 from .keys import ALGORITHM, SigningKey
 from .resources import ResourceRegistry
 
 logger = logging.getLogger("palaia_hub.oauth.verifier")
+
+#: A profile's first successful OAuth verify this process, handed the
+#: profile path and the ``AccessToken`` fastmcp's own ``JWTVerifier``
+#: produced. See :class:`_ConnectedJWTVerifier` and
+#: :func:`oauth_client_connected_hook`.
+OnOAuthVerified = Callable[[str, AccessToken], None]
+
+
+class _ConnectedJWTVerifier(JWTVerifier):
+    """A ``JWTVerifier`` that also fires ``on_verified`` once per client.
+
+    Closes issue #272: ``client.connected`` (and so the funnel's
+    ``client_connected_at``, see :mod:`palaia_hub.funnel`) previously only
+    fired from :class:`~palaia_hub.auth.store.TokenStore`'s ``on_verified``
+    hook on a SPEC-108 ``plt_`` token's first ``verify()`` — the real OAuth
+    2.1 JWT path never touched it, because fastmcp's own ``JWTVerifier``
+    does all the validation with no hook point of its own. Subclassing (as
+    opposed to wrapping in a plain :class:`~fastmcp.server.auth.TokenVerifier`)
+    keeps this an actual ``JWTVerifier`` instance, so
+    :func:`summarize_profile_auth`'s ``isinstance`` check and everything
+    else that inspects the verifier chain keeps working unchanged.
+
+    Dedup is "first successful verify this *verifier instance*'s
+    lifetime", keyed by ``client_id`` (falling back to ``subject`` — a
+    resource-owner ``sub`` claim without a ``client_id`` is still one
+    client worth counting once) — the JWT-side equivalent of the ``plt_``
+    side's per-token-id dedup, since an OAuth access token is short-lived
+    and re-issued per session, so keying on the token itself would fire on
+    every refresh. A verifier is rebuilt (and so this dedup resets) only
+    when its profile itself is rebuilt (a runtime profile edit, or the
+    wizard's first vault); harmless either way, since
+    :meth:`~palaia_hub.funnel.FunnelStore.record_client_connected` is
+    itself first-write-wins.
+    """
+
+    def __init__(
+        self, *args: object, on_verified: OnOAuthVerified, profile: str, **kwargs: object
+    ) -> None:
+        super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+        self._on_verified = on_verified
+        self._profile = profile
+        self._seen_clients: set[str] = set()
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        access = await super().verify_token(token)
+        if access is not None:
+            client_key = access.client_id or access.subject or "unknown"
+            if client_key not in self._seen_clients:
+                self._seen_clients.add(client_key)
+                try:
+                    self._on_verified(self._profile, access)
+                except Exception:  # noqa: BLE001 - a hook must not break verification
+                    logger.exception(
+                        "client.connected hook failed", extra={"profile": self._profile}
+                    )
+        return access
+
+
+def oauth_client_connected_hook(event_bus: EventBus) -> OnOAuthVerified:
+    """Build the ``on_oauth_verified`` callback that fires ``client.connected``.
+
+    The OAuth-side counterpart to how :func:`palaia_hub.app.create_app`
+    wires :class:`~palaia_hub.auth.store.TokenStore`'s own
+    ``on_verified`` hook onto the same event — deliberately never leaks
+    the bearer token or client secret: only the OAuth ``client_id`` (public
+    by design — RFC 6749 §2.2) and the profile path reach the bus, and from
+    there the dashboard's event feed and any configured webhook.
+    """
+
+    def _hook(profile: str, access: AccessToken) -> None:
+        publish_event(
+            event_bus,
+            "client.connected",
+            origin="auth",
+            data={
+                "client_id": access.client_id,
+                "profile": profile,
+                "auth_method": "oauth",
+            },
+        )
+
+    return _hook
 
 
 class ProfileAuth(MultiAuth):
@@ -78,7 +161,11 @@ class ProfileAuth(MultiAuth):
 
 
 def build_jwt_verifier(
-    key: SigningKey, resources: ResourceRegistry, profile: str
+    key: SigningKey,
+    resources: ResourceRegistry,
+    profile: str,
+    *,
+    on_verified: OnOAuthVerified | None = None,
 ) -> JWTVerifier:
     """A ``JWTVerifier`` accepting only *this* profile's access tokens.
 
@@ -86,12 +173,26 @@ def build_jwt_verifier(
         key: the signing key whose public half verifies tokens.
         resources: the registry that owns the canonical audience strings.
         profile: which profile's audience to pin to.
+        on_verified: given, the returned verifier is a
+            :class:`_ConnectedJWTVerifier` instead of a plain
+            ``JWTVerifier`` — see that class's docstring (issue #272).
+            Omitted (the default), behavior is identical to before this
+            parameter existed.
     """
-    return JWTVerifier(
+    if on_verified is None:
+        return JWTVerifier(
+            public_key=key.public_pem(),
+            algorithm=ALGORITHM,
+            issuer=resources.issuer,
+            audience=resources.audience(profile),
+        )
+    return _ConnectedJWTVerifier(
         public_key=key.public_pem(),
         algorithm=ALGORITHM,
         issuer=resources.issuer,
         audience=resources.audience(profile),
+        on_verified=on_verified,
+        profile=profile,
     )
 
 
@@ -101,6 +202,7 @@ def build_profile_auth(
     key: SigningKey | None = None,
     resources: ResourceRegistry | None = None,
     token_store: TokenStore | None = None,
+    on_oauth_verified: OnOAuthVerified | None = None,
 ) -> dict[str, AuthProvider]:
     """One :class:`AuthProvider` per profile path, combining every credential.
 
@@ -112,6 +214,12 @@ def build_profile_auth(
             SPEC-108-only posture, unchanged from before this SPEC.
         resources: the resource registry; required together with ``key``.
         token_store: the MVP token store. Omit to serve OAuth only.
+        on_oauth_verified: given (together with ``key``/``resources``),
+            each profile's JWT verifier fires this on its first successful
+            verify of a given client this process (issue #272) — see
+            :func:`oauth_client_connected_hook` for the production wiring
+            onto the hub's event bus. Omitted (the default), behavior is
+            identical to before this parameter existed.
 
     Returns:
         ``{profile path: AuthProvider}`` ready for
@@ -129,7 +237,9 @@ def build_profile_auth(
     for profile in list(profiles):
         verifiers: list[TokenVerifier] = []
         if key is not None and resources is not None:
-            verifiers.append(build_jwt_verifier(key, resources, profile))
+            verifiers.append(
+                build_jwt_verifier(key, resources, profile, on_verified=on_oauth_verified)
+            )
         if token_store is not None:
             verifiers.append(PalaiaTokenVerifier(token_store, profile))
         if not verifiers:
@@ -179,9 +289,11 @@ def log_profile_auth(providers: Mapping[str, AuthProvider]) -> None:
 
 
 __all__ = [
+    "OnOAuthVerified",
     "ProfileAuth",
     "build_jwt_verifier",
     "build_profile_auth",
     "log_profile_auth",
+    "oauth_client_connected_hook",
     "summarize_profile_auth",
 ]

--- a/v3/server/src/palaia_hub/serve.py
+++ b/v3/server/src/palaia_hub/serve.py
@@ -61,7 +61,7 @@ from .messenger.store import MessengerStore
 from .notifications import NotificationStore
 from .notifications.store import NOTIFICATIONS_RELATIVE_PATH
 from .oauth import AuthorizationServer
-from .oauth.verifier import build_profile_auth
+from .oauth.verifier import build_profile_auth, oauth_client_connected_hook
 from .registry import RegistryClient
 from .stash.service import StashService
 from .stash.store import StashStore
@@ -322,11 +322,21 @@ async def build_production_app(
     # once, instead of only ever the latter (the gap this closes: before
     # this SPEC, a hub with `oauth.enabled: true` and `auth_enabled: false`
     # mounted its gateway with no verifier at all).
+    # Issue #272: an OAuth JWT never touches TokenStore.on_verified (that
+    # hook only fires from a SPEC-108 `plt_` token's verify()), so
+    # `client.connected` — and the funnel's `client_connected_at` — never
+    # fired for an OAuth-only client. `on_oauth_verified` closes that gap
+    # the same way `token_store.on_verified` is wired in `app.create_app`:
+    # one hook, called on a JWT's first successful verify this process.
+    on_oauth_verified = (
+        oauth_client_connected_hook(event_bus) if oauth_server is not None else None
+    )
     token_verifiers = build_profile_auth(
         [p.path for p in profiles],
         key=oauth_server.key if oauth_server is not None else None,
         resources=oauth_server.resources if oauth_server is not None else None,
         token_store=token_store if config.auth_enabled else None,
+        on_oauth_verified=on_oauth_verified,
     )
 
     def _auth_provider_for(path: str) -> Any | None:
@@ -343,6 +353,7 @@ async def build_production_app(
             key=oauth_server.key if oauth_server is not None else None,
             resources=oauth_server.resources if oauth_server is not None else None,
             token_store=token_store if config.auth_enabled else None,
+            on_oauth_verified=on_oauth_verified,
         ).get(path)
 
     dynamic_gateway = DynamicGateway(

--- a/v3/server/tests/e2e/test_spec506_phase5_gate.py
+++ b/v3/server/tests/e2e/test_spec506_phase5_gate.py
@@ -351,17 +351,13 @@ def test_full_funnel_fresh_home_to_second_client_recall(
     assert status["first_memory_at"] is not None, (
         f"the real claude CLI's reply was: {payload.get('result')!r}"
     )
-    # Honest gap, not asserted away: client.connected (and so
-    # client_connected_at) only fires from a SPEC-108 plt_ token's first
-    # verify() (palaia_hub.app's own "client.connected fires on a token's
-    # first successful verify()" comment) — an OAuth JWT never touches
-    # that hook. Filed as
-    # https://github.com/byte5ai/palaia/issues/272; not fixed here per
-    # this SPEC's "no behavior changes outside release plumbing" rule,
-    # and it does not affect time_to_first_memory_seconds below, which is
-    # computed from hub_started_at/first_memory_at alone
-    # (palaia_hub.funnel.FunnelSnapshot.time_to_first_memory_seconds).
-    assert status["client_connected_at"] is None
+    # Fixed by https://github.com/byte5ai/palaia/issues/272: session A's
+    # real OAuth 2.1 JWT now fires client.connected on its first successful
+    # verify() too (palaia_hub.oauth.verifier.build_jwt_verifier's
+    # `on_verified` hook, wired onto the funnel's bus in
+    # palaia_hub.serve.build_production_app) — not only a SPEC-108 plt_
+    # token's own TokenStore.on_verified hook, as before this fix.
+    assert status["client_connected_at"] is not None
 
     # --- Session B: a scripted fastmcp.Client carrying a real SPEC-108
     # plt_ token, minted through the real REST surface (the wizard's
@@ -390,10 +386,14 @@ def test_full_funnel_fresh_home_to_second_client_recall(
         f"B's recall output did not contain A's exact fact.\nrecall result: {recalled_text}"
     )
 
-    # client.connected now fires — B's plt_ token, unlike A's OAuth token,
-    # goes through TokenStore.verify().
+    # client_connected_at was already set from A's OAuth connect above (see
+    # https://github.com/byte5ai/palaia/issues/272); B's plt_ token verify
+    # is a second client.connected the funnel's own first-write-wins
+    # record_client_connected() leaves the timestamp exactly as A set it.
+    status_before = status["client_connected_at"]
     status = admin.get("/api/funnel/status").json()
     assert status["client_connected_at"] is not None
+    assert status["client_connected_at"] == status_before
 
     wall_elapsed = time.monotonic() - wall_start
     hub_side_seconds = status["time_to_first_memory_seconds"]

--- a/v3/server/tests/oauth/harness.py
+++ b/v3/server/tests/oauth/harness.py
@@ -21,6 +21,7 @@ from fastapi import FastAPI
 from palaia_hub.app import create_app
 from palaia_hub.auth.store import TokenStore
 from palaia_hub.config import HubConfig, OAuthSettings
+from palaia_hub.events import EventBus
 from palaia_hub.gateway.build import GatewayASGI, build_gateway
 from palaia_hub.gateway.config import GatewayConfig, ProfileConfig, VaultMountConfig
 from palaia_hub.gateway.fake_vault import FakeVaultService
@@ -32,6 +33,7 @@ from palaia_hub.oauth import (
     SigningKey,
     StaticCimdFetcher,
     build_profile_auth,
+    oauth_client_connected_hook,
     set_owner_password,
 )
 
@@ -87,6 +89,11 @@ class Harness:
     clock: Clock
     cimd: StaticCimdFetcher
     home: Path
+    #: The bus `create_app` publishes onto — also what
+    #: `oauth_client_connected_hook` (issue #272) is wired to below, so a
+    #: test can assert on `client.connected` the same way it would in
+    #: production. Same object `app.state.event_bus` holds.
+    event_bus: EventBus
     profiles: tuple[str, ...] = field(default=PROFILES)
 
     def audience(self, profile: str) -> str:
@@ -132,18 +139,29 @@ def build_harness(
         vaults=[VaultMountConfig(key=VAULT_KEY, name=VAULT_KEY, purpose="Work vault.")],
         profiles=[ProfileConfig(path=profile, vaults=[VAULT_KEY]) for profile in profiles],
     )
+    # Built here (not left for `create_app` to build its own) so
+    # `oauth_client_connected_hook` (issue #272) and `create_app` publish
+    # onto the same bus a test can assert against.
+    event_bus = EventBus()
     providers = build_profile_auth(
         profiles,
         key=key,
         resources=server.resources,
         token_store=token_store if with_plt_tokens else None,
+        on_oauth_verified=oauth_client_connected_hook(event_bus),
     )
     gateway = build_gateway(
         gateway_config,
         {VAULT_KEY: FakeVaultService()},
         token_verifiers=providers,  # type: ignore[arg-type]
     )
-    app = create_app(config, gateway=gateway, oauth_server=server, token_store=token_store)
+    app = create_app(
+        config,
+        gateway=gateway,
+        oauth_server=server,
+        token_store=token_store,
+        event_bus=event_bus,
+    )
     return Harness(
         app=app,
         gateway=gateway,
@@ -155,5 +173,6 @@ def build_harness(
         clock=clock,
         cimd=cimd,
         home=home,
+        event_bus=event_bus,
         profiles=profiles,
     )

--- a/v3/server/tests/oauth/test_client_connected_event.py
+++ b/v3/server/tests/oauth/test_client_connected_event.py
@@ -1,0 +1,178 @@
+"""Issue #272: an OAuth-authenticated client must fire `client.connected`.
+
+Before this fix, `client.connected` (and so the SPEC-504 funnel's
+`client_connected_at`, see `palaia_hub.funnel`) only ever fired from
+`TokenStore.on_verified` — a SPEC-108 `plt_` token's own hook. A real OAuth
+2.1 access token, verified by fastmcp's own `JWTVerifier`
+(`palaia_hub.oauth.verifier.build_profile_auth`), never touched that hook at
+all, so a hub whose very first connected client used OAuth (the common case
+for the real `claude` CLI, `test_spec506_phase5_gate.py`'s own repro) never
+recorded its first-client milestone until some *other*, `plt_`-token client
+happened to connect too.
+
+These tests exercise the real OAuth 2.1 + PKCE code flow over
+`httpx.ASGITransport` (the same rig `test_flow_e2e.py` uses) and assert
+`client.connected` fires on the harness's own event bus — the same bus
+`palaia_hub.funnel.wire_funnel_tracking` subscribes to in production.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from palaia_hub.events.schema import Envelope
+from palaia_hub.oauth.verifier import (
+    build_jwt_verifier,
+    build_profile_auth,
+    summarize_profile_auth,
+)
+
+from .harness import CIMD_CLIENT_ID, CIMD_REDIRECT_URI, Harness
+from .test_flow_e2e import _client
+
+
+@pytest.mark.anyio
+async def test_oauth_verify_fires_client_connected(harness: Harness) -> None:
+    """A client that authenticates over OAuth alone still fires the event —
+    no `plt_` token involved anywhere in this test."""
+    seen: list[Envelope] = []
+    harness.event_bus.on(seen.append)
+
+    async with harness.app.router.lifespan_context(harness.app):
+        scripted = await _client(harness)
+        async with scripted.http:
+            as_metadata = await scripted.authorization_server_metadata(harness.server.issuer)
+            await scripted.sign_in()
+            response = await scripted.authorize(
+                as_metadata,
+                client_id=CIMD_CLIENT_ID,
+                redirect_uri=CIMD_REDIRECT_URI,
+                resource=harness.audience("alpha"),
+            )
+            code = await scripted.code_from(response)
+            tokens = await scripted.exchange(
+                as_metadata,
+                code=code,
+                client_id=CIMD_CLIENT_ID,
+                redirect_uri=CIMD_REDIRECT_URI,
+            )
+            result = await scripted.call_tool(
+                "alpha", str(tokens["access_token"]), "work_memory_search", {"query": "x"}
+            )
+
+    assert result.isError is not True
+
+    connected = [e for e in seen if e.event == "client.connected"]
+    assert len(connected) == 1, seen
+    envelope = connected[0]
+    assert envelope.origin == "auth"
+    assert envelope.data["profile"] == "alpha"
+    assert envelope.data["client_id"] == CIMD_CLIENT_ID
+    assert envelope.data["auth_method"] == "oauth"
+    # Never leak the bearer token or a client secret onto the (dashboard-
+    # observable) event.
+    assert "token" not in envelope.data
+    assert "access_token" not in envelope.data
+    assert "client_secret" not in envelope.data
+
+
+@pytest.mark.anyio
+async def test_oauth_verify_fires_client_connected_only_once_per_client(
+    harness: Harness,
+) -> None:
+    """Repeat calls with the same client (fresh tokens, same client_id) do
+    not re-fire the event — same "first use this process" contract the
+    `plt_` side's `TokenStore.on_verified` already gives."""
+    seen: list[Envelope] = []
+    harness.event_bus.on(seen.append)
+
+    async with harness.app.router.lifespan_context(harness.app):
+        scripted = await _client(harness)
+        async with scripted.http:
+            as_metadata = await scripted.authorization_server_metadata(harness.server.issuer)
+            await scripted.sign_in()
+
+            for _ in range(2):
+                response = await scripted.authorize(
+                    as_metadata,
+                    client_id=CIMD_CLIENT_ID,
+                    redirect_uri=CIMD_REDIRECT_URI,
+                    resource=harness.audience("alpha"),
+                )
+                code = await scripted.code_from(response)
+                tokens = await scripted.exchange(
+                    as_metadata,
+                    code=code,
+                    client_id=CIMD_CLIENT_ID,
+                    redirect_uri=CIMD_REDIRECT_URI,
+                )
+                result = await scripted.call_tool(
+                    "alpha", str(tokens["access_token"]), "work_memory_search", {"query": "x"}
+                )
+                assert result.isError is not True
+
+    connected = [e for e in seen if e.event == "client.connected"]
+    assert len(connected) == 1, seen
+
+
+@pytest.mark.anyio
+async def test_a_token_rejected_at_verification_does_not_fire_the_event(
+    harness: Harness,
+) -> None:
+    """A profile-B call with an alpha-scoped token 401s and must not count
+    as a connection."""
+    seen: list[Envelope] = []
+    harness.event_bus.on(seen.append)
+
+    async with harness.app.router.lifespan_context(harness.app):
+        scripted = await _client(harness)
+        async with scripted.http:
+            as_metadata = await scripted.authorization_server_metadata(harness.server.issuer)
+            await scripted.sign_in()
+            response = await scripted.authorize(
+                as_metadata,
+                client_id=CIMD_CLIENT_ID,
+                redirect_uri=CIMD_REDIRECT_URI,
+                resource=harness.audience("alpha"),
+            )
+            code = await scripted.code_from(response)
+            tokens = await scripted.exchange(
+                as_metadata,
+                code=code,
+                client_id=CIMD_CLIENT_ID,
+                redirect_uri=CIMD_REDIRECT_URI,
+            )
+            bad = await scripted.http.get(
+                "/mcp/beta/",
+                headers={"Authorization": f"Bearer {tokens['access_token']}"},
+            )
+            assert bad.status_code == 401
+
+    connected = [e for e in seen if e.event == "client.connected"]
+    assert connected == []
+
+
+def test_build_jwt_verifier_without_on_verified_is_unchanged(harness: Harness) -> None:
+    """The default (no hook) path stays exactly the plain `JWTVerifier` it
+    always was — no wrapper class in the way when nobody asked for one."""
+    from fastmcp.server.auth.providers.jwt import JWTVerifier
+
+    verifier = build_jwt_verifier(harness.key, harness.resources, "alpha")
+    assert type(verifier) is JWTVerifier
+
+
+def test_summarize_profile_auth_still_labels_a_hooked_verifier_as_oauth(
+    harness: Harness,
+) -> None:
+    """`summarize_profile_auth`'s `isinstance(source, JWTVerifier)` check
+    (SPEC-203 deliverable #6's startup summary) must still recognize the
+    wrapped verifier as OAuth, not fall through to its defensive branch."""
+    providers = build_profile_auth(
+        ["alpha"],
+        key=harness.key,
+        resources=harness.resources,
+        on_oauth_verified=lambda profile, access: None,
+    )
+    lines = summarize_profile_auth(providers)
+    assert len(lines) == 1
+    assert "oauth2 (access JWT)" in lines[0]


### PR DESCRIPTION
Fixes #272.

`client.connected` (and the funnel's `client_connected_at`) only fired from the `plt_` token store's `on_verified` hook — the OAuth 2.1 JWT path never touched it, so OAuth-connected clients (the wizard's default path) were invisible to the funnel. A `JWTVerifier` subclass fires the same event once per client on first successful verify (deduped by `client_id`, falling back to `sub`), wired through `serve.py` for every profile verifier — including ones the `auth_provider_factory` creates for wizard-created vaults. No token contents or secrets reach the event payload.

Found by the SPEC-506 gate harness; the gate e2e's workaround assertion is replaced by the real expectation.

Evidence: ruff + mypy clean; oauth + funnel suites 276 passed; new regression test `server/tests/oauth/test_client_connected_event.py`; full suite running before merge.

(Recovered and completed from an infrastructure-aborted agent run — work re-verified from scratch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790783862&installation_model_id=428086&pr_number=285&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F285&signature=94b0f8b4c676feb098a2708e8b1988e386983c9ca765324459d997106ac43aab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->