### PR TITLE
feat(docs-site): serve the docs at palaia.byte5.ai/docs

### DIFF
--- a/v3/site/docs/astro.config.mjs
+++ b/v3/site/docs/astro.config.mjs
@@ -3,12 +3,44 @@
 import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
 
+const BASE = "/docs";
+
+// Content here was authored with root-absolute internal links (e.g.
+// `/install/`, `/connect/`) from when the site would have lived at a domain
+// root. Served under `base`, those links must carry the `/docs` prefix or they
+// point outside the docs site. Astro prefixes the base to its own generated
+// links and assets and to relative Markdown links — but NOT to absolute URLs
+// written by hand in Markdown. This remark plugin does that, once, for every
+// content link/image, so authors can keep writing `/foo/` and stay correct.
+// (`scripts/check-links.mjs` verifies the result: no `/docs/...` link is left
+// dangling.)
+function remarkBaseAbsoluteLinks() {
+  const withBase = (url) => {
+    if (typeof url !== "string" || !url.startsWith("/") || url.startsWith("//")) return url;
+    if (url === BASE || url.startsWith(`${BASE}/`)) return url;
+    return `${BASE}${url}`;
+  };
+  const walk = (node) => {
+    if (!node || typeof node !== "object") return;
+    if (
+      (node.type === "link" || node.type === "image" || node.type === "definition") &&
+      typeof node.url === "string"
+    ) {
+      node.url = withBase(node.url);
+    }
+    if (Array.isArray(node.children)) node.children.forEach(walk);
+  };
+  return (tree) => walk(tree);
+}
+
 export default defineConfig({
-  // A placeholder — hosting/DNS for this site is out of this SPEC's scope
-  // (SPEC-503 non-goals), and Starlight/Astro's sitemap needs *some* origin
-  // to build absolute URLs against. Set this to the real domain once one
-  // is chosen; nothing else in the site depends on this value being right.
-  site: "https://docs.palaia.example",
+  // The docs are served as a subpath of the palaia homepage: the
+  // palaia-homepage repo serves this build at palaia.byte5.ai/docs (see that
+  // repo's DOCS-HOSTING.md). `base` makes every link and asset resolve under
+  // /docs; `site` gives the absolute origin for sitemap/canonical URLs.
+  site: "https://palaia.byte5.ai",
+  base: BASE,
+  markdown: { remarkPlugins: [remarkBaseAbsoluteLinks] },
   integrations: [
     starlight({
       title: "palaia docs",

--- a/v3/site/docs/scripts/check-links.mjs
+++ b/v3/site/docs/scripts/check-links.mjs
@@ -11,6 +11,14 @@ import { fileURLToPath } from "node:url";
 const PROJECT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const DIST = path.join(PROJECT_ROOT, "dist");
 
+// The site is served under a base path (astro.config.mjs `base`), so its links
+// are `/docs/...` while the build output stays flat under dist/ (Astro does not
+// nest the physical files under the base). Read the base from the config —
+// rather than duplicating the literal — and strip it before resolving a link
+// against dist.
+const CONFIG = readFileSync(path.join(PROJECT_ROOT, "astro.config.mjs"), "utf8");
+const BASE = (CONFIG.match(/\bBASE\s*=\s*["'`]([^"'`]+)["'`]/)?.[1] ?? "").replace(/\/$/, "");
+
 function walk(dir) {
   const out = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -25,7 +33,11 @@ function walk(dir) {
 // a route resolves if either the exact file or its directory-index form
 // exists.
 function routeExists(routePath) {
-  const clean = routePath.split("#")[0].split("?")[0];
+  let clean = routePath.split("#")[0].split("?")[0];
+  // Links carry the base prefix; the flat dist output does not — strip it.
+  if (BASE && (clean === BASE || clean.startsWith(`${BASE}/`))) {
+    clean = clean.slice(BASE.length) || "/";
+  }
   if (clean === "" || clean === "/") return existsSync(path.join(DIST, "index.html"));
   const relative = clean.replace(/^\//, "");
   const asFile = path.join(DIST, relative);

--- a/v3/site/docs/src/pages/onboarding.astro
+++ b/v3/site/docs/src/pages/onboarding.astro
@@ -41,6 +41,10 @@ const STORES = [
 ] as const;
 
 const REPO = "https://github.com/byte5ai/palaia";
+// Site base, normalized without a trailing slash — prefix in-site links so
+// they resolve under the base rather than at the domain root. Each link below
+// adds its own leading slash. See astro.config.mjs.
+const BASE = import.meta.env.BASE_URL.replace(/\/$/, "");
 ---
 
 <StarlightPage frontmatter={{
@@ -144,7 +148,7 @@ const REPO = "https://github.com/byte5ai/palaia";
       <li>
         <strong>Synology NAS</strong> — its Container Manager runs the <em>Compose file</em> tab's
         file as a "project"; no terminal needed on the NAS itself. See the{" "}
-        <a href="/install-synology/">step-by-step Synology walkthrough</a> for exactly where to
+        <a href={`${BASE}/install-synology/`}>step-by-step Synology walkthrough</a> for exactly where to
         click.
       </li>
       <li class="op-machine-rented">
@@ -171,7 +175,7 @@ const REPO = "https://github.com/byte5ai/palaia";
     <p>
       Once it is running, open <code>http://palaia.local</code> in a browser on the same network
       — or, if that address does not resolve yet (some setups need one network flag; see{" "}
-      <a href="/install/#finding-it-on-your-network-palaialocal">Install it</a> for the one-line
+      <a href={`${BASE}/install/#finding-it-on-your-network-palaialocal`}>Install it</a> for the one-line
       fix), the address printed to the container's own log, which always works:{" "}
       <code>http://&lt;host&gt;:8420</code>.
     </p>
@@ -180,8 +184,8 @@ const REPO = "https://github.com/byte5ai/palaia";
     <p>
       From there, a short setup wizard runs in the browser: an administrator sign-in, your first
       memory, and connecting the first AI tool you use — no file editing, no extra commands. See{" "}
-      <a href="/first-shared-memory/">Your first shared memory</a> for what that looks like end
-      to end, or <a href="/install/">Install it</a> for the longer version of everything on this
+      <a href={`${BASE}/first-shared-memory/`}>Your first shared memory</a> for what that looks like end
+      to end, or <a href={`${BASE}/install/`}>Install it</a> for the longer version of everything on this
       page.
     </p>
   </div>


### PR DESCRIPTION
Sets the docs site up to be served as a subpath of the palaia homepage — **palaia.byte5.ai/docs** — resolving handoff decisions #1–#3 (domain/site URL). No new site, domain, or hosting: the homepage repo (`byte5ai/palaia-homepage`) serves this build under `/docs`.

## Changes (all in `v3/site/docs`)
- **astro.config.mjs**: `site: https://palaia.byte5.ai`, `base: /docs` (was the `docs.palaia.example` placeholder). Adds a small remark plugin that prefixes the base to root-absolute internal links written by hand in Markdown — Astro bases its own generated links/assets but not hand-written absolute Markdown links, so without this the ~50 in-content `/foo/` links would point outside `/docs`. Authors keep writing `/foo/`.
- **src/pages/onboarding.astro**: bases its four in-site links via `BASE_URL`.
- **scripts/check-links.mjs**: strips the base before resolving a link against the flat `dist/` output (read from the config, not duplicated).

## Verification
`npm run build` (astro build + link-check: 24 pages, 0 broken), `check:generated` (11 pages), `vitest` (24 passed), `eslint`, `astro check` — all green.

## How it is served
See `palaia-homepage/DOCS-HOSTING.md` and byte5ai/palaia-homepage#PENDING. That repo commits this build output into `docs-dist/` and Vercel deploys it; ongoing docs changes flow: edit here → build → copy `dist` → `palaia-homepage/docs-dist` → commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790860978&installation_model_id=428086&pr_number=303&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F303&signature=4ddd236e682a6bd76ed8c8c567fc2ad6c6c291b73a1de121064e710ba780e408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->