### PR TITLE
fix: repair v3 image publish — trivy-action tag moved to v-prefix

### DIFF
--- a/.github/workflows/v3-release.yml
+++ b/.github/workflows/v3-release.yml
@@ -158,7 +158,7 @@ jobs:
           fi
 
       - name: Scan image for secrets
-        uses: aquasecurity/trivy-action@0.32.0
+        uses: aquasecurity/trivy-action@v0.32.0
         with:
           image-ref: ${{ env.IMAGE }}:edge-${{ steps.tags.outputs.short_sha }}
           scanners: secret


### PR DESCRIPTION
**Discovery:** every run of the "v3 hub image" workflow since it first triggered on `main` (2026-08-26, 19 of 19 runs) failed within seconds at action resolution:

```
##[error]Unable to resolve action `aquasecurity/trivy-action@0.32.0`, unable to find version `0.32.0`
```

Upstream re-tagged its releases with a `v` prefix; the bare `0.32.0` tag no longer resolves. Consequence: **`ghcr.io/byte5ai/palaia-hub:edge` was never published**, even though the root README's quickstart and the deploy docs point at it. (CI stayed green because the docker smoke e2e builds the image locally — only the publish path was broken.)

**Fix:** pin `aquasecurity/trivy-action@v0.32.0` — the same release under its valid tag, matching this workflow's existing tag-pin convention.

After merge, the push to `main` itself re-triggers the workflow, which should publish `:edge` for the first time; I'll verify that run and the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790862010&installation_model_id=428086&pr_number=304&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F304&signature=e815bfe05f8c870705941259d6e62cbc84a160ae6468c34d8e198097bff35365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->