### PR TITLE
fix(v3): drop ldconfig aux-cache from the Pi image before the manifest

### DIFF
--- a/v3/deploy/pi-image/build.sh
+++ b/v3/deploy/pi-image/build.sh
@@ -199,6 +199,12 @@ EOF
 
     rm -f "${rootfs}/usr/sbin/policy-rc.d"
     rm -f "${rootfs}/usr/bin/qemu-aarch64-static"
+    # ldconfig's binary cache embeds mtimes/inodes, so it differs between
+    # two otherwise-identical runs (the ONE file run #1 of the workflow
+    # caught) — and ldconfig regenerates it on first boot anyway. Dropping
+    # it keeps the image honest about determinism instead of excluding it
+    # from the check.
+    rm -f "${rootfs}/var/cache/ldconfig/aux-cache"
     rm -rf "${rootfs}/var/lib/apt/lists"/*
     rm -rf "${rootfs}/var/cache/apt/archives"/*.deb
 


### PR DESCRIPTION
The [first real run](https://github.com/byte5ai/palaia/actions/runs/33418381607) of `v3-pi-image.yml` proved the pipeline end to end except for exactly one file: `var/cache/ldconfig/aux-cache` embeds mtimes/inodes and differed between the two reproducibility runs (59k+ other files identical). ldconfig regenerates it on first boot, so this deletes it from the rootfs — smaller image, honest determinism — rather than excluding it from the check.

Part of #280. I'll re-dispatch the workflow after merge to confirm green.

`bash -n` clean; `server/tests/deploy/test_pi_image.py` 14 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790789854&installation_model_id=428086&pr_number=293&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F293&signature=db75a48a46d2089185da47f639fd5af592d3192c3c673642804a1a468e91750c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->