### PR TITLE
feat(v3): pre-declared OAuth vault scopes in config (#273)

### DIFF
--- a/v3/server/src/palaia_hub/cli.py
+++ b/v3/server/src/palaia_hub/cli.py
@@ -273,19 +273,33 @@ def _gateway_profiles_for_oauth(config: HubConfig) -> list[ProfileConfig]:
     resolution ``palaia_hub.serve.build_production_app`` uses to build the
     real gateway (SPEC-301 deliverable #3's "one source of truth"), so the
     CLI's OAuth-server assembly (built before the gateway exists, see
-    ``_maybe_oauth_server``'s caller) never disagrees with it.
+    ``_maybe_oauth_server``'s caller) never disagrees with it about which
+    profiles exist or what else each one carries.
+
+    ``include_pending=True`` (#273): unlike ``build_production_app``, which
+    only wants what it can mount *right now*, the OAuth server's grantable
+    scope ceiling has to be decided once, at construction, and never
+    changes after (:class:`~palaia_hub.oauth.service.AuthorizationServer`'s
+    class docstring) — so a vault a ``gateway.profiles`` entry pre-declares
+    but the wizard has not created yet still has to contribute its scopes
+    here, or an operator could never turn on Cloud mode + OAuth before
+    running the wizard's first "create a vault" step. See
+    ``resolve_profiles``'s own docstring for the full reasoning, including
+    why this never lets a live token do anything the real mount does not
+    also allow.
 
     Falls back to the deprecated ``oauth.profiles`` list only when nothing
     resolves from the gateway's own shape at all (no ``gateway:`` section
-    *and* no vault registered yet) — "an old config still works" (SPEC-301
-    acceptance criterion), for the one case that genuinely has nothing
-    else to go on. The moment even one vault exists, the gateway's own
-    ``default`` profile resolves and takes over, same as any other config.
+    *and* no vault registered yet, pending or real) — "an old config still
+    works" (SPEC-301 acceptance criterion), for the one case that
+    genuinely has nothing else to go on. The moment even one vault exists
+    (or is pre-declared), the gateway's own ``default`` profile resolves
+    and takes over, same as any other config.
     """
     vault_keys = sorted(VaultRegistry().names())
     try:
         profiles = resolve_full_gateway_profiles(
-            config, vault_keys, default_profile=DEFAULT_GATEWAY_PROFILE
+            config, vault_keys, default_profile=DEFAULT_GATEWAY_PROFILE, include_pending=True
         )
     except GatewaySettingsError as exc:
         print(f"palaia-hub: {exc}", file=sys.stderr)
@@ -296,7 +310,17 @@ def _gateway_profiles_for_oauth(config: HubConfig) -> list[ProfileConfig]:
 
 
 def _maybe_oauth_server(config: HubConfig) -> AuthorizationServer | None:
-    """Build the authorization server if config asks for one; else ``None``."""
+    """Build the authorization server if config asks for one; else ``None``.
+
+    This is the CLI's own stricter boot-time guard (issue #273): it still
+    refuses to start with genuinely zero profiles, pending or real — that
+    part is unchanged. What #273 fixes is upstream of here, in
+    ``_gateway_profiles_for_oauth``: a ``gateway.profiles`` entry that
+    pre-declares a vault the wizard has not created yet now makes
+    ``profiles`` below non-empty (its scopes are reserved), so this guard
+    only fires when the operator has not even said what this hub will
+    eventually serve.
+    """
     if not config.oauth.enabled:
         return None
     if not config.oauth.issuer:
@@ -312,7 +336,10 @@ def _maybe_oauth_server(config: HubConfig) -> AuthorizationServer | None:
         print(
             "palaia-hub: oauth.enabled is true but this hub serves no MCP profiles "
             "yet, so no resource can be named in a token. Fix: create a vault first "
-            "(the wizard, or `palaia-hub import ...`).",
+            "(the wizard, or `palaia-hub import ...`), or pre-declare one in "
+            "config.yaml's `gateway.profiles[].vaults` before it exists (e.g. "
+            "`gateway:\\n  profiles:\\n    - path: default\\n      vaults: [work]`) "
+            "so OAuth scopes are reserved for it from the very first boot.",
             file=sys.stderr,
         )
         raise SystemExit(1)

--- a/v3/server/src/palaia_hub/config.py
+++ b/v3/server/src/palaia_hub/config.py
@@ -227,6 +227,12 @@ exposure:
 #   # its identity (the MCP URL segment, and the OAuth resource audience if
 #   # OAuth is on) — set once, never renamed; give it a `label` instead if
 #   # you want a friendlier display name.
+#   #
+#   # A vault listed here does not have to exist yet: naming it pre-declares
+#   # that this profile will (eventually) serve it, so `oauth.enabled: true`
+#   # can be turned on — and its scopes granted — before you have ever run
+#   # the dashboard's "create a vault" wizard step. It mounts for real, with
+#   # no restart, the moment that vault is created.
 #   profiles:
 #     - path: default
 #       label: Default

--- a/v3/server/src/palaia_hub/gateway/settings_bridge.py
+++ b/v3/server/src/palaia_hub/gateway/settings_bridge.py
@@ -21,6 +21,7 @@ module is the one place that converts between it and
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
@@ -32,13 +33,19 @@ from ..modes.patch import replace_config_section
 from ..upstream.models import UpstreamConfig
 from .config import CURATOR_PROFILE_PATH, ProfileConfig, VaultMountConfig
 
+logger = logging.getLogger("palaia_hub.gateway.settings_bridge")
+
 
 class GatewaySettingsError(ValueError):
     """``config.yaml``'s ``gateway:`` section is structurally fine (it is
     already a valid :class:`~palaia_hub.config.GatewaySettings`) but
-    disagrees with reality — e.g. a profile names a vault key that is not
-    actually registered. Distinct from the :class:`pydantic.ValidationError`
-    the settings model itself already raises for a malformed section.
+    disagrees with reality — e.g. a profile names an external server key
+    that is not listed under ``gateway.upstreams``. Distinct from the
+    :class:`pydantic.ValidationError` the settings model itself already
+    raises for a malformed section, and — since #273 — no longer raised for
+    a profile's vault key that simply does not exist *yet*: see
+    :func:`resolve_profiles`'s docstring for why that case is a legitimate
+    pre-declaration, not an error.
     """
 
 
@@ -82,6 +89,7 @@ def resolve_profiles(
     vault_keys: Sequence[str],
     *,
     default_profile: str,
+    include_pending: bool = False,
 ) -> list[ProfileConfig]:
     """The ordinary (non-curator) profiles this hub serves.
 
@@ -90,10 +98,59 @@ def resolve_profiles(
     every vault in ``vault_keys``, or no profiles at all when there are no
     vaults yet. A populated ``profiles`` list is authoritative instead.
 
+    **Pre-declared vaults (#273).** A configured profile's ``vaults`` may
+    name a key that is not (yet) in ``vault_keys`` — an operator writing
+    ``gateway.profiles`` before ever running the first-run wizard, saying
+    "the ``default`` profile will serve a vault named ``work``, create it
+    in a minute." That is never an error (this function used to raise
+    :class:`GatewaySettingsError` for it; it no longer does — see that
+    class's docstring). Instead, ``include_pending`` picks which of two
+    views of the same declared shape this call returns, because this
+    function's two production callers each need a different one:
+
+    * ``include_pending=False`` (the default —
+      :func:`palaia_hub.serve.build_production_app`'s use, via
+      :func:`resolve_full_gateway_profiles`): the *mountable* shape. A
+      pending vault key is left out of the returned
+      ``ProfileConfig.vaults`` — there is nothing to mount yet, and
+      :class:`~palaia_hub.gateway.config.GatewayConfig`'s own validator
+      would refuse a profile naming a vault absent from its ``vaults``
+      list regardless. Logged once at ``INFO``, not raised: the config is
+      not wrong, only ahead of vault creation. Nothing further has to
+      happen for it to catch up — the moment the vault is registered
+      (``POST /api/vaults``), :meth:`~palaia_hub.gateway.dynamic.
+      DynamicGateway.add_vault` appends its key straight onto this same
+      profile's *live* vault list, no restart and no second call to this
+      function required.
+    * ``include_pending=True`` (:func:`palaia_hub.cli.
+      _gateway_profiles_for_oauth`'s use): the *declared* shape — every
+      vault key the profile names, mounted or not. This is what the
+      OAuth authorization server's grantable-scope ceiling
+      (:func:`palaia_hub.cli._profile_scopes`) is computed from, because
+      :class:`~palaia_hub.oauth.service.AuthorizationServer` freezes that
+      ceiling at construction and never mutates it afterward (see its
+      class docstring): a pending vault's scopes have to be decided now,
+      before the wizard creates it, or Cloud mode + OAuth simply cannot
+      be turned on before the first vault exists.
+
+    Granting a scope for a vault that is not mounted yet never widens
+    anything a live token can actually do: nothing enforces the scope
+    until the vault is mounted (there is no tool on the wire to invoke,
+    and :mod:`palaia_hub.auth.enforcement` has nothing to check it
+    against before then). By the time a client could present such a
+    token to a real tool call, the vault has to already be mounted —
+    which happens only once its key is registered, at which point the
+    pre-declared ceiling and the real mount already agree, by
+    construction: the declaration is what the mount converges to, never
+    the other way around, so there is nothing to reconcile at
+    vault-creation time.
+
     Raises:
-        GatewaySettingsError: a configured profile names a vault key not in
-            ``vault_keys`` (a vault that either never existed or was
-            renamed/removed since the section was written).
+        GatewaySettingsError: a configured profile names an *external
+            server* key not in ``gateway.upstreams``. Unlike a vault, an
+            upstream has no wizard-driven "not created yet" story — there
+            is no asynchronous flow that will register it later — so an
+            unknown upstream key stays a hard, loud config error.
     """
     if settings is None or not settings.profiles:
         if not vault_keys:
@@ -104,14 +161,20 @@ def resolve_profiles(
     known_upstreams = {u.key for u in settings.upstreams}
     resolved: list[ProfileConfig] = []
     for profile in settings.profiles:
-        unknown = [v for v in profile.vaults if v not in known]
-        if unknown:
-            raise GatewaySettingsError(
-                f"config.yaml: gateway.profiles[path={profile.path!r}] references "
-                f"vault key(s) {unknown} that are not registered on this hub (it "
-                f"has: {sorted(known) or 'none'}). Fix: create the vault first, or "
-                f"remove it from this profile's `vaults` list in config.yaml."
+        pending = [v for v in profile.vaults if v not in known]
+        if pending and not include_pending:
+            logger.info(
+                "config.yaml: gateway.profiles[path=%r] pre-declares vault "
+                "key(s) %s not yet registered on this hub — its tools stay "
+                "absent until the vault is created (the dashboard wizard, "
+                "or `palaia-hub import ...`), but its OAuth scopes (if "
+                "oauth.enabled) are already reserved for this profile.",
+                profile.path,
+                sorted(pending),
             )
+        vaults = (
+            list(profile.vaults) if include_pending else [v for v in profile.vaults if v in known]
+        )
         unknown_upstreams = [u for u in profile.upstreams if u not in known_upstreams]
         if unknown_upstreams:
             raise GatewaySettingsError(
@@ -125,7 +188,7 @@ def resolve_profiles(
             ProfileConfig(
                 path=profile.path,
                 label=profile.label,
-                vaults=list(profile.vaults),
+                vaults=vaults,
                 stash=profile.stash,
                 directory=profile.directory,
                 messenger=profile.messenger,
@@ -158,6 +221,7 @@ def resolve_full_gateway_profiles(
     vault_keys: Sequence[str],
     *,
     default_profile: str,
+    include_pending: bool = False,
 ) -> list[ProfileConfig]:
     """:func:`resolve_profiles` plus the curator's own profile, when it runs.
 
@@ -165,9 +229,20 @@ def resolve_full_gateway_profiles(
     which needs to know every resource up front) and
     ``palaia_hub.serve.build_production_app`` (building the real gateway)
     call, so the two never compute a different profile list for the same
-    config (SPEC-301 deliverable #3's "one source of truth").
+    config (SPEC-301 deliverable #3's "one source of truth") — they differ
+    only in ``include_pending`` (see :func:`resolve_profiles`), never in
+    which profiles exist or what else each one carries.
+
+    The curator's own profile is exempt from ``include_pending``: it is
+    always synthesized from the vaults *actually* registered
+    (``vault_keys``), never from a pre-declaration — the curator has no
+    config surface of its own naming vaults ahead of their creation, and
+    synthesizing it from a pending key would let curation start on a vault
+    that does not exist.
     """
-    profiles = resolve_profiles(config.gateway, vault_keys, default_profile=default_profile)
+    profiles = resolve_profiles(
+        config.gateway, vault_keys, default_profile=default_profile, include_pending=include_pending
+    )
     if config.curator.enabled and vault_keys:
         # Deferred import: the curator package pulls in fastmcp, which this
         # module otherwise has no need for (it only touches config.py's

--- a/v3/server/tests/gateway/test_settings_bridge.py
+++ b/v3/server/tests/gateway/test_settings_bridge.py
@@ -92,13 +92,56 @@ def test_resolve_profiles_uses_configured_shape() -> None:
     assert profiles[1].messenger is False
 
 
-def test_resolve_profiles_unknown_vault_raises() -> None:
+def test_resolve_profiles_pending_vault_is_dropped_from_the_mountable_shape() -> None:
+    """#273: a profile pre-declaring a vault key that is not registered yet
+    is not an error — the pending key is simply absent from the *mountable*
+    ``ProfileConfig.vaults`` this default (``include_pending=False``) view
+    returns, since there is nothing to mount yet."""
     settings = GatewaySettings(
-        profiles=[GatewayProfileSettings(path="alpha", vaults=["ghost"])]
+        profiles=[GatewayProfileSettings(path="alpha", vaults=["work", "ghost"])]
+    )
+
+    profiles = resolve_profiles(settings, ["work"], default_profile="default")
+
+    assert profiles == [ProfileConfig(path="alpha", vaults=["work"])]
+
+
+def test_resolve_profiles_include_pending_keeps_the_full_declared_shape() -> None:
+    """#273: the OAuth-scope-ceiling view (``include_pending=True``) keeps a
+    not-yet-registered vault key instead of dropping it — this is what lets
+    the authorization server pre-grant that vault's scopes before it exists."""
+    settings = GatewaySettings(
+        profiles=[GatewayProfileSettings(path="alpha", vaults=["work", "ghost"])]
+    )
+
+    profiles = resolve_profiles(
+        settings, ["work"], default_profile="default", include_pending=True
+    )
+
+    assert profiles == [ProfileConfig(path="alpha", vaults=["work", "ghost"])]
+
+
+def test_resolve_profiles_all_pending_still_resolves_the_profile() -> None:
+    """A profile whose every declared vault is still pending still exists
+    (with an empty mountable vault list) rather than vanishing or raising —
+    the "operator turns on Cloud+OAuth before the wizard's first vault"
+    scenario #273 exists for."""
+    settings = GatewaySettings(profiles=[GatewayProfileSettings(path="default", vaults=["work"])])
+
+    profiles = resolve_profiles(settings, [], default_profile="default")
+
+    assert profiles == [ProfileConfig(path="default", vaults=[])]
+
+
+def test_resolve_profiles_unknown_upstream_still_raises() -> None:
+    """Unlike a pending vault, an unknown *external server* key stays a hard
+    error — there is no wizard-driven "not connected yet" story for it."""
+    settings = GatewaySettings(
+        profiles=[GatewayProfileSettings(path="alpha", vaults=[], upstreams=["ghost"])]
     )
 
     with pytest.raises(GatewaySettingsError, match="ghost"):
-        resolve_profiles(settings, ["work"], default_profile="default")
+        resolve_profiles(settings, [], default_profile="default")
 
 
 def test_resolve_full_gateway_profiles_adds_curator_profile_when_enabled() -> None:

--- a/v3/server/tests/oauth/test_gateway_config_spec301.py
+++ b/v3/server/tests/oauth/test_gateway_config_spec301.py
@@ -142,6 +142,114 @@ async def test_old_oauth_profiles_config_still_works_with_no_gateway_section(
     assert set(oauth_server.resources.profiles) == {"legacy"}
 
 
+def _write_precreated_config(home: Path) -> None:
+    """#273: `default` is declared up front, pre-naming a vault ("work")
+    that does not exist on this hub yet — the config an operator writes to
+    get Cloud mode + OAuth working *before* ever running the wizard."""
+    (home / "config.yaml").write_text(
+        "mode: cloud\n"
+        "host: 127.0.0.1\n"
+        "oauth:\n"
+        "  enabled: true\n"
+        "  issuer: https://testserver\n"
+        # Sidesteps the dashboard's own admin sign-in gate (SPEC-401, on by
+        # default in cloud mode) — this test drives `POST /api/vaults`
+        # directly, the way the wizard's already-signed-in browser session
+        # does; asserting *that* gate is a different SPEC's test.
+        "dashboard:\n"
+        "  require_sign_in: false\n"
+        "gateway:\n"
+        "  profiles:\n"
+        "    - path: default\n"
+        "      vaults: [work]\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.anyio
+async def test_precreated_vault_scopes_boot_before_the_wizard_creates_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#273: a `gateway.profiles` entry naming a vault the wizard has not
+    created yet must (1) not crash the hub at boot, (2) already reserve
+    that vault's OAuth scopes for its profile, and (3) mount the real vault
+    with no restart, and no scope mismatch, the moment it is created —
+    exactly the "Cloud mode + OAuth from the very first boot" scenario the
+    issue describes."""
+    monkeypatch.setenv("PALAIA_HOME", str(tmp_path))
+    _write_precreated_config(tmp_path)
+    config = load_config(home=tmp_path, create_if_missing=False)
+    assert config.gateway is not None
+    assert list(VaultRegistry().names()) == []  # zero vaults registered — the whole point
+
+    # 1. Boots at all: the old behavior raised GatewaySettingsError here.
+    oauth_server = _maybe_oauth_server(config)
+    assert oauth_server is not None
+
+    # 2. The pending vault's scopes are already reserved for "default" —
+    # computed from the *declared* shape, not the (currently empty) real one.
+    assert oauth_server.resources.profiles == ("default",)
+    audience = oauth_server.resources.audience("default")
+    assert oauth_server.scopes_for(audience) == ("vault:work:read", "vault:work:write")
+
+    production = await build_production_app(config, home=tmp_path, oauth_server=oauth_server)
+    try:
+        async with production.app.router.lifespan_context(production.app):
+            # The real gateway mounted "default" with zero vaults (nothing
+            # to mount yet) — not zero *profiles*, and cloud mode's own
+            # auth-policy check (every mounted profile needs a verifier)
+            # still passed, or build_production_app would have raised.
+            assert "default" in production.dynamic_gateway.profile_servers
+            async with Client(production.dynamic_gateway.profile_servers["default"]) as client:
+                names = {t.name for t in await client.list_tools()}
+            assert not any(name.startswith("work_") for name in names)
+
+            provisioned = provision_machine_client(
+                oauth_server.store,
+                client_name="pre-provisioned job",
+                audience=audience,
+                scopes=["vault:work:read", "vault:work:write"],
+                now=oauth_server.now(),
+            )
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=production.app), base_url=BASE_URL
+            ) as http:
+                # 3. The wizard's own REST endpoint creates the vault —
+                # DynamicGateway.add_vault reconciles it onto "default" live.
+                create_response = await http.post(
+                    "/api/vaults", json={"key": "work", "purpose": "Work notes."}
+                )
+                assert create_response.status_code == 200, create_response.text
+
+                token_response = await http.post(
+                    "/oauth/token",
+                    data={
+                        "grant_type": "client_credentials",
+                        "client_id": provisioned.client.client_id,
+                        "client_secret": provisioned.client_secret,
+                    },
+                )
+                assert token_response.status_code == 200, token_response.text
+                access_token = str(token_response.json()["access_token"])
+
+            # A token minted against the pre-declared scopes — no restart,
+            # no re-wiring — now works against the just-created real vault.
+            transport = mcp_client_transport(
+                production.app, f"{BASE_URL}/mcp/default/", token=access_token
+            )
+            async with Client(transport) as client:
+                result = await client.call_tool_mcp(
+                    "work_memory_search", {"query": "anything"}
+                )
+            assert result.isError is not True
+    finally:
+        await production.dynamic_gateway.aclose()
+        if production.stash_store is not None:
+            production.stash_store.close()
+        for index in production.indexes.values():
+            await index.close()
+
+
 def test_profile_scopes_include_mounted_builtin_families() -> None:
     """An OAuth client can be granted the stash/directory/messenger scopes
     of the profiles that actually mount those families (SPEC-403 follow-up:


### PR DESCRIPTION
Fixes #273

## Problem

An operator who wants Cloud mode + OAuth from the very first boot — before ever running the first-run wizard's "create a vault" step — could not express "the `default` profile will serve a vault named `work`, create it in a minute" in `config.yaml`. Naming a not-yet-registered vault key under `gateway.profiles[].vaults` raised `GatewaySettingsError` and crashed the **entire hub** at boot (not just the OAuth server): `resolve_full_gateway_profiles`/`resolve_profiles` is the one function both `palaia_hub.cli._maybe_oauth_server` and `palaia_hub.serve.build_production_app` call, so the error blocked the real gateway mount too, not only the AS.

## Design decision: two views of the same declared shape, reconciled by construction

`resolve_profiles` gains an `include_pending: bool = False` parameter instead of raising on a not-yet-registered vault key. Its two production callers now deliberately diverge:

- **`include_pending=False`** (default — `build_production_app`'s real gateway build): the *mountable* view. A pending vault key is silently dropped from the returned `ProfileConfig.vaults` (there is nothing to mount yet — `GatewayConfig`'s own validator would refuse a profile naming a vault absent from its `vaults` list regardless). Logged at INFO, never raised.
- **`include_pending=True`** (`cli._gateway_profiles_for_oauth`, feeding `_profile_scopes`): the *declared* view — every vault key the profile names, mounted or not. This is what `AuthorizationServer`'s grantable-scope ceiling is computed from, because that class freezes the ceiling at construction and never mutates it afterward (confirmed: no `add_`/`register_`/`update_` method touches `self._profile_scopes`).

**Reconciliation, and which wins:** the *declaration* is always authoritative for the scope ceiling, and the real mount converges to it — never the other way. Nothing needs to mutate the frozen `AuthorizationServer` state when the wizard later creates the vault: `DynamicGateway.add_vault` already appends the newly-registered key onto the *same* profile's live `vaults` list (this is the existing SPEC-504 mechanism, unchanged), so the real mount simply catches up to what was already declared. No restart, no re-wiring, no scope re-computation.

**Why this never widens what a live token can do:** a pre-declared scope alone grants nothing extra in practice — nothing enforces it until the vault is actually mounted (no tool exists on the wire, and `palaia_hub.auth.enforcement` has nothing to check the scope against before then). By the time a client could present a token carrying `vault:<key>:*` to a real tool call, the vault has to already be mounted, at which point the pre-declared ceiling and the real mount already agree by construction.

**Left unchanged, intentionally:**
- Consent is untouched — nothing here mints or issues a token differently; it only changes what scope ceiling *exists* to be granted.
- `gateway.profiles[].upstreams` referencing an unknown external server key still raises `GatewaySettingsError` — an upstream has no wizard-driven "not created yet" story the way a vault does.
- The CLI's own stricter boot-time guard (`_maybe_oauth_server` refusing to start with zero profiles) is untouched — it now simply sees a non-empty (pending-inclusive) profile list once an operator pre-declares one, per the issue's own suggested constraint ("closes this without touching the CLI's own stricter boot-time guard").
- The deprecated `oauth.profiles` fallback path is untouched.

## Test evidence

- `v3/server/tests/gateway/test_settings_bridge.py`: replaced the old "unknown vault raises" test with unit coverage of both `include_pending` views, an all-pending profile still resolving, and confirmation that an unknown *upstream* key still raises.
- `v3/server/tests/oauth/test_gateway_config_spec301.py`: new end-to-end test (`test_precreated_vault_scopes_boot_before_the_wizard_creates_it`) — boots a `mode: cloud` hub with `oauth.enabled: true` and **zero registered vaults**, a `gateway.profiles` entry pre-declaring vault `work`; asserts the hub boots (no `GatewaySettingsError`), the AS's scope ceiling for `default` already includes `vault:work:read`/`vault:work:write`, the real gateway mounts `default` with no vault tools yet, then drives the real `POST /api/vaults` wizard endpoint and shows a token minted against the pre-declared scopes works against the just-created vault with no restart.
- All existing tests updated/kept green (`test_cli_oauth.py`'s legacy-`oauth.profiles` path, `test_serve_gateway_config_spec301.py`, the SPEC-506 funnel gate test) confirming no regression to the funnel script's documented workaround or the deprecated-field fallback.

Full suite: **2228 passed, 24 skipped, 0 failed** (`uv run pytest server/tests -q`, run standalone from `<worktree>/v3`). `ruff check server` and `mypy server/src` both clean.

## Deviations from the brief

- None of substance. The issue's own suggested fix location (a `register_profile_scopes` mutator on `AuthorizationServer`) was deliberately **not** taken — the `include_pending` split avoids ever mutating frozen AS state at all, which is a smaller, more auditable change and sidesteps any question of thread-safety on a live mutation.
- Also updated `_maybe_oauth_server`'s "no MCP profiles yet" error message and `config.py`'s `DEFAULT_CONFIG_TEMPLATE` gateway-profiles comment to name the new pre-declaration path (house rule: config errors/docs name the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790785917&installation_model_id=428086&pr_number=290&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F290&signature=c98eb132eff34c9cb7fbbb09557bce3d23e8e6e2f9a57ea83b7b4e7ebca499c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->