### PR TITLE
docs: root README — palaia v3 first, top-OSS structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,226 +1,363 @@
-```
-             .__         .__
-___________  |  | _____  |__|____
-\____ \__  \ |  | \__  \ |  \__  \
-|  |_> > __ \|  |__/ __ \|  |/ __ \_
-|   __(____  /____(____  /__(____  /
-|__|       \/          \/        \/
-```
+<!-- graphic: hero — logo/wordmark + tagline banner, light + dark variant, SVG preferred (issue #298 item 1). Drops in directly above the <h1>; the text below must keep working without it. -->
 
-# The Knowledge System for AI Agent Teams
+<div align="center">
 
-**Your agents forget. palaia doesn't.**
+# palaia
 
-[![CI](https://github.com/byte5ai/palaia/actions/workflows/ci.yml/badge.svg)](https://github.com/byte5ai/palaia/actions/workflows/ci.yml)
-[![PyPI](https://img.shields.io/pypi/v/palaia)](https://pypi.org/project/palaia/)
-[![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![OpenClaw Plugin](https://img.shields.io/badge/OpenClaw-Plugin-blueviolet)](https://openclaw.ai)
+**One self-hosted hub. Every AI tool you use shares one memory, one toolbox, and one way to talk to each other.**
 
----
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Release](https://img.shields.io/badge/release-3.0.0--rc1-orange.svg)](v3/CHANGELOG.md)
+[![v3 CI](https://github.com/byte5ai/palaia/actions/workflows/v3-ci.yml/badge.svg)](https://github.com/byte5ai/palaia/actions/workflows/v3-ci.yml)
+[![Container image](https://img.shields.io/badge/image-ghcr.io%2Fbyte5ai%2Fpalaia--hub-blue?logo=docker&logoColor=white)](v3/deploy/README.md)
 
-> **palaia v3 is on its way — a ground-up rewrite.** A self-hosted hub that
-> unifies memory, MCP tools, and agent communication across AI providers, replacing
-> the package-per-machine install below. Track progress in
-> [`v3/MASTERPLAN.md`](v3/MASTERPLAN.md).
->
-> **v2 (this README) is now maintenance-only.** It stays fully installable and keeps
-> receiving hotfixes (security, data loss, broken release) on the
-> [`v2-maintenance`](https://github.com/byte5ai/palaia/tree/v2-maintenance) branch —
-> no new features land here. Nobody is stranded: when v3 is ready for you,
-> [the migration guide](v3/docs/migrate-from-v2.md) covers what carries over
-> (all of it — one command imports your existing knowledge, unchanged), what
-> changes, what v3 doesn't have yet, and how to roll back if you change your mind.
+[Quickstart](#quickstart-60-seconds) · [What you get](#what-you-get) · [Architecture](#architecture) · [Docs](v3/site/docs/src/content/docs/) · [Migrating from v2](v3/docs/migrate-from-v2.md) · [Security](v3/SECURITY.md)
+
+</div>
+
+> [!IMPORTANT]
+> **palaia v3 is a release candidate (`3.0.0-rc1`), not a final release.**
+> Everything described below is implemented and covered by tests, but `3.0.0` is not
+> tagged yet — an external security review and a real non-developer usability run
+> still stand between here and the tag
+> ([`v3/RELEASING.md`](v3/RELEASING.md) is the ordered list). Run it, break it, tell
+> us. Keep backups. **palaia v2 remains the stable, supported product** until v3 is
+> tagged — see [palaia v2](#palaia-v2-maintenance-mode).
 
 ---
 
-## What palaia Does
+## Why palaia exists
 
-AI agents are stateless by default. Every session starts from scratch — no memory of past decisions, no shared knowledge between agents, no context that survives a restart.
+If you use more than one AI tool, you are living in an N × M problem.
 
-palaia gives your agents a persistent, searchable knowledge store. They save what they learn. They find it again by meaning, not keyword. They share it across tools and sessions — automatically.
+Every MCP server has to be configured in every client — a different config file, a
+different syntax, its own credentials, its own update cycle. And nothing any of them
+learns ever reaches the others: tell one assistant a decision on Monday, and another
+has never heard of it on Tuesday. Your accumulated context is scattered across
+vendors, and mostly lost.
 
----
+palaia collapses N × M into **N + M**. Each client connects **once** to your hub.
+Each tool is installed **once** in your hub. What one agent learns, every agent
+knows. It runs on your own hardware, and your memory is a folder of plain Markdown
+files you can open, read, grep, and back up like any other document — no account to
+be locked out of, no vendor that has to stay in business.
 
-## What palaia Is Not
+Think Home Assistant, for your AI stack.
 
-- Not a chatbot or prompt manager
-- Not a cloud service (everything runs locally)
-- Not a vector database you manage yourself (it manages itself)
-- Not limited to one tool — works across OpenClaw, Claude Code, and any MCP client
+<!-- graphic: 30-second demo — animated GIF or short capture: install one-liner → wizard → first memory saved from one client → recalled from a second client (issue #298 item 2). Goes here, above the Quickstart. -->
 
----
+## Quickstart (60 seconds)
 
-## What You Get
-
-| Capability | What it means |
-|------------|---------------|
-| **Agents remember across sessions** | Knowledge survives restarts, tool switches, and team handoffs |
-| **Find anything by meaning** | Hybrid BM25 + vector search across 6 embedding providers |
-| **Zero-config local setup** | SQLite with native SIMD vector search — no separate database process |
-| **Works everywhere via MCP** | OpenClaw and Claude Code: paste a prompt, done. Claude Desktop, Cursor, any MCP host: manual config. |
-| **Multi-agent ready** | Private, team, and public scopes — agents see what they should |
-| **Agent isolation** | `--isolated` mode for strict per-agent memory boundaries |
-| **Crash-safe by default** | SQLite WAL mode survives power loss, kills, OOM |
-| **Fast** | Embed server keeps model in RAM — CLI queries ~1.5s, MCP/Plugin <500ms |
-| **WebUI memory explorer** | `palaia ui` — browse, search, create entries in the browser. Localhost only. |
-| **Scales when needed** | Swap to PostgreSQL + pgvector for distributed teams, no code changes |
-
----
-
-## Comparison
-
-| Feature | palaia | claude-mem | Mem0 | OpenClaw Built-in |
-|---------|--------|-----------|------|-------------------|
-| Local-first | Yes | Yes | Yes (optional cloud) | Yes |
-| Cross-tool (MCP) | Yes (any MCP client) | No (Claude Code only) | No | No (OpenClaw only) |
-| Native Vector Search | sqlite-vec / pgvector | ChromaDB (separate) | FAISS (embedded) | No |
-| Structured Types | memory/process/task | Yes (6 categories) | No | No |
-| Multi-Agent Scopes | private/team/public | Partial (session isolation) | Yes (user/agent/run) | No |
-| Smart Tiering | HOT/WARM/COLD | No | No | No |
-| Embedding Providers | 6 (configurable) | 1 (fixed) | Cloud | External (5+) |
-| Open Source | MIT | AGPL-3.0 | Apache 2.0 | MIT |
-| Crash-safe (WAL) | Yes | Yes (WAL) | Partial (SQLite, not primary) | No |
-
----
-
-## Install
-
-### Recommended: Paste into your agent
-
-Both OpenClaw and Claude Code support fully autonomous setup. Copy the prompt below and paste it directly into your agent's chat — the agent handles everything from there.
-
-**OpenClaw** — copy this prompt into your OpenClaw agent:
-
-```text
-Install or update the palaia memory skill from ClawHub to the latest version (even if already present). Read the SKILL.md completely and follow it step by step. Run palaia init, then palaia doctor --fix and resolve all warnings — don't stop until the doctor report is clean. Set up completely.
-```
-
-**Claude Code** — copy this prompt into Claude Code:
-
-```text
-Install palaia for persistent memory in this Claude Code environment.
-Run: pip install "palaia[mcp,fastembed]" && palaia init && palaia setup claude-code --global
-Then tell me to restart Claude Code so the MCP tools become active.
-After restart, read the CLAUDE.md and follow its instructions.
-```
-
-See [Claude Code Integration](docs/claude-code.md) for the full guide.
-
-### Manual Setup
-
-**OpenClaw:**
+You need Docker ([Docker Desktop](https://www.docker.com/products/docker-desktop/) on
+macOS/Windows, Docker Engine on Linux). That is the whole prerequisite list.
 
 ```bash
-pip install "palaia[fastembed]"
-palaia init
-openclaw plugins install @byte5ai/palaia
-palaia doctor --fix
+docker run -d --name palaia-hub \
+  -p 8420:8420 \
+  -v palaia_home:/data \
+  --restart unless-stopped \
+  --security-opt no-new-privileges:true --cap-drop ALL \
+  --read-only --tmpfs /tmp --tmpfs /run \
+  ghcr.io/byte5ai/palaia-hub:stable
 ```
 
-Then activate the memory slot in your OpenClaw config:
-```json5
-// openclaw.json
-{
-  plugins: {
-    slots: { memory: "palaia" }
-  }
-}
+Until `3.0.0` is tagged there is no `stable` image yet — swap the last line for
+`ghcr.io/byte5ai/palaia-hub:edge`, which is built from `main` on every change. The
+three [release channels](v3/deploy/README.md#updates-spec-501) are `stable`, `beta`
+and `edge`; `palaia-hub update --channel <name>` switches a Compose install between
+them.
+
+Then open **`http://palaia.local`** in a browser on the same network. If that name
+does not resolve — Docker's bridge network doesn't forward mDNS, and Docker Desktop
+never will — use the address the container prints on startup (`docker logs
+palaia-hub`), which always works: `http://<host>:8420`. Both paths are documented in
+[`v3/deploy/README.md`](v3/deploy/README.md#mdns-httppalaialocal).
+
+From there a setup wizard takes over in the browser: sign in, choose how far your hub
+should reach, create your first memory, connect your first AI tool. No config files,
+no second command. See
+[Your first shared memory](v3/site/docs/src/content/docs/first-shared-memory.md) for
+what that looks like end to end.
+
+**Other ways to install:**
+
+| Your machine | How |
+|---|---|
+| A file you keep, or Portainer-style setups | [`docker-compose.yml`](v3/deploy/docker-compose.yml) — `cd v3/deploy && docker compose up -d` |
+| A script that checks Docker first, then prints the address | [`install.sh`](v3/deploy/install.sh) — `curl -fsSL https://raw.githubusercontent.com/byte5ai/palaia/main/v3/deploy/install.sh \| bash` |
+| Umbrel, CasaOS, Runtipi, TrueNAS SCALE | Packages built and kept current in [`v3/deploy/stores/`](v3/deploy/stores/) — not listed in the official catalogs yet, so install the same image with Docker or Compose for now |
+| Synology NAS | Container Manager runs the compose file as a "project", no terminal — [step-by-step guide](v3/site/docs/src/content/docs/install-synology.md) |
+| Raspberry Pi | Works today on 64-bit Raspberry Pi OS with Docker, same one-liner. A flash-and-boot card image is in progress: [`v3/deploy/pi-image/`](v3/deploy/pi-image/) |
+| A rented server (Hetzner, DigitalOcean, AWS, …) | Paste [`cloud-init.yaml`](v3/deploy/cloud-init.yaml) into the provider's user-data field — it installs Docker, joins your private network, and never exposes the hub to the open internet |
+
+The full onboarding page (with copy buttons and the platform picker) lives at
+[`v3/site/docs/src/pages/onboarding.astro`](v3/site/docs/src/pages/onboarding.astro);
+the docs site is not publicly hosted yet, so this repository is the source of truth.
+
+## Pick your path
+
+| You are… | Start here |
+|---|---|
+| **New to palaia** | The [Quickstart](#quickstart-60-seconds) above, then [What is palaia?](v3/site/docs/src/content/docs/index.md) and [Your first shared memory](v3/site/docs/src/content/docs/first-shared-memory.md). Then connect the tools you actually use: [connect guides, one per client](v3/site/docs/src/content/docs/connect/clients/). |
+| **An engineer who wants the design** | [Architecture](#architecture) below, then [`v3/MASTERPLAN.md`](v3/MASTERPLAN.md) (vision, pillars, full system design), the [ADRs](v3/decisions/), the [executable SPECs](v3/specs/), and [`v3/README.md`](v3/README.md) for dev setup and the test/lint commands. |
+| **Already running palaia** | [Updating, backing up, migrating](#already-running-palaia) — including the [v2 → v3 migration guide](v3/docs/migrate-from-v2.md) and where to get [help](#community--support). |
+
+## What you get
+
+Grouped by what it does for you, not by what module it lives in. Every item below
+ships in `3.0.0-rc1` — the full list is in [`v3/CHANGELOG.md`](v3/CHANGELOG.md).
+
+### Memory that outlives the session
+
+- **A vault of plain Markdown files you own** — one note per thing, YAML frontmatter,
+  wikilinks and backlinks. Obsidian opens it as-is. The format is
+  [formally specified](v3/docs/vault-format.md) and pinned by a conformance suite.
+- **Every change is a real git commit**, written by the hub with a meaningful message
+  (which agent, which client, why). `git log` is your audit trail; `git revert` is
+  your undo.
+- **Search that finds meaning, not just strings** — full-text and hybrid text+vector
+  recall, with graph traversal ("continue where we left off") and token-budget-aware
+  context assembly. Optional local embeddings; without them, search degrades cleanly
+  to text-only rather than breaking.
+- **An inbox and a curator.** Agents drop what they learn mid-work without deciding
+  where it belongs; an asynchronous curator files, merges and de-duplicates it.
+  Adding knowledge is autonomous — rewriting or retiring existing notes only ever
+  becomes a proposal you approve.
+- **Skills that teach your tools to save and look things up on their own**, so you
+  stop having to ask every time.
+
+### Connect every AI tool, once
+
+- **One MCP endpoint** for Claude Code, Claude Desktop, claude.ai, ChatGPT, Codex,
+  Gemini/Antigravity CLI, Grok, LM Studio — and anything else that speaks MCP. Each
+  has its [own connect guide](v3/site/docs/src/content/docs/connect/clients/).
+- **A one-click desktop bundle (MCPB)** — download, click, connected. No address to
+  type, no token to paste.
+- **Real auth, not a shared secret:** sign in with GitHub, Google or any OIDC
+  provider, plus a full OAuth 2.1 authorization server (dynamic client registration,
+  PKCE, token rotation) — and per-client tokens for tools that don't do OAuth.
+- **Per-client tool profiles.** Give your phone's assistant a narrow tool set and
+  your desktop everything, from one place, with zero client-side config. Each profile
+  is its own endpoint URL.
+- **Three access modes — Locked, Cloud, Open** — chosen in a wizard, enforced in
+  code, so how far your memory reaches is a decision you made
+  ([modes explained](v3/docs/exposure.md)).
+
+### A marketplace, and automations
+
+- **Install a tool once; every connected AI has it.** A curated add-on index and a
+  one-click marketplace in the dashboard, plus support for any
+  [external MCP server](v3/docs/external-servers.md) with its credentials in an
+  encrypted store — entered once, never again in a client config file.
+- **An event bus with a rules editor.** A new note, a recall, a message, an idle
+  session — hook any of it to webhooks, notifications, tool runs or memory writes
+  ([events](v3/docs/events.md)).
+- **An SDK for add-on authors**, with local testing and a submission flow
+  ([`v3/sdk/`](v3/sdk/README.md)).
+
+### Agents that can find and hand off to each other
+
+- **A session directory:** one AI session can discover another already working on
+  something related — by what it's doing, never by a hardcoded name.
+- **Structured messages between sessions**, including a `handoff` type that carries a
+  reference *into memory* instead of duplicating the text
+  ([messenger](v3/docs/messenger.md)).
+- **Skills that make tools check their inbox and hand off work unprompted**, plus a
+  team screen showing who is doing what.
+
+### Operations you can live with
+
+- **A dashboard that is the product**, not an afterthought: setup wizard, memory
+  explorer, per-client connect pages, marketplace, profile editor, health — plus
+  three in-chat MCP Apps (hub status, recall explorer, review queue) so some of it
+  never needs a browser tab at all.
+- **One-click backup** of the entire hub home, and a documented offline restore
+  ([backup & restore](v3/docs/backup-restore.md)).
+- **Release channels** (`stable` / `beta` / `edge`) and an in-dashboard update check.
+- **A hardened container**: non-root, all capabilities dropped, read-only filesystem,
+  `no-new-privileges` — the flags in the Quickstart are not decoration.
+
+<!-- graphic: dashboard screenshots — hub status, memory explorer, connect page, marketplace, from the current build (issue #298 item 4). One row of four, or a single wide shot of the home screen, goes here. -->
+
+## The two moments it clicks
+
+These are the claims palaia is built to make, and both are proven end to end by tests
+that run a real hub over a real socket — not described, *asserted*.
+
+**1. Install a tool once; every AI already has it.** One marketplace install call,
+two clients with completely different credentials, on two different profiles, zero
+client-side configuration on either — both list the new tool and both can call it.
+Evidence:
+[`test_spec308_phase3_gate.py`](v3/server/tests/e2e/test_spec308_phase3_gate.py),
+written up in
+[client-matrix-results §7](v3/docs/client-matrix-results.md).
+
+**2. What one tool learns, the next one already knows.** From an empty hub: wizard →
+vault → a real client connects over OAuth and writes a fact → a second client, on a
+different credential, recalls that exact fact. Under 13 seconds, twice in a row, with
+no reconfiguration between them. Evidence:
+[`test_spec506_phase5_gate.py`](v3/server/tests/e2e/test_spec506_phase5_gate.py),
+written up in
+[client-matrix-results §9](v3/docs/client-matrix-results.md).
+
+Being honest about the edges: those runs use a real client CLI and a real scripted MCP
+client, not a phone and not a second vendor's binary — the hub's protocol surface is
+not client-specific, but the phone-shaped and second-vendor-shaped versions of these
+demos are owner tasks still open. Every such gap is listed, by name, in
+[client-matrix-results](v3/docs/client-matrix-results.md) rather than glossed over.
+
+## Architecture
+
+<!-- graphic: architecture diagram — hub in the middle, AI tools connecting via MCP, vault/marketplace/messenger as the three pillars, light + dark (issue #298 item 3). Replaces the mermaid block below when it lands. -->
+
+```mermaid
+flowchart LR
+    C["AI clients<br/>desktop · CLI · web · phone"]
+    subgraph HUB["palaia hub — one host, one endpoint"]
+        GW["MCP gateway<br/>streamable HTTP + OAuth 2.1"]
+        MEM["Memory engine"]
+        MSG["Messenger &amp;<br/>session directory"]
+        STORE["Marketplace &amp;<br/>add-on manager"]
+        UI["Dashboard"]
+    end
+    VAULT[("Markdown vault<br/>git-versioned")]
+    IDX[("SQLite index<br/>FTS + vectors<br/>rebuildable")]
+    UP["Add-ons &amp; external<br/>MCP servers"]
+
+    C -->|one connection each| GW
+    GW --> MEM & MSG & STORE
+    GW --> UP
+    MEM --> VAULT & IDX
 ```
 
-Restart the gateway: `openclaw gateway restart`
+The parts worth knowing before you read code:
 
-**Claude Code:**
+- **One hub, one endpoint.** The gateway aggregates built-in tools, installed add-ons
+  and external MCP servers behind a single streamable-HTTP endpoint per profile
+  (`/mcp/<profile>`), so the URL a client connects to already selects its tool
+  surface. Names are namespaced and user-renamable — an agent must be able to pick
+  the right tool from the surface alone.
+- **Files are the source of truth.** The vault is plain Markdown + YAML frontmatter
+  in a git repository. Writes go to disk synchronously; there is no
+  accepted-but-not-yet-persisted state. Crash safety comes from git and atomic
+  writes, not from a custom WAL.
+- **The database is derived, and disposable.** A per-vault SQLite index (full-text +
+  `sqlite-vec` vectors) is rebuilt from the vault on every start. Delete it and
+  nothing is lost. A known trade-off is documented rather than hidden: metadata
+  filters on a vector query are applied after the KNN step, so a heavily filtered
+  query over-fetches before filtering ([MASTERPLAN §5.1](v3/MASTERPLAN.md)).
+- **Auth is real.** OAuth 2.1 with dynamic client registration and PKCE, IdP sign-in
+  (GitHub / Google / OIDC), and per-client bearer tokens for clients that can't do
+  OAuth. Scopes are enforced hub-side; a client only ever sees what its token allows.
+- **Exposure is an explicit mode.** Locked / Cloud / Open change what is reachable and
+  what sign-in is mandatory, enforced at config-load, wizard and request time
+  ([exposure](v3/docs/exposure.md), [threat model](v3/docs/security/threat-model.md)).
+- **Vaults are physically isolated.** One vault with scopes, or many fully separate
+  ones (work / personal / a project) — a search in one can never surface another's
+  content.
+
+Go deeper: [`v3/MASTERPLAN.md`](v3/MASTERPLAN.md) is the source of truth for scope and
+design; [`v3/decisions/`](v3/decisions/) holds the ADRs; [`v3/specs/`](v3/specs/) holds
+the executable SPECs (one SPEC = one branch = one PR);
+[`v3/README.md`](v3/README.md) has the dev setup, test and lint commands.
+
+## Why palaia — and when not to
+
+**Reach for palaia if** you use two or more AI tools and are tired of configuring the
+same MCP server in each of them; if you want your AI's memory to be files you own on
+hardware you control; if you self-host already and want an appliance rather than a
+weekend project; or if you want agents on different machines and different providers
+to be able to hand work to each other.
+
+**Look elsewhere if** you use exactly one AI tool and its built-in memory is enough —
+palaia's whole point is the second tool; if you want a hosted service with no server
+to run, because palaia is self-hosted by design and there is no cloud version; if you
+need a chat UI or an agent framework, because palaia hosts no models and orchestrates
+no reasoning — it is the layer underneath those; or if you need a workflow from the
+[v2 feature list](v3/docs/migrate-from-v2.md#what-v3-doesnt-have-yet) that v3 hasn't
+carried over yet — that table is kept honest, check it before you move.
+
+## Already running palaia
+
+**Update.** The dashboard shows an "update available" banner and updates in one click.
+On the command line it is pull-and-recreate:
+
+```bash
+docker pull ghcr.io/byte5ai/palaia-hub:stable
+docker stop palaia-hub && docker rm palaia-hub
+# re-run the same `docker run` command from the Quickstart
+```
+
+With Compose, `palaia-hub update --channel stable --file docker-compose.yml` rewrites
+the pinned tag, then `docker compose pull && docker compose up -d`. Details and the
+channel semantics: [`v3/deploy/README.md`](v3/deploy/README.md#updates-spec-501).
+
+**Back up first.** "Back up" in the dashboard streams a `tar.gz` of the whole hub home
+— config, every vault including its git history, OAuth keys, the encrypted secret
+store, tokens, hooks and automations. Or from the host:
+
+```bash
+docker run --rm -v palaia_home:/data -v "$(pwd)":/backup alpine \
+  tar czf /backup/palaia-backup.tar.gz -C /data .
+```
+
+What is in the archive, what is deliberately left out, and how to restore offline:
+[backup & restore](v3/docs/backup-restore.md).
+
+**Coming from palaia v2?** One command imports your existing store into a v3 vault,
+entry by entry, with provenance preserved. It only ever *reads* your v2 install, so
+rolling back means deleting what it wrote. Read
+[Moving from palaia v2 to v3](v3/docs/migrate-from-v2.md) first — especially the table
+of what v3 does not carry yet.
+
+**Something wrong?** [Troubleshooting](v3/site/docs/src/content/docs/troubleshooting.md)
+covers the common ones, then see [Community & support](#community--support).
+
+## palaia v2 (maintenance mode)
+
+palaia v2 — the Python package at the repository root, a memory system built primarily
+for OpenClaw — is **stable, still installable, and still supported**. It is in
+maintenance mode: no new features, but critical hotfixes (security, data loss, a broken
+release) land on the
+[`v2-maintenance`](https://github.com/byte5ai/palaia/tree/v2-maintenance) branch, and
+`v2.x.y` tags are cut from there.
 
 ```bash
 pip install "palaia[mcp,fastembed]"
 palaia init
-palaia setup claude-code --global
 ```
 
-Restart Claude Code after setup.
+Its documentation is unchanged and still current:
+[Getting started](docs/getting-started.md) ·
+[CLI reference](docs/cli-reference.md) ·
+[Configuration](docs/configuration.md) ·
+[MCP server](docs/mcp.md) ·
+[Multi-agent](docs/multi-agent.md) ·
+[Architecture](ARCHITECTURE.md) ·
+[Changelog](CHANGELOG.md) ·
+[PyPI](https://pypi.org/project/palaia/)
 
-### Other MCP Clients (Claude Desktop, Cursor)
+Nobody is being pushed off it. When you are ready, the
+[migration guide](v3/docs/migrate-from-v2.md) covers what carries over, what changes,
+what is missing, and how to roll back.
 
-```bash
-pip install "palaia[mcp,fastembed]"
-palaia init
-```
+## Community & support
 
-Add to your MCP config:
-- Claude Desktop: `~/.config/claude/claude_desktop_config.json`
-- Cursor: `.cursor/mcp.json`
-```json
-{
-  "mcpServers": {
-    "palaia": {
-      "command": "palaia-mcp"
-    }
-  }
-}
-```
+- **Questions, bugs, feature requests** — [open an issue](https://github.com/byte5ai/palaia/issues).
+  A version, your access mode, and what you expected instead gets you a useful answer
+  fastest.
+- **Security vulnerabilities** — please do **not** open a public issue. Use GitHub's
+  [private vulnerability reporting](https://github.com/byte5ai/palaia/security/advisories/new)
+  (the "Report a vulnerability" button on the Security tab). It is the only monitored
+  channel; there is no security email address. Response targets and scope:
+  [`v3/SECURITY.md`](v3/SECURITY.md).
+- **Contributing** — [`CONTRIBUTING.md`](CONTRIBUTING.md) for the general process,
+  [`AGENTS.md`](AGENTS.md) for the rules every contributor (human or agent) follows —
+  most importantly the strict v2/v3 separation: a PR touches files of exactly one
+  track. v3 dev setup is in [`v3/README.md`](v3/README.md).
+- **Following along** — [`v3/CHANGELOG.md`](v3/CHANGELOG.md) for what shipped,
+  [`v3/RELEASING.md`](v3/RELEASING.md) for what stands between `3.0.0-rc1` and `3.0.0`.
 
-Note: These clients require manual MCP configuration. palaia provides the memory tools, but you need to instruct the agent yourself.
+## License
 
-### Optional Extras
-
-```bash
-pip install "palaia[curate]"       # Knowledge curation
-pip install "palaia[postgres]"     # PostgreSQL + pgvector backend
-```
-
-Note: `palaia[fastembed]` already includes sqlite-vec for native vector search and the embed-server auto-starts on first query. No manual optimization needed.
-
-**Upgrading?** `palaia upgrade` — auto-detects install method, preserves extras, runs doctor.
-
-## Quick Start
-
-```bash
-palaia write "API rate limit is 100 req/min" \
-  --type memory --tags api,limits                   # Save knowledge
-palaia query "what's the rate limit"                # Find it by meaning
-palaia status                                        # Check health
-```
-
----
-
-## Documentation
-
-| Document | Description |
-|----------|-------------|
-| [Getting Started](docs/getting-started.md) | Installation, first steps, quick tour |
-| [Storage & Search](docs/backends.md) | SQLite, PostgreSQL, sqlite-vec, pgvector, embedding providers |
-| [Claude Code](docs/claude-code.md) | Claude Code integration, setup command, paste-this prompt |
-| [MCP Server](docs/mcp.md) | Setup for Claude Desktop, Cursor, tool reference, read-only mode |
-| [Embed Server](docs/embed-server.md) | Performance optimization, socket transport, daemon mode |
-| [Multi-Agent](docs/multi-agent.md) | Scopes, agent identity, team setup, aliases |
-| [Configuration](docs/configuration.md) | All config keys, embedding chain, tuning |
-| [CLI Reference](docs/cli-reference.md) | All commands with flags and examples |
-| [Migration Guide](docs/migration-guide.md) | Import from other systems, flat-file migration |
-| [Architecture](ARCHITECTURE.md) | Module map, data flows, design decisions |
-| [SKILL.md](palaia/SKILL.md) | Agent-facing documentation (what agents read) |
-| [Contributing](CONTRIBUTING.md) | Versioning, release process, development setup |
-| [Changelog](CHANGELOG.md) | Release history |
-
----
-
-## Development
-
-```bash
-git clone https://github.com/byte5ai/palaia.git
-cd palaia
-pip install -e ".[dev]"
-pytest
-```
-
-## Links
-
-- [palaia.ai](https://palaia.ai) — Homepage
-- [PyPI](https://pypi.org/project/palaia/) — Package registry
-- [ClawHub](https://clawhub.com/skills/palaia) — Install via agent skill
-- [OpenClaw](https://openclaw.ai) — The agent platform palaia is built for
-- [CHANGELOG](CHANGELOG.md) — Release history
-
----
-
-MIT — (c) 2026 [byte5 GmbH](https://byte5.de)
+[MIT](LICENSE) — © 2026 [byte5 GmbH](https://byte5.de)


### PR DESCRIPTION
The root README still pitched v2 with a v3 banner bolted on top, while `main` ships v3 at `3.0.0-rc1`. This inverts it: **v3 is the story**, v2 gets a short, respectful maintenance section. Touches only `README.md` — the one sanctioned cross-track file per `AGENTS.md`.

## Research takeaways applied, and where each landed

Studied Immich, Supabase, Paperless-ngx, n8n, ripgrep and fzf directly, plus README best-practice writeups (repoclip, pushpen, the "awesome README" analyses). Synthesized, not copied:

| Pattern (source) | Where it landed here |
|---|---|
| **Above-the-fold pitch density** — name, one plain-language sentence, badges, nav row, all before the first scroll (all six; repoclip's "decreasing urgency" order) | Centered hero block: `# palaia`, one bolded sentence, four badges, a six-item nav row |
| **A small badge set that answers real evaluator questions** — 3–5, no decoration (pushpen: "every badge should answer a question a real evaluator asks") | Exactly four: license, release, CI, container image. No vanity badges |
| **Honest warning box near the top** (Immich's backup warning; Paperless-ngx's demo disclaimer) | `> [!IMPORTANT]` release-candidate callout: what RC means, what still stands between here and `3.0.0`, and that v2 is still the stable product |
| **"Why this exists" narrative before features** (Supabase's "How it works"; repoclip step 3) | *Why palaia exists* — the N × M problem, collapsed to N + M, ending on the "Home Assistant for your AI stack" line |
| **Quickstart inside the first screen or two, copy-pasteable, tested** (repoclip; n8n's two install paths) | *Quickstart (60 seconds)*: prerequisite line → the real hardened one-liner → `palaia.local` with the honest mDNS fallback → "the wizard takes over" |
| **Platform-first install taxonomy** (fzf: package managers by OS; Immich/Paperless: Docker-first with alternatives) | A 6-row install table: Compose, install script, the four self-hosting stores, Synology, Pi, rented server (cloud-init) |
| **Show, don't tell / demo above the pitch** (top-repo analyses: a GIF outperforms prose) | 30-second-demo graphic slot sits immediately above the Quickstart; the text is written to work without it |
| **Feature list grouped by value, not module** (n8n's six capability bullets; Supabase's checkmark list) | *What you get* in five value groups: memory, connect every AI tool, marketplace & automations, agent teamwork, operations |
| **Proof over assertion** (ripgrep's benchmark tables as evidence rather than claim) | *The two moments it clicks* — both demo claims linked to the actual e2e test files and the written-up gate evidence |
| **Paired honest positioning instead of a competitor matrix** (ripgrep's "Why should I / Why shouldn't I") | *Why palaia — and when not to*. Deliberately replaces v2's feature matrix, which claimed things about other projects we cannot verify today |
| **Audience routing** (pushpen: optimize for users, route contributors elsewhere) | *Pick your path* table, placed right after the Quickstart so newcomers are already served before the router appears |
| **Community/support with a named security channel** (Paperless-ngx's contribution paths) | *Community & support*: issues, GitHub private vulnerability reporting (no email — none exists), contributing incl. the v2/v3 separation rule, and how to follow releases |
| **Maintenance/EOL handled respectfully, never buried** (Immich's note boxes) | *palaia v2 (maintenance mode)*: still installable, hotfixes on `v2-maintenance`, all old docs linked, "nobody is being pushed off it" |

**Deliberately not applied:** a star-history chart (would advertise a number, and the brief forbids invented or vanity metrics on a repo that hasn't launched), a translations block (no translations exist), and a contributor graph (not earned yet). Also dropped: the ASCII-art logo. It cost eight lines of the most valuable screen real estate on the page, rendered as a code block rather than a wordmark, and carried v2's identity into a v3 pitch — the hero graphic slot (#298 item 1) is the right replacement, and until it lands the plain `# palaia` heading reads better than the ASCII did.

## Audience-path map

| Audience | Entry point | Path |
|---|---|---|
| **Newcomer** | Hero → RC callout → *Why palaia exists* | *Quickstart (60 seconds)*: Docker one-liner → `palaia.local` (with the always-works `:8420` fallback) → the browser wizard. Then the platform table (Compose, install.sh, Umbrel/CasaOS/Runtipi/TrueNAS, Synology, Pi, VPS cloud-init), then *Pick your path* → "What is palaia?" + "Your first shared memory" + per-client connect guides |
| **Expert** | *Pick your path* row 2, or the *Architecture* nav link | *Architecture*: mermaid overview + six bullets (one endpoint per profile, files as source of truth, disposable SQLite/sqlite-vec index incl. the documented KNN-prefilter trade-off, OAuth 2.1 + per-client tokens, Locked/Cloud/Open, physical vault isolation) → MASTERPLAN, ADRs, SPECs, `v3/README.md` dev setup. *The two moments it clicks* links straight into the e2e test files |
| **Existing user** | *Pick your path* row 3 | *Already running palaia*: update (dashboard banner, docker pull-and-recreate, `palaia-hub update --channel`), back up (dashboard action + host `tar` command, link to backup & restore), migrate from v2 (guide + the "what v3 doesn't have yet" table), troubleshooting → *Community & support* |

## Graphic slots (ref #298)

All four are HTML comments naming the issue item; the text reads correctly with none of them present.

1. `<!-- graphic: hero ... -->` — line 1, directly above the `<h1>` (#298 item 1)
2. `<!-- graphic: 30-second demo ... -->` — immediately above *Quickstart* (#298 item 2)
3. `<!-- graphic: architecture diagram ... -->` — top of *Architecture*; notes that it replaces the mermaid block when it lands (#298 item 3)
4. `<!-- graphic: dashboard screenshots ... -->` — end of *What you get* (#298 item 4)

Badges (#298 item 5) are part of this text rewrite, as that issue anticipated.

## Truthfulness and verification

- **Links:** 45 relative links + 3 cross-file anchors + 16 in-page anchors, all script-checked, zero broken. The docs site is not hosted, so every docs link points at its in-repo source path.
- **Commands:** the `docker run` block is byte-identical to `v3/deploy/README.md`'s Quick start fence (asserted by script, the same fence the onboarding page extracts). The `install.sh` raw URL, PyPI, Docker Desktop, the `v2-maintenance` branch and byte5.de all return 200. GitHub `/actions/` and `/security/advisories/new` return 403 to anonymous curl from this sandbox — as does the v2 CI badge already live on `main`, so that is the environment, not the URL.
- **Added honesty the old README lacked:** there is no `stable` image until `3.0.0` is tagged, so the Quickstart says so and names `:edge`. The two demo claims are stated as e2e-proven *and* immediately qualified — the phone-shaped and second-vendor-shaped versions of those demos are still owner tasks, per `client-matrix-results`.
- **No invented numbers, testimonials or stars. No model names** (client/product names only). `grep -ci "todo\|placeholder\|lorem"` = 0.
- **Track separation:** `git diff --stat` is one file, `README.md`.

Do not merge — the architect reviews this as a writing-quality gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790850237&installation_model_id=428086&pr_number=300&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F300&signature=ea03ac406429a6e0415f3fd0ffb86ea19083c26c89f24f55412e474ace8ed11b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->