### PR TITLE
fix: prevent stale embedding vectors after note changes

### DIFF
--- a/v3/server/src/palaia_hub/index/service.py
+++ b/v3/server/src/palaia_hub/index/service.py
@@ -348,17 +348,15 @@ class VaultIndex:
                 "vector table unavailable (%s); backlog left pending", self.db.vectors.reason
             )
             return 0
-        texts = [text for _, text in rows]
+        claims = [(chunk_id, fingerprint) for chunk_id, fingerprint, _ in rows]
+        texts = [text for _, _, text in rows]
         try:
             vectors = await asyncio.to_thread(embedder.embed, texts)
         except Exception as exc:  # noqa: BLE001 - backend-specific failures
             logger.warning("embedding batch failed: %s", exc)
-            await asyncio.to_thread(self._record_failures, [chunk_id for chunk_id, _ in rows])
+            await asyncio.to_thread(self._record_failures, claims)
             return 0
-        await asyncio.to_thread(
-            self._store_vectors, [chunk_id for chunk_id, _ in rows], vectors
-        )
-        return len(rows)
+        return await asyncio.to_thread(self._store_vectors, claims, vectors)
 
     async def drain_embeddings(self, *, timeout: float = 120.0) -> int:
         """Embed everything pending (test/CLI helper); returns chunks embedded."""
@@ -372,40 +370,53 @@ class VaultIndex:
         self._emit_backlog_drained_if_empty(total)
         return total
 
-    def _claim_batch(self) -> list[tuple[int, str]]:
+    def _claim_batch(self) -> list[tuple[int, str, str]]:
         with self.db.lock:
             rows = self.db.conn.execute(
-                "SELECT id, text FROM chunks WHERE state = 'pending' "
+                "SELECT id, fingerprint, text FROM chunks WHERE state = 'pending' "
                 "ORDER BY id LIMIT ?",
                 (self._embedding.batch_size,),
             ).fetchall()
-        return [(int(row["id"]), str(row["text"])) for row in rows]
+        return [
+            (int(row["id"]), str(row["fingerprint"]), str(row["text"]))
+            for row in rows
+        ]
 
-    def _store_vectors(self, chunk_ids: Sequence[int], vectors: Sequence[Sequence[float]]) -> None:
+    def _store_vectors(
+        self, claims: Sequence[tuple[int, str]], vectors: Sequence[Sequence[float]]
+    ) -> int:
         import sqlite_vec
 
+        stored = 0
         with self.db.lock:
             conn = self.db.conn
-            for chunk_id, vector in zip(chunk_ids, vectors, strict=True):
+            for (chunk_id, fingerprint), vector in zip(claims, vectors, strict=True):
+                updated = conn.execute(
+                    "UPDATE chunks SET state = 'ready', attempts = 0 "
+                    "WHERE id = ? AND fingerprint = ? AND state = 'pending'",
+                    (chunk_id, fingerprint),
+                )
+                if updated.rowcount != 1:
+                    logger.debug("skipping stale embedding claim for chunk %s", chunk_id)
+                    continue
                 conn.execute("DELETE FROM vec_chunks WHERE rowid = ?", (chunk_id,))
                 conn.execute(
                     "INSERT INTO vec_chunks(rowid, embedding) VALUES (?, ?)",
                     (chunk_id, sqlite_vec.serialize_float32(list(vector))),
                 )
-                conn.execute(
-                    "UPDATE chunks SET state = 'ready', attempts = 0 WHERE id = ?", (chunk_id,)
-                )
+                stored += 1
             conn.commit()
+        return stored
 
-    def _record_failures(self, chunk_ids: Sequence[int]) -> None:
+    def _record_failures(self, claims: Sequence[tuple[int, str]]) -> None:
         with self.db.lock:
             conn = self.db.conn
-            for chunk_id in chunk_ids:
+            for chunk_id, fingerprint in claims:
                 conn.execute(
                     "UPDATE chunks SET attempts = attempts + 1, "
                     "state = CASE WHEN attempts + 1 >= ? THEN 'failed' ELSE 'pending' END "
-                    "WHERE id = ?",
-                    (_MAX_EMBED_ATTEMPTS, chunk_id),
+                    "WHERE id = ? AND fingerprint = ? AND state = 'pending'",
+                    (_MAX_EMBED_ATTEMPTS, chunk_id, fingerprint),
                 )
             conn.commit()
 

--- a/v3/server/tests/index/test_embeddings.py
+++ b/v3/server/tests/index/test_embeddings.py
@@ -9,6 +9,9 @@ in ``test_hybrid_relevance.py``.
 
 from __future__ import annotations
 
+import asyncio
+import threading
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -22,6 +25,21 @@ pytestmark = pytest.mark.anyio
 
 def _stub_config(**kwargs: Any) -> EmbeddingConfig:
     return EmbeddingConfig(enabled=True, model="stub/hashed-bow", **kwargs)
+
+
+class BlockingStubEmbedder(StubEmbedder):
+    """Pause one batch so a vault change can race its storage step."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def embed(self, texts: Sequence[str]) -> list[list[float]]:
+        self.started.set()
+        if not self.release.wait(5):
+            raise RuntimeError("test embedder was not released")
+        return super().embed(texts)
 
 
 # ------------------------------------------------------------------- chunking
@@ -183,6 +201,86 @@ async def test_editing_a_note_only_re_embeds_its_changed_chunks(
     assert pending, "the changed tail must be re-embedded"
     assert ready, "unchanged chunks must keep their vectors"
     assert len(pending) < len(chunks_before)
+
+
+async def test_edit_during_embedding_does_not_store_a_stale_vector(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    embedder = BlockingStubEmbedder()
+    engine, index = await open_index(
+        golden_work_vault,
+        embedding=_stub_config(),
+        embedder=embedder,
+        build=False,
+    )
+    await engine.write_note("notes/race", body="original text", title="Race")
+
+    embedding = asyncio.create_task(index.embed_next_batch())
+    assert await asyncio.to_thread(embedder.started.wait, 5)
+    with index.db.lock:
+        claimed = index.db.conn.execute(
+            "SELECT id, fingerprint FROM chunks WHERE ref = ?", ("notes/race",)
+        ).fetchone()
+
+    current = await engine.read_note("notes/race")
+    await engine.edit_note(
+        "notes/race", body="replacement text", expected_checksum=current.checksum
+    )
+    with index.db.lock:
+        changed = index.db.conn.execute(
+            "SELECT id, fingerprint, state FROM chunks WHERE ref = ?", ("notes/race",)
+        ).fetchone()
+    assert changed["id"] == claimed["id"]
+    assert changed["fingerprint"] != claimed["fingerprint"]
+    assert changed["state"] == "pending"
+
+    embedder.release.set()
+    assert await embedding == 0
+    with index.db.lock:
+        final = index.db.conn.execute(
+            "SELECT fingerprint, state FROM chunks WHERE ref = ?", ("notes/race",)
+        ).fetchone()
+        vectors = index.db.conn.execute(
+            "SELECT count(*) AS n FROM vec_chunks WHERE rowid = ?", (claimed["id"],)
+        ).fetchone()["n"]
+    assert final["fingerprint"] == changed["fingerprint"]
+    assert final["state"] == "pending"
+    assert vectors == 0
+
+
+async def test_delete_during_embedding_does_not_leave_an_orphan_vector(
+    golden_work_vault: Path, open_index: Any
+) -> None:
+    embedder = BlockingStubEmbedder()
+    engine, index = await open_index(
+        golden_work_vault,
+        embedding=_stub_config(),
+        embedder=embedder,
+        build=False,
+    )
+    await engine.write_note("notes/race", body="original text", title="Race")
+
+    embedding = asyncio.create_task(index.embed_next_batch())
+    assert await asyncio.to_thread(embedder.started.wait, 5)
+    with index.db.lock:
+        claimed = index.db.conn.execute(
+            "SELECT id FROM chunks WHERE ref = ?", ("notes/race",)
+        ).fetchone()
+
+    note = await engine.read_note("notes/race")
+    await engine.delete_note("notes/race")
+    embedder.release.set()
+    assert await embedding == 0
+    with index.db.lock:
+        chunks = index.db.conn.execute(
+            "SELECT count(*) AS n FROM chunks WHERE id = ?", (claimed["id"],)
+        ).fetchone()["n"]
+        vectors = index.db.conn.execute(
+            "SELECT count(*) AS n FROM vec_chunks WHERE rowid = ?", (claimed["id"],)
+        ).fetchone()["n"]
+    assert note.path == "notes/race.md"
+    assert chunks == 0
+    assert vectors == 0
 
 
 async def test_reindex_preserves_ready_vectors(


### PR DESCRIPTION
## Summary / Problem

Embedding runs outside the index database lock, so a note edit or delete can
complete while an older embedding batch is still running. The old batch was
then written by chunk ID alone, marking a replacement chunk ready or leaving a
vector row without a chunk.

## Changes

- Carry each chunk fingerprint with the embedding claim.
- Store a vector only when the chunk still exists with the claimed fingerprint
  and is still pending.
- Apply the same fingerprint guard when recording embedding failures, and
  report only vectors actually stored by a batch.
- Add deterministic edit-during-embed and delete-during-embed regressions that
  assert pending replacement chunks and zero orphan vectors.

## Tests

- `uv run --project server pytest --basetemp=<isolated> server/tests/index -q` — 65 passed, 2 skipped.
- `uv run --project server pytest --basetemp=<isolated> server/tests/index/test_embeddings.py server/tests/index/test_incremental.py -q` — 27 passed.
- `uv run --project server ruff check server/src/palaia_hub/index/service.py server/tests/index/test_embeddings.py` — passed.
- The full v3 server suite completed with 2,210 passed, 35 skipped, 25 pre-existing failures, and 10 environment/integration errors after excluding the repository's CRLF-incompatible `test_resolution_conformance.py` collection fixture. The failures were outside the changed files, including Docker mirror image resolution and unrelated platform/integration scenarios.

## Compatibility / Known limitations

No schema, public API, or embedding model changes are introduced. A claim that
becomes stale is left pending so the replacement content can be embedded by a
later batch. The repository-wide mypy run remains blocked by the existing
unused-ignore error in `v3/server/src/palaia_hub/index/embeddings.py:130`.

## Issue link

Fixes #336

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/palaia/pr/410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791252421&installation_model_id=428086&pr_number=410&repository=byte5ai%2Fpalaia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fpalaia%2Fpull%2F410&signature=96bdaa96c626bee03f6b3476f4bd9129332dfeb4be216f98346e9988c0bd460f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->