### PR TITLE
docs: bring the palaia ASCII logo back to the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 <!-- graphic: hero banner (logo/wordmark + tagline), light + dark, SVG preferred (issue #298 item 1). Goes directly above the <h1>. -->
 
+```
+             .__         .__
+___________  |  | _____  |__|____
+\____ \__  \ |  | \__  \ |  \__  \
+|  |_> > __ \|  |__/ __ \|  |/ __ \_
+|   __(____  /____(____  /__(____  /
+|__|       \/          \/        \/
+```
+
 <div align="center">
 
-# palaia
-
-**Your AI tools finally share one memory.**
+# Your AI tools finally share one memory.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/byte5ai/palaia?include_prereleases&label=release)](https://github.com/byte5ai/palaia/releases)


### PR DESCRIPTION
The ASCII logo went missing in the #300 rewrite. It is the project's only logo, and every benchmark README leads with one. Restored byte-identical to the last README that carried it (verified by diff), at the very top; the tagline becomes the page's h1, the same layout the README had before #300. Root README only, no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790931018&installation_model_id=428086&pr_number=309&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F309&signature=47919284cd29f83e4ad627265fca6788562830aa943cde788aa5707d8928f909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->