### PR TITLE
fix(v3): pin tmp to close the mcpb build advisory

### DIFF
--- a/v3/docs/security/dependencies.md
+++ b/v3/docs/security/dependencies.md
@@ -60,30 +60,30 @@ Run on 2026-08-25, against the current lockfiles:
 | Python runtime dependencies (`uv export --no-dev`) | **No known vulnerabilities** |
 | Python including dev dependencies | **No known vulnerabilities** |
 | `v3/web` (8 runtime, 723 dev packages) | **0 vulnerabilities** |
-| `v3/tools/build-mcpb` (1 runtime, 55 dev packages) | 1 high, 4 low — see below |
+| `v3/tools/build-mcpb` (1 runtime, 55 dev packages) | **0 vulnerabilities** — see below |
 
-### The one open finding
+### Resolved: the `tmp` finding (formerly tracked as issue #264)
 
 `tmp <= 0.2.5` (GHSA-52f5-9888-hmc6, GHSA-ph9p-34f9-6g65 — arbitrary
 temporary file write via a symlinked `dir`, and path traversal via an
-unsanitized prefix) reaches `v3/tools/build-mcpb` through
+unsanitized prefix) reached `v3/tools/build-mcpb` through
 `@anthropic-ai/mcpb → @inquirer/prompts → @inquirer/editor →
-external-editor → tmp`. **No fix is available upstream.**
+external-editor → tmp`, pinned at `tmp@0.0.33` by that chain's own
+`package.json` ranges. `@anthropic-ai/mcpb` had no newer release to pick up
+a patched `@inquirer` chain — but `tmp@0.2.6` (current: `0.2.7`) fixes both
+advisories on its own, and nothing in `external-editor`'s use of `tmp`
+needed the older major. A `package.json` **`overrides`** entry pins
+`tmp` to `^0.2.6` underneath the unpatched chain, narrower than waiting on
+an upstream `@anthropic-ai/mcpb` release: it changes only the one
+transitive package the advisories are actually about, not the chain
+carrying it. `npm audit` is clean; `npm ci && npm run build` and the
+proxy's own test suite still pass unchanged.
 
-Accepted, with reasons:
-
-- it is a **build-time devDependency of the bundle packer**, not a runtime
-  dependency of the hub or the dashboard — nothing in the published image or
-  the published bundle contains it;
-- the vulnerable path is reached only through `@inquirer`'s interactive
-  editor prompt, which the packer never invokes (its build is
-  non-interactive: `mcpb validate` and `mcpb pack`);
-- exploiting it requires local control of the arguments passed to `tmp`,
-  i.e. an attacker who already runs code on the build machine.
-
-**Review trigger:** re-check on every dependency sweep, and upgrade
-`@anthropic-ai/mcpb` as soon as a release ships a patched `@inquirer`
-chain. If this is still open at 3.0, it is listed in the release notes.
+This was accepted for a time (build-time devDependency only, reached only
+through an interactive prompt the packer's non-interactive `mcpb validate`/
+`mcpb pack` never invokes) — see the closed issue for that original
+reasoning — but a clean override was available, so it no longer needs to
+carry into 3.0 on a review trigger.
 
 ## Reproducing the audit
 

--- a/v3/tools/build-mcpb/package-lock.json
+++ b/v3/tools/build-mcpb/package-lock.json
@@ -540,16 +540,6 @@
         "node": ">= 6.13.0"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -612,16 +602,13 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/type-fest": {

--- a/v3/tools/build-mcpb/package.json
+++ b/v3/tools/build-mcpb/package.json
@@ -10,5 +10,8 @@
   },
   "devDependencies": {
     "@anthropic-ai/mcpb": "2.1.2"
+  },
+  "overrides": {
+    "tmp": "^0.2.6"
   }
 }


### PR DESCRIPTION
## What

Closes the `tmp` advisory `npm audit` reports in `v3/tools/build-mcpb` via a `package.json` `overrides` entry pinning `tmp` to `^0.2.6`.

## Why

Fixes #264. `npm audit` in `v3/tools/build-mcpb` reported 1 high (GHSA-52f5-9888-hmc6, GHSA-ph9p-34f9-6g65) reached through `@anthropic-ai/mcpb -> @inquirer/prompts -> @inquirer/editor -> external-editor -> tmp@0.0.33`. The issue's suggested fix ("upgrade `@anthropic-ai/mcpb` once it ships a patched `@inquirer` chain") isn't available yet — `2.1.2` is still the latest release on npm — but that's not actually needed: `tmp@0.2.6` (current: `0.2.7`) fixes both advisories on its own, and nothing about `external-editor`'s use of `tmp` requires the older major.

## How

- Added `"overrides": {"tmp": "^0.2.6"}` to `v3/tools/build-mcpb/package.json` — pins only the one transitive package the advisories are about, narrower than forcing a chain-wide bump and not dependent on an upstream release.
- Regenerated `package-lock.json` with `npm install` (verified against a clean `npm ci` afterward). The only dependency delta is `tmp` `0.0.33` → `0.2.7`, and dropping its now-unused `os-tmpdir` sub-dependency.
- Updated `v3/docs/security/dependencies.md`'s "accepted" writeup for this finding to reflect the resolution.

## Test evidence

```
$ cd v3/tools/build-mcpb && npm ci
added 54 packages, and audited 55 packages in 1s
found 0 vulnerabilities

$ npm audit
found 0 vulnerabilities

$ npm run build
...
📦  palaia@3.0.0-rc1
...
built and signed .../v3/tools/build-mcpb/dist/palaia.mcpb

$ npm test
# tests 17
# pass 17
# fail 0
```

```
$ cd v3 && uv run ruff check server
All checks passed!

$ uv run mypy server/src
Success: no issues found in 193 source files
```

`uv run pytest server/tests -q` also run for regression coverage (no Python source touched by this change).

## Checklist

- [x] Tests added/updated (n/a — dependency-only fix; existing `npm audit`/build/test are the regression check)
- [x] `npm ci && npm audit` clean
- [x] `npm run build` and `npm test` pass
- [x] `ruff check server` / `mypy server/src` pass
- [x] Documentation updated (`v3/docs/security/dependencies.md`)
- [x] No force pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790784601&installation_model_id=428086&pr_number=288&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F288&signature=0ef4a7a7e7506582573f41611dbe36d5ed88f49b0a741fb6e62dde462fde12bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->