### PR TITLE
docs: README must not promise teams — palaia is single-user today

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ ___________  |  | _____  |__|____
 <!-- graphic: 30-second demo GIF (issue #298 item 2): the install command, the setup wizard, a memory saved from one AI tool and recalled from another. Goes here, before the first paragraph. -->
 
 palaia is a hub you run yourself: on a server in your office, in your own cloud
-account, or on a machine at home. Every AI tool you and your team use connects to it
+account, or on a machine at home. Every AI tool you use connects to it
 once: Claude, ChatGPT, Codex, Gemini, and any other tool that speaks MCP, the open
 standard AI tools use to reach outside data and tools. From then on they share one
 memory and one set of tools, and they can hand work to each other. Your data stays in


### PR DESCRIPTION
"Every AI tool you and your team use" implied multi-user support that does not exist yet (#311 lists what is missing). Back to "you". The "Your agents can work as a team" benefit stays: it describes one person's agents cooperating, which is what ships. No other multi-user claims found in the README, how-it-works, or the RC1 release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmoFqGsh8gwDDSTTbXNxBp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790932913&installation_model_id=428086&pr_number=312&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F312&signature=7620038a4000f0c27a94532adbc7907e2fadfc1bf15419984d50208eeeaae277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->