### PR TITLE
fix(v3): warm and retry embedder probes

### DIFF
--- a/v3/server/src/palaia_hub/index/service.py
+++ b/v3/server/src/palaia_hub/index/service.py
@@ -66,6 +66,11 @@ logger = logging.getLogger("palaia_hub.index.service")
 #: safety net — every indexing write wakes it immediately.
 _WORKER_POLL_SECONDS = 2.0
 
+#: A failed model load is usually transient (for example, a temporary network
+#: error during the first model download), so keep retrying without spinning.
+_EMBEDDER_RETRY_INITIAL_SECONDS = 1.0
+_EMBEDDER_RETRY_MAX_SECONDS = 60.0
+
 #: A chunk that fails this many times is parked as ``failed`` instead of
 #: spinning the worker forever on the same input.
 _MAX_EMBED_ATTEMPTS = 3
@@ -110,7 +115,9 @@ class VaultIndex:
         self._doctor = VaultDoctor(engine)
         self._embedder: Embedder | None = embedder
         self._embedder_failed = ""
-        self._embedder_probed = embedder is not None
+        self._embedder_probe_attempts = 0
+        self._embedder_retry_at = 0.0
+        self._embedder_lock = asyncio.Lock()
         self._unsubscribe: Callable[[], None] | None = None
         self._worker: asyncio.Task[None] | None = None
         self._wake = asyncio.Event()
@@ -283,27 +290,54 @@ class VaultIndex:
     async def _ensure_embedder(self) -> Embedder | None:
         if self._embedder is not None:
             return self._embedder
-        if self._embedder_probed:
+        if time.monotonic() < self._embedder_retry_at:
             return None
-        self._embedder_probed = True
-        try:
-            embedder = await asyncio.to_thread(build_embedder, self._embedding)
-        except EmbedderUnavailableError as exc:
-            self._embedder_failed = str(exc)
-            logger.warning("embeddings unavailable: %s", exc)
-            return None
-        self._embedder = embedder
-        self.db.meta_set(META_EMBED_MODEL, embedder.name)
-        self.db.meta_set(META_EMBED_DIM, str(embedder.dim))
-        return embedder
+        async with self._embedder_lock:
+            if self._embedder is not None:
+                return self._embedder
+            if time.monotonic() < self._embedder_retry_at:
+                return None
+            try:
+                embedder = await asyncio.to_thread(build_embedder, self._embedding)
+            except EmbedderUnavailableError as exc:
+                self._embedder_probe_attempts += 1
+                delay = min(
+                    _EMBEDDER_RETRY_INITIAL_SECONDS
+                    * 2 ** (self._embedder_probe_attempts - 1),
+                    _EMBEDDER_RETRY_MAX_SECONDS,
+                )
+                self._embedder_retry_at = time.monotonic() + delay
+                self._embedder_failed = str(exc)
+                logger.warning("embeddings unavailable; retrying in %.1fs: %s", delay, exc)
+                return None
+            self._embedder = embedder
+            self._embedder_failed = ""
+            self._embedder_probe_attempts = 0
+            self._embedder_retry_at = 0.0
+            self.db.meta_set(META_EMBED_MODEL, embedder.name)
+            self.db.meta_set(META_EMBED_DIM, str(embedder.dim))
+            return embedder
 
     async def _worker_loop(self) -> None:
         """Drain the embed backlog in batches, forever."""
         while not self._closing:
             try:
-                await asyncio.wait_for(self._wake.wait(), timeout=_WORKER_POLL_SECONDS)
+                await self._ensure_embedder()
+                timeout = min(
+                    _WORKER_POLL_SECONDS,
+                    max(0.0, self._embedder_retry_at - time.monotonic())
+                    if self._embedder is None
+                    else _WORKER_POLL_SECONDS,
+                )
+                await asyncio.wait_for(self._wake.wait(), timeout=timeout)
             except TimeoutError:
                 pass
+            except asyncio.CancelledError:  # pragma: no cover - shutdown
+                raise
+            except Exception:  # noqa: BLE001 - the worker must survive anything
+                logger.exception("embed worker wakeup failed")
+                await asyncio.sleep(_WORKER_POLL_SECONDS)
+                continue
             self._wake.clear()
             embedded_this_wake = 0
             try:

--- a/v3/server/tests/index/test_embeddings.py
+++ b/v3/server/tests/index/test_embeddings.py
@@ -9,13 +9,23 @@ in ``test_hybrid_relevance.py``.
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any
 
 import pytest
 from stub_embedder import StubEmbedder
 
-from palaia_hub.index import EmbeddingConfig, chunk_text, embeddable_text, fingerprint
+from palaia_hub.index import (
+    EmbedderUnavailableError,
+    EmbeddingConfig,
+    VaultIndex,
+    chunk_text,
+    embeddable_text,
+    fingerprint,
+)
+from palaia_hub.index import service as index_service
+from palaia_hub.vault import EventBus, VaultEngine
 
 pytestmark = pytest.mark.anyio
 
@@ -140,8 +150,6 @@ async def test_background_worker_drains_the_backlog_without_being_asked(
     golden_work_vault: Path, open_index: Any
 ) -> None:
     """The write path never embeds; the worker does, on its own."""
-    import asyncio
-
     _, index = await open_index(
         golden_work_vault, embedding=_stub_config(), embedder=StubEmbedder()
     )
@@ -155,6 +163,78 @@ async def test_background_worker_drains_the_backlog_without_being_asked(
     status = index.status()
     assert status.embeds.pending == 0
     assert status.embeds.ready > 0
+
+
+async def test_worker_warms_embedder_for_a_ready_index_after_restart(
+    golden_work_vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A persisted vector index loads its model in the worker, not a query."""
+    db_path = tmp_path / "index.sqlite3"
+    engine = VaultEngine(golden_work_vault, "work", bus=EventBus())
+    await engine.open(purpose="embedder warmup test", create=True)
+    first = VaultIndex(
+        engine,
+        path=db_path,
+        embedding=_stub_config(batch_size=16),
+        embedder=StubEmbedder(),
+    )
+    await first.open(start_worker=False)
+    try:
+        await first.drain_embeddings()
+        assert first.status().embeds.pending == 0
+        assert first.status().embeds.ready > 0
+    finally:
+        await first.close()
+
+    warmed = StubEmbedder()
+    builds = 0
+
+    def build(_config: EmbeddingConfig) -> StubEmbedder:
+        nonlocal builds
+        builds += 1
+        return warmed
+
+    monkeypatch.setattr(index_service, "build_embedder", build)
+    reopened = VaultIndex(engine, path=db_path, embedding=_stub_config(batch_size=16))
+    await reopened.open(build=False)
+    try:
+        reopened.start_worker()
+        deadline = asyncio.get_running_loop().time() + 1.0
+        while builds == 0 and asyncio.get_running_loop().time() < deadline:
+            await asyncio.sleep(0.01)
+        assert builds == 1
+    finally:
+        await reopened.close()
+        await engine.close()
+
+
+async def test_failed_embedder_probe_retries_after_backoff(
+    golden_work_vault: Path, open_index: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A transient model-load failure must not disable vectors permanently."""
+    attempts = 0
+    recovered = StubEmbedder()
+
+    def build(_config: EmbeddingConfig) -> StubEmbedder:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise EmbedderUnavailableError("temporary model download failure")
+        return recovered
+
+    monkeypatch.setattr(index_service, "build_embedder", build)
+    _, index = await open_index(golden_work_vault, embedding=_stub_config())
+
+    assert await index.embed_next_batch() == 0
+    assert attempts == 1
+    assert await index.embed_next_batch() == 0
+    assert attempts == 1
+
+    # Advance past the production backoff without making the test sleep.
+    index._embedder_retry_at = 0.0
+    assert await index.embed_next_batch() > 0
+    assert attempts == 2
+    assert index.status().embeds.reason == ""
 
 
 async def test_editing_a_note_only_re_embeds_its_changed_chunks(


### PR DESCRIPTION
Fixes #362

## Background

When a v3 index was reopened with persisted vectors, the embed worker did not
load the configured model until the first vector or hybrid query. A failed
model probe was also remembered permanently, so a transient download or model
startup failure disabled embeddings for the rest of the process.

## Changes

- Warm the embedder from the background worker before it waits for indexing
  work, including when the persisted backlog is empty.
- Retry unavailable embedder probes with exponential backoff capped at 60
  seconds.
- Serialize concurrent worker/query probes and clear the degraded state after
  a later probe succeeds.
- Add regression coverage for restart warmup and recovery after a transient
  probe failure.

## Compatibility

The public index API, database schema, and FTS fallback are unchanged. Model
loading remains off the write path and still runs in a worker thread.

## Verification

- `uv run pytest server/tests/index/test_embeddings.py -q` — 18 passed.
- `uv run pytest server/tests/index --ignore=server/tests/index/test_hybrid_relevance.py -q` — 65 passed.
- `uv run ruff check server/src/palaia_hub/index/service.py server/tests/index/test_embeddings.py` — passed.
- `uv run mypy server/src` — passed.
- `uv lock --check` and `git diff --check` — passed.

The full v3 Python suite was attempted with UTF-8 enabled, but collection is
currently blocked by the existing `server/tests/recall/test_resolution_conformance.py`
fixture format assertion. The optional real-model relevance test was not
completed because its model download made no progress on this Windows host.
Other v3 web/docs/MCPB checks were also attempted; their existing generated
content, line-ending, deploy-snippet, and Windows `spawn EINVAL` failures are
unrelated to this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790951135&installation_model_id=428086&pr_number=408&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F408&signature=427e4c5b98107c64775ec12668c5f19f89b6f4bd661d25ff9e85397a83964b05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->