### PR TITLE
fix: bump trivy-action to v0.36.0 — old pin's installer path is dead

### DIFF
--- a/.github/workflows/v3-release.yml
+++ b/.github/workflows/v3-release.yml
@@ -164,7 +164,12 @@ jobs:
           fi
 
       - name: Scan image for secrets
-        uses: aquasecurity/trivy-action@v0.32.0
+        # v0.36.0 — older releases (v0.32.0 included) install their pinned
+        # trivy binary via the install script from upstream's *current* main
+        # branch, which no longer supports those old pinned versions: run
+        # 33516927595 died in "Install Trivy" resolving v0.64.1. The latest
+        # action pins a current trivy (v0.70.x) that its installer supports.
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ env.IMAGE }}:edge-${{ steps.tags.outputs.short_sha }}
           scanners: secret


### PR DESCRIPTION
Third and hopefully last repair on the image pipeline. Run [33516927595](https://github.com/byte5ai/palaia/actions/runs/33516927595) got **build, push, arm64 smoke (with the new deadline) and the size check green for the first time** — then died in the secret scan's own setup: trivy-action v0.32.0 installs its pinned trivy (v0.64.1) via the install script checked out from upstream's *current* `main`, which no longer serves that old version ("found version: 0.64.1" → immediate exit 1 in `Install Trivy`).

v0.36.0 (latest) pins a current trivy (v0.70.x) that its installer supports. The inputs used here (`image-ref`, `scanners`, `exit-code`, `severity`) are unchanged between the releases per the upstream changelog.

No CI runs on this PR (workflow-only path); the merge push to `main` is the retest — only the trivy step is unproven now, everything before it was green on the last run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790864625&installation_model_id=428086&pr_number=307&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F307&signature=b8e174e8234ce90c916054b1e4df2705ea91efbf3263f5a0912352c5fb83ace7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->