### PR TITLE
docs: website handoff — repo state and open decisions for the site session

### DIFF
--- a/v3/docs/website-handoff.md
+++ b/v3/docs/website-handoff.md
@@ -1,0 +1,51 @@
+# Website handoff — for the session owning palaia's public website
+
+This document is the engineering side's handoff to whoever runs the public
+website. It states what exists in this repository, what decisions are open,
+and where the seams are. The website session has authority over everything
+public-facing; nothing here prescribes design.
+
+## What exists (all in this repo, CI-verified on every PR)
+
+- **The documentation site**: `v3/site/docs` — Astro Starlight, 23 pages.
+  Build: `npm ci && npm run build` (from that directory). CI job
+  `docs-site` builds and link-checks every PR; `npm run check:generated`
+  guards the 11 generated pages (per-client connect pages, Synology guide)
+  against drift from their sources.
+- **The onboarding page**: `/onboarding` within that site — platform
+  picker (Docker / Compose / app stores / "Looking for your machine?"),
+  every command drift-tested against `v3/deploy`'s real files. This is the
+  functional successor to palaia.byte5.ai's job.
+- **Content rules the site enforces**: a jargon lint (plain language,
+  server-side test `server/tests/docs_site/`), screenshot slots as HTML
+  comments (`SHOTLIST.md` lists them), one canonical copy per fact
+  (generated, never hand-copied).
+
+## What is deliberately NOT decided here (yours)
+
+1. **Domain + DNS** — `astro.config.mjs`'s `site:` is the placeholder
+   `https://docs.palaia.example`. After choosing the real domain, update
+   it and re-run `tests/onboarding.test.ts` + `tests/generated-pages.test.ts`.
+2. **Hosting + deploy** — CI builds the site but deploys nowhere. Any
+   static host works on `dist/`; a deploy workflow does not exist yet.
+3. **Marketing** — every page is functional, none is promotional. Whether
+   a marketing landing page fronts the docs site (or lives elsewhere) is
+   a website-session decision. The root README's pitch (being rewritten,
+   see PR "docs: root README — palaia v3 first") is the closest existing
+   marketing copy and free to reuse.
+4. **Graphics** — slots are marked in pages and `SHOTLIST.md`; issue #298
+   tracks the README's graphic orders, same convention.
+
+## Seams to respect
+
+- Command snippets must keep coming from the drift mechanism
+  (`scripts/lib/deploy-snippets.mjs`) — never paste a command literal.
+- The jargon lint applies to all `.md` content — plain words, no protocol
+  names in user-facing text.
+- `palaia.local` is the hub's real mDNS name (works only on the user's
+  home network) — not a placeholder, do not "fix" it into a domain.
+
+## Contact seam
+
+Engineering-side changes to the site go through PRs in this repo as
+usual; this document is updated when the seams change.


### PR DESCRIPTION
Owner request (2026-09-01): the public website is owned by a different session; this is the engineering side's handoff document (`v3/docs/website-handoff.md`) — what exists (docs site, onboarding page, drift/lint mechanics), what is deliberately that session's to decide (domain/DNS, hosting/deploy, marketing, graphics), and the seams to respect. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790849806&installation_model_id=428086&pr_number=299&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F299&signature=31110dd39069c0fb8be9e9b0467b97f20457260bbaf003f765f393ec00a630d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->