### PR TITLE
feat(v3): token scope picker in ConnectPanel (#270)

### DIFF
--- a/v3/web/src/components/ConnectPanel.test.tsx
+++ b/v3/web/src/components/ConnectPanel.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Issue 270: the per-vault read/save picker in `ConnectPanel`'s "Issue
+ * token" step. Three cases mirror the issue's own "Suggested acceptance":
+ * the picker shows the target profile's vaults all checked by default,
+ * unchecking a box narrows what gets sent, and a caller who never touches
+ * the picker gets the exact one-click flow that existed before it.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { GatewayProfile } from "../lib/api/client";
+import { api } from "../lib/api/client";
+import type { GuidedClient } from "../lib/clients";
+import { ConnectPanel } from "./ConnectPanel";
+import { ToastProvider } from "./Toast";
+
+function DummyIcon() {
+  return null;
+}
+
+const CLIENT: GuidedClient = {
+  kind: "guided",
+  id: "test-client",
+  name: "Test Client",
+  icon: DummyIcon,
+  estimate: "one command · 1 min",
+  command: (origin, profile) => `connect ${origin}/mcp/${profile}`,
+  prompt: (origin, profile) => `Please connect to ${origin}/mcp/${profile}`,
+};
+
+const DEFAULT_PROFILE: GatewayProfile = {
+  path: "default",
+  label: null,
+  vaults: ["work", "personal"],
+  stash: false,
+  hidden_tools: [],
+  semantic_routing: false,
+  tool_count: 15,
+  upstreams: [],
+  managed: false,
+};
+
+function mount() {
+  return render(
+    <ToastProvider>
+      <ConnectPanel client={CLIENT} />
+    </ToastProvider>,
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ConnectPanel's read/save picker (issue #270)", () => {
+  it("shows every vault the target profile mounts, read and save both checked by default", async () => {
+    vi.spyOn(api, "listTokens").mockResolvedValue([]);
+    vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([DEFAULT_PROFILE]);
+
+    mount();
+
+    expect(await screen.findByText("work")).toBeInTheDocument();
+    expect(screen.getByText("personal")).toBeInTheDocument();
+
+    const checkboxes = screen.getAllByRole("checkbox") as HTMLInputElement[];
+    expect(checkboxes).toHaveLength(4); // read + save, for each of two vaults
+    for (const checkbox of checkboxes) {
+      expect(checkbox.checked).toBe(true);
+    }
+  });
+
+  it("sends the narrower explicit list once a box is unchecked, instead of an empty one", async () => {
+    vi.spyOn(api, "listTokens").mockResolvedValue([]);
+    vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([DEFAULT_PROFILE]);
+    const createSpy = vi.spyOn(api, "createToken").mockResolvedValue({
+      info: {
+        id: "tok_1",
+        name: "Test Client",
+        profile: "default",
+        scopes: [],
+        created_at: "2026-01-01T00:00:00Z",
+        revoked_at: null,
+        last_used_at: null,
+      },
+      token: "plt_secret",
+    });
+
+    mount();
+
+    await screen.findByText("work");
+    const rows = screen.getAllByRole("checkbox");
+    // Row order: work-read, work-save, personal-read, personal-save.
+    fireEvent.click(rows[1]!); // uncheck "work"'s Save box
+
+    fireEvent.click(screen.getByRole("button", { name: /issue token/i }));
+
+    await waitFor(() => expect(createSpy).toHaveBeenCalledTimes(1));
+    expect(createSpy).toHaveBeenCalledWith({
+      name: "Test Client",
+      profile: "default",
+      scopes: ["vault:work:read", "vault:personal:read", "vault:personal:write"],
+    });
+  });
+
+  it("leaves the one-click flow unaffected when nobody touches the picker", async () => {
+    vi.spyOn(api, "listTokens").mockResolvedValue([]);
+    vi.spyOn(api, "listGatewayProfiles").mockResolvedValue([DEFAULT_PROFILE]);
+    const createSpy = vi.spyOn(api, "createToken").mockResolvedValue({
+      info: {
+        id: "tok_1",
+        name: "Test Client",
+        profile: "default",
+        scopes: [],
+        created_at: "2026-01-01T00:00:00Z",
+        revoked_at: null,
+        last_used_at: null,
+      },
+      token: "plt_secret",
+    });
+
+    mount();
+
+    await screen.findByText("work");
+    fireEvent.click(screen.getByRole("button", { name: /issue token/i }));
+
+    await waitFor(() => expect(createSpy).toHaveBeenCalledTimes(1));
+    // No `scopes` field at all — byte-for-byte what this call sent before
+    // the picker existed, so the server's own default keeps deciding.
+    expect(createSpy).toHaveBeenCalledWith({ name: "Test Client", profile: "default" });
+  });
+
+  it("degrades to no picker, and the one-click flow still works, when no gateway is attached", async () => {
+    vi.spyOn(api, "listTokens").mockResolvedValue([]);
+    vi.spyOn(api, "listGatewayProfiles").mockRejectedValue(new Error("no gateway attached"));
+    const createSpy = vi.spyOn(api, "createToken").mockResolvedValue({
+      info: {
+        id: "tok_1",
+        name: "Test Client",
+        profile: "default",
+        scopes: [],
+        created_at: "2026-01-01T00:00:00Z",
+        revoked_at: null,
+        last_used_at: null,
+      },
+      token: "plt_secret",
+    });
+
+    mount();
+
+    await screen.findByRole("button", { name: /issue token/i });
+    expect(screen.queryAllByRole("checkbox")).toHaveLength(0);
+
+    fireEvent.click(screen.getByRole("button", { name: /issue token/i }));
+
+    await waitFor(() => expect(createSpy).toHaveBeenCalledTimes(1));
+    expect(createSpy).toHaveBeenCalledWith({ name: "Test Client", profile: "default" });
+  });
+});

--- a/v3/web/src/components/ConnectPanel.tsx
+++ b/v3/web/src/components/ConnectPanel.tsx
@@ -22,10 +22,23 @@
  * unmounted profile path by hand; step 3 below tells the truth about
  * whichever path is actually in play by polling for a real first call
  * rather than faking one.
+ *
+ * Issue 270: step 1 also offers a per-vault read/save picker (checkboxes
+ * next to each vault the target tool profile mounts), all checked by
+ * default — the same "every vault, read and save" shape `palaia_hub.auth.
+ * routes`'s empty-`scopes` default already grants, so a caller who never
+ * touches the picker sends exactly what it always has: no `scopes` field
+ * at all, letting that server-side default do the work. Only unchecking a
+ * box switches this panel to sending an explicit, narrower list — see
+ * `explicitScopes` below. The picker never sends an empty explicit list on
+ * purpose: an empty `scopes` array is the server's "use the default"
+ * sentinel (that module's docstring), so "everything unchecked" would
+ * silently grant full access instead of none — `wouldGrantNothing` below
+ * blocks Issue token in that one case rather than let it widen access.
  */
 import { useEffect, useMemo, useState } from "react";
 
-import type { CreatedToken, TokenInfo } from "../lib/api/client";
+import type { CreatedToken, GatewayProfile, TokenInfo } from "../lib/api/client";
 import { api } from "../lib/api/client";
 import type { GuidedClient } from "../lib/clients";
 import { describeApiError } from "../lib/errors";
@@ -65,6 +78,12 @@ export function ConnectPanel({
   const [token, setToken] = useState<TokenInfo | null>(null);
   const [tab, setTab] = useState<"command" | "prompt" | "file">("command");
   const [error, setError] = useState<string | null>(null);
+  const [profiles, setProfiles] = useState<GatewayProfile[] | null>(null);
+  // Every entry a caller has explicitly *un*checked, as `vault-key:read` /
+  // `vault-key:write`. Absence means checked — so a vault this panel has
+  // never rendered a checkbox for (the profile isn't known yet, or has no
+  // vaults) never ends up narrower by accident.
+  const [unchecked, setUnchecked] = useState<Set<string>>(new Set());
 
   // Look for an already-issued, non-revoked token for this client on
   // mount — inside the effect's own promise callback, never synchronously
@@ -98,6 +117,78 @@ export function ConnectPanel({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [client.name]);
 
+  // Which vaults the target tool profile mounts, for the read/save picker
+  // below — the same `/api/gateway/profiles` listing the tool-profile
+  // editor already reads (ToolProfiles.tsx), not a new endpoint. Fetched
+  // once on mount: this panel only needs to look a profile name up in an
+  // already-fetched list, not refetch on every keystroke in the profile
+  // field.
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .listGatewayProfiles()
+      .then((list) => {
+        if (!cancelled) setProfiles(list);
+      })
+      .catch(() => {
+        // no gateway attached, or a transient failure — the picker simply
+        // stays hidden and issuing a token behaves exactly as it did
+        // before this panel could show one (no explicit scopes, ever).
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // A caller can retype the profile name before issuing; whatever was
+  // unchecked for the previous name shouldn't silently narrow a different
+  // profile's vaults once it resolves. Adjusted during render rather than
+  // in an effect — the pattern React's own docs recommend for "reset some
+  // state when a prop changes" (react.dev/learn/you-might-not-need-an-
+  // effect#adjusting-some-state-when-a-prop-changes) — since a `useEffect`
+  // that calls `setState` unconditionally on every commit is exactly the
+  // cascading-render shape `react-hooks/set-state-in-effect` flags.
+  const [previousProfileDraft, setPreviousProfileDraft] = useState(profileDraft);
+  if (profileDraft !== previousProfileDraft) {
+    setPreviousProfileDraft(profileDraft);
+    setUnchecked(new Set());
+  }
+
+  const targetProfile = profiles?.find((candidate) => candidate.path === profileDraft) ?? null;
+  const mountedVaults = targetProfile?.vaults ?? [];
+
+  function isChecked(vaultKey: string, permission: "read" | "write"): boolean {
+    return !unchecked.has(`${vaultKey}:${permission}`);
+  }
+
+  function togglePermission(vaultKey: string, permission: "read" | "write", checked: boolean) {
+    setUnchecked((prev) => {
+      const next = new Set(prev);
+      const id = `${vaultKey}:${permission}`;
+      if (checked) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  // Nothing has been unchecked: this is today's behavior, so no explicit
+  // list is built at all (see `issueToken` below).
+  const pickerTouched = unchecked.size > 0;
+  const explicitScopes = pickerTouched
+    ? mountedVaults.flatMap((key) => {
+        const scopes: string[] = [];
+        if (isChecked(key, "read")) scopes.push(`vault:${key}:read`);
+        if (isChecked(key, "write")) scopes.push(`vault:${key}:write`);
+        return scopes;
+      })
+    : [];
+  // Every box unchecked would resolve to an empty list — which the server
+  // reads as "no explicit scopes were sent, use the default" (see this
+  // file's header comment), the opposite of what an operator unchecking
+  // everything means. Block issuing rather than silently grant more than
+  // shown.
+  const wouldGrantNothing = pickerTouched && explicitScopes.length === 0;
+
   const origin = typeof window !== "undefined" ? window.location.origin : "";
   const profile = token?.profile ?? profileDraft;
   const connected = Boolean(token?.last_used_at);
@@ -124,7 +215,16 @@ export function ConnectPanel({
     setIssuing(true);
     setError(null);
     try {
-      const result: CreatedToken = await api.createToken({ name: client.name, profile: profileDraft });
+      // No `scopes` field at all unless the picker was actually touched —
+      // this is what keeps the one-click flow byte-for-byte what it always
+      // sent, so the server's own "empty scopes = everything this profile
+      // mounts" default (still the no-touch path) is the one deciding
+      // what a caller who never opens the picker gets.
+      const body =
+        pickerTouched && explicitScopes.length > 0
+          ? { name: client.name, profile: profileDraft, scopes: explicitScopes }
+          : { name: client.name, profile: profileDraft };
+      const result: CreatedToken = await api.createToken(body);
       setToken(result.info);
       setPlaintext(result.token);
       onTokenIssued?.(result.info);
@@ -213,7 +313,55 @@ export function ConnectPanel({
                   style={{ maxWidth: 220 }}
                   aria-label="Tool profile name"
                 />
-                <Button variant="primary" onClick={issueToken} disabled={issuing}>
+              </div>
+              {mountedVaults.length > 0 ? (
+                <div className="stack stack--2">
+                  <span className="field__label">What {client.name} can read or save</span>
+                  <p className="t-xs t-muted">
+                    Every vault below is included, both ways, by default — the same as today.
+                    Uncheck a box to leave a vault out, or to give read-only access to it.
+                  </p>
+                  <div className="stack stack--2">
+                    {mountedVaults.map((vaultKey) => (
+                      <div key={vaultKey} className="row row--wrap" style={{ gap: 14 }}>
+                        <span className="t-sm t-mono">{vaultKey}</span>
+                        <label className="row" style={{ gap: 4 }}>
+                          <input
+                            type="checkbox"
+                            checked={isChecked(vaultKey, "read")}
+                            onChange={(event) =>
+                              togglePermission(vaultKey, "read", event.target.checked)
+                            }
+                          />
+                          <span className="t-xs">Read</span>
+                        </label>
+                        <label className="row" style={{ gap: 4 }}>
+                          <input
+                            type="checkbox"
+                            checked={isChecked(vaultKey, "write")}
+                            onChange={(event) =>
+                              togglePermission(vaultKey, "write", event.target.checked)
+                            }
+                          />
+                          <span className="t-xs">Save</span>
+                        </label>
+                      </div>
+                    ))}
+                  </div>
+                  {wouldGrantNothing ? (
+                    <p className="field__error">
+                      Check at least one box — leaving every vault unchecked would give this
+                      client full access instead of none.
+                    </p>
+                  ) : null}
+                </div>
+              ) : null}
+              <div className="row row--wrap">
+                <Button
+                  variant="primary"
+                  onClick={issueToken}
+                  disabled={issuing || wouldGrantNothing}
+                >
                   {issuing ? "Issuing…" : "Issue token"}
                 </Button>
               </div>


### PR DESCRIPTION
Fixes #270

## What

`ConnectPanel.tsx`'s "Issue token" step now shows a per-vault read/save picker for the vaults the target tool profile mounts, instead of always sending `scopes: []` silently.

- Each vault the profile mounts (`/api/gateway/profiles`, the same endpoint `ToolProfiles.tsx` already reads — no new server endpoint) gets a Read and a Save checkbox, both checked by default.
- Untouched picker → the call sends **no `scopes` field at all**, byte-for-byte what it always sent. The server's existing SPEC-504 empty-scopes default (read+write on every vault the profile mounts) keeps deciding, so the one-click "Issue token" flow for someone who never opens the picker is unaffected.
- Unchecking a box → sends an explicit, narrower `scopes` list (`vault:<key>:read` / `vault:<key>:write`, per `auth/scopes.py`) instead of `[]`.
- Unchecking *every* box for every vault is blocked (Issue token disabled, with an inline explanation) rather than silently sent: an empty explicit list is indistinguishable from "picker not touched" on the server (`auth/routes.py`'s documented sentinel) and would otherwise widen access instead of narrowing it — violates the "never widen what a token can do" rule.
- No "scopes" in the UI copy — the section is titled "What `<client>` can read or save", with plain "Read"/"Save" checkboxes per vault (the dashboard's existing word for the thing).

## No server changes

`POST /api/auth/tokens` already accepts an explicit `scopes` list (SPEC-108); `auth/routes.py`'s empty-list-defaults-to-full-access behavior (the SPEC-504 interim fix) is untouched — it stays the no-touch path exactly as before.

## Test plan

From `v3/web`:
- [x] `npm run lint` — 0 errors (4 pre-existing warnings, unrelated to this change)
- [x] `npm run typecheck` — clean
- [x] `npx vitest run` — **115/115 passed** (23 test files), including 4 new tests in `ConnectPanel.test.tsx`:
  - shows every vault the target profile mounts, both boxes checked by default
  - sends the narrower explicit list once a box is unchecked, instead of `[]`
  - leaves the one-click flow unaffected when nobody touches the picker (no `scopes` field sent)
  - degrades to no picker (and the one-click flow still works) when no gateway is attached
- [x] `npm run build` — clean production build
- No server files touched, so the Python suite was not re-run.
- `grep -rn '^<<<<<<< ' v3` — empty.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790784063&installation_model_id=428086&pr_number=286&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F286&signature=1bce747801c3b2f7eb3953650366257448dc6cd1bf25fc0621d370162958681e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->