### PR TITLE
feat(v3): Pi appliance image pipeline (SPEC-603)

### DIFF
--- a/.github/workflows/v3-pi-image.yml
+++ b/.github/workflows/v3-pi-image.yml
@@ -10,16 +10,7 @@ name: v3 Pi appliance image
 on:
   workflow_dispatch: {}
   push:
-    # TEMPORARY, for this PR only — see the PR description's "workflow-run
-    # bootstrap" note: GitHub only accepts a `workflow_dispatch` API call
-    # for a workflow already known to it (present on the default branch,
-    # or already fired by a matching push), so a brand-new workflow file
-    # cannot be dispatched from a feature branch at all. `pi-image-ci-test-*`
-    # is this workflow's own, deliberately non-colliding tag pattern (never
-    # matched by publish.yml's `v*` or v3-release.yml's `v3.*`) used once to
-    # get a real run and is removed again before merge — the real trigger
-    # is `v3.*`, immediately below, unchanged.
-    tags: ['v3.*', 'pi-image-ci-test-*']
+    tags: ['v3.*']
 
 permissions:
   contents: write # only used to attach the release asset on a tag push

--- a/.github/workflows/v3-pi-image.yml
+++ b/.github/workflows/v3-pi-image.yml
@@ -10,7 +10,16 @@ name: v3 Pi appliance image
 on:
   workflow_dispatch: {}
   push:
-    tags: ['v3.*']
+    # TEMPORARY, for this PR only — see the PR description's "workflow-run
+    # bootstrap" note: GitHub only accepts a `workflow_dispatch` API call
+    # for a workflow already known to it (present on the default branch,
+    # or already fired by a matching push), so a brand-new workflow file
+    # cannot be dispatched from a feature branch at all. `pi-image-ci-test-*`
+    # is this workflow's own, deliberately non-colliding tag pattern (never
+    # matched by publish.yml's `v*` or v3-release.yml's `v3.*`) used once to
+    # get a real run and is removed again before merge — the real trigger
+    # is `v3.*`, immediately below, unchanged.
+    tags: ['v3.*', 'pi-image-ci-test-*']
 
 permissions:
   contents: write # only used to attach the release asset on a tag push

--- a/.github/workflows/v3-pi-image.yml
+++ b/.github/workflows/v3-pi-image.yml
@@ -1,0 +1,92 @@
+name: v3 Pi appliance image
+
+# SPEC-603: builds and verifies the palaia Raspberry Pi appliance image
+# (v3/deploy/pi-image/). Deliberately NOT run on every push/PR — this
+# customizes a real OS image (loop-mount, chroot under arm64 emulation,
+# a double-build reproducibility check, xz -9 compression) and can take a
+# while; see v3/deploy/pi-image/README.md. Manual dispatch, or the same
+# v3.* release tag v3-release.yml already reacts to (see that workflow's
+# own comment on why tag pushes have no `paths` filter).
+on:
+  workflow_dispatch: {}
+  push:
+    tags: ['v3.*']
+
+permissions:
+  contents: write # only used to attach the release asset on a tag push
+
+jobs:
+  build-and-verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Free up disk space
+        # A customized Pi Lite image, built twice for the reproducibility
+        # check, needs several GB of scratch space this runner's default
+        # free space is not reliably enough for once the preinstalled
+        # toolchains nobody here uses are counted. Cheap insurance, no
+        # external action dependency.
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" \
+            2>/dev/null || true
+          df -h /
+
+      - name: Set up QEMU (arm64 emulation)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Install image-build tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            qemu-user-static parted e2fsprogs xz-utils dosfstools
+
+      - name: Build the appliance image (double-build reproducibility check)
+        working-directory: v3/deploy/pi-image
+        run: sudo ./build.sh
+
+      - name: Inspect rootfs (Docker enabled, palaia unit enabled, mDNS on, SSH off)
+        working-directory: v3/deploy/pi-image
+        run: sudo ./inspect.sh /tmp/pi-image-build/run-1/palaia-appliance.img
+
+      - name: Fix output ownership (root -> runner, for upload-artifact)
+        run: sudo chown -R "$(id -u):$(id -g)" /tmp/pi-image-build/out
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: palaia-appliance-image
+          path: |
+            /tmp/pi-image-build/out/*.img.xz
+            /tmp/pi-image-build/out/*.img.xz.sha256
+          retention-days: 14
+
+      - name: Attach to GitHub release, if one exists for this tag
+        if: startsWith(github.ref, 'refs/tags/v3.')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            gh release upload "${tag}" /tmp/pi-image-build/out/*.img.xz /tmp/pi-image-build/out/*.img.xz.sha256 \
+              --repo "${GITHUB_REPOSITORY}" --clobber
+          else
+            echo "::notice::No GitHub release exists yet for tag ${tag} (see v3/RELEASING.md — release creation is an owner step, not automated). The image is attached as a workflow artifact instead; re-run this workflow (workflow_dispatch, ref=${tag}) once the release exists to attach it there too."
+          fi
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### Pi appliance image"
+            if [ -f /tmp/pi-image-build/out/*.img.xz.sha256 ]; then
+              echo '```'
+              cat /tmp/pi-image-build/out/*.img.xz.sha256
+              echo '```'
+              ls -lh /tmp/pi-image-build/out/*.img.xz | awk '{print "Size: "$5}'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/v3/decisions/005-pi-appliance-image-base.md
+++ b/v3/decisions/005-pi-appliance-image-base.md
@@ -1,0 +1,87 @@
+# ADR-005: Pi appliance image — customize a pinned base image, not pi-gen
+
+- **Status:** Accepted
+- **Date:** 2026-08-31
+- **Deciders:** Claude (SPEC-603 implementation), for owner review
+
+## Context
+
+SPEC-603 asks for "a `pi-gen`-based (or equivalently standard, justified in
+an ADR note) image build" of a Raspberry Pi appliance: Raspberry Pi OS Lite
+arm64 + Docker + the palaia-hub container, auto-started, mDNS on, SSH off,
+built and verified inside a `workflow_dispatch`/release-tag GitHub Actions
+job that "may be slow" but must reproduce, and that must let CI actually
+loop-mount and inspect the result. The constraint doing the most work here
+is that this has to run, unattended and honestly, inside a shared GitHub
+Actions runner — no privileged access beyond what `ubuntu-latest` (a real
+VM, not a nested container) already grants: loop devices and `--privileged`
+Docker both work there, but wall-clock and disk are both bounded, and a
+build that only sometimes reproduces is worse than one that's honest about
+a narrower scope it can actually prove.
+
+## Decision
+
+Build the image by **customizing a pinned, checksum-verified, pre-built
+Raspberry Pi OS Lite (arm64) release** — loop-mount it, `chroot` in under
+arm64 emulation (`binfmt_misc`/`qemu-user-static`), `apt-get install
+docker.io`, drop in one systemd unit, done — rather than driving `pi-gen`.
+Full reasoning and what this does and doesn't prove for reproducibility:
+`v3/deploy/pi-image/README.md`'s "Reproducibility" section; this ADR
+records why, not the mechanics (those are the scripts themselves).
+
+## Alternatives considered
+
+- **`pi-gen` (the SPEC's named default)** — `pi-gen` builds Raspberry Pi OS
+  itself from source, via `debootstrap` against a *live* Raspbian apt
+  mirror, through several sequential stages (stage0-stage2 for Lite alone).
+  Two costs made it a worse fit here than the SPEC's own escape hatch
+  anticipated:
+  1. **Reproducibility gets strictly harder, not easier.** `debootstrap`ping
+     the whole OS from a rolling mirror means *every* package in the image
+     — not just the one this pipeline actually adds (Docker) — is subject
+     to day-to-day version drift, and `pi-gen` has no built-in apt-snapshot
+     pinning to close that gap. Starting from a Raspberry Pi Foundation
+     release that's already pinned by URL + sha256 confines the
+     live-mirror problem to exactly one package.
+  2. **CI cost, for the same deliverable.** A full stage0-2 `debootstrap`
+     build is meaningfully slower and heavier (more network, more disk,
+     more failure surface — package-index outages, mirror flakiness,
+     `pi-gen`'s own stage/export bookkeeping) than installing one package
+     into an already-built OS. The SPEC explicitly permits "slow"; it does
+     not require paying for a full OS rebuild when the actual deliverable
+     is "Raspberry Pi OS Lite plus Docker plus one unit file."
+  Vendoring `pi-gen` as a pinned dependency (a fixed commit SHA) would
+  still leave both costs in place — it isn't a middle ground here.
+- **`rpi-image-gen` / other third-party image builders** — newer, less
+  battle-tested than `pi-gen`, and share `pi-gen`'s core reproducibility
+  property (build-from-source against a live mirror); no clear win over
+  either option above.
+- **A cloud-init-driven first-boot install (SPEC-601's pattern, adapted)**
+  — install Docker + palaia on first boot instead of baking them into the
+  image. Rejected because it reintroduces exactly the "one thing to paste
+  in a terminal" gap #280 exists to close for the Home-Assistant-comparison
+  audience — SPEC-601's server already covers that audience; SPEC-603 is
+  the *offline-flash* answer, and needs everything present before first
+  boot.
+
+## Consequences
+
+- **Easier**: the CI job is fast enough to actually run to completion and
+  be watched (no full-OS `debootstrap`); the reproducibility check the
+  SPEC asks for is meaningful and cheap to compute (diff a rootfs manifest
+  between two runs of the one thing this pipeline actually controls);
+  re-pinning the base OS (`pin-base-image.sh`) is a single, auditable,
+  explicit step rather than an implicit "whatever the mirror serves today."
+- **Harder**: the base OS's own package versions are frozen at whatever
+  the pinned Raspberry Pi OS build shipped, until someone re-pins — this
+  appliance does not get base-OS security patches for free between
+  re-pins (documented in `README.md`; unattended-upgrades vs. reflash
+  guidance is the open question #280 itself flags, not resolved here).
+- **Follow-up created**: `README.md` documents the one real gap against
+  "flash, boot, done" fully offline — `palaia.service`'s `docker run`
+  still pulls the hub image from GHCR on first start, since this pipeline
+  does not bake the container image's own layers into the `.img.xz`.
+  Pre-baking that is a reasonable next step but adds real size to the
+  image; left as a deliberate, stated gap rather than silently expanded
+  scope. `BOOT-TEST.md` asks the owner to record how visible this was on
+  a real network.

--- a/v3/deploy/pi-image/BOOT-TEST.md
+++ b/v3/deploy/pi-image/BOOT-TEST.md
@@ -1,0 +1,98 @@
+# Boot test protocol (owner action)
+
+SPEC-603 deliverable #4. CI proves the image builds, is reproducible, and
+contains what it should ([`README.md`](README.md#verification)) — it
+cannot boot real hardware. This is the one-page protocol for the part
+that only a physical Pi can prove, and the measurements
+[#280](https://github.com/byte5ai/palaia/issues/280) needs before the
+Home Assistant add-on question can be decided.
+
+Everything below references only what `build.sh`/`systemd/palaia.service`
+actually do — if a step here describes something the image doesn't do,
+that's a bug in this file, not a step to perform anyway.
+
+## What you need
+
+- A Raspberry Pi 4 or 5 (record which — #280 wants the number by model).
+  2GB, 4GB, and 8GB RAM variants each get their own run if you have them;
+  the RAM number is exactly what #280's measurement request is for.
+- A microSD card or USB SSD, [Raspberry Pi
+  Imager](https://www.raspberrypi.com/software/), and the `.img.xz`
+  released from a green `v3-pi-image.yml` run (GitHub release assets, or
+  a local `sudo ./build.sh` output).
+- A network the Pi and your other device share (mDNS needs to be on the
+  same LAN segment/VLAN — it doesn't cross routed subnets).
+- A second device to test from (phone or laptop, browser only — the
+  point of this whole SPEC is that you never need a terminal for this
+  part).
+
+## Flash
+
+1. Raspberry Pi Imager → "Choose OS" → "Use custom" → the downloaded
+   `.img.xz` (Imager decompresses it itself, no manual `xz -d` needed).
+2. **Do not** open "Edit settings" unless you specifically want to enable
+   SSH for this test run (see `README.md`'s "SSH off by default"
+   section) — the point of this protocol is testing the image's own
+   defaults, not a customized one.
+3. Write, wait for verification, eject, insert into the Pi, power on.
+
+## Timeline to record
+
+Start a stopwatch at power-on.
+
+| Milestone | What to watch for | Typical (record actual) |
+|---|---|---|
+| First boot begins | Pi's activity LED starts flickering | seconds |
+| Filesystem expansion / first-boot services | LED activity continues, can take longer on a slower card | ~30-90s |
+| `palaia.service` starts, pulls the image | Nothing visible on the Pi itself — see the network-dependency note below | varies with your network |
+| `http://palaia.local:8420/` answers | Load it from your second device | record the wall-clock time from power-on |
+
+**Note on first-run network dependency**: `palaia.service`'s `docker run`
+pulls `ghcr.io/byte5ai/palaia-hub:stable` from GHCR the first time it
+runs (the appliance image itself does not bundle that image's layers —
+this is the one honest gap against "flash, boot, done" fully offline; a
+follow-up could pre-bake the image into the `.img.xz` and is out of this
+SPEC's scope). Record whether your test network's speed made this
+noticeable, and roughly how long the pull itself took, separate from the
+OS boot time above.
+
+If `http://palaia.local:8420/` never answers: check `README.md`'s mDNS
+caveat (same-LAN-segment requirement) before assuming something is
+broken — try the Pi's IP address directly (visible on your router's
+client list, or a monitor plugged into the Pi) as a fallback.
+
+## Resource measurements (feeds #280 + the HA add-on decision)
+
+Record all of these, from an SSH session you enable *after* the timeline
+above (or a monitor+keyboard) — enabling SSH for measurement purposes is
+expected; just don't conflate "I turned SSH on to measure this" with
+"the image ships with SSH on" (it doesn't — that's what
+`inspect.sh` checks).
+
+1. **Idle**: `docker stats --no-stream palaia-hub` and `free -h`, at
+   least 5 minutes after `http://palaia.local` first answered, with no
+   browser tab open against it.
+2. **Under the funnel walk**: the same two commands, immediately after
+   walking through the onboarding funnel a real first-time user would —
+   the same "install → first memory" sequence
+   `server/src/palaia_hub/funnel.py` instruments hub-side: open the
+   wizard, connect or create a vault, let it index, write or capture one
+   memory, run one query against it. Capture RSS/CPU at the point right
+   after that query returns (worst-case, not the cool-down after).
+3. Repeat both for every Pi model/RAM combination you have available.
+
+Report format (paste into the #280 thread or a comment on this SPEC's
+PR): Pi model, RAM, storage type (SD card class / USB SSD), idle RSS,
+idle CPU%, funnel-walk-peak RSS, funnel-walk-peak CPU%, time-to-`palaia.
+local` from the timeline above.
+
+## Pass/fail
+
+- Pass: `http://palaia.local:8420/` answers from a second device without
+  any terminal use, the wizard loads, and the measurements above are
+  recorded for at least one Pi model.
+- Fail (file an issue, don't just note it here): image doesn't boot,
+  service doesn't start, mDNS doesn't resolve within ~5 minutes of the
+  dashboard itself being reachable by IP (ruling out "not booted yet" as
+  the cause), or SSH is somehow already enabled on a fresh flash with no
+  "Edit settings" used.

--- a/v3/deploy/pi-image/README.md
+++ b/v3/deploy/pi-image/README.md
@@ -1,0 +1,140 @@
+# palaia Raspberry Pi appliance image
+
+SPEC-603 (`v3/specs/SPEC-603-pi-appliance-image.md`), the buildable half of
+[#280](https://github.com/byte5ai/palaia/issues/280): take a Pi, flash one
+image, boot, open the browser. No terminal.
+
+This is packaging only — nothing here changes the hub product itself. It
+takes the exact container image [`v3/deploy/`](../) already ships
+(`ghcr.io/byte5ai/palaia-hub:stable`) and preinstalls it, Docker, and one
+systemd unit onto Raspberry Pi OS Lite.
+
+## What the image ships
+
+- **Raspberry Pi OS Lite (arm64)**, unmodified except for what's below —
+  see [Base image](#base-image) for exactly which build and why.
+- **Docker** (`docker.io` from the base image's own apt archive), enabled
+  at boot.
+- **`palaia.service`** ([`systemd/palaia.service`](systemd/palaia.service)),
+  enabled at boot: runs `ghcr.io/byte5ai/palaia-hub:stable` with
+  `--network host` and the exact same [SPEC-502 hardening
+  flags](../install.sh) `install.sh` and `docker-compose.yml` use
+  (`--security-opt no-new-privileges:true --cap-drop ALL --read-only
+  --tmpfs /tmp --tmpfs /run`) — one posture, never a forked copy (checked
+  by `server/tests/deploy/test_pi_image.py`, the same drift-test pattern
+  `test_cloud_init.py` already applies to `cloud-init.yaml`).
+- **mDNS**: the container's own announcer
+  ([`mdns_announce.py`](../mdns_announce.py)) reaches the LAN because
+  `palaia.service` runs the container on the host network stack — a Pi
+  appliance is always a dedicated Linux host, so this has none of the
+  desktop-Docker caveats `docker-compose.yml`'s own `network_mode: host`
+  comment documents for a shared machine. First boot: open
+  `http://palaia.local:8420/`.
+- **The same `:stable` release channel** the container has always had
+  (SPEC-501) — `PALAIA_CHANNEL` is baked into the image at
+  `v3-release.yml`'s build time, read back by `GET /api/update/check`.
+  Updating this appliance today is `ssh` in and `docker pull … &&
+  systemctl restart palaia` — the dashboard's "Update available" banner
+  currently shows the generic manual-recreate message
+  (`deployment: unknown`) rather than a Pi-specific one, since teaching it
+  a `pi-image` deployment value is a product change (SPEC-501's territory,
+  not this packaging-only SPEC) and is filed as follow-up, not silently
+  done here.
+- **SSH off by default** — the base image's own default, left untouched
+  and asserted by CI (see [Verification](#verification)). To enable it:
+  flash the image, then before first boot, use Raspberry Pi Imager's own
+  "Edit settings" (gear icon) → Services → Enable SSH, or manually create
+  an empty file named `ssh` in the image's boot partition. Same mechanism
+  Raspberry Pi OS always uses; nothing palaia-specific.
+
+## Base image
+
+Raspberry Pi OS Lite (arm64), pinned by URL + sha256 in
+[`base-image.env`](base-image.env) — currently the
+`2026-06-18-raspios-trixie-arm64-lite` build, Raspberry Pi Foundation's own
+release. `build.sh` refuses to run against anything that doesn't match
+that checksum. Re-pin with [`pin-base-image.sh`](pin-base-image.sh) when a
+refresh is wanted (e.g. a base-OS security update); this never happens
+automatically.
+
+## Reproducibility
+
+What `build.sh` actually proves, and what it doesn't:
+
+- **Proven, and checked by CI on every run**: the *customization step*
+  (installing Docker, dropping in `palaia.service`, enabling/disabling
+  units) is deterministic. `build.sh` runs that step twice, against two
+  independent copies of the same checksum-verified base image, and diffs
+  a sha256 manifest of the resulting rootfs (every file's path and
+  content hash, excluding the handful of paths that are legitimately
+  per-run noise — apt's own cache/lists timing metadata, `/var/log`,
+  `/tmp`, `/etc/machine-id` and its dbus equivalent, none of which this
+  image ever ships anyway). A mismatch fails the build.
+- **Not claimed**: bit-for-bit identical `.img.xz` output *across
+  different days or weeks*. `apt-get install docker.io` resolves against
+  whatever the live Debian/Raspbian archive is currently serving — the
+  same real-world tradeoff every `apt-get install` in every Dockerfile in
+  this repo already has (see `v3/deploy/Dockerfile`'s own `apt-get
+  update && apt-get install`). The base OS itself doesn't have this
+  problem (pinned, checksummed), only the one package this pipeline adds
+  to it.
+
+This scope is why `v3/decisions/005-pi-appliance-image-base.md` picked
+"customize a pinned, pre-built base image" over `pi-gen`: `pi-gen`
+`debootstrap`s the entire OS from a live mirror on every run, which would
+put *all* of Raspberry Pi OS inside the same non-reproducible-over-time
+category this pipeline keeps to one package.
+
+## Size budget
+
+Budget: **900MB compressed** (`.img.xz`), checked by `build.sh` after
+compression — the same "budget stated and checked" pattern
+`v3-release.yml`'s container-image size check already uses. Rough
+accounting behind that number: the unmodified base `.img.xz` is already
+~500MB; `docker.io` and its dependencies (containerd, runc, iptables,
+supporting libraries) add on the order of 150-220MB of real (non-zero,
+so it compresses less well than the padding around it) content; the
+700MB of growth `build.sh` appends to make room for that install is
+mostly zero-filled and compresses to nearly nothing. 900MB leaves
+meaningful headroom above that estimate; `build.sh`'s own check is the
+actual gate, not this paragraph.
+
+## Building locally
+
+Needs root (loop devices, `chroot`), `qemu-user-static`/binfmt registered
+for arm64 (`docker run --privileged --rm tonistiigi/binfmt --install
+arm64`, or `docker/setup-qemu-action` in CI), and the usual disk image
+toolchain (`parted`, `e2fsprogs`, `xz-utils`, `util-linux`).
+
+```bash
+sudo ./build.sh
+sudo ./inspect.sh /tmp/pi-image-build/run-1/palaia-appliance.img
+```
+
+Output: `/tmp/pi-image-build/out/palaia-appliance-v<VERSION>.img.xz` (+
+`.sha256`). Override `PI_IMAGE_WORK_DIR`/`PI_IMAGE_OUTPUT_DIR` to change
+where.
+
+## Verification
+
+What CI can verify, and does, on every `workflow_dispatch`/release-tag
+run of `.github/workflows/v3-pi-image.yml` (never on a PR — this is slow):
+
+1. **Reproducibility** — `build.sh`'s own double-build-and-diff, above.
+2. **Rootfs inspection** (`inspect.sh`, loop-mounted read-only) — Docker
+   enabled, `palaia.service` enabled and running the `:stable` image with
+   host networking, SSH not enabled and no `/boot` ssh marker file.
+3. **Size budget** — the compressed image against the number above.
+
+What CI *cannot* verify — the image never actually boots in CI, on real
+hardware, with a real network — is the owner's job, protocol in
+[`BOOT-TEST.md`](BOOT-TEST.md).
+
+## Data
+
+Same volume convention as every other palaia install path: `palaia_home`,
+a named Docker volume holding everything under `/data` (config, vault,
+index). `docker volume inspect palaia_home` / `docker exec palaia-hub ls
+/data` and ordinary Docker volume backup tooling all work identically to
+the compose or one-liner install — nothing about running from this image
+changes where or how that volume is managed.

--- a/v3/deploy/pi-image/base-image.env
+++ b/v3/deploy/pi-image/base-image.env
@@ -1,0 +1,15 @@
+# Pinned Raspberry Pi OS Lite (arm64) base image — SPEC-603.
+#
+# build.sh sources this file and refuses to proceed if the downloaded
+# file's sha256 doesn't match BASE_IMAGE_SHA256. This is the whole
+# reproducibility story for the *base OS*: the same committed URL+checksum
+# is what every build (CI or an owner's own machine) starts from, today or
+# a year from now, for as long as Raspberry Pi Foundation keeps this dated
+# build online.
+#
+# Re-pin with `./pin-base-image.sh` when a refresh is wanted (e.g. a
+# security-relevant base OS update) — it fetches the *current* "latest"
+# build, rewrites this file, and prints what changed. Never hand-edit
+# BASE_IMAGE_URL without also updating BASE_IMAGE_SHA256 to match.
+BASE_IMAGE_URL="https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2026-06-19/2026-06-18-raspios-trixie-arm64-lite.img.xz"
+BASE_IMAGE_SHA256="acff736ca7945e3b305f07cda4abdb870910e12634991da69783611756e381b3"

--- a/v3/deploy/pi-image/build.sh
+++ b/v3/deploy/pi-image/build.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# SPEC-603: builds the palaia Raspberry Pi appliance image.
+#
+# Starts from the pinned, checksum-verified Raspberry Pi OS Lite (arm64)
+# release named in base-image.env (see that file's own comment — this is
+# the "equivalently standard, justified in an ADR note" alternative to
+# pi-gen; the reasoning lives in v3/decisions/005-pi-appliance-image-base.md).
+# Customizes it offline (loop-mount + chroot, arm64 emulated via
+# binfmt_misc/qemu-user-static) to add Docker, the palaia.service unit, and
+# nothing else — SSH stays exactly as the base image ships it (disabled by
+# default; see README.md for how an owner enables it).
+#
+# Runs the customization step TWICE, against two independent copies of the
+# same verified base image, and diffs a content-hash manifest of the
+# resulting rootfs between them (see compute_manifest below for the small,
+# documented set of inherently volatile paths it excludes — apt list
+# caches, logs, /etc/machine-id, etc., none of which this build ever ships
+# in the final image anyway). Identical manifests is this pipeline's
+# reproducibility proof — see README.md's "Reproducibility" section for
+# exactly what that does and does not claim.
+#
+# Must run as root (loop devices, mount, chroot) — the workflow invokes it
+# under `sudo`. Not meant to run inside a container itself: it needs real
+# loop devices and a real chroot, which GitHub's ubuntu-latest runners
+# provide (a full VM, not a nested container) but a `docker run` sandbox
+# generally does not.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+V3_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+WORK_DIR="${PI_IMAGE_WORK_DIR:-/tmp/pi-image-build}"
+OUTPUT_DIR="${PI_IMAGE_OUTPUT_DIR:-${WORK_DIR}/out}"
+#: Extra space appended to the base image before customizing, so Docker
+#: (~180-220MB of packages on arm64: docker.io, containerd, runc, iptables
+#: and friends) plus the palaia unit file have somewhere to land without a
+#: partition-full failure mid-`apt-get install`. Mostly-zero padding, which
+#: xz compresses to nearly nothing — see README.md's size-budget numbers
+#: for why this doesn't blow the stated budget.
+GROWTH_MB="${PI_IMAGE_GROWTH_MB:-700}"
+#: Checked against the final compressed .img.xz — see README.md.
+SIZE_BUDGET_MB="${PI_IMAGE_SIZE_BUDGET_MB:-900}"
+
+VERSION="$(tr -d '[:space:]' < "${V3_ROOT}/VERSION")"
+OUT_NAME="palaia-appliance-v${VERSION}"
+
+# shellcheck source=base-image.env
+source "${SCRIPT_DIR}/base-image.env"
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "build.sh: must run as root (loop devices, mount, chroot) — try 'sudo $0'" >&2
+    exit 1
+fi
+
+for tool in curl xz losetup parted mkfs.ext4 resize2fs e2fsck chroot sha256sum truncate; do
+    if ! command -v "${tool}" >/dev/null 2>&1; then
+        echo "build.sh: required tool '${tool}' not found on PATH" >&2
+        exit 1
+    fi
+done
+
+mkdir -p "${WORK_DIR}" "${OUTPUT_DIR}"
+
+# ---------------------------------------------------------------------------
+# Download + verify the pinned base image once, shared by both runs.
+# ---------------------------------------------------------------------------
+BASE_XZ="${WORK_DIR}/base.img.xz"
+if [ ! -f "${BASE_XZ}" ] || ! (echo "${BASE_IMAGE_SHA256}  ${BASE_XZ}" | sha256sum -c - >/dev/null 2>&1); then
+    echo "build.sh: downloading pinned base image..."
+    curl -fL --retry 3 -o "${BASE_XZ}.tmp" "${BASE_IMAGE_URL}"
+    mv "${BASE_XZ}.tmp" "${BASE_XZ}"
+fi
+echo "build.sh: verifying base image checksum..."
+echo "${BASE_IMAGE_SHA256}  ${BASE_XZ}" | sha256sum -c -
+
+# ---------------------------------------------------------------------------
+# Cleanup bookkeeping: every run pushes onto this stack whatever it mounted
+# or attached, and unwind_all tears it down in reverse order — including on
+# a mid-run failure, so a failed CI attempt never leaves a stuck loop device
+# or bind mount behind on the runner.
+# ---------------------------------------------------------------------------
+declare -a CLEANUP_STACK=()
+push_cleanup() { CLEANUP_STACK+=("$1"); }
+unwind_all() {
+    local i cmd
+    for ((i = ${#CLEANUP_STACK[@]} - 1; i >= 0; i--)); do
+        cmd="${CLEANUP_STACK[i]}"
+        eval "${cmd}" || true
+    done
+    CLEANUP_STACK=()
+}
+trap unwind_all EXIT
+
+#: The small set of rootfs paths that are legitimately different between
+#: two otherwise-identical customization runs (or simply not meaningful to
+#: compare) — apt's own cache/lists carry the live mirror's timing
+#: metadata, /etc/machine-id and the dbus/systemd equivalents are meant to
+#: be regenerated per-boot (this image never ships one; see README.md),
+#: and /var/log, /tmp, /run hold this run's own transient noise. Anything
+#: NOT matched here is asserted byte-identical across both runs.
+EXCLUDE_RE='^(var/lib/apt/lists/|var/log/|var/cache/apt/archives/|tmp/|run/|root/\.bash_history$|etc/machine-id$|var/lib/dbus/machine-id$|var/lib/systemd/random-seed$)'
+
+compute_manifest() {
+    local rootfs="$1" out="$2"
+    ( cd "${rootfs}" && find . -xdev -type f -printf '%P\n' ) \
+        | grep -vE "${EXCLUDE_RE}" \
+        | LC_ALL=C sort \
+        | while IFS= read -r rel; do
+            sha256sum "${rootfs}/${rel}" | awk -v p="${rel}" '{print $1"  "p}'
+        done > "${out}"
+}
+
+# ---------------------------------------------------------------------------
+# One full customization run: copy the verified base image, grow it, loop
+# mount it, chroot in and install Docker + the palaia unit, then hash the
+# resulting rootfs. Called twice (run "1" and run "2") with independent
+# copies so a diff between their manifests is a real reproducibility check,
+# not a comparison against itself.
+# ---------------------------------------------------------------------------
+build_one() {
+    local run_id="$1"
+    local run_dir="${WORK_DIR}/run-${run_id}"
+    local img="${run_dir}/palaia-appliance.img"
+    local rootfs="${run_dir}/rootfs"
+
+    rm -rf "${run_dir}"
+    mkdir -p "${run_dir}" "${rootfs}"
+
+    echo "build.sh[run ${run_id}]: decompressing base image..."
+    xz -dk -T0 -c "${BASE_XZ}" > "${img}"
+    truncate -s "+${GROWTH_MB}M" "${img}"
+
+    echo "build.sh[run ${run_id}]: attaching loop device..."
+    local loopdev
+    loopdev="$(losetup --find --show -P "${img}")"
+    push_cleanup "losetup -d '${loopdev}' 2>/dev/null"
+
+    echo "build.sh[run ${run_id}]: growing the rootfs partition..."
+    parted --script "${loopdev}" resizepart 2 100%
+    # partprobe/kernel re-read of the new partition table size.
+    partprobe "${loopdev}" 2>/dev/null || true
+    udevadm settle 2>/dev/null || true
+    e2fsck -f -y "${loopdev}p2" || true
+    resize2fs "${loopdev}p2"
+
+    mount "${loopdev}p2" "${rootfs}"
+    push_cleanup "umount '${rootfs}'"
+
+    # Networking for apt-get inside the chroot: swap in the host's own
+    # working resolv.conf for the duration of the chroot step, restoring
+    # whatever was there before (typically a systemd-resolved symlink on
+    # this base image) right after — restored explicitly below, right
+    # after the chroot step, rather than only in the cleanup stack, so the
+    # manifest this run hashes reflects the same file the shipped image
+    # ships, not this run's temporary DNS setup. A bind mount would try to
+    # mount over wherever that symlink resolves to, which doesn't exist
+    # under a chroot with no systemd running — hence a plain swap instead.
+    resolv_backup=""
+    if [ -e "${rootfs}/etc/resolv.conf" ] || [ -L "${rootfs}/etc/resolv.conf" ]; then
+        resolv_backup="${rootfs}/etc/.resolv.conf.pi-image-orig"
+        mv "${rootfs}/etc/resolv.conf" "${resolv_backup}"
+    fi
+    cp /etc/resolv.conf "${rootfs}/etc/resolv.conf"
+
+    for pseudo in dev proc sys; do
+        mount --bind "/${pseudo}" "${rootfs}/${pseudo}"
+        push_cleanup "umount -l '${rootfs}/${pseudo}'"
+    done
+
+    # Belt-and-suspenders arm64 emulation: docker/setup-qemu-action (run by
+    # the workflow before this script) registers binfmt_misc handlers with
+    # the "F" (fix-binary) flag, which the kernel resolves at registration
+    # time — a bare chroot should already work through it with no extra
+    # step. Also copying the static interpreter into the rootfs itself is
+    # the same defensive step pi-gen's own build takes, and costs nothing:
+    # it is deleted again below, before this run's manifest is computed, so
+    # it never reaches the shipped image or skews the reproducibility diff.
+    if [ -x /usr/bin/qemu-aarch64-static ]; then
+        cp /usr/bin/qemu-aarch64-static "${rootfs}/usr/bin/qemu-aarch64-static"
+    fi
+
+    # Stop package postinst scripts from trying to actually start services
+    # inside the chroot (there is no running init to talk to) — standard
+    # Debian chroot-customization practice.
+    cat > "${rootfs}/usr/sbin/policy-rc.d" <<'EOF'
+#!/bin/sh
+exit 101
+EOF
+    chmod +x "${rootfs}/usr/sbin/policy-rc.d"
+
+    echo "build.sh[run ${run_id}]: installing Docker in the chroot..."
+    chroot "${rootfs}" /bin/bash -c '
+        set -euo pipefail
+        export DEBIAN_FRONTEND=noninteractive LANG=C
+        apt-get update
+        apt-get install -y --no-install-recommends docker.io
+        apt-get clean
+    '
+
+    rm -f "${rootfs}/usr/sbin/policy-rc.d"
+    rm -f "${rootfs}/usr/bin/qemu-aarch64-static"
+    rm -rf "${rootfs}/var/lib/apt/lists"/*
+    rm -rf "${rootfs}/var/cache/apt/archives"/*.deb
+
+    # Restore whatever /etc/resolv.conf the base image actually ships,
+    # before the manifest below hashes it — see the comment above.
+    rm -f "${rootfs}/etc/resolv.conf"
+    if [ -n "${resolv_backup}" ]; then
+        mv "${resolv_backup}" "${rootfs}/etc/resolv.conf"
+    fi
+
+    echo "build.sh[run ${run_id}]: installing the palaia unit..."
+    install -m 644 "${SCRIPT_DIR}/systemd/palaia.service" "${rootfs}/etc/systemd/system/palaia.service"
+
+    # `systemctl --root=<path>` works entirely offline (pure [Install]
+    # symlink math against the given tree) — no chroot/emulation needed for
+    # this step, unlike installing the docker.io package itself above.
+    systemctl --root="${rootfs}" enable docker.service palaia.service
+    # Explicit and idempotent, even though the base image already ships
+    # ssh.service un-enabled by default (see README.md's "Enabling SSH"
+    # section) — this line is what inspect.sh's "SSH off" assertion is
+    # actually asserting stays true, not an assumption about the base image.
+    systemctl --root="${rootfs}" disable ssh.service 2>/dev/null || true
+
+    echo "build.sh[run ${run_id}]: hashing rootfs..."
+    compute_manifest "${rootfs}" "${run_dir}/manifest.txt"
+    echo "build.sh[run ${run_id}]: $(wc -l < "${run_dir}/manifest.txt") files in manifest"
+
+    # Tear this run's own mounts/loop down now (in reverse order) so run 2
+    # starts clean, rather than waiting for the script-wide EXIT trap.
+    unwind_all
+}
+
+build_one 1
+build_one 2
+
+echo "build.sh: comparing the two runs' rootfs manifests..."
+if ! diff -u "${WORK_DIR}/run-1/manifest.txt" "${WORK_DIR}/run-2/manifest.txt" > "${WORK_DIR}/manifest.diff"; then
+    echo "build.sh: REPRODUCIBILITY CHECK FAILED — the two runs produced" >&2
+    echo "different rootfs content (see below). This is the SPEC-603" >&2
+    echo "'builds reproducibly' acceptance criterion failing, not a" >&2
+    echo "flake — do not retry blindly, read the diff." >&2
+    cat "${WORK_DIR}/manifest.diff" >&2
+    exit 1
+fi
+echo "build.sh: reproducibility check passed — identical rootfs content across both runs."
+
+echo "build.sh: compressing final image..."
+xz -9 -T0 -c "${WORK_DIR}/run-1/palaia-appliance.img" > "${OUTPUT_DIR}/${OUT_NAME}.img.xz"
+( cd "${OUTPUT_DIR}" && sha256sum "${OUT_NAME}.img.xz" > "${OUT_NAME}.img.xz.sha256" )
+
+size_mb=$(( $(stat -c%s "${OUTPUT_DIR}/${OUT_NAME}.img.xz") / 1024 / 1024 ))
+echo "build.sh: compressed image size: ${size_mb} MB (budget: ${SIZE_BUDGET_MB} MB)"
+if [ "${size_mb}" -ge "${SIZE_BUDGET_MB}" ]; then
+    echo "build.sh: image exceeds the ${SIZE_BUDGET_MB}MB compressed budget (SPEC-603)." >&2
+    exit 1
+fi
+
+echo "build.sh: done."
+echo "  image:    ${OUTPUT_DIR}/${OUT_NAME}.img.xz (${size_mb} MB)"
+echo "  checksum: ${OUTPUT_DIR}/${OUT_NAME}.img.xz.sha256"
+echo "  raw rootfs for inspect.sh: ${WORK_DIR}/run-1/palaia-appliance.img"

--- a/v3/deploy/pi-image/build.sh
+++ b/v3/deploy/pi-image/build.sh
@@ -155,7 +155,7 @@ build_one() {
     # ships, not this run's temporary DNS setup. A bind mount would try to
     # mount over wherever that symlink resolves to, which doesn't exist
     # under a chroot with no systemd running — hence a plain swap instead.
-    resolv_backup=""
+    local resolv_backup=""
     if [ -e "${rootfs}/etc/resolv.conf" ] || [ -L "${rootfs}/etc/resolv.conf" ]; then
         resolv_backup="${rootfs}/etc/.resolv.conf.pi-image-orig"
         mv "${rootfs}/etc/resolv.conf" "${resolv_backup}"

--- a/v3/deploy/pi-image/inspect.sh
+++ b/v3/deploy/pi-image/inspect.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# SPEC-603 acceptance: "rootfs inspection assertions green" — loop-mounts a
+# built (uncompressed) .img read-only and checks the four things the SPEC
+# names: Docker enabled, palaia unit enabled, mDNS on, SSH off. Exits
+# non-zero with a clear reason on the first assertion that fails.
+#
+# Usage: sudo ./inspect.sh /path/to/palaia-appliance.img
+set -euo pipefail
+
+IMG="${1:?usage: inspect.sh <path-to-.img>}"
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "inspect.sh: must run as root (loop devices, mount) — try 'sudo $0 $*'" >&2
+    exit 1
+fi
+
+WORK="$(mktemp -d)"
+ROOTFS="${WORK}/rootfs"
+BOOT="${WORK}/boot"
+mkdir -p "${ROOTFS}" "${BOOT}"
+
+declare -a CLEANUP_STACK=()
+push_cleanup() { CLEANUP_STACK+=("$1"); }
+unwind_all() {
+    local i cmd
+    for ((i = ${#CLEANUP_STACK[@]} - 1; i >= 0; i--)); do
+        cmd="${CLEANUP_STACK[i]}"
+        eval "${cmd}" || true
+    done
+    rm -rf "${WORK}"
+}
+trap unwind_all EXIT
+
+loopdev="$(losetup --find --show -P -r "${IMG}")"
+push_cleanup "losetup -d '${loopdev}' 2>/dev/null"
+
+mount -o ro "${loopdev}p2" "${ROOTFS}"
+push_cleanup "umount '${ROOTFS}'"
+mount -o ro "${loopdev}p1" "${BOOT}"
+push_cleanup "umount '${BOOT}'"
+
+fail() {
+    echo "inspect.sh: FAIL — $1" >&2
+    exit 1
+}
+pass() {
+    echo "inspect.sh: ok — $1"
+}
+
+# --- Docker enabled --------------------------------------------------------
+if [ -L "${ROOTFS}/etc/systemd/system/multi-user.target.wants/docker.service" ] \
+    || [ -L "${ROOTFS}/lib/systemd/system/multi-user.target.wants/docker.service" ]; then
+    pass "docker.service is enabled (multi-user.target.wants symlink present)"
+else
+    fail "docker.service is not enabled — no multi-user.target.wants symlink found"
+fi
+[ -e "${ROOTFS}/lib/systemd/system/docker.service" ] \
+    || fail "docker.service unit file is missing — docker.io did not install correctly"
+[ -x "${ROOTFS}/usr/bin/dockerd" ] || [ -x "${ROOTFS}/usr/sbin/dockerd" ] \
+    || fail "dockerd binary missing from the image"
+
+# --- palaia unit enabled ----------------------------------------------------
+PALAIA_UNIT="${ROOTFS}/etc/systemd/system/palaia.service"
+[ -f "${PALAIA_UNIT}" ] || fail "palaia.service unit file is missing"
+if [ -L "${ROOTFS}/etc/systemd/system/multi-user.target.wants/palaia.service" ]; then
+    pass "palaia.service is enabled (multi-user.target.wants symlink present)"
+else
+    fail "palaia.service is not enabled — no multi-user.target.wants symlink found"
+fi
+grep -q 'ghcr.io/byte5ai/palaia-hub:stable' "${PALAIA_UNIT}" \
+    || fail "palaia.service does not run the :stable channel image"
+
+# --- mDNS on -----------------------------------------------------------------
+# The image's own mDNS announcer (v3/deploy/mdns_announce.py) runs inside
+# the palaia-hub container and needs the host network to reach the LAN —
+# see systemd/palaia.service's own comment. "mDNS on" for this appliance
+# means: the unit runs the container with host networking, and nothing in
+# the image disables the announcer.
+grep -q -- '--network host' "${PALAIA_UNIT}" \
+    || fail "palaia.service does not run the container with --network host — mDNS could not reach the LAN"
+if grep -rq 'PALAIA_MDNS_ENABLED=0' "${ROOTFS}/etc/systemd/system/" 2>/dev/null; then
+    fail "found PALAIA_MDNS_ENABLED=0 — the appliance image must not disable mDNS"
+fi
+pass "mDNS announcer is on (host networking, not disabled)"
+
+# --- SSH off -----------------------------------------------------------------
+if [ -L "${ROOTFS}/etc/systemd/system/multi-user.target.wants/ssh.service" ] \
+    || [ -L "${ROOTFS}/lib/systemd/system/multi-user.target.wants/ssh.service" ]; then
+    fail "ssh.service is enabled — the appliance image must ship with SSH off by default"
+fi
+if [ -e "${BOOT}/ssh" ] || [ -e "${BOOT}/firmware/ssh" ]; then
+    fail "found a /boot ssh marker file baked into the image — SSH must not be pre-enabled"
+fi
+pass "SSH is off (no enabled unit, no /boot ssh marker file)"
+
+echo "inspect.sh: all rootfs assertions passed."

--- a/v3/deploy/pi-image/pin-base-image.sh
+++ b/v3/deploy/pi-image/pin-base-image.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Re-pins base-image.env to the *current* Raspberry Pi OS Lite (arm64)
+# build. Run this by hand when a refresh is wanted; it is never invoked by
+# CI — the build always uses whatever is already committed in
+# base-image.env, which is what makes a CI run reproducible against
+# itself (see README.md's "Reproducibility" section).
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+latest_url="$(curl -fsSI "https://downloads.raspberrypi.org/raspios_lite_arm64_latest" \
+    | grep -i '^location:' | tr -d '\r' | awk '{print $2}')"
+if [ -z "${latest_url}" ]; then
+    echo "pin-base-image: could not resolve the 'latest' redirect" >&2
+    exit 1
+fi
+
+sha256="$(curl -fsS "${latest_url}.sha256" | awk '{print $1}')"
+if [ -z "${sha256}" ]; then
+    echo "pin-base-image: could not fetch a checksum for ${latest_url}" >&2
+    exit 1
+fi
+
+cat > base-image.env <<EOF
+# Pinned Raspberry Pi OS Lite (arm64) base image — SPEC-603.
+#
+# build.sh sources this file and refuses to proceed if the downloaded
+# file's sha256 doesn't match BASE_IMAGE_SHA256. This is the whole
+# reproducibility story for the *base OS*: the same committed URL+checksum
+# is what every build (CI or an owner's own machine) starts from, today or
+# a year from now, for as long as Raspberry Pi Foundation keeps this dated
+# build online.
+#
+# Re-pin with `./pin-base-image.sh` when a refresh is wanted (e.g. a
+# security-relevant base OS update) — it fetches the *current* "latest"
+# build, rewrites this file, and prints what changed. Never hand-edit
+# BASE_IMAGE_URL without also updating BASE_IMAGE_SHA256 to match.
+BASE_IMAGE_URL="${latest_url}"
+BASE_IMAGE_SHA256="${sha256}"
+EOF
+
+echo "pin-base-image: base-image.env now pinned to:"
+echo "  ${latest_url}"
+echo "  sha256:${sha256}"

--- a/v3/deploy/pi-image/systemd/palaia.service
+++ b/v3/deploy/pi-image/systemd/palaia.service
@@ -1,0 +1,40 @@
+[Unit]
+Description=palaia hub (appliance image)
+Documentation=https://github.com/byte5ai/palaia
+After=docker.service network-online.target
+Requires=docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+# --network host: the image's own mDNS announcer (v3/deploy/mdns_announce.py,
+# baked into the palaia-hub image and started by its entrypoint.sh whenever
+# PALAIA_MDNS_ENABLED=1, the default) needs the host's real network to
+# advertise http://palaia.local — Docker's default bridge network does not
+# forward multicast to the LAN. This appliance is always a dedicated Linux
+# host, so host networking has none of the caveats it has on the compose
+# path (see docker-compose.yml's own `network_mode: host` comment, written
+# for a shared/desktop host where this is opt-in instead of the default).
+#
+# The five flags from --security-opt through --tmpfs /run are install.sh's
+# own SPEC-502 hardening set, reused verbatim (never a second, forked copy —
+# see install.sh's own comment) — server/tests/deploy/test_pi_image.py
+# checks this file for drift against install.sh the same way
+# test_cloud_init.py already does for cloud-init.yaml.
+ExecStartPre=-/usr/bin/docker rm -f palaia-hub
+ExecStart=/usr/bin/docker run --rm --name palaia-hub \
+    --network host \
+    -v palaia_home:/data \
+    --security-opt no-new-privileges:true \
+    --cap-drop ALL \
+    --read-only \
+    --tmpfs /tmp \
+    --tmpfs /run \
+    ghcr.io/byte5ai/palaia-hub:stable
+ExecStop=/usr/bin/docker stop --time 30 palaia-hub
+Restart=on-failure
+RestartSec=5
+TimeoutStartSec=300
+
+[Install]
+WantedBy=multi-user.target

--- a/v3/server/tests/deploy/test_pi_image.py
+++ b/v3/server/tests/deploy/test_pi_image.py
@@ -1,0 +1,213 @@
+"""SPEC-603: static, no-privilege checks on the Pi appliance image pipeline
+(``v3/deploy/pi-image/``).
+
+This file cannot itself loop-mount, chroot into, or boot anything — that
+needs root, real loop devices, and (for the boot half) real hardware, none
+of which this test environment has. What it *can* and does check, matching
+this repo's own established pattern for deploy artifacts CI can't fully
+exercise (``test_cloud_init.py``'s docstring makes the same point for
+SPEC-601):
+
+1. The pieces the real pipeline is built from are internally consistent —
+   ``base-image.env``'s pinned URL and checksum look like a real, matched
+   pair; ``systemd/palaia.service`` never forks ``install.sh``'s own
+   SPEC-502 hardening flag list (the same drift-test pattern
+   ``test_cloud_init.py`` already applies); the shell scripts at least
+   parse (``bash -n``).
+2. The things ``.github/workflows/v3-pi-image.yml`` and ``inspect.sh``
+   assert at runtime (Docker enabled, palaia unit enabled, mDNS on, SSH
+   off) are assertions this file can *also* make about the static unit
+   file, one layer removed from a real rootfs — so a change that would
+   obviously break one of those four assertions is caught here too,
+   without waiting for the next real image build.
+
+The actual "does it build, is it reproducible, does it pass inspection"
+proof is the real ``workflow_dispatch``/release-tag run of
+``v3-pi-image.yml`` — see that run's link in this SPEC's PR description,
+not this file.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# v3/server/tests/deploy -> v3/server/tests -> v3/server -> v3 -> v3/deploy
+DEPLOY_ROOT = Path(__file__).resolve().parents[3] / "deploy"
+PI_IMAGE_ROOT = DEPLOY_ROOT / "pi-image"
+
+#: Same extractor pattern test_cloud_init.py uses — pulled from install.sh's
+#: own text so this test cannot drift from the real flag list on either
+#: side.
+_HARDENING_BLOCK_RE = re.compile(r"--restart unless-stopped.*?--tmpfs /run", re.DOTALL)
+
+
+def _extract_hardening_flags(install_sh_text: str) -> list[str]:
+    match = _HARDENING_BLOCK_RE.search(install_sh_text)
+    assert match, (
+        "install.sh's docker run block no longer has the expected shape "
+        "(looked for '--restart unless-stopped' ... '--tmpfs /run') — "
+        "update this extractor to match, never hand-copy the flag list instead"
+    )
+    lines = [line.strip().rstrip("\\").strip() for line in match.group(0).splitlines()]
+    # install.sh's own block starts with a flag this appliance's systemd
+    # unit deliberately does not repeat (`--restart unless-stopped`
+    # duplicates systemd's own `Restart=`/`RestartSec=`, which
+    # palaia.service already sets) — every *other* line is the SPEC-502
+    # hardening set proper, which must match verbatim.
+    return [line for line in lines if line and line != "--restart unless-stopped"]
+
+
+def test_pi_image_directory_layout() -> None:
+    for name in (
+        "README.md",
+        "BOOT-TEST.md",
+        "base-image.env",
+        "build.sh",
+        "inspect.sh",
+        "pin-base-image.sh",
+        "systemd/palaia.service",
+    ):
+        path = PI_IMAGE_ROOT / name
+        assert path.is_file(), f"missing {path} — SPEC-603 deliverable"
+
+
+def test_scripts_are_executable_and_parse() -> None:
+    for name in ("build.sh", "inspect.sh", "pin-base-image.sh"):
+        path = PI_IMAGE_ROOT / name
+        assert path.stat().st_mode & 0o111, f"{path} is not executable"
+        result = subprocess.run(
+            ["bash", "-n", str(path)], capture_output=True, text=True, timeout=30
+        )
+        assert result.returncode == 0, f"{path} failed to parse:\n{result.stderr}"
+
+
+@pytest.mark.skipif(shutil.which("shellcheck") is None, reason="shellcheck not on PATH")
+@pytest.mark.parametrize("name", ["build.sh", "inspect.sh", "pin-base-image.sh"])
+def test_scripts_pass_shellcheck(name: str) -> None:
+    result = subprocess.run(
+        ["shellcheck", "--severity=warning", str(PI_IMAGE_ROOT / name)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_base_image_env_is_a_matched_pinned_pair() -> None:
+    text = (PI_IMAGE_ROOT / "base-image.env").read_text(encoding="utf-8")
+
+    url_match = re.search(r'BASE_IMAGE_URL="([^"]+)"', text)
+    sha_match = re.search(r'BASE_IMAGE_SHA256="([0-9a-f]{64})"', text)
+    assert url_match, "base-image.env has no BASE_IMAGE_URL"
+    assert sha_match, "base-image.env has no 64-hex-char BASE_IMAGE_SHA256"
+
+    url = url_match.group(1)
+    assert url.startswith("https://downloads.raspberrypi.org/raspios_lite_arm64/"), (
+        f"BASE_IMAGE_URL does not look like a Raspberry Pi OS Lite (arm64) release: {url!r}"
+    )
+    assert url.endswith(".img.xz"), f"BASE_IMAGE_URL should point at a .img.xz: {url!r}"
+    assert "lite" in url.lower(), f"BASE_IMAGE_URL should be the Lite build, not desktop: {url!r}"
+    assert "arm64" in url.lower(), f"BASE_IMAGE_URL should be arm64, not armhf: {url!r}"
+
+
+def test_palaia_service_hardening_flags_match_install_sh_verbatim() -> None:
+    """Drift test: the Pi appliance's systemd unit must reuse install.sh's
+    own SPEC-502 hardening flags verbatim, never a second, forked copy —
+    same pattern test_cloud_init.py already applies to cloud-init.yaml."""
+    install_sh = (DEPLOY_ROOT / "install.sh").read_text(encoding="utf-8")
+    unit = (PI_IMAGE_ROOT / "systemd" / "palaia.service").read_text(encoding="utf-8")
+
+    flags = _extract_hardening_flags(install_sh)
+    assert flags, "no hardening flags extracted from install.sh"
+    for flag in flags:
+        assert flag in unit, (
+            f"palaia.service's docker run command is missing install.sh's own "
+            f"{flag!r} flag — the two must never fork this list"
+        )
+
+
+def test_palaia_service_runs_the_stable_channel_image() -> None:
+    unit = (PI_IMAGE_ROOT / "systemd" / "palaia.service").read_text(encoding="utf-8")
+    assert "ghcr.io/byte5ai/palaia-hub:stable" in unit, (
+        "the appliance must run the :stable release channel (SPEC-501), not a moving tag"
+    )
+
+
+def test_palaia_service_is_installed_and_enabled_by_wanted_by() -> None:
+    unit = (PI_IMAGE_ROOT / "systemd" / "palaia.service").read_text(encoding="utf-8")
+    assert "[Install]" in unit and "WantedBy=multi-user.target" in unit, (
+        "palaia.service has no [Install] WantedBy=multi-user.target — "
+        "`systemctl --root=<rootfs> enable palaia.service` (build.sh) has nothing to act on"
+    )
+
+
+def test_palaia_service_uses_host_networking_for_mdns() -> None:
+    """'mDNS on' (SPEC-603 acceptance) depends on the container reaching the
+    host's real network — see mdns_announce.py's own docstring for why
+    Docker's default bridge network can't do this."""
+    unit = (PI_IMAGE_ROOT / "systemd" / "palaia.service").read_text(encoding="utf-8")
+    assert "--network host" in unit
+    assert "PALAIA_MDNS_ENABLED=0" not in unit
+
+
+def test_build_sh_enables_docker_and_disables_ssh() -> None:
+    build_sh = (PI_IMAGE_ROOT / "build.sh").read_text(encoding="utf-8")
+    assert re.search(r"systemctl --root=.* enable .*docker\.service", build_sh), (
+        "build.sh no longer enables docker.service — "
+        "'Docker enabled' assertion would have nothing behind it"
+    )
+    assert re.search(r"systemctl --root=.* enable .*palaia\.service", build_sh), (
+        "build.sh no longer enables palaia.service"
+    )
+    assert "disable ssh.service" in build_sh, (
+        "build.sh should explicitly (and idempotently) disable ssh.service, "
+        "not rely only on the base image's own default — see README.md"
+    )
+    assert "apt-get install" in build_sh and "docker.io" in build_sh
+
+
+def test_inspect_sh_asserts_the_four_spec_603_properties() -> None:
+    """The SPEC's own acceptance wording: 'loop-mount inspection asserts:
+    Docker enabled, palaia unit enabled, mDNS on, SSH off'."""
+    inspect_sh = (PI_IMAGE_ROOT / "inspect.sh").read_text(encoding="utf-8")
+    for marker in (
+        "docker.service",
+        "palaia.service",
+        "--network host",
+        "ssh.service",
+    ):
+        assert marker in inspect_sh, f"inspect.sh no longer checks for {marker!r}"
+
+
+def test_workflow_is_dispatch_and_tag_only_never_pr() -> None:
+    workflow_path = (
+        Path(__file__).resolve().parents[4] / ".github" / "workflows" / "v3-pi-image.yml"
+    )
+    assert workflow_path.is_file(), f"missing {workflow_path}"
+    text = workflow_path.read_text(encoding="utf-8")
+
+    assert "workflow_dispatch" in text
+    assert re.search(r"tags:\s*\[.?v3\.\*.?\]", text), (
+        "workflow should trigger on v3.* release tags, matching v3-release.yml's own tags"
+    )
+    assert "pull_request" not in text, (
+        "SPEC-603: 'it must not run on every PR' — "
+        "this workflow must never gain a pull_request trigger"
+    )
+
+
+def test_readme_states_a_size_budget_matching_build_sh() -> None:
+    readme = (PI_IMAGE_ROOT / "README.md").read_text(encoding="utf-8")
+    build_sh = (PI_IMAGE_ROOT / "build.sh").read_text(encoding="utf-8")
+
+    budget_match = re.search(r"SIZE_BUDGET_MB:-(\d+)", build_sh)
+    assert budget_match, "build.sh has no PI_IMAGE_SIZE_BUDGET_MB default to check against"
+    budget = budget_match.group(1)
+    assert budget in readme, (
+        f"README.md's stated size budget doesn't mention build.sh's actual default ({budget}MB)"
+    )


### PR DESCRIPTION
## What

`v3/deploy/pi-image/`: the buildable half of SPEC-603 — a flashable Raspberry Pi appliance image (Raspberry Pi OS Lite arm64 + Docker + `palaia-hub:stable`, auto-started, mDNS on, SSH off by default), plus `.github/workflows/v3-pi-image.yml` (manual `workflow_dispatch` + `v3.*` release tags only — never PRs) that builds it, double-build-reproducibility-checks it, loop-mount-inspects it, and checks it against a stated size budget.

Part of #280 — the boot test itself stays an owner action (`BOOT-TEST.md`).

## Why

#280: "flash, boot, done" — Home Assistant's install bar, for the audience already comfortable with Umbrel/Home Assistant/a NAS. This SPEC builds and verifies everything a CI runner can; a physical Pi is the owner's job.

## How

**Base: a pinned, checksum-verified Raspberry Pi OS Lite release, customized — not `pi-gen`.** SPEC-603 names `pi-gen` as the default with an escape hatch ("or equivalently standard, justified in an ADR note"). `v3/decisions/005-pi-appliance-image-base.md` is that ADR: `pi-gen` `debootstrap`s the *entire* OS from a live apt mirror on every run, which makes reproducibility strictly harder (every package drifts, not just the one this pipeline adds) and the CI job strictly slower, for the same deliverable. `build.sh` instead loop-mounts + `chroot`s (arm64 via `binfmt_misc`/`qemu-user-static`) into the pinned base, installs `docker.io`, drops in one systemd unit, and ships it.

**Reproducibility, scoped honestly.** `build.sh` runs the customization step *twice* against independent copies of the same verified base image and diffs a sha256 manifest of the resulting rootfs (excluding the small set of paths that are legitimately per-run noise — apt cache/lists, logs, `/etc/machine-id`, none of which the image ships anyway). What this does **not** claim: bit-identical output across different days (the one package this pipeline adds still resolves against whatever the live Debian archive serves that day — the same tradeoff every `apt-get install` in this repo's own Dockerfile already has). `README.md`'s "Reproducibility" section spells this out.

**Rootfs inspection (`inspect.sh`)** loop-mounts the built `.img` read-only and asserts the SPEC's own four properties: Docker enabled, `palaia.service` enabled and running `:stable` with `--network host` (mDNS on — see `mdns_announce.py`'s own note on why bridge networking can't reach the LAN), SSH not enabled and no `/boot` ssh marker.

**`systemd/palaia.service`** reuses `install.sh`'s SPEC-502 hardening flags verbatim — checked by a drift test (`server/tests/deploy/test_pi_image.py`), same pattern `test_cloud_init.py` already established for SPEC-601's cloud-init template.

**Size budget: 900MB compressed**, checked by `build.sh` after `xz -9` (base is ~500MB; Docker + deps add ~150-220MB of real content; the growth padding is mostly zero and compresses away — see `README.md` for the full accounting).

**One stated, honest gap**, not silently expanded scope: `palaia.service`'s `docker run` still pulls the hub image from GHCR on first boot — this pipeline doesn't bake the container's own layers into the `.img.xz`. `BOOT-TEST.md` asks the owner to record how visible this was on a real network; pre-baking it is reasonable future work, not done here.

No product changes — packaging only. Full v3 suite unchanged (below).

### Workflow-run bootstrap (read before reviewing the extra revert-pair commits)

I could not get a real green (or red) `v3-pi-image.yml` run for this PR, and I'm not claiming the image builds. Two things stopped me, both worth knowing about:

1. **GitHub's `workflow_dispatch` API only accepts a workflow already known to GitHub** (present on the default branch, or already fired by a matching push event). A brand-new workflow file on a feature branch isn't dispatchable — confirmed with a `404` from the dispatch endpoint and its absence from `list_workflows` even after pushing.
2. The standard workaround — push a scoped test tag matching this workflow's own tag trigger, which fires via `push` regardless of default-branch registration — is itself **blocked**: this session's git remote returns `HTTP 403` specifically on `git push <tag>` (branch pushes work fine). That looks like a deliberate guardrail against exactly this kind of agent-triggered release/tag action, and I didn't try to route around it.

I did attempt option 2 briefly (commits `52d0a1a`/`d237019` in this branch's history — temporarily widening the trigger to a non-colliding test tag pattern, then reverting once the tag push itself failed with 403). That pair is a real, honest record of the attempt, left in rather than rewritten away.

**Net result: this workflow has never actually executed.** Everything short of that is verified (below) — scripts parse and pass `shellcheck`, the workflow YAML validates, the static drift/consistency tests pass, and the approach (loop devices + privileged chroot on `ubuntu-latest`, a real VM) is well-established practice, not a guess. But "the image builds, is reproducible, and passes inspection in CI" is unverified by an actual run as of this PR. **Recommend:** run `workflow_dispatch` on this branch yourself (via the GitHub UI/API, which you have and I don't) before merging, or after merging to `main` — either gets a real first run; I did not want to force one around the two guardrails above.

## Verification

- `uv run ruff check server` — clean
- `uv run mypy server/src` — clean, no issues in 193 source files
- `uv run pytest server/tests -q` — **2242 passed, 29 skipped**, 0 failed (`server/tests/deploy` alone: 37 passed, including 14 new `test_pi_image.py` tests) — nothing existing changed, packaging-only confirmed
- YAML-validated `.github/workflows/v3-pi-image.yml`
- `shellcheck` (0.9.0) on `build.sh`/`inspect.sh`/`pin-base-image.sh`: clean except two info/style-level false positives inside a heredoc and an unfollowed `source` (both expected, noted in `test_pi_image.py`'s own shellcheck test which skips gracefully where `shellcheck` isn't installed)
- `bash -n` on all three scripts: clean
- `grep -rn '^<<<<<<< '` over `v3` and `.github`: none

## Checklist

- [x] Tests added (`server/tests/deploy/test_pi_image.py`)
- [x] `uv run pytest server/tests -q` passes (2242 passed, 29 skipped)
- [x] `uv run ruff check server` / `uv run mypy server/src` pass
- [x] Documentation added (`README.md`, `BOOT-TEST.md`, ADR-005)
- [x] No force pushes
- [ ] **Not done**: a real `v3-pi-image.yml` run — see "Workflow-run bootstrap" above; owner action before/at merge

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790788276&installation_model_id=428086&pr_number=291&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F291&signature=d7191f80579e2e0d41cf58d6622b8b0a4eb5ddc894673833bb0e0de10701dca4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->