### PR TITLE
feat(v3): backup & restore floor (SPEC-604)

### DIFF
--- a/v3/docs/backup-restore.md
+++ b/v3/docs/backup-restore.md
@@ -1,0 +1,154 @@
+# palaia Backup & Restore
+
+> **Normative.** Implements [SPEC-604](../specs/SPEC-604-backup-restore.md):
+> `GET /api/backup` (`server/src/palaia_hub/backup.py`,
+> `server/src/palaia_hub/backup_api.py`), the dashboard's "Back up" action
+> (`web/src/routes/Home.tsx`), and the offline restore path documented here.
+> The user-facing version of this page (no repository-internal terms) is
+> [Back up & restore](../site/docs/src/content/docs/backup-restore.md) on
+> the docs site.
+
+## 1. What the archive contains, and why
+
+`GET /api/backup` streams a `tar.gz` of the whole hub home — the same
+directory every store in this package persists under
+(`palaia_hub.config.palaia_home()`, or `PALAIA_HOME` if set):
+
+- `config.yaml`, `vaults.yaml`
+- every vault: notes, `.git` history, `meta/vault.md`
+- `oauth/oauth.sqlite3`, `oauth/signing-key.pem`
+- `secrets.sqlite3` **and** `secrets.key` — the upstream credential store
+  and the key it is encrypted under (SPEC-302,
+  `server/src/palaia_hub/upstream/secrets.py`). Leaving either one out
+  would make a "backup" that cannot restore secrets, which the SPEC states
+  plainly is not a backup at all.
+- `tokens.yaml`, `hooks.yaml`, `hooks_outbox.sqlite3`,
+  `automations.yaml`, `automations_outbox.sqlite3`,
+  `notifications.sqlite3`, `stash.db`, `directory.db`, `messenger.db`,
+  the marketplace caches, `funnel_stats.json`, `mode_audit.jsonl`
+
+**Excluded on purpose: each vault's `.palaia/index.sqlite3`.** It is
+rebuildable state, not a system of record — the notes on disk are the
+source of truth. It is left out to keep the archive smaller, and this is
+safe *because* the index is already rebuilt from the vault's notes on every
+hub start (`VaultIndex.open(build=True)`, the default, called for every
+vault in `serve.py`/`cli.py`) — restoring an archive with no index file
+puts a vault in exactly the state it is in the first time it is ever
+opened, a path already exercised on every boot. Proven by
+`server/tests/backup/test_archive.py` (the exclusion itself) and
+`server/tests/e2e/test_spec604_backup_restore.py` (the rebuild, end to
+end, against a real restored home).
+
+**Not included: a vault registered at a custom path outside the hub
+home.** `VaultRegistry` allows an absolute path anywhere on disk; the
+default "create a memory" flow always places one under the home
+(`<home>/vaults/<key>`), so this only matters for an operator who chose a
+custom location deliberately. Back that vault up separately (it is a plain
+git-tracked directory — copy it, or use your own backup tooling on it).
+
+## 2. Consistency claim
+
+There is no cross-store quiesce lock — building one would be new machinery
+invented for this feature alone, which the SPEC explicitly asks not to do.
+What is actually claimed, and why it holds:
+
+- **Every SQLite database** (found by content — the on-disk magic header,
+  not by filename convention, since this repository uses both `.sqlite3`
+  and `.db` for the same thing) is captured through SQLite's own online
+  backup API (`sqlite3.Connection.backup`) into an in-memory database, then
+  serialized. That is correct even while another connection holds the file
+  open in WAL mode with committed rows still sitting in `-wal`, unlike a
+  raw file copy — see `server/tests/backup/test_archive.py::
+  test_a_sqlite_snapshot_includes_wal_resident_data_and_omits_the_wal_file`.
+- **Everything else** (`config.yaml`, `vaults.yaml`, notes, the YAML
+  stores) is written via `palaia_hub.vault.atomic.atomic_write_bytes` — a
+  temp file plus `os.replace` — so a read mid-write can only ever see the
+  whole old content or the whole new content. A vault's `.git` history is
+  git's own content-addressed, effectively-immutable object store.
+
+**Not claimed:** that the archive is one atomic snapshot *across* stores.
+Two stores written to in the same second could land a moment apart in one
+archive. For a single-operator personal hub with no distributed
+transaction spanning multiple stores, that gap is not a real exposure —
+see `docs/security/threat-model.md` §8, item 9.
+
+## 3. Restore — offline, by design
+
+A dashboard *upload*-restore endpoint is explicitly out of scope for this
+pass (SPEC-604 non-goal: "too much risk surface for this pass" — accepting
+an arbitrary uploaded archive that gets unpacked over a running hub's own
+state is a materially larger attack surface than a download). Restore is a
+few manual steps instead:
+
+**stop the hub → unpack the archive into its data volume → start it again.**
+
+Both the one-liner install and the compose file use the same named Docker
+volume (`palaia_home` by default) as the hub's home, so the unpack step is
+identical either way.
+
+### Unpack the archive into the volume
+
+```bash
+# Run once, regardless of which of the two variants below started the hub.
+# Replace the filename with the one you actually downloaded.
+docker run --rm \
+  -v palaia_home:/data \
+  -v "$PWD":/backup \
+  alpine sh -c "rm -rf /data/* /data/.[!.]* /data/..?* 2>/dev/null; \
+                tar xzf /backup/palaia-backup-YYYYMMDDTHHMMSSZ.tar.gz -C /data"
+```
+
+The `rm -rf` clears the volume first (including dotfiles) — omit it only
+if you are restoring into a genuinely empty volume (a fresh install), in
+which case there is nothing to clear.
+
+### One-liner variant
+
+```bash
+docker rm -f palaia-hub          # stop, if it exists
+# (unpack step above)
+docker run -d --name palaia-hub \
+  -p 8420:8420 -v palaia_home:/data --restart unless-stopped \
+  --security-opt no-new-privileges:true --cap-drop ALL \
+  --read-only --tmpfs /tmp --tmpfs /run \
+  ghcr.io/byte5ai/palaia-hub:stable
+```
+
+### Compose variant
+
+```bash
+cd v3/deploy
+docker compose down
+# (unpack step above, still pointed at the palaia_home volume this
+#  compose file declares)
+docker compose up -d
+```
+
+On the next start, every store opens exactly as it does on any other
+boot — including each vault's search index, which rebuilds itself from the
+restored notes. There is no separate "restore mode": a hub that starts
+against a home directory built this way behaves identically to one that
+grew there naturally.
+
+## 4. Security posture
+
+- `GET /api/backup` sits behind the admin session gate
+  (`palaia_hub.admin_session`) like every other `/api/*` route, in every
+  mode that gates one at all — no opt-in parameter exists to mount it
+  without that gate wrapping it (`palaia_hub.app.create_app`).
+- The archive is built and streamed straight into the HTTP response body;
+  `server/src/palaia_hub/backup.py` never writes it to a temp file, so
+  there is no window where a full copy of a hub's secrets sits in a
+  world-readable location server-side.
+- `Cache-Control: no-store` is set on the response.
+- The dashboard's "Back up" button carries the warning in plain language:
+  *this file can act as your hub — store it like you would a password.*
+
+## 5. Verifying this yourself
+
+```bash
+cd v3
+uv run pytest server/tests/backup -q
+uv run pytest server/tests/e2e/test_spec604_backup_restore.py -q
+uv run pytest server/tests/security/test_threat_model_coverage.py -q
+```

--- a/v3/docs/security/external-review-brief.md
+++ b/v3/docs/security/external-review-brief.md
@@ -27,6 +27,11 @@
    read.
 6. **The parser and the renderers** — the paths untrusted content takes from
    a Markdown file to a browser or an AI client.
+7. **The backup archive (`GET /api/backup`, SPEC-604)** — the one response
+   in the whole system that intentionally contains everything: every
+   secret, every key, every vault, in one file. Its gating, its
+   consistency claim, and the fact that it never touches disk server-side
+   deserve the same scrutiny as the secret store itself.
 
 **Explicitly out of scope for this engagement:**
 
@@ -106,6 +111,9 @@ directory):
    per-caller identity the limiter keys on.
 8. `server/src/palaia_hub/upstream/secrets.py` — the encrypted store, and the
    stated rule that no value ever leaves the process.
+9. `server/src/palaia_hub/backup.py` — the whole-home archive, its
+   file-by-content SQLite snapshotting, and the honest statement of what its
+   consistency guarantee is (and is not).
 
 ---
 
@@ -186,6 +194,11 @@ outside answer to:
 5. Is the failed-attempt limiter's proxy handling (`X-Forwarded-For` from a
    loopback peer only, last entry wins) sound for every deployment shape we
    ship?
+6. `GET /api/backup` has no opt-in parameter and mounts unconditionally,
+   specifically so it can never exist without the admin session gate
+   wrapping it. Is that construction actually load-bearing, or is there a
+   path (a future refactor of `create_app`, a different app assembly for
+   some deployment shape) where it could end up exposed?
 
 ## Accepted risks
 

--- a/v3/docs/security/threat-model.md
+++ b/v3/docs/security/threat-model.md
@@ -29,6 +29,7 @@
 | **Messenger envelopes** | `<home>/messenger.db`, plain text bodies | What the user's agents said to each other |
 | **Stash entries** | `<home>/stash.db` | Hand-off payloads between agents — often the most recent, most specific working context |
 | **The owner password hash** | `<home>/oauth/oauth.sqlite3`, argon2id | Offline cracking → the whole hub |
+| **A downloaded backup archive** | Wherever the owner saved it after `GET /api/backup` (SPEC-604) — outside the hub's control from that point on | Everything in every row above, in one file. Restoring it onto another host impersonates this hub completely |
 
 The first two rows are the reason the product exists; the rest are the doors
 to them.
@@ -147,6 +148,7 @@ See [§8](#8-accepted-risks-and-open-gaps).
 | `/api/automations` | event-triggered actions | |
 | `/api/notifications` | the dashboard notification centre | |
 | `/api/connect` | the connect page's client bundles (MCPB) | |
+| `/api/backup` | downloads the whole hub home as one `tar.gz` (SPEC-604) — config, every vault, the OAuth store, **the upstream secret store and its encryption key** | the single highest-value response in this table: a full-home archive can impersonate the hub outright; **always mounted, gated like everything else in this section, streamed, never written to disk** |
 | `/api/update` | release-channel update check against GHCR (SPEC-501) — read-only, outbound fetch is size/time-capped, "cannot check" is a state not an error | makes one outbound registry request |
 | `/api/funnel` | local-only first-run funnel status — wizard-step timestamps, time-to-first-memory (SPEC-504) — **read-only**, never accepts a caller-supplied timestamp | every value it returns was set from a real server-side event, never from a request; `server/tests/funnel/test_no_egress.py` proves the whole path never opens a socket |
 | `/api/_test` | a deliberately slow endpoint for shutdown testing | **only exists when `PALAIA_TEST_SLOW_ENDPOINT_SECONDS` is set**; never in a shipped hub |
@@ -161,6 +163,8 @@ See [§8](#8-accepted-risks-and-open-gaps).
 | Clickjacking / sniffing / referrer leakage | A content-security policy per surface, `nosniff`, `no-referrer`, `DENY` framing, and HSTS when the request arrived over TLS | `server/src/palaia_hub/security/headers.py`, `server/tests/security/test_security_headers.py` |
 | Script injection through vault content in the dashboard | The dashboard renders note bodies as text (React escapes); `dangerouslySetInnerHTML` appears nowhere in `web/src` | `server/tests/security/test_injection_surfaces.py` |
 | Locking the operator out of a fresh hub | The gate stays open until a way in exists (an owner account or a provider), then latches closed on the next call | `server/src/palaia_hub/admin_session.py`, `server/tests/test_admin_session.py` |
+| A full-home backup archive read by anyone but the owner (secrets, signing keys, every vault, in one download) | `GET /api/backup` (SPEC-604) sits behind the same admin gate as everything else in this table — no separate opt-in, no route that exists without it; the archive is built and streamed straight to the response body and never written to a temp file server-side, so there is no on-disk copy to leave world-readable even briefly; the dashboard's "Back up" button carries an explicit "store this like a password" warning | `server/src/palaia_hub/backup.py`, `server/src/palaia_hub/backup_api.py`, `server/tests/backup/test_routes.py`, `web/src/routes/Home.tsx` |
+| A raw file copy of a SQLite store mid-write landing torn or missing WAL-resident rows in the archive | Every database is captured through SQLite's own online-backup API into an in-memory snapshot, not by copying bytes off disk — correct even while another connection holds the file open in WAL mode | `server/src/palaia_hub/backup.py`, `server/tests/backup/test_archive.py::test_a_sqlite_snapshot_includes_wal_resident_data_and_omits_the_wal_file` |
 
 ---
 
@@ -275,6 +279,24 @@ argue with them; that is what the list is for.
    request arrives over TLS — see `docs/exposure.md`.
 8. **No hardware-backed key storage.** The signing key and the secret-store
    key are files, protected by file modes and by whatever the host provides.
+9. **A backup is not one atomic snapshot across every store.** Each
+   individual file in the archive is internally consistent (every SQLite
+   database goes through the engine's own online-backup API; every other
+   file is written atomically, so a read mid-write only ever sees the whole
+   old or whole new content — see `server/src/palaia_hub/backup.py`'s
+   module docstring). There is no cross-store quiesce lock, so two stores
+   written to in the same second could land a moment apart in one archive.
+   Building a global write-freeze was explicitly out of scope for this pass
+   ("use what each store already supports, don't invent" — SPEC-604); for a
+   single-operator personal hub with no distributed transaction spanning
+   multiple stores, that gap is not a real exposure.
+10. **A vault registered at a path outside the hub home is not covered.**
+    `GET /api/backup` archives the hub home directory; a vault created at a
+    custom absolute path elsewhere on disk (`vault_registry.py` allows this)
+    is not inside it. The default "create a vault" flow always places one
+    under the home, so this only affects an operator who deliberately chose
+    a custom location — documented in `v3/docs/backup-restore.md`, not
+    silently missed.
 
 ---
 

--- a/v3/server/src/palaia_hub/app.py
+++ b/v3/server/src/palaia_hub/app.py
@@ -34,6 +34,7 @@ from .automations import (
     build_automations_router,
 )
 from .automations.outbox import OUTBOX_RELATIVE_PATH as AUTOMATIONS_OUTBOX_RELATIVE_PATH
+from .backup_api import build_backup_router
 from .config import HubConfig, load_config, palaia_home
 from .curator import CuratorScheduler
 from .curator.wiring import CuratorWiring
@@ -740,6 +741,14 @@ def create_app(
     # hub has a funnel store from its first boot, whether or not a vault
     # exists yet.
     app.include_router(build_funnel_router(funnel_store))
+
+    # SPEC-604: always mounted, same posture as the two routers just above —
+    # every hub has a home directory to archive from its first boot. Gated
+    # like every other `/api/*` route by the admin session middleware added
+    # below (see `palaia_hub.admin_session`'s module docstring); this route
+    # has no opt-in parameter of its own precisely so it can never be
+    # mounted without that gate wrapping it.
+    app.include_router(build_backup_router(home=hub_home))
 
     if token_store is not None:
         app.include_router(build_auth_router(token_store, dynamic_gateway=dynamic_gateway))

--- a/v3/server/src/palaia_hub/backup.py
+++ b/v3/server/src/palaia_hub/backup.py
@@ -1,0 +1,326 @@
+"""The backup archive: everything a restore needs, streamed as one ``tar.gz``
+(SPEC-604 deliverable #1).
+
+**What is in the archive.** The whole hub home, byte for byte: ``config.yaml``,
+``vaults.yaml``, every vault (notes, git history, manifest), the OAuth store
+and its signing key, the upstream secret store *and* its encryption key
+(``upstream/secrets.py`` — a backup that cannot restore secrets is not a
+backup), tokens, hooks, automations, notifications, the marketplace caches,
+the funnel stats, the mode-change audit log. The one thing left out on
+purpose:
+
+**What is excluded, and why that is safe.** Each vault's search index
+(``<vault>/.palaia/index.sqlite3`` — see :data:`palaia_hub.index.db.
+INDEX_RELATIVE_PATH`) is rebuildable state, not a system of record — the
+notes on disk are. It is excluded to keep the archive small. This is safe
+*because* :meth:`palaia_hub.index.service.VaultIndex.open` already rebuilds
+it from the vault's notes on every hub start (``build=True`` by default,
+called from ``serve.py`` and ``cli.py`` for every vault) — restoring an
+archive with no index file is exactly the state a hub is in the first time
+it ever opens a vault, and that path is exercised on every boot already, not
+invented for this feature. ``server/tests/backup/test_archive.py`` and the
+SPEC-604 e2e round trip both prove the rebuild happens.
+
+**The consistency claim, stated honestly.** There is no cross-store quiesce
+lock in this hub — building one would be new machinery invented for this
+feature alone, which the SPEC explicitly asks not to do ("use what each
+store already supports, don't invent"). What each store already supports:
+
+* Every SQLite database (found by content — the on-disk magic header, not by
+  filename convention, since stores use both ``.sqlite3`` and ``.db``) is
+  captured through SQLite's own online backup API
+  (:meth:`sqlite3.Connection.backup`) into an in-memory database, then
+  serialized with :meth:`sqlite3.Connection.serialize`. That is a
+  transactionally consistent snapshot as of one moment, taken *through* the
+  database engine rather than by copying bytes off disk — it is correct even
+  while another connection holds the file open in WAL mode with committed
+  pages still sitting in ``-wal``, unlike a raw file copy. Those ``-wal``/
+  ``-shm``/``-journal`` siblings are therefore never added to the archive
+  themselves; the snapshot already contains everything they hold.
+* Everything else this hub persists (``config.yaml``, ``vaults.yaml``, vault
+  notes, the YAML stores) is written via
+  :func:`palaia_hub.vault.atomic.atomic_write_bytes` — a temp file plus
+  ``os.replace`` — so a plain read mid-write can only ever see the complete
+  old content or the complete new content, never a torn mix. A vault's own
+  ``.git`` history is git's content-addressed object store, immutable once
+  written; only refs move, and a ref update is itself a single ``rename``.
+
+So every *individual* file in the archive is internally consistent. What is
+**not** claimed: that the archive is one atomic snapshot *across* stores —
+two different stores written to in the same second could land a heartbeat
+apart in the archive. For a personal single-hub deployment with no
+distributed transaction spanning multiple stores, that gap is not a real
+risk; it is written down here, not glossed over, exactly as the SPEC asks.
+
+**Where it never touches disk.** The archive is built entirely in memory and
+on the wire: SQLite snapshots live in a Python ``bytes`` object just long
+enough to become one tar member, and the tar/gzip stream itself is written
+straight to the queue :func:`iter_archive_bytes` drains — this module never
+creates a temp file, so there is no window where a full copy of the hub's
+secrets sits in a world-readable temp directory. See
+:mod:`palaia_hub.backup_api` for the ``GET /api/backup`` route this backs,
+which is reachable only behind the admin session gate
+(:mod:`palaia_hub.admin_session`) — see that module's docstring for why
+every ``/api/*`` route is gated by construction.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import queue
+import sqlite3
+import tarfile
+import threading
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+from .index.db import INDEX_RELATIVE_PATH
+
+logger = logging.getLogger("palaia_hub.backup")
+
+#: The filename the download offers, timestamped so successive backups from
+#: the same hub never collide in a browser's downloads folder.
+ARCHIVE_MEDIA_TYPE = "application/gzip"
+
+#: SQLite's own on-disk magic header (see the file format doc, §1.3) — used
+#: to find databases *by content*, since this repository's stores use both
+#: ``.sqlite3`` and ``.db`` for the same thing (``upstream/secrets.py`` vs.
+#: ``curator/wiring.py``'s ``STASH_FILENAME``) and a name-based rule would
+#: silently miss one the day a new store picks yet another convention.
+_SQLITE_MAGIC = b"SQLite format 3\x00"
+
+#: The write-ahead/rollback siblings SQLite creates next to a database
+#: (:data:`palaia_hub.security.files.SQLITE_SIBLING_SUFFIXES` minus the
+#: empty string — that one *is* the database). Never added to the archive
+#: on their own: the online-backup snapshot of the base file already
+#: contains every page they hold.
+_SQLITE_SIBLING_SUFFIXES = ("-wal", "-shm", "-journal")
+
+#: How large a chunk :func:`iter_archive_bytes` yields at a time. Large
+#: enough that gzip's own framing overhead is negligible, small enough that
+#: the archive streams rather than buffering minutes of output before the
+#: first byte reaches the client.
+_CHUNK_SIZE = 256 * 1024
+
+#: Backpressure: the builder thread blocks once this many chunks are queued
+#: and not yet sent, so a slow client cannot make this module buffer an
+#: unbounded amount of a hub's data in memory.
+_QUEUE_DEPTH = 4
+
+
+class BackupError(RuntimeError):
+    """Building the archive failed. The message names the offending path,
+    never file contents."""
+
+
+def archive_filename(*, now: float | None = None) -> str:
+    """The download's suggested filename, timestamped to the second (UTC)."""
+    stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime(now))
+    return f"palaia-backup-{stamp}.tar.gz"
+
+
+def _strip_sqlite_sibling_suffix(name: str) -> str:
+    for suffix in _SQLITE_SIBLING_SUFFIXES:
+        if name.endswith(suffix):
+            return name[: -len(suffix)]
+    return name
+
+
+def _is_excluded_index_path(rel_posix: str) -> bool:
+    """Is ``rel_posix`` a vault's search index, or one of its siblings?
+
+    Matches at any depth, because a vault's path under the hub home is
+    whatever the operator (or the wizard) chose — only the *tail* is fixed
+    by the index's own layout.
+    """
+    return _strip_sqlite_sibling_suffix(rel_posix).endswith(INDEX_RELATIVE_PATH)
+
+
+def _looks_like_sqlite(path: Path) -> bool:
+    try:
+        with path.open("rb") as handle:
+            header = handle.read(len(_SQLITE_MAGIC))
+    except OSError:
+        return False
+    return header == _SQLITE_MAGIC
+
+
+def _snapshot_sqlite(path: Path) -> bytes:
+    """A consistent point-in-time copy of the SQLite database at ``path``.
+
+    Goes through SQLite's own online-backup API rather than reading the
+    file's bytes directly — see this module's docstring for why that
+    matters with a WAL-mode writer possibly still attached. The destination
+    is an in-memory database, serialized to ``bytes``
+    (:meth:`sqlite3.Connection.serialize`, Python 3.11+): nothing here ever
+    touches disk.
+    """
+    try:
+        # Not opened with ``mode=ro`` URI: that would need the path
+        # percent-encoded (hub homes can contain spaces), and ``.backup()``
+        # never issues a write against the source regardless of how it was
+        # opened.
+        source = sqlite3.connect(str(path))
+    except sqlite3.Error as exc:
+        raise BackupError(f"could not open {path.name} for backup: {exc}") from exc
+    try:
+        destination = sqlite3.connect(":memory:")
+        try:
+            source.backup(destination)
+            return destination.serialize()
+        finally:
+            destination.close()
+    except sqlite3.Error as exc:
+        raise BackupError(f"could not snapshot {path.name}: {exc}") from exc
+    finally:
+        source.close()
+
+
+def _sorted_walk(home: Path) -> Iterator[Path]:
+    """Every directory and file under ``home``, deterministically ordered.
+
+    ``followlinks=False``: a hub home never legitimately contains a symlink
+    to outside itself, and following one could walk arbitrarily far off the
+    home this archive is supposed to be scoped to.
+    """
+    for dirpath, dirnames, filenames in os.walk(home, followlinks=False):
+        dirnames.sort()
+        current = Path(dirpath)
+        if current != home:
+            yield current
+        for name in sorted(filenames):
+            yield current / name
+
+
+def _add_tree(tar: tarfile.TarFile, home: Path) -> None:
+    sqlite_bases: set[Path] = set()
+    for path in _sorted_walk(home):
+        rel = path.relative_to(home)
+        rel_posix = rel.as_posix()
+        if _is_excluded_index_path(rel_posix):
+            continue
+        if path.is_dir():
+            info = tar.gettarinfo(str(path), arcname=rel_posix)
+            tar.addfile(info)
+            continue
+        if path.is_symlink():
+            # No legitimate use in a hub home; never followed, never stored.
+            continue
+        if _looks_like_sqlite(path):
+            data = _snapshot_sqlite(path)
+            info = tarfile.TarInfo(rel_posix)
+            info.size = len(data)
+            info.mtime = int(path.stat().st_mtime)
+            info.mode = 0o600
+            tar.addfile(info, _BytesReader(data))
+            sqlite_bases.add(path)
+            continue
+        base_name = _strip_sqlite_sibling_suffix(path.name)
+        if base_name != path.name and (path.parent / base_name) in sqlite_bases:
+            # Represented by the snapshot above — its pages are exactly
+            # what this write-ahead/journal file holds.
+            continue
+        info = tar.gettarinfo(str(path), arcname=rel_posix)
+        with path.open("rb") as handle:
+            tar.addfile(info, handle)
+
+
+class _BytesReader:
+    """The minimal read-only file object :meth:`tarfile.TarFile.addfile`
+    needs, over an in-memory snapshot. Avoids pulling in ``io.BytesIO`` just
+    to note that this class exists solely to hand ``bytes`` through the same
+    ``addfile(info, fileobj)`` path every other tar member uses."""
+
+    __slots__ = ("_data", "_pos")
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+        self._pos = 0
+
+    def read(self, size: int = -1) -> bytes:
+        if size < 0:
+            chunk = self._data[self._pos :]
+            self._pos = len(self._data)
+        else:
+            chunk = self._data[self._pos : self._pos + size]
+            self._pos += len(chunk)
+        return chunk
+
+
+class _QueueWriter:
+    """A write-only file object that hands ``tarfile``'s output to a queue
+    in fixed-size chunks, so :func:`iter_archive_bytes` can stream them out
+    without the whole archive ever existing as one in-memory object."""
+
+    def __init__(self, sink: queue.Queue[bytes | BaseException | None]) -> None:
+        self._sink = sink
+        self._buffer = bytearray()
+
+    def write(self, data: bytes) -> int:
+        self._buffer.extend(data)
+        while len(self._buffer) >= _CHUNK_SIZE:
+            self._sink.put(bytes(self._buffer[:_CHUNK_SIZE]))
+            del self._buffer[:_CHUNK_SIZE]
+        return len(data)
+
+    def flush(self) -> None:  # pragma: no cover - gzip calls this; no-op
+        pass
+
+    def close_out(self) -> None:
+        if self._buffer:
+            self._sink.put(bytes(self._buffer))
+            self._buffer.clear()
+
+
+def _build_in_thread(home: Path, sink: queue.Queue[bytes | BaseException | None]) -> None:
+    writer = _QueueWriter(sink)
+    try:
+        with tarfile.open(fileobj=writer, mode="w|gz") as tar:  # type: ignore[call-overload]
+            _add_tree(tar, home)
+        writer.close_out()
+    except BaseException as exc:  # noqa: BLE001 - handed to the consumer, not swallowed
+        logger.exception("backup archive build failed")
+        sink.put(exc)
+        return
+    sink.put(None)
+
+
+def iter_archive_bytes(home: Path) -> Iterator[bytes]:
+    """Yield the ``tar.gz`` of ``home`` in chunks, building it on a worker
+    thread as it goes.
+
+    A synchronous generator on purpose: FastAPI/Starlette hand a sync
+    generator's ``content`` to
+    :func:`starlette.concurrency.iterate_in_threadpool`, which runs each
+    ``next()`` call — including this generator's blocking ``queue.get()`` —
+    off the event loop. The archive is built by a second, dedicated thread
+    so ``tarfile``'s own blocking writes never have to fit inside a single
+    ``next()`` call either; the two threads only ever talk through the
+    bounded queue, which is also what gives a slow client backpressure all
+    the way back to the SQLite snapshot loop.
+    """
+    sink: queue.Queue[bytes | BaseException | None] = queue.Queue(maxsize=_QUEUE_DEPTH)
+    builder = threading.Thread(
+        target=_build_in_thread, args=(home, sink), daemon=True, name="palaia-backup-build"
+    )
+    builder.start()
+    try:
+        while True:
+            item = sink.get()
+            if item is None:
+                return
+            if isinstance(item, BaseException):
+                raise item
+            yield item
+    finally:
+        builder.join(timeout=5.0)
+
+
+__all__ = [
+    "ARCHIVE_MEDIA_TYPE",
+    "BackupError",
+    "archive_filename",
+    "iter_archive_bytes",
+]

--- a/v3/server/src/palaia_hub/backup_api.py
+++ b/v3/server/src/palaia_hub/backup_api.py
@@ -1,0 +1,57 @@
+"""``GET /api/backup`` — download the whole hub home as one ``tar.gz``
+(SPEC-604 deliverable #1).
+
+Always mounted, the same posture as ``/api/health``/``/api/info``/the funnel
+router (:mod:`palaia_hub.app`): every hub has a home directory from the
+moment it first boots, so there is nothing to opt into and no store this
+route depends on beyond the filesystem itself. Gated the same way every
+other ``/api/*`` route is — see :mod:`palaia_hub.admin_session`'s module
+docstring for why that is true by construction rather than by remembering
+to wire a dependency here — which is the whole security posture this
+endpoint relies on: the archive contains upstream secrets and their
+encryption key (:mod:`palaia_hub.upstream.secrets`), so it must never be
+reachable without a live owner session, in every mode that gates.
+
+Nothing here writes the archive to disk; :func:`palaia_hub.backup.
+iter_archive_bytes` streams it straight from the builder thread to the
+response body. ``Cache-Control: no-store`` on top, so nothing between the
+hub and the browser is tempted to keep a copy either.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter
+from starlette.responses import StreamingResponse
+
+from .backup import ARCHIVE_MEDIA_TYPE, archive_filename, iter_archive_bytes
+
+BACKUP_PATH = "/api/backup"
+
+
+def build_backup_router(*, home: Path) -> APIRouter:
+    """Build the ``/api/backup`` router.
+
+    Args:
+        home: the hub home to archive — the same directory every other
+            store in this package persists under.
+    """
+    router = APIRouter(tags=["backup"])
+
+    @router.get(BACKUP_PATH)
+    async def download_backup() -> StreamingResponse:
+        filename = archive_filename()
+        return StreamingResponse(
+            iter_archive_bytes(home),
+            media_type=ARCHIVE_MEDIA_TYPE,
+            headers={
+                "Content-Disposition": f'attachment; filename="{filename}"',
+                "Cache-Control": "no-store",
+            },
+        )
+
+    return router
+
+
+__all__ = ["BACKUP_PATH", "build_backup_router"]

--- a/v3/server/tests/backup/test_archive.py
+++ b/v3/server/tests/backup/test_archive.py
@@ -1,0 +1,194 @@
+"""``palaia_hub.backup``: the archive builder (SPEC-604 deliverable #1).
+
+Router-level behavior (headers, admin gating) lives in ``test_routes.py``;
+this file is about what actually ends up inside the ``tar.gz`` — the
+excluded index, and the online-backup snapshot's honesty about WAL-resident
+data.
+"""
+
+from __future__ import annotations
+
+import io
+import sqlite3
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from palaia_hub.backup import ARCHIVE_MEDIA_TYPE, archive_filename, iter_archive_bytes
+from palaia_hub.index.db import INDEX_RELATIVE_PATH
+
+
+def build_archive(home: Path) -> tarfile.TarFile:
+    """Drain :func:`iter_archive_bytes` and open the result as a tarfile —
+    the same bytes a client of ``GET /api/backup`` would receive, just
+    collected in memory instead of streamed over a socket."""
+    data = b"".join(iter_archive_bytes(home))
+    return tarfile.open(fileobj=io.BytesIO(data), mode="r:gz")
+
+
+def test_archive_filename_is_timestamped_and_stable_within_a_second() -> None:
+    name = archive_filename(now=1_800_000_000)
+    assert name == "palaia-backup-20270115T080000Z.tar.gz"
+    assert archive_filename(now=1_800_000_000) == name
+
+
+def test_media_type_is_gzip() -> None:
+    assert ARCHIVE_MEDIA_TYPE == "application/gzip"
+
+
+def test_plain_files_and_directory_structure_are_preserved(tmp_path: Path) -> None:
+    home = tmp_path
+    (home / "config.yaml").write_text("mode: locked\n", encoding="utf-8")
+    vault = home / "vaults" / "work"
+    vault.mkdir(parents=True)
+    (vault / "note.md").write_text("# hi\n\nbody\n", encoding="utf-8")
+
+    with build_archive(home) as tar:
+        names = set(tar.getnames())
+        assert "config.yaml" in names
+        assert "vaults/work/note.md" in names
+        content = tar.extractfile("vaults/work/note.md")
+        assert content is not None
+        assert content.read() == b"# hi\n\nbody\n"
+
+
+def test_the_vault_search_index_is_excluded(tmp_path: Path) -> None:
+    home = tmp_path
+    palaia_dir = home / "vaults" / "work" / ".palaia"
+    palaia_dir.mkdir(parents=True)
+    index_path = palaia_dir / "index.sqlite3"
+    conn = sqlite3.connect(str(index_path))
+    conn.execute("CREATE TABLE notes(permalink TEXT)")
+    conn.commit()
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.close()
+    assert index_path.name == Path(INDEX_RELATIVE_PATH).name
+
+    with build_archive(home) as tar:
+        names = tar.getnames()
+        assert not any(name.endswith("index.sqlite3") for name in names), names
+        assert not any("index.sqlite3-" in name for name in names), names
+        # The directory that *held* the index is still there — nothing about
+        # excluding the index should hide the rest of the vault's engine
+        # storage were something else ever to live alongside it.
+        assert "vaults/work/.palaia" in names
+
+
+def test_a_deeply_nested_vault_path_still_has_its_index_excluded(tmp_path: Path) -> None:
+    """The exclusion matches by *tail*, not by a fixed depth — a vault
+    registered at a custom path still under `home` must be covered."""
+    home = tmp_path
+    nested = home / "custom" / "place" / "my-vault" / ".palaia"
+    nested.mkdir(parents=True)
+    (nested / "index.sqlite3").write_bytes(b"SQLite format 3\x00" + b"\x00" * 100)
+
+    with build_archive(home) as tar:
+        names = tar.getnames()
+        assert not any(name.endswith("index.sqlite3") for name in names), names
+
+
+def test_sqlite_databases_are_found_by_content_not_extension(tmp_path: Path) -> None:
+    """`stash.db`/`directory.db`/`messenger.db` are real SQLite databases
+    under a `.db` name (`curator/wiring.py`, `serve.py`) — the archive must
+    snapshot them the same consistent way as every `.sqlite3` store."""
+    home = tmp_path
+    db_path = home / "stash.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE entries(k TEXT, v TEXT)")
+    conn.execute("INSERT INTO entries VALUES ('key', 'value')")
+    conn.commit()
+    conn.close()
+
+    with build_archive(home) as tar:
+        member = tar.extractfile("stash.db")
+        assert member is not None
+        snapshot_bytes = member.read()
+
+    restored_path = tmp_path / "restored-stash.db"
+    restored_path.write_bytes(snapshot_bytes)
+    restored = sqlite3.connect(str(restored_path))
+    row = restored.execute("SELECT v FROM entries WHERE k = 'key'").fetchone()
+    assert row == ("value",)
+    restored.close()
+
+
+def test_a_sqlite_snapshot_includes_wal_resident_data_and_omits_the_wal_file(
+    tmp_path: Path,
+) -> None:
+    """The consistency claim, proven: data committed but still sitting in
+    `-wal` (never checkpointed) makes it into the snapshot, and the raw
+    `-wal`/`-shm` files themselves are never added as their own members."""
+    home = tmp_path
+    db_path = home / "secrets.sqlite3"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("CREATE TABLE secrets(name TEXT PRIMARY KEY, value TEXT)")
+    conn.commit()
+    conn.execute("INSERT INTO secrets VALUES ('github-token', 'ghp_super_secret')")
+    conn.commit()  # committed, but WAL checkpoints on its own schedule
+    assert (home / "secrets.sqlite3-wal").exists(), "test setup assumption: WAL is active"
+
+    try:
+        with build_archive(home) as tar:
+            names = tar.getnames()
+            assert "secrets.sqlite3" in names
+            assert "secrets.sqlite3-wal" not in names
+            assert "secrets.sqlite3-shm" not in names
+            member = tar.extractfile("secrets.sqlite3")
+            assert member is not None
+            snapshot_bytes = member.read()
+    finally:
+        conn.close()
+
+    # Restored to a real file rather than `:memory:`: the snapshot's own
+    # header still says `journal_mode=WAL` (copied verbatim from the
+    # source), and SQLite's `:memory:` databases cannot honor that — this
+    # is exactly what a real restore does (write the archive member back to
+    # a file on disk), so that is what this proves against.
+    restored_path = tmp_path / "restored-secrets.sqlite3"
+    restored_path.write_bytes(snapshot_bytes)
+    restored = sqlite3.connect(str(restored_path))
+    value = restored.execute(
+        "SELECT value FROM secrets WHERE name = 'github-token'"
+    ).fetchone()
+    assert value == ("ghp_super_secret",)
+    restored.close()
+
+
+def test_the_secret_key_file_travels_alongside_the_secret_store(tmp_path: Path) -> None:
+    """Not a SQLite file at all — a raw Fernet key
+    (`upstream/secrets.py::SECRETS_KEY_NAME`) — so it must go through the
+    plain-copy path, not be silently skipped as some kind of sibling."""
+    home = tmp_path
+    (home / "secrets.key").write_bytes(b"\x01" * 32)
+
+    with build_archive(home) as tar:
+        member = tar.extractfile("secrets.key")
+        assert member is not None
+        assert member.read() == b"\x01" * 32
+
+
+def test_an_empty_home_yields_a_valid_empty_archive(tmp_path: Path) -> None:
+    home = tmp_path / "brand-new"
+    home.mkdir()
+
+    with build_archive(home) as tar:
+        assert tar.getnames() == []
+
+
+def test_a_symlink_is_never_followed_or_stored(tmp_path: Path) -> None:
+    home = tmp_path
+    (home / "real.md").write_text("real content\n", encoding="utf-8")
+    outside = tmp_path.parent / "outside-secret.md"
+    outside.write_text("should never appear in a backup\n", encoding="utf-8")
+    link = home / "link.md"
+    try:
+        link.symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks not supported on this filesystem")
+
+    with build_archive(home) as tar:
+        names = tar.getnames()
+        assert "real.md" in names
+        assert "link.md" not in names

--- a/v3/server/tests/backup/test_routes.py
+++ b/v3/server/tests/backup/test_routes.py
@@ -1,0 +1,94 @@
+"""``GET /api/backup`` (SPEC-604): mounted unconditionally, gated by the
+admin session middleware.
+
+The 401/403 matrix itself is already exercised for every gated route,
+`/api/backup` included, by ``test_admin_session.py``'s route walk — see
+that file's module docstring for why the walk (not a hand-maintained path
+list) is the load-bearing test. What is worth its own file here is the
+route's *own* behavior: headers, content, and that a signed-in caller
+really does get back a working archive of the home it was pointed at.
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from palaia_hub.admin_session import CSRF_HEADER
+from palaia_hub.app import create_app
+from palaia_hub.backup_api import BACKUP_PATH
+from palaia_hub.config import HubConfig, OAuthSettings
+from palaia_hub.oauth import AuthorizationServer, set_owner_password
+from palaia_hub.oauth.login import CSRF_COOKIE, SESSION_COOKIE
+
+ISSUER = "https://hub.example.test"
+OWNER = "owner"
+PASSWORD = "a-long-enough-passphrase"  # noqa: S105 - test fixture
+NOW = 1_800_000_000
+
+
+def test_backup_is_mounted_with_no_opt_in_parameter(tmp_path: Path) -> None:
+    """Same posture as `/api/health` — a bare `create_app()` still serves it."""
+    app = create_app(HubConfig(), home=tmp_path)
+    client = TestClient(app)
+
+    response = client.get(BACKUP_PATH)
+
+    assert response.status_code == 200
+
+
+def test_backup_headers_and_body(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text("mode: locked\n", encoding="utf-8")
+    vault = tmp_path / "vaults" / "work"
+    vault.mkdir(parents=True)
+    (vault / "note.md").write_text("# Hello\n\nBody.\n", encoding="utf-8")
+
+    app = create_app(HubConfig(), home=tmp_path)
+    client = TestClient(app)
+
+    response = client.get(BACKUP_PATH)
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/gzip"
+    assert response.headers["cache-control"] == "no-store"
+    disposition = response.headers["content-disposition"]
+    assert disposition.startswith("attachment; filename=\"palaia-backup-")
+    assert disposition.endswith(".tar.gz\"")
+
+    with tarfile.open(fileobj=io.BytesIO(response.content), mode="r:gz") as tar:
+        names = tar.getnames()
+        assert "config.yaml" in names
+        assert "vaults/work/note.md" in names
+
+
+def test_backup_requires_an_admin_session_when_the_gate_is_on(tmp_path: Path) -> None:
+    """A focused, single-route confirmation alongside the route-walk
+    coverage in `test_admin_session.py` — this endpoint carries secrets, so
+    it gets its own explicit "no session, no archive" assertion too."""
+    config = HubConfig(
+        mode="cloud",
+        host="127.0.0.1",
+        oauth=OAuthSettings(enabled=True, issuer=ISSUER),
+    )
+    server = AuthorizationServer.build(config, {"default": ["vault:work:read"]}, home=tmp_path)
+    set_owner_password(server.store, OWNER, PASSWORD, now=NOW)
+    app = create_app(config, home=tmp_path, oauth_server=server)
+
+    try:
+        with TestClient(app) as client:
+            anonymous = client.get(BACKUP_PATH)
+            assert anonymous.status_code == 401
+            assert "sign_in_url" in anonymous.json()
+
+            session, _expires = server.store.create_login_session(
+                OWNER, now=NOW, ttl=server.settings.session_ttl
+            )
+            client.cookies.set(SESSION_COOKIE, session)
+            client.cookies.set(CSRF_COOKIE, "csrf-value")
+            signed_in = client.get(BACKUP_PATH, headers={CSRF_HEADER: "csrf-value"})
+            assert signed_in.status_code == 200
+    finally:
+        server.store.close()

--- a/v3/server/tests/e2e/support/hub_server_backup.py
+++ b/v3/server/tests/e2e/support/hub_server_backup.py
@@ -1,0 +1,157 @@
+"""SPEC-604 e2e hub process: a real Cloud-mode hub with a vault under its
+own home directory, one upstream secret, and both auth doors a real client
+needs to touch — everything the backup/restore round trip has to prove.
+
+Same "real subprocess, real socket" shape as ``hub_server.py``/
+``hub_server_oauth.py``, with the pieces this scenario specifically needs:
+
+* **The vault lives under the hub's own home**
+  (``<home>/vaults/<key>``, the wizard's own default layout —
+  ``dashboard_api.py::create_vault``). ``GET /api/backup`` archives the
+  home directory, so the vault has to be inside it for a whole-hub restore
+  to mean anything here.
+* **MCP auth is a plain SPEC-108 bearer token**
+  (:class:`~palaia_hub.auth.store.TokenStore`, same as
+  ``hub_server_token.py``) rather than OAuth — this scenario is about the
+  archive, not about re-running the PKCE flow, and a bearer token is a
+  single line for :class:`simulator.SimulatedClient` to use either side of
+  the restore.
+* **The dashboard's admin session still needs a real sign-in**
+  (:class:`~palaia_hub.oauth.AuthorizationServer`) — ``GET /api/backup``
+  itself is behind that gate, and this scenario proves the *download* is
+  gated, not just that the archive is correct.
+* **A secret is pre-populated** (``--secret-name``/``--secret-value``) so
+  the test has a known plaintext to compare against after the restore —
+  the only honest way to prove a secret "round-trips" is to know what it
+  was supposed to come back as.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from pathlib import Path
+
+import uvicorn
+
+from palaia_hub.app import create_app
+from palaia_hub.auth import TokenStore, build_profile_verifiers
+from palaia_hub.config import HubConfig, OAuthSettings
+from palaia_hub.gateway.build import build_gateway
+from palaia_hub.gateway.config import GatewayConfig, ProfileConfig, VaultMountConfig
+from palaia_hub.gateway.wiring import EngineVaultService
+from palaia_hub.index import EmbeddingConfig, VaultIndex
+from palaia_hub.oauth import (
+    AuthorizationServer,
+    OAuthStore,
+    SigningKey,
+    now_seconds,
+    set_owner_password,
+)
+from palaia_hub.upstream.secrets import SecretStore
+from palaia_hub.vault import EventBus, VaultEngine, VaultWatcher
+
+logger = logging.getLogger("e2e.hub_server_backup")
+
+VAULT_KEY = "work"
+PROFILE = "default"
+
+
+async def _run(
+    *,
+    host: str,
+    port: int,
+    home: Path,
+    username: str,
+    password: str,
+    secret_name: str | None,
+    secret_value: str | None,
+) -> None:
+    vault_dir = home / "vaults" / VAULT_KEY
+    engine = VaultEngine(vault_dir, VAULT_KEY, bus=EventBus())
+    await engine.open(purpose="SPEC-604 backup/restore e2e vault", create=True)
+    index = VaultIndex(engine, embedding=EmbeddingConfig(enabled=False))
+    await index.open()
+    watcher = VaultWatcher(engine)
+    await watcher.start()
+
+    issuer = f"http://{host}:{port}"
+    config = HubConfig(
+        mode="cloud", host=host, port=port, oauth=OAuthSettings(enabled=True, issuer=issuer)
+    )
+
+    oauth_store = OAuthStore(home)
+    oauth_store.open()
+    signing_key = SigningKey.load_or_create(home)
+    oauth_server = AuthorizationServer(
+        settings=config.oauth,
+        profile_scopes={PROFILE: [f"vault:{VAULT_KEY}:read", f"vault:{VAULT_KEY}:write"]},
+        store=oauth_store,
+        key=signing_key,
+    )
+    set_owner_password(oauth_store, username, password, now=now_seconds())
+
+    secret_store = SecretStore(home)
+    if secret_name and secret_value:
+        secret_store.put(secret_name, secret_value)
+
+    token_store = TokenStore(home=home)
+    gateway_config = GatewayConfig(
+        vaults=[VaultMountConfig(key=VAULT_KEY, name=VAULT_KEY, purpose="SPEC-604 e2e vault.")],
+        profiles=[ProfileConfig(path=PROFILE, vaults=[VAULT_KEY])],
+    )
+    verifiers = build_profile_verifiers([PROFILE], token_store)
+    gateway = build_gateway(
+        gateway_config, {VAULT_KEY: EngineVaultService(engine, index)}, token_verifiers=verifiers
+    )
+    app = create_app(
+        config,
+        gateway=gateway,
+        oauth_server=oauth_server,
+        token_store=token_store,
+        secret_store=secret_store,
+        home=home,
+    )
+
+    uv_server = uvicorn.Server(uvicorn.Config(app, host=host, port=port, log_level="info"))
+    try:
+        await uv_server.serve()
+    finally:
+        await watcher.stop()
+        await index.close()
+        await engine.close()
+        secret_store.close()
+        oauth_store.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--home", required=True, help="the hub home this process persists under")
+    parser.add_argument("--username", default="owner")
+    parser.add_argument("--password", default="a-long-enough-passphrase")
+    parser.add_argument("--secret-name", default=None)
+    parser.add_argument("--secret-value", default=None)
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+    )
+
+    asyncio.run(
+        _run(
+            host=args.host,
+            port=args.port,
+            home=Path(args.home),
+            username=args.username,
+            password=args.password,
+            secret_name=args.secret_name,
+            secret_value=args.secret_value,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/v3/server/tests/e2e/test_spec604_backup_restore.py
+++ b/v3/server/tests/e2e/test_spec604_backup_restore.py
@@ -1,0 +1,315 @@
+"""SPEC-604 acceptance criterion #1, the whole point of this feature, end
+to end against real subprocesses:
+
+    fresh hub -> write memory -> download backup -> NEW fresh home ->
+    restore per the documented steps -> the memory is back and a client
+    can read it
+
+Plus the two criteria that go with it:
+
+* **secrets round-trip** — a known plaintext, put into the secret store
+  before the backup, is still decryptable after the restore.
+* **if indexes are excluded, restore provably rebuilds them** — the
+  restored home has no ``.palaia/index.sqlite3`` right after unpacking
+  (proving the exclusion), and a real search against the restored hub
+  finds the note (proving the rebuild the exclusion depends on actually
+  happens, not just that a file reappears).
+
+Restore itself is driven exactly the way ``docs/backup-restore.md`` and the
+docs-site page describe it: stop the hub, unpack the archive into the data
+directory, start it again — no special "restore mode," just a second
+``hub_server_backup.py`` process pointed at the unpacked directory.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+from conftest import RunningHub, free_port, wait_for_health
+from simulator import SimulatedClient
+
+from palaia_hub.upstream.secrets import SecretStore
+
+pytestmark = pytest.mark.anyio
+
+_SCRIPT = Path(__file__).parent / "support" / "hub_server_backup.py"
+
+OWNER_USERNAME = "owner"
+OWNER_PASSWORD = "a-long-enough-passphrase"  # noqa: S105 - test fixture
+SECRET_NAME = "spec604-upstream-token"
+SECRET_VALUE = "s3cr3t-upstream-value-do-not-log-me"  # noqa: S105 - test fixture
+
+
+def _spawn(
+    *, home: Path, log_path: Path, secret_name: str | None = None, secret_value: str | None = None
+) -> RunningHub:
+    """Launch a real ``hub_server_backup.py`` subprocess over ``home``.
+
+    A local factory rather than ``conftest.py``'s ``hub_factory``: that one
+    drives ``hub_server.py``, whose ``--vault-dir``/``--vault-key`` shape
+    does not fit this scenario (the vault has to live *inside* ``home`` for
+    a whole-home backup to mean anything — see ``hub_server_backup.py``'s
+    module docstring). Same subprocess discipline throughout: ``sys.
+    executable`` directly, never a ``uv run`` wrapper, so ``.kill()``/
+    ``.stop()`` really terminates the server process (SPEC-102/103's
+    kill-test finding, restated in every other e2e support script here).
+    """
+    port = free_port()
+    args = [
+        sys.executable,
+        str(_SCRIPT),
+        "--port",
+        str(port),
+        "--home",
+        str(home),
+        "--username",
+        OWNER_USERNAME,
+        "--password",
+        OWNER_PASSWORD,
+    ]
+    if secret_name and secret_value:
+        args += ["--secret-name", secret_name, "--secret-value", secret_value]
+
+    log_file = log_path.open("w")
+    process = subprocess.Popen(  # noqa: S603 - fixed argv, no shell
+        args, stdout=log_file, stderr=subprocess.STDOUT
+    )
+    try:
+        wait_for_health(port)
+    except Exception:
+        process.kill()
+        process.wait(timeout=5)
+        raise
+    return RunningHub(process=process, port=port, profiles=["default"], log_path=log_path)
+
+
+HubBackupFactory = Callable[..., RunningHub]
+
+
+@pytest.fixture
+def hub_factory(tmp_path: Path) -> Iterator[HubBackupFactory]:
+    """Shadows ``conftest.py``'s module-level ``hub_factory`` fixture for
+    every test in this file — pytest resolves a fixture defined in the test
+    module itself before the one in ``conftest.py``. Tears down every hub
+    it started, same as the one it shadows."""
+    started: list[RunningHub] = []
+
+    def factory(
+        *,
+        home: Path,
+        log_name: str = "hub.log",
+        secret_name: str | None = None,
+        secret_value: str | None = None,
+    ) -> RunningHub:
+        hub = _spawn(
+            home=home,
+            log_path=tmp_path / log_name,
+            secret_name=secret_name,
+            secret_value=secret_value,
+        )
+        started.append(hub)
+        return hub
+
+    yield factory
+
+    for hub in started:
+        hub.stop()
+
+
+def _sign_in(base_url: str) -> httpx.Client:
+    """A real password sign-in over a real socket — the same double-submit
+    dance ``test_spec209_client_matrix.py::_csrf_and_sign_in`` uses, kept
+    local here since this is the only test in this file that needs it."""
+    client = httpx.Client(base_url=base_url, follow_redirects=False, timeout=10.0)
+    login_form = client.get("/oauth/login")
+    match = re.search(r'name="csrf_token"\s+value="([^"]+)"', login_form.text)
+    assert match is not None, login_form.text
+    signed_in = client.post(
+        "/oauth/login",
+        data={
+            "username": OWNER_USERNAME,
+            "password": OWNER_PASSWORD,
+            "csrf_token": match.group(1),
+            "next": "",
+        },
+    )
+    assert signed_in.status_code == 303, signed_in.text
+    assert "palaia_oauth_session" in client.cookies
+    return client
+
+
+def _mint_token(client: httpx.Client, *, name: str) -> str:
+    """Mint a real SPEC-108 bearer token through the same admin-gated
+    ``POST /api/auth/tokens`` route the dashboard's "Connect a client"
+    panel calls — the plaintext this returns is what a real MCP client
+    would be handed once, never logged or stored anywhere else."""
+    csrf = client.cookies.get("palaia_oauth_csrf", "")
+    response = client.post(
+        "/api/auth/tokens",
+        json={
+            "name": name,
+            "profile": "default",
+            "scopes": ["vault:work:read", "vault:work:write"],
+        },
+        headers={"X-Palaia-CSRF": csrf},
+    )
+    assert response.status_code == 200, response.text
+    return str(response.json()["token"])
+
+
+async def test_fresh_hub_to_backup_to_new_home_to_restore_to_readable_memory(
+    tmp_path: Path, hub_factory: HubBackupFactory
+) -> None:
+    home1 = tmp_path / "home1"
+    hub1 = hub_factory(
+        home=home1,
+        log_name="hub1.log",
+        secret_name=SECRET_NAME,
+        secret_value=SECRET_VALUE,
+    )
+
+    # --- downloading the backup with no session at all is refused (SPEC-604
+    # acceptance: "the endpoint 401s without an admin session in every mode
+    # that gates" — the route-walk matrix in test_admin_session.py covers
+    # every OTHER gated route; this is the one specific to this endpoint,
+    # against a real socket rather than the ASGI test transport). ---
+    anonymous = httpx.get(f"http://127.0.0.1:{hub1.port}/api/backup", timeout=5.0)
+    assert anonymous.status_code == 401, anonymous.text
+
+    # --- sign in as the owner, mint a real client token the same way the
+    # dashboard's "Connect a client" panel does, and download the backup —
+    # all through the one admin session. ---
+    signed_in = _sign_in(f"http://127.0.0.1:{hub1.port}")
+    try:
+        token = _mint_token(signed_in, name="spec604-e2e-client")
+
+        # --- write a memory through a real MCP client, using that token. ---
+        async with SimulatedClient(
+            hub1.profile_url(), client_name="spec604-writer", token=token
+        ) as client:
+            write_result = await client.call_tool_ok(
+                "work_memory_write",
+                {
+                    "title": "SPEC-604 Round Trip",
+                    "body": "This note has to survive a backup and a restore onto a new home.",
+                },
+            )
+            assert "SPEC-604 Round Trip" in write_result.text
+
+        response = signed_in.get("/api/backup")
+        assert response.status_code == 200, response.text
+        assert response.headers["content-type"] == "application/gzip"
+        archive_bytes = response.content
+    finally:
+        signed_in.close()
+
+    archive_path = tmp_path / "palaia-backup.tar.gz"
+    archive_path.write_bytes(archive_bytes)
+
+    hub1.stop()
+
+    # --- "NEW fresh home": a directory that never existed before, unpacked
+    # exactly the way docs/backup-restore.md's restore steps say. ---
+    home2 = tmp_path / "home2"
+    home2.mkdir()
+    with tarfile.open(archive_path, mode="r:gz") as tar:
+        tar.extractall(home2, filter="data")
+
+    # --- the excluded index is provably absent right after unpacking — the
+    # acceptance criterion's other half (the rebuild) is checked once hub2
+    # is up, below. ---
+    restored_index = home2 / "vaults" / "work" / ".palaia" / "index.sqlite3"
+    assert not restored_index.exists(), (
+        "the archive should not have shipped the rebuildable search index"
+    )
+
+    # --- secrets round-trip: the plaintext put into hub1's secret store
+    # before the backup is still decryptable from the restored home, using
+    # only what the archive shipped (secrets.sqlite3 AND secrets.key). ---
+    restored_secrets = SecretStore(home2)
+    try:
+        assert restored_secrets.get(SECRET_NAME) == SECRET_VALUE
+    finally:
+        restored_secrets.close()
+
+    # --- start a hub against the restored home: no special "restore mode,"
+    # the same process this whole scenario has used throughout. ---
+    hub2 = hub_factory(home=home2, log_name="hub2.log")
+
+    # --- the rebuild half of the index-exclusion acceptance criterion: the
+    # index file exists again, rebuilt on this very start. ---
+    assert restored_index.exists(), (
+        "the search index should have rebuilt itself on the restored hub's first start"
+    )
+
+    # --- the headline moment: a client reads the memory back, through the
+    # restored hub, having never touched hub1 at all. The SAME token minted
+    # against hub1 still works here too — `tokens.yaml` is part of the whole
+    # -home archive like everything else, so a restore brings back not just
+    # the data but the access a client already had to it. ---
+    async with SimulatedClient(
+        hub2.profile_url(), client_name="spec604-reader", token=token
+    ) as client:
+        read_result = await client.call_tool_ok(
+            "work_memory_read", {"permalink": "spec-604-round-trip"}
+        )
+        assert "survive a backup and a restore" in read_result.text
+
+        search_result = await client.call_tool_ok(
+            "work_memory_search", {"query": "SPEC-604 Round Trip"}
+        )
+        assert "SPEC-604 Round Trip" in search_result.text
+
+
+async def test_restore_does_not_require_the_index_directory_to_pre_exist(
+    tmp_path: Path, hub_factory: HubBackupFactory
+) -> None:
+    """A vault whose `.palaia/` directory the archive never created at all
+    (rather than an empty one) still starts cleanly — covers a restore from
+    an archive built before any index had ever been opened once."""
+    home1 = tmp_path / "home1"
+    hub1 = hub_factory(home=home1, log_name="hub1.log")
+
+    signed_in = _sign_in(f"http://127.0.0.1:{hub1.port}")
+    try:
+        token = _mint_token(signed_in, name="spec604-e2e-client-2")
+
+        async with SimulatedClient(
+            hub1.profile_url(), client_name="spec604-writer-2", token=token
+        ) as client:
+            await client.call_tool_ok(
+                "work_memory_write",
+                {"title": "No Index Yet", "body": "Backed up before any search ever ran."},
+            )
+
+        response = signed_in.get("/api/backup")
+        assert response.status_code == 200
+        archive_bytes = response.content
+    finally:
+        signed_in.close()
+    hub1.stop()
+
+    home2 = tmp_path / "home2"
+    home2.mkdir()
+    archive_path = tmp_path / "backup2.tar.gz"
+    archive_path.write_bytes(archive_bytes)
+    with tarfile.open(archive_path, mode="r:gz") as tar:
+        tar.extractall(home2, filter="data")
+    shutil.rmtree(home2 / "vaults" / "work" / ".palaia", ignore_errors=True)
+
+    hub2 = hub_factory(home=home2, log_name="hub2.log")
+    assert hub2.is_alive()
+
+    async with SimulatedClient(
+        hub2.profile_url(), client_name="spec604-reader-2", token=token
+    ) as client:
+        result = await client.call_tool_ok("work_memory_read", {"permalink": "no-index-yet"})
+        assert "Backed up before any search ever ran" in result.text

--- a/v3/site/docs/astro.config.mjs
+++ b/v3/site/docs/astro.config.mjs
@@ -58,6 +58,7 @@ export default defineConfig({
         { label: "Profiles & access", slug: "access" },
         { label: "Agents & messages", slug: "agents-messages" },
         { label: "Automations", slug: "automations" },
+        { label: "Back up & restore", slug: "backup-restore" },
         { label: "Troubleshooting & FAQ", slug: "troubleshooting" },
         { label: "For developers", slug: "developers" },
       ],

--- a/v3/site/docs/src/content/docs/backup-restore.md
+++ b/v3/site/docs/src/content/docs/backup-restore.md
@@ -1,0 +1,87 @@
+---
+title: Back up & restore
+description: One button downloads everything palaia has saved. Here's what's in that file, and how to bring it back.
+---
+
+## Back up
+
+On the dashboard's home screen, **Back up** downloads one file with
+everything palaia has saved on your behalf: every memory, your sign-in and
+connection setup, and anything else you've connected (saved passwords or
+keys for other tools included).
+
+**Treat that file like a password.** Anyone who has it can act as your hub
+— read everything in it and, if they restore it somewhere, look and behave
+exactly like your setup. Store it the way you'd store a password: in a
+password manager or an encrypted drive, never in a plain, shared, or
+public place, and never sent casually over email or chat.
+
+You need to be signed in as the administrator to download one — the same
+sign-in the dashboard itself uses.
+
+One thing is deliberately left out to keep the file smaller: the part that
+makes searching fast. It isn't a record of anything — it's rebuilt
+automatically from your actual notes the moment a restored install starts
+up, so leaving it out costs you nothing.
+
+<!-- screenshot: the "Back up" action on the dashboard home screen, with
+     its warning text visible -->
+
+## Restore
+
+Restoring is a few manual steps rather than a button, on purpose — bringing
+back a full download like this is a bigger, less-frequent action than
+anything else the dashboard does day to day, and it's safer to walk through
+deliberately than to trigger by accident from a web page.
+
+The idea in three steps: **stop palaia, replace its saved data with what's
+in your download, start it again.**
+
+If you installed with the one-line command from [Install it](/install/):
+
+```bash
+docker rm -f palaia-hub
+
+docker run --rm \
+  -v palaia_home:/data \
+  -v "$PWD":/backup \
+  alpine sh -c "rm -rf /data/* /data/.[!.]* /data/..?* 2>/dev/null; \
+                tar xzf /backup/palaia-backup-YOUR-FILE.tar.gz -C /data"
+
+docker run -d --name palaia-hub \
+  -p 8420:8420 -v palaia_home:/data --restart unless-stopped \
+  --security-opt no-new-privileges:true --cap-drop ALL \
+  --read-only --tmpfs /tmp --tmpfs /run \
+  ghcr.io/byte5ai/palaia-hub:stable
+```
+
+If you installed with the docker-compose file:
+
+```bash
+cd v3/deploy
+docker compose down
+
+docker run --rm \
+  -v palaia_home:/data \
+  -v "$PWD":/backup \
+  alpine sh -c "rm -rf /data/* /data/.[!.]* /data/..?* 2>/dev/null; \
+                tar xzf /backup/palaia-backup-YOUR-FILE.tar.gz -C /data"
+
+docker compose up -d
+```
+
+Replace `palaia-backup-YOUR-FILE.tar.gz` with the actual name of the file
+you downloaded, and run these from the folder you saved it in.
+
+Open the dashboard once it's back up — everything should look exactly the
+way it did when you took the backup, including your connected tools.
+Setting this up on a brand-new machine works the same way: install palaia
+there first (so the empty saved-data location exists), then run the
+restore steps against it before connecting anything.
+
+## Not yet supported
+
+Restoring by uploading a file straight from the dashboard isn't available
+yet — the offline steps above are the only path back in this release.
+There's also no automatic or scheduled backup: **Back up** downloads one
+file, once, whenever you choose to run it.

--- a/v3/web/src/lib/api/client.ts
+++ b/v3/web/src/lib/api/client.ts
@@ -734,6 +734,13 @@ export const api = {
   /** Same-origin URL for the SSE stream — passed straight to `EventSource`
    * by `useEventStream` (./events.ts), never fetched with `fetch`. */
   eventsUrl: () => `${API_BASE}/api/events`,
+  /** SPEC-604: same-origin URL for the "Back up" download — a plain `<a
+   * href download>` in `Home.tsx`, never fetched with `fetch`. It is a
+   * `GET`, so no CSRF token is needed (`SAFE_METHODS` above); the browser
+   * navigation carries the session cookie the same way any same-origin GET
+   * does, and the admin gate answers 401 (redirecting to sign-in) exactly
+   * like it would for a fetch call if that session is missing. */
+  backupUrl: () => `${API_BASE}/api/backup`,
 
   // ---- SPEC-110: wizard + memory explorer ----
   listVaults: () => getJson<VaultSummary[]>("/api/vaults"),

--- a/v3/web/src/routes/Home.test.tsx
+++ b/v3/web/src/routes/Home.test.tsx
@@ -208,3 +208,40 @@ describe("first-memory celebration copy — no jargon (system.md §3 rule 0)", (
     }
   });
 });
+
+describe("Home — SPEC-604 back up", () => {
+  const BANNED = [
+    /\bmcp\b/i,
+    /\boauth\b/i,
+    /\bjwt\b/i,
+    /\basgi\b/i,
+    /\bapi\b/i,
+    /\bjson\b/i,
+    /\bvault\b/i,
+    /\bfunnel\b/i,
+  ];
+
+  it("shows a download link to the backup endpoint, and its warning", async () => {
+    mockApi({ funnel: NO_FUNNEL });
+
+    mount();
+
+    const card = await screen.findByTestId("backup-card");
+    const link = screen.getByRole("link", { name: /back up now/i });
+    expect(link).toHaveAttribute("href", api.backupUrl());
+    expect(link).toHaveAttribute("download");
+    expect(card).toHaveTextContent(/store it like you.d store a password/i);
+  });
+
+  it("the card's own text uses no in-house word", async () => {
+    mockApi({ funnel: NO_FUNNEL });
+
+    mount();
+
+    const card = await screen.findByTestId("backup-card");
+    const text = card.textContent ?? "";
+    for (const pattern of BANNED) {
+      expect(text).not.toMatch(pattern);
+    }
+  });
+});

--- a/v3/web/src/routes/Home.tsx
+++ b/v3/web/src/routes/Home.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from "react";
 import { Link, useOutletContext } from "react-router-dom";
 
-import { Badge, CardFoot, CardHead, EmptyState } from "../components";
+import { Badge, CardBody, CardFoot, CardHead, EmptyState } from "../components";
 import type { FunnelStatus, InfoResponse, TokenInfo, VaultSummary } from "../lib/api/client";
 import { api } from "../lib/api/client";
+import { docsUrl } from "../lib/docs";
 import type { EventStreamState, VaultChangeEntry } from "../lib/events";
-import { CheckIcon, ClientsIcon, ExplorerIcon } from "../shell/icons";
+import { CheckIcon, ClientsIcon, ExplorerIcon, WarningIcon } from "../shell/icons";
 
 interface InboxAggregate {
   count: number;
@@ -377,6 +378,40 @@ export function Home() {
             ) : null}
           </CardFoot>
         </div>
+      </section>
+
+      {/* SPEC-604: the dashboard's one "Back up" action. Always shown — the
+       * endpoint behind it (GET /api/backup) is mounted on every hub with
+       * no opt-in parameter, the same posture as /api/health — so there is
+       * no service-not-configured state to branch on here. */}
+      <section className="card" data-testid="backup-card">
+        <CardHead title="back up" />
+        <CardBody className="stack stack--3">
+          <p className="t-sm t-muted">
+            Downloads one file with everything this hub has saved — every memory, your sign-in
+            and connection setup, and any saved keys for tools you&rsquo;ve connected.
+          </p>
+          <div className="banner banner--warn">
+            <WarningIcon className="icon icon--sm" />
+            <div>
+              <p className="banner__title">This file can act as your hub.</p>
+              <p className="t-sm t-muted">
+                Anyone who has it can read everything in it. Store it like you&rsquo;d store a
+                password — never somewhere shared or public.
+              </p>
+            </div>
+          </div>
+        </CardBody>
+        <CardFoot>
+          <a className="btn btn--primary btn--sm" href={api.backupUrl()} download>
+            Back up now
+          </a>
+          <span className="t-meta">
+            <a href={docsUrl("/backup-restore/")} target="_blank" rel="noreferrer">
+              How restore works
+            </a>
+          </span>
+        </CardFoot>
       </section>
     </div>
   );


### PR DESCRIPTION
## What

Implements [SPEC-604](v3/specs/SPEC-604-backup-restore.md): `GET /api/backup`
(admin-gated, streamed, never written to disk) downloads the whole hub home
as one `tar.gz` — every memory, config, the OAuth store, and the upstream
secret store plus its encryption key. Restore is documented, offline steps
(no upload endpoint — explicit non-goal). Each vault's search index is
excluded to keep the archive smaller, and proven to rebuild automatically on
the restored hub's first start.

## Why

"Operation maximally easy" currently fails at the first question every
self-hoster asks: how do I back this up? Nothing in the product or docs
answered it.

## How

- `server/src/palaia_hub/backup.py` — the archive builder. Walks the hub
  home; every SQLite database (found by content, not filename — this repo
  uses both `.sqlite3` and `.db`) is captured through SQLite's own online
  backup API into an in-memory snapshot and serialized, rather than copied
  as raw bytes; everything else is a plain streamed copy. Streams via a
  bounded queue + a dedicated builder thread, consumed by a sync generator
  (Starlette wraps it in a threadpool automatically) — nothing is ever
  buffered whole in memory or written to disk.
- `server/src/palaia_hub/backup_api.py` — `GET /api/backup`, mounted
  **unconditionally** in `create_app` (no opt-in parameter), the same
  posture as `/api/health`/`/api/info` — so it can never exist without the
  admin session gate wrapping it.
- `web/src/routes/Home.tsx` — the dashboard's "Back up" card: a download
  link plus the plain-language warning ("this file can act as your hub —
  store it like you'd store a password").
- `v3/docs/backup-restore.md` (normative) + the docs-site page (jargon-free,
  passes the shared jargon lint) — what's in the archive, the consistency
  claim, and the compose/one-liner restore steps.
- `v3/docs/security/threat-model.md` + `external-review-brief.md` — the new
  route group, two new threat rows, and two new accepted-risk entries (the
  cross-store consistency scope, and vaults registered outside the hub
  home). The coverage test (`test_threat_model_coverage.py`) forces this;
  confirmed it fails without the update and passes with it.

### The consistency claim, explained

There is **no cross-store quiesce lock** — building one would be new
machinery invented for this feature alone, which the SPEC explicitly asks
not to do ("use what each store already supports, don't invent"). What is
actually claimed:

- **Every SQLite database** is captured through `sqlite3.Connection.backup()`
  into an in-memory database, then `serialize()`d — a transactionally
  consistent snapshot taken *through* the engine, correct even while another
  connection holds the file open in WAL mode with committed rows still
  sitting in `-wal`. Proven directly:
  `test_archive.py::test_a_sqlite_snapshot_includes_wal_resident_data_and_omits_the_wal_file`
  writes to a live WAL-mode connection (never checkpointed) and confirms the
  snapshot has the data while the raw `-wal`/`-shm` files are never added to
  the archive themselves.
- **Everything else** (`config.yaml`, `vaults.yaml`, notes, YAML stores) is
  written via the existing atomic-write primitive (temp file + `os.replace`),
  so a read mid-write only ever sees the whole old or whole new content.
- **Not claimed:** one atomic snapshot *across* stores — two stores written
  to in the same second could land a moment apart in one archive. For a
  single-operator personal hub with no distributed transaction spanning
  multiple stores, that gap is written down as an accepted risk (threat
  model §8, item 9), not glossed over.

### What the archive includes / excludes, and why

**Included:** `config.yaml`, `vaults.yaml`, every vault (notes, `.git`
history, manifest), `oauth/oauth.sqlite3` + `signing-key.pem`,
`secrets.sqlite3` **and** `secrets.key`, `tokens.yaml`, hooks/automations
stores + their outboxes, `notifications.sqlite3`, `stash.db`,
`directory.db`, `messenger.db`, marketplace caches, `funnel_stats.json`,
`mode_audit.jsonl`.

**Excluded:** each vault's `.palaia/index.sqlite3` (and its `-wal`/`-shm`/
`-journal` siblings) — rebuildable state, not a system of record.
`VaultIndex.open(build=True)` (the default, called for every vault on every
hub start) already rebuilds it from the vault's notes; restoring with no
index file puts a vault in exactly the state it's in the first time it's
ever opened, a path already exercised on every boot, not invented for this
feature.

**Not covered (documented, not silently missed):** a vault registered at a
custom absolute path outside the hub home (`VaultRegistry` allows this; the
default "create a memory" flow never does).

### Deviations from a literal reading of the spec

None load-bearing. Two judgment calls worth naming:

1. SQLite databases are matched **by content** (magic header) rather than by
   filename, since this repo already uses both `.sqlite3` and `.db` for the
   same kind of store — a name-based rule would have silently missed
   `stash.db`/`directory.db`/`messenger.db`. Covered by
   `test_sqlite_databases_are_found_by_content_not_extension`.
2. The route is mounted **unconditionally** (no opt-in parameter) rather
   than gated behind an existing service parameter — deliberate, so the
   only way it can ever be reachable is through the admin session gate that
   wraps every `/api/*` route, with no path that skips it by omitting a
   constructor argument.

## Test evidence

```
$ uv run ruff check server
All checks passed!

$ uv run mypy server/src
Success: no issues found in 195 source files

$ uv run pytest server/tests -q
2244 passed, 29 skipped, 148 warnings in 582.37s (0:09:42)

$ uv run pytest server/tests/backup server/tests/e2e/test_spec604_backup_restore.py server/tests/security -q
104 passed in 30.01s
```

`server/tests/e2e/test_spec604_backup_restore.py` (2 tests, real subprocess
hubs, real sockets, real MCP client) run standalone 3x with no flakes.

```
$ cd web && npm run lint && npm run typecheck && npx vitest run && npm run build
0 errors (4 pre-existing warnings, unrelated) / tsc clean / 117 passed / build succeeds

$ cd site/docs && npm test && npm run build
24 passed / build + link-check succeeds, "Back up & restore" page included

$ grep -rn '^<<<<<<< ' v3
(empty)
```

## Checklist

- [x] Tests added/updated (unit, router, e2e round trip, web component,
      threat-model coverage)
- [x] Full `server/tests` suite green (2244 passed, 0 failed)
- [x] `ruff check` / `mypy server/src` clean
- [x] `web` lint/typecheck/tests/build clean
- [x] `site/docs` tests/build clean, jargon lint green
- [x] Documentation updated (`v3/docs/backup-restore.md`, docs-site page,
      threat model, external-review brief)
- [x] No force pushes
- [ ] **Not requesting merge** — this PR needs an architect security review
      before merge, per the task instructions.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790789050&installation_model_id=428086&pr_number=292&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F292&signature=30449efcb6f710cc177a61253fd2de30e4fda9d8d7fd3196843abdb709f437ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->