### PR TITLE
test(v3): deadline-poll watcher echo test, not sleep

### DIFF
--- a/v3/server/tests/vault/test_watcher.py
+++ b/v3/server/tests/vault/test_watcher.py
@@ -61,6 +61,35 @@ async def watched(make_engine: EngineFactory, debounce_ms: int = 100):
     return engine, watcher, collector
 
 
+async def wait_until_watcher_settles(
+    watcher: VaultWatcher, *, timeout: float = 10.0, quiet: float = 0.3
+) -> None:
+    """Poll ``watcher.stats.batches`` until it stops changing for ``quiet``
+    seconds, or ``timeout`` elapses.
+
+    A fixed sleep is exactly what made
+    ``test_engine_writes_are_echoes_not_watcher_events`` flaky under
+    full-suite CPU contention (#253): a delay generous enough on a quiet
+    machine can still be shorter than the watcher's actual debounce + batch
+    processing time once the event loop is starved of scheduling slices.
+    Waiting for the batch counter to go quiet ties the wait to what the
+    watcher actually did, not to a wall-clock guess — and ``stats.echoes``/
+    ``stats.events`` are updated synchronously as part of processing each
+    batch (before any ``await`` on an empty-events batch), so once
+    ``batches`` has gone quiet those counters have already settled too.
+    """
+    deadline = time.monotonic() + timeout
+    last_batches = watcher.stats.batches
+    quiet_since = time.monotonic()
+    while time.monotonic() < deadline:
+        await asyncio.sleep(0.02)
+        if watcher.stats.batches != last_batches:
+            last_batches = watcher.stats.batches
+            quiet_since = time.monotonic()
+        elif time.monotonic() - quiet_since >= quiet:
+            return
+
+
 # ----------------------------------------------------------------- integration
 
 
@@ -161,7 +190,11 @@ async def test_engine_writes_are_echoes_not_watcher_events(
             body="y\n",
             expected_checksum=(await engine.read_note("notes/a")).checksum,
         )
-        events = await collector.drain(settle=0.8)
+        # #253: wait for the watcher to actually finish processing the
+        # resulting filesystem batch(es) instead of a fixed sleep, which a
+        # busy machine can outrun (see wait_until_watcher_settles).
+        await wait_until_watcher_settles(watcher)
+        events = await collector.drain(settle=0.05)
     finally:
         await watcher.stop()
     # Only the engine's own (non-external) events reached the bus.


### PR DESCRIPTION
## What

Makes `test_engine_writes_are_echoes_not_watcher_events` (`v3/server/tests/vault/test_watcher.py`) robust under full-suite load by replacing its fixed 0.8s sleep with a deadline-based poll for the watcher to actually finish processing.

## Why

Fixes #253. The test wrote two notes through the engine, slept a fixed 0.8s, then asserted the watcher had detected both writes as echoes (not re-published them as external events). Under full-suite CPU contention that 0.8s can be shorter than the watcher's actual debounce (100ms in this test) + batch-processing time once the event loop is starved of scheduling slices — the assertions then fire before the watcher has finished, which is exactly the failure observed once in #253 (1/1945 full-suite, passed 3/3 standalone immediately after on the same commit).

## How

Added `wait_until_watcher_settles()`: polls `watcher.stats.batches` until it stops changing for a quiet period (300ms), up to a generous 10s deadline, instead of sleeping a fixed amount. `watcher.stats.echoes`/`.events` are updated synchronously as part of processing each batch (see `VaultWatcher._run` / `process_batch`), so once `batches` has gone quiet those counters — and the events the test asserts on — have already settled too. The test still checks exactly what it checked before (`[event.external for event in events] == [False, False]`, `stats.events == 0`, `stats.echoes >= 1`); it just measures once the watcher is provably done rather than after a wall-clock guess. Never skipped or quarantined.

## Test evidence

Standalone, 5x in a row:

```
$ uv run pytest server/tests/vault/test_watcher.py::test_engine_writes_are_echoes_not_watcher_events -q
1 passed in 2.61s
1 passed in 1.04s
1 passed in 1.05s
1 passed in 1.05s
1 passed in 1.03s
```

Full `test_watcher.py` file (no regressions in sibling tests):

```
$ uv run pytest server/tests/vault/test_watcher.py -v
10 passed in 6.22s
```

```
$ uv run ruff check server
All checks passed!

$ uv run mypy server/src
Success: no issues found in 193 source files
```

Full `uv run pytest server/tests -q` also run (see PR description checklist below) — no failures.

## Checklist

- [x] Tests added/updated
- [x] `ruff check server` / `mypy server/src` pass
- [x] `pytest server/tests -q` passes, including 5x standalone reruns of the fixed test
- [x] No force pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790784715&installation_model_id=428086&pr_number=289&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F289&signature=cd5d6582a5d6a89cf617e34fc37a4b52be4b7f46b24c46f99735450a9e365c9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->