### PR TITLE
fix: arm64 QEMU smoke waits on a 10-minute deadline

### DIFF
--- a/.github/workflows/v3-release.yml
+++ b/.github/workflows/v3-release.yml
@@ -128,19 +128,25 @@ jobs:
         run: docker pull "${IMAGE}:edge-${{ steps.tags.outputs.short_sha }}" || true
 
       - name: arm64 smoke test (QEMU) — starts and answers /api/health
+        # Deadline, not a fixed retry count: under QEMU emulation the hub's
+        # Python cold start takes minutes, not seconds — this workflow's
+        # first real run (33515957674) showed the app alive and progressing
+        # (startup banner, mDNS announce) but not yet listening when a 60s
+        # window expired. 10 minutes is the honest budget for emulated
+        # arm64; native starts answer in seconds and exit the loop early.
         run: |
           docker run -d --name palaia-hub-arm64 --platform linux/arm64 \
             -p 18420:8420 "${IMAGE}:edge-${{ steps.tags.outputs.short_sha }}"
-          for i in $(seq 1 30); do
-            if curl -fsS http://localhost:18420/api/health; then
-              echo "arm64 image healthy"
-              exit 0
+          deadline=$(( $(date +%s) + 600 ))
+          until curl -fsS http://localhost:18420/api/health; do
+            if [ "$(date +%s)" -ge "${deadline}" ]; then
+              echo "arm64 image never became healthy within 10 minutes" >&2
+              docker logs palaia-hub-arm64 >&2 || true
+              exit 1
             fi
-            sleep 2
+            sleep 5
           done
-          echo "arm64 image never became healthy" >&2
-          docker logs palaia-hub-arm64 >&2 || true
-          exit 1
+          echo "arm64 image healthy"
 
       - name: Image size check (< 400MB compressed, per SPEC-112)
         run: |


### PR DESCRIPTION
Follow-up to #304. The workflow's first run past action resolution ([33515957674](https://github.com/byte5ai/palaia/actions/runs/33515957674)) proved **build and push work** — the smoke step pulled the freshly pushed `edge-e0126635f44c` image from GHCR — but then failed the arm64 health check.

Root cause: the check retried 30×2s (~60 seconds), while an arm64-under-QEMU Python cold start takes minutes. The dumped container log shows the app alive and progressing (startup banner, mDNS announce, nginx up and proxying) but the backend not yet listening on :8421 when the window expired — no crash, no traceback, just emulation slowness on a step that had never run before today.

Fix: a 600-second deadline polling every 5s, with the same log dump on failure. Native-speed starts still exit the loop in seconds.

`test_version_drift.py` (12 passed, includes the workflow tag-parsing pin) and YAML parse are green. No CI runs on this PR (workflow-only path, outside `v3/**`); the merge push to `main` is the real retest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790863267&installation_model_id=428086&pr_number=306&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F306&signature=60fc8583df88d850dac428519151327110b5785b8cd7cba423ec656794966a59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->